### PR TITLE
fix(compiler): lower TypeScript enums, keep JSON __proto__ own, size compile stacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +866,12 @@ checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -1835,7 +1856,9 @@ dependencies = [
  "oxc_syntax",
  "oxc_transformer",
  "oxc_transformer_plugins",
+ "proptest",
  "serde_json",
+ "tempfile",
  "thiserror",
 ]
 
@@ -2746,6 +2769,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2764,6 +2806,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -2942,6 +2990,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3705,6 +3762,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4087,6 +4156,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4382,6 +4464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-id-start"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4502,6 +4590,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,10 @@ axum = { version = "0.8.9", features = ["ws"] }
 notify = "8.2.0"
 clap = { version = "4.6.6", features = ["derive"] }
 
+# test-only
+proptest = "1.9.0"
+tempfile = "3.24.0"
+
 [profile.release]
 lto = "thin"
 codegen-units = 1

--- a/crates/oj/src/main.rs
+++ b/crates/oj/src/main.rs
@@ -61,8 +61,18 @@ enum Command {
     },
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
+    // Compilation happens on runtime threads, and it recurses once per level of
+    // bracket nesting; the default 2 MiB is not enough for generated code, and
+    // a stack overflow aborts the process instead of failing one module.
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_stack_size(oj_compiler::COMPILE_STACK_SIZE)
+        .build()?
+        .block_on(run())
+}
+
+async fn run() -> anyhow::Result<()> {
     match Cli::parse().command {
         Command::Dev {
             root,

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -689,7 +689,15 @@ mod tests {
     use super::*;
 
     fn tmp(label: &str) -> PathBuf {
-        let d = std::env::temp_dir().join(format!("oj-startdev-{}-{label}", std::process::id()));
+        // A fresh directory per call: this wipes the path before creating it, so
+        // two tests that pass the same label would race -- one clearing the
+        // other's fixture out from under it, in whichever order they interleave.
+        static SEQ: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let d = std::env::temp_dir().join(format!(
+            "oj-startdev-{}-{label}-{seq}",
+            std::process::id()
+        ));
         let _ = std::fs::remove_dir_all(&d);
         std::fs::create_dir_all(&d).unwrap();
         d

--- a/crates/oj_compiler/Cargo.toml
+++ b/crates/oj_compiler/Cargo.toml
@@ -22,3 +22,7 @@ memchr.workspace = true
 serde_json.workspace = true
 oxc_codegen.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true
+tempfile.workspace = true

--- a/crates/oj_compiler/src/bundle.rs
+++ b/crates/oj_compiler/src/bundle.rs
@@ -111,6 +111,9 @@ fn compile_esm_factory(
 
     let scoping = SemanticBuilder::new()
         .with_excess_capacity(2.0)
+        // See `compile_module`: the TypeScript transform needs this to lower
+        // `enum` instead of panicking.
+        .with_enum_eval(true)
         .build(&program);
     let scoping = scoping.semantic.into_scoping();
     let mut transform_options = TransformOptions::default();

--- a/crates/oj_compiler/src/cjs.rs
+++ b/crates/oj_compiler/src/cjs.rs
@@ -40,6 +40,7 @@ pub fn has_module_syntax_pub(path: &Path, source_text: &str) -> bool {
     has_module_syntax(path, source_text)
 }
 
+#[derive(Debug)]
 pub struct CjsFactoryAnalysis {
     pub body: String,
     pub requires: Vec<String>,

--- a/crates/oj_compiler/src/json.rs
+++ b/crates/oj_compiler/src/json.rs
@@ -14,6 +14,13 @@ fn named_keys(value: &serde_json::Value) -> Vec<String> {
 }
 
 fn is_safe_export_name(name: &str) -> bool {
+    // `__proto__` is a valid identifier but not a usable export here: the
+    // export tables are object literals, and `__proto__: value` in one sets the
+    // prototype instead of defining the property. The key stays reachable on
+    // the default export.
+    if name == "__proto__" {
+        return false;
+    }
     const RESERVED: &[&str] = &[
         "default", "class", "const", "let", "var", "function", "return", "import", "export", "new",
         "delete", "void", "typeof", "in", "of", "do", "if", "else", "switch", "case", "for",
@@ -35,9 +42,37 @@ fn parse(source: &str, url: &str) -> Result<serde_json::Value, CompileError> {
     })
 }
 
+/// Whether the document has a `__proto__` key at any depth.
+fn has_proto_key(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Object(map) => {
+            map.contains_key("__proto__") || map.values().any(has_proto_key)
+        }
+        serde_json::Value::Array(items) => items.iter().any(has_proto_key),
+        _ => false,
+    }
+}
+
+/// The JS expression for the document. JSON is a subset of JS expression
+/// syntax, so the source text is normally spliced in verbatim -- except that
+/// `{"__proto__": x}` as an object literal sets the prototype rather than
+/// defining a property, which would make the imported module disagree with
+/// `JSON.parse` on the same bytes. Those documents are parsed at runtime
+/// instead.
+fn js_expression(source: &str, value: &serde_json::Value) -> String {
+    let raw = source.trim();
+    if has_proto_key(value) {
+        return format!(
+            "JSON.parse({})",
+            serde_json::Value::String(raw.to_string())
+        );
+    }
+    raw.to_string()
+}
+
 pub fn to_esm(source: &str, url: &str) -> Result<String, CompileError> {
     let value = parse(source, url)?;
-    let raw = source.trim();
+    let raw = js_expression(source, &value);
     let mut out = format!("const __oj_json = {raw};\nexport default __oj_json;\n");
     for key in named_keys(&value) {
         out.push_str(&format!("export const {key} = __oj_json[{key:?}];\n"));
@@ -47,7 +82,7 @@ pub fn to_esm(source: &str, url: &str) -> Result<String, CompileError> {
 
 pub fn to_factory_body(source: &str, url: &str) -> Result<String, CompileError> {
     let value = parse(source, url)?;
-    let raw = source.trim();
+    let raw = js_expression(source, &value);
     let mut getters = vec!["\"default\": () => __oj_json".to_string()];
     for key in named_keys(&value) {
         getters.push(format!("{key:?}: () => __oj_json[{key:?}]"));

--- a/crates/oj_compiler/src/lib.rs
+++ b/crates/oj_compiler/src/lib.rs
@@ -22,6 +22,16 @@ use oxc_transformer_plugins::{ReplaceGlobalDefines, ReplaceGlobalDefinesConfig};
 
 pub type ImportRewriter<'r> = dyn FnMut(&str) -> Option<String> + 'r;
 
+/// Stack size for any thread that compiles a module.
+///
+/// Parsing, transforming and printing are all recursive descent: one frame per
+/// level of bracket nesting. The 2 MiB a runtime thread gets by default runs
+/// out somewhere under a thousand levels, and an overflow aborts the process
+/// rather than failing the one file -- a generated or minified module can take
+/// the whole dev server down with it. Hand-written source stays two orders of
+/// magnitude below this; generated code does not.
+pub const COMPILE_STACK_SIZE: usize = 16 * 1024 * 1024;
+
 static F_IMPORT_META_ENV: LazyLock<Finder<'static>> =
     LazyLock::new(|| Finder::new("import.meta.env"));
 static F_IMPORT_META_GLOB: LazyLock<Finder<'static>> =
@@ -210,6 +220,9 @@ pub fn compile_module(
 
     let semantic_ret = SemanticBuilder::new()
         .with_excess_capacity(2.0)
+        // Required by the TypeScript transform to lower `enum`: without it the
+        // transformer panics rather than reporting a diagnostic.
+        .with_enum_eval(true)
         .build(&program);
     let scoping = semantic_ret.semantic.into_scoping();
 

--- a/crates/oj_compiler/tests/adverse.rs
+++ b/crates/oj_compiler/tests/adverse.rs
@@ -1,0 +1,594 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+//! Hostile and malformed module sources. Every entry point in the compiler is
+//! reached from a file on disk that oj did not write, so the contract is
+//! uniform: return a `CompileError`, or return code — never panic, never hang,
+//! never emit something that is not valid JavaScript.
+
+use std::path::Path;
+
+use oj_compiler::{cjs, compile, glob, interop, json, CompileError, CompileOptions};
+
+/// Re-parses generated code, so a test can assert output validity rather than
+/// output shape. `.mjs` so the module syntax is accepted.
+fn parses(code: &str) -> bool {
+    compile(Path::new("/verify.mjs"), code, &CompileOptions::prod()).is_ok()
+}
+
+fn dev(path: &str, source: &str) -> Result<oj_compiler::CompileOutput, CompileError> {
+    compile(Path::new(path), source, &CompileOptions::dev())
+}
+
+#[test]
+fn malformed_sources_are_errors_not_panics() {
+    let cases: &[(&str, &str)] = &[
+        ("unterminated string", "const a = \"oops"),
+        ("unterminated template", "const a = `oops"),
+        ("unterminated comment", "/* oops"),
+        ("unterminated regex", "const a = /oops"),
+        ("stray brace", "}"),
+        ("stray bracket", "]"),
+        ("lone else", "else {}"),
+        ("reserved binding", "const class = 1;"),
+        ("await outside async", "function f() { await x; }"),
+        ("bad jsx", "const a = <div><span></div>;"),
+        ("bad ts generic", "const a: Map<string = 1;"),
+        ("decorator on nothing", "@dec"),
+        ("html in js", "<!DOCTYPE html><html></html>"),
+        ("binary-ish", "\u{0}\u{1}\u{2}\u{3}"),
+    ];
+    for (label, source) in cases {
+        match dev("/src/App.tsx", source) {
+            Err(CompileError::Parse { .. }) | Err(CompileError::Transform { .. }) => {}
+            Err(other) => panic!("{label}: unexpected error kind: {other}"),
+            Ok(out) => panic!("{label}: accepted invalid source, emitted: {}", out.code),
+        }
+    }
+}
+
+#[test]
+fn lone_surrogate_escapes_round_trip_unchanged() {
+    // `"\ud800"` is a legal string literal that is not well-formed UTF-16. It
+    // must reach the browser as written, not as a replacement character.
+    let out = dev("/src/App.ts", "export const a = \"\\ud800\\udc00 \\ud800\";").unwrap();
+    assert!(out.code.contains("\\ud800"), "escape rewritten: {}", out.code);
+    assert!(parses(&out.code), "invalid output: {}", out.code);
+}
+
+#[test]
+fn errors_that_are_semantic_rather_than_syntactic_pass_through() {
+    // oj does not run oxc's semantic checker on every file in dev: these are
+    // early errors per the spec, and the browser reports them. Pinned here so
+    // the boundary is a decision rather than a surprise -- what matters is that
+    // the emitted code is exactly as wrong as the input, not silently repaired.
+    for source in [
+        "let a = 1; let a = 2;",
+        "const a = 1; a = 2;",
+        "return 1;",
+        "with (x) {}",
+    ] {
+        match compile(Path::new("/src/App.ts"), source, &CompileOptions::dev()) {
+            Ok(out) => assert!(!out.code.is_empty(), "{source}"),
+            Err(CompileError::Parse { .. }) | Err(CompileError::Transform { .. }) => {}
+            Err(other) => panic!("{source}: unexpected error kind: {other}"),
+        }
+    }
+}
+
+#[test]
+fn an_unsupported_extension_is_refused_by_name() {
+    let err = dev("/src/styles.css", "body { color: red }").unwrap_err();
+    assert!(
+        matches!(err, CompileError::UnsupportedFileType(_)),
+        "got {err}"
+    );
+    // A path with no extension at all.
+    assert!(matches!(
+        dev("/src/Makefile", "all:").unwrap_err(),
+        CompileError::UnsupportedFileType(_)
+    ));
+}
+
+#[test]
+fn deeply_nested_expressions_do_not_overflow_a_compile_thread() {
+    // Parsing, transforming and printing all recurse once per nesting level, so
+    // the depth a file may reach is a function of the stack oj gives the thread
+    // that compiles it. A generated or minified module nests far deeper than
+    // anything written by hand, and an overflow aborts the whole process rather
+    // than failing the one file -- hence `COMPILE_STACK_SIZE`, which the CLI
+    // installs as the runtime's thread stack size. On the 2 MiB a thread gets
+    // by default, the array case below already aborts at depth 900.
+    let handle = std::thread::Builder::new()
+        .stack_size(oj_compiler::COMPILE_STACK_SIZE)
+        .spawn(|| {
+            for depth in [64usize, 512] {
+                for (open, close) in [("[", "]"), ("(", ")"), ("{a:", "}"), ("f(", ")")] {
+                    let source = format!(
+                        "export const x = {}1{};",
+                        open.repeat(depth),
+                        close.repeat(depth)
+                    );
+                    // Accepted or rejected, but never a crash.
+                    let _ = dev("/src/deep.ts", &source);
+                }
+                let ternary = format!(
+                    "export const x = {}1{};",
+                    "a ? ".repeat(depth),
+                    " : 0".repeat(depth)
+                );
+                let _ = dev("/src/ternary.ts", &ternary);
+            }
+            // The shape a data-shaped generated file actually reaches.
+            let arrays = format!("export const x = {}1{};", "[".repeat(2_000), "]".repeat(2_000));
+            assert!(dev("/src/arrays.ts", &arrays).is_ok());
+            // A long flat chain is iterative in the parser but not in codegen.
+            let chain = format!("export const x = 1{};", "+1".repeat(5_000));
+            let _ = dev("/src/chain.ts", &chain);
+        })
+        .unwrap();
+    handle.join().expect("no overflow on a compile-sized stack");
+}
+
+#[test]
+fn very_large_sources_compile_in_linear_time() {
+    let big: String = (0..20_000)
+        .map(|i| format!("export const v{i} = {i};\n"))
+        .collect();
+    let out = dev("/src/big.ts", &big).unwrap();
+    assert!(out.code.contains("v19999"));
+
+    let long_string = format!("export const s = \"{}\";", "a".repeat(2_000_000));
+    assert!(dev("/src/long.ts", &long_string).is_ok());
+
+    let mut many_imports: String = (0..5_000)
+        .map(|i| format!("import d{i} from \"./d{i}.js\";\n"))
+        .collect();
+    // Used, so the TypeScript transform cannot elide them.
+    many_imports.push_str("export const all = [");
+    for i in 0..5_000 {
+        many_imports.push_str(&format!("d{i},"));
+    }
+    many_imports.push_str("];\n");
+    let out = dev("/src/imports.ts", &many_imports).unwrap();
+    assert_eq!(out.imports.len(), 5_000);
+}
+
+#[test]
+fn unused_type_only_imports_are_elided_from_a_typescript_module() {
+    // Documented TypeScript semantics, and the reason the count above needs its
+    // imports used: an unused import in a .ts file is not a module edge.
+    let out = dev("/src/App.ts", "import d from \"./d.js\";\nexport const a = 1;").unwrap();
+    assert!(out.imports.is_empty(), "{:?}", out.imports);
+    // In a .js module there is no elision.
+    let out = dev("/src/App.js", "import d from \"./d.js\";\nexport const a = 1;").unwrap();
+    assert_eq!(out.imports, vec!["./d.js".to_string()]);
+    // A bare side-effect import is kept either way.
+    let out = dev("/src/App.ts", "import \"./side-effect.css\";").unwrap();
+    assert_eq!(out.imports, vec!["./side-effect.css".to_string()]);
+}
+
+#[test]
+fn unicode_identifiers_and_bidi_text_survive_a_round_trip() {
+    let source = "export const café = 1;\n\
+                  export const 日本 = 2;\n\
+                  export const $ = \"\u{202e}reversed\u{202c}\";\n\
+                  export const zwj = \"👩‍👩‍👧‍👦\";\n";
+    let out = dev("/src/unicode.ts", &source).unwrap();
+    assert!(parses(&out.code), "invalid output: {}", out.code);
+    let mut names = oj_compiler::exports(source, Path::new("/src/unicode.ts"));
+    names.sort();
+    assert_eq!(names, ["$", "café", "zwj", "日本"]);
+}
+
+#[test]
+fn line_terminators_inside_strings_stay_escaped_in_the_output() {
+    // U+2028 and U+2029 are legal in a JS string literal but break naive
+    // concatenation into a `<script>` or a source map.
+    let source = "export const s = \"a\u{2028}b\u{2029}c\";";
+    let out = dev("/src/sep.ts", source).unwrap();
+    assert!(parses(&out.code), "invalid output: {}", out.code);
+}
+
+#[test]
+fn a_module_that_imports_itself_is_still_compiled() {
+    let out = dev("/src/App.tsx", "import \"./App\";\nexport const a = 1;").unwrap();
+    assert_eq!(out.imports, vec!["./App".to_string()]);
+}
+
+#[test]
+fn hostile_import_specifiers_are_reported_verbatim_and_rewritten_once() {
+    let source = "\
+import a from \"../../../../../../etc/passwd\";
+import b from \"/absolute/path\";
+import c from \"http://evil.example/x.js\";
+import d from \"data:text/javascript,export default 1\";
+import e from \"\";
+import f from \" \t\";
+import g from \"./a\\u0000b\";
+export { a, b, c, d, e, f, g };
+";
+    let out = dev("/src/App.tsx", source).unwrap();
+    assert_eq!(out.imports.len(), 7, "{:?}", out.imports);
+    assert!(out.imports.contains(&"../../../../../../etc/passwd".to_string()));
+    assert!(out.imports.contains(&"http://evil.example/x.js".to_string()));
+
+    // A rewriter sees each specifier exactly once and its answer is what lands
+    // in the output.
+    let mut seen: Vec<String> = Vec::new();
+    let mut rewriter = |spec: &str| {
+        seen.push(spec.to_string());
+        Some(format!("/@resolved/{}", seen.len()))
+    };
+    let out = oj_compiler::compile_module(
+        Path::new("/src/App.tsx"),
+        source,
+        &CompileOptions::dev(),
+        Some(&mut rewriter),
+    )
+    .unwrap();
+    assert_eq!(seen.len(), 7, "each specifier once: {seen:?}");
+    assert!(parses(&out.code), "invalid output: {}", out.code);
+    assert!(!out.code.contains("etc/passwd"), "{}", out.code);
+}
+
+#[test]
+fn a_rewriter_that_returns_junk_cannot_break_the_output_grammar() {
+    let source = "import a from \"./a\";\nimport(\"./b\");\nexport { a };";
+    for junk in [
+        "\"; evil(); \"",
+        "a\nb",
+        "\\",
+        "'",
+        "${x}",
+        "\u{2028}",
+        "\0",
+        "",
+    ] {
+        let mut rewriter = |_: &str| Some(junk.to_string());
+        let out = oj_compiler::compile_module(
+            Path::new("/src/App.tsx"),
+            source,
+            &CompileOptions::dev(),
+            Some(&mut rewriter),
+        )
+        .unwrap();
+        assert!(
+            parses(&out.code),
+            "rewriting to {junk:?} produced invalid code: {}",
+            out.code
+        );
+    }
+}
+
+#[test]
+fn json_that_is_not_json_is_an_error() {
+    for source in [
+        "",
+        " ",
+        "{",
+        "{,}",
+        "{\"a\":}",
+        "{'a':1}",
+        "{a:1}",
+        "{\"a\":1,}",
+        "// comment\n{}",
+        "{\"a\":1}{\"b\":2}",
+        "NaN",
+        "undefined",
+        "01",
+        "0x10",
+        "'string'",
+    ] {
+        assert!(
+            json::to_esm(source, "/data.json").is_err(),
+            "accepted invalid JSON: {source:?}"
+        );
+        assert!(json::to_factory_body(source, "/data.json").is_err());
+    }
+}
+
+#[test]
+fn json_keys_that_are_not_identifiers_are_default_only() {
+    let source = r#"{"kebab-case":1,"with space":2,"1numeric":3,"":4,"default":5,"class":6,"ok":7}"#;
+    let esm = json::to_esm(source, "/data.json").unwrap();
+    assert!(parses(&esm), "invalid output: {esm}");
+    assert!(esm.contains("export const ok ="));
+    for bad in ["kebab-case", "with space", "1numeric", "class"] {
+        assert!(
+            !esm.contains(&format!("export const {bad}")),
+            "exported {bad}: {esm}"
+        );
+    }
+    assert_eq!(
+        esm.matches("export default").count(),
+        1,
+        "exactly one default: {esm}"
+    );
+}
+
+#[test]
+fn a_json_proto_key_stays_an_own_property() {
+    // `{"__proto__": ...}` spliced into an object literal sets the prototype
+    // instead of a property, so `import data from './d.json'` would disagree
+    // with `JSON.parse` on the same bytes -- and the value would leak onto the
+    // object as inherited state.
+    let source = r#"{"__proto__":{"polluted":true},"ok":1}"#;
+    let esm = json::to_esm(source, "/data.json").unwrap();
+    assert!(parses(&esm), "invalid output: {esm}");
+    assert!(
+        !esm.contains("\"__proto__\":") || esm.contains("[\"__proto__\"]"),
+        "a bare __proto__ key must not reach an object literal: {esm}"
+    );
+    assert!(
+        !esm.contains("export const __proto__"),
+        "__proto__ is not an exportable name: {esm}"
+    );
+
+    let factory = json::to_factory_body(source, "/data.json").unwrap();
+    assert!(
+        !factory.contains("\"__proto__\": ()"),
+        "a __proto__ getter would replace the namespace prototype: {factory}"
+    );
+    // Nested occurrences count too: it is the JS object literal that is unsafe.
+    let nested = json::to_esm(r#"{"a":{"__proto__":{"x":1}}}"#, "/data.json").unwrap();
+    assert!(parses(&nested), "invalid output: {nested}");
+    assert!(
+        !nested.contains("\"__proto__\":") || nested.contains("[\"__proto__\"]"),
+        "{nested}"
+    );
+}
+
+#[test]
+fn json_scalars_and_deep_nesting_are_accepted() {
+    for source in ["1", "-0.5e10", "\"str\"", "true", "false", "null", "[]", "{}"] {
+        let esm = json::to_esm(source, "/data.json").unwrap();
+        assert!(parses(&esm), "{source} -> {esm}");
+        assert!(json::to_factory_body(source, "/data.json").is_ok());
+    }
+    // serde_json has a recursion limit; hitting it must be an error, not a crash.
+    let deep = format!("{}1{}", "[".repeat(2_000), "]".repeat(2_000));
+    let _ = json::to_esm(&deep, "/data.json");
+}
+
+#[test]
+fn json_strings_with_script_terminators_are_safe_to_inline() {
+    let source = r#"{"html":"</script><script>alert(1)</script>","sep":"a b"}"#;
+    let esm = json::to_esm(source, "/data.json").unwrap();
+    assert!(parses(&esm), "invalid output: {esm}");
+    let factory = json::to_factory_body(source, "/data.json").unwrap();
+    assert!(!factory.is_empty());
+}
+
+#[test]
+fn cjs_lowering_survives_every_require_shape() {
+    let source = r#"
+const a = require("./a");
+const b = require(`./b`);
+const c = require("./c" + suffix);
+const d = require(name);
+const e = require();
+const f = require("./f", "extra");
+const g = module.require("./g");
+const h = require.resolve("./h");
+try { var i = require("./i"); } catch (_) {}
+if (typeof require === "function") { require("./j"); }
+exports.k = 1;
+module.exports = { l: 2 };
+Object.defineProperty(exports, "__esModule", { value: true });
+"#;
+    let mut resolve = |spec: &str| Some(format!("/resolved{spec}"));
+    let out = cjs::wrap_cjs(
+        Path::new("/node_modules/pkg/index.js"),
+        "/node_modules/pkg/index.js",
+        source,
+        &mut resolve,
+    )
+    .unwrap();
+    assert!(!out.code.is_empty());
+
+    let analysis = cjs::analyze_for_factory(Path::new("/node_modules/pkg/index.js"), source).unwrap();
+    // Only statically known specifiers can be pre-resolved.
+    for spec in &analysis.requires {
+        assert!(
+            !spec.is_empty(),
+            "empty specifier in {:?}",
+            analysis.requires
+        );
+    }
+    let mut sorted = analysis.requires.clone();
+    sorted.sort();
+    sorted.dedup();
+    assert_eq!(sorted.len(), analysis.requires.len(), "requires deduped");
+}
+
+#[test]
+fn cjs_lowering_reports_parse_errors() {
+    let err = cjs::analyze_for_factory(Path::new("/node_modules/pkg/index.js"), "const a = (")
+        .unwrap_err();
+    assert!(matches!(err, CompileError::Parse { .. }), "{err}");
+}
+
+#[test]
+fn module_syntax_detection_never_panics() {
+    for source in [
+        "",
+        "import",
+        "export",
+        "import.meta",
+        "import(\"x\")",
+        "const import1 = 1;",
+        "// export const a = 1;",
+        "\"use strict\"; module.exports = 1;",
+        "#!/usr/bin/env node\nmodule.exports = 1;",
+        "const a = (",
+    ] {
+        let _ = cjs::has_module_syntax_pub(Path::new("/node_modules/pkg/index.js"), source);
+    }
+    assert!(cjs::has_module_syntax_pub(
+        Path::new("/x.js"),
+        "export const a = 1;"
+    ));
+    assert!(!cjs::has_module_syntax_pub(
+        Path::new("/x.js"),
+        "module.exports = 1;"
+    ));
+}
+
+#[test]
+fn glob_expansion_of_hostile_patterns_stays_inside_the_grammar() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("locales")).unwrap();
+    std::fs::write(dir.path().join("locales/en.json"), "{}").unwrap();
+    std::fs::write(dir.path().join("secret.txt"), "s3cret").unwrap();
+    let entry = dir.path().join("src.js");
+
+    for pattern in [
+        "./locales/*.json",
+        "../*",
+        "../../../../../../etc/*",
+        "/etc/*",
+        "**/*",
+        "./{a,b}/*.json",
+        "./[[:alpha:]]*",
+        "./locales/../secret.txt",
+        "",
+        "./\u{0}",
+        "./*.json?raw",
+    ] {
+        let source = format!("export const m = import.meta.glob({pattern:?});");
+        let out = glob::expand_source(&source, &entry);
+        assert!(
+            compile(Path::new("/verify.mjs"), &out, &CompileOptions::prod()).is_ok(),
+            "pattern {pattern:?} produced invalid code: {out}"
+        );
+    }
+}
+
+#[test]
+fn glob_options_that_make_no_sense_are_ignored_safely() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("locales")).unwrap();
+    std::fs::write(dir.path().join("locales/en.json"), "{}").unwrap();
+    let entry = dir.path().join("src.js");
+
+    for options in [
+        "{ eager: true }",
+        "{ eager: \"yes\" }",
+        "{ import: \"default\" }",
+        "{ import: \"a b\" }",
+        "{ import: \"\\\"; evil(); \\\"\" }",
+        "{ query: \"?raw\" }",
+        "{ query: \"raw\" }",
+        "{ query: \"\\\" + evil() + \\\"\" }",
+        "{ as: \"url\" }",
+        "{ unknown: 1 }",
+        "{}",
+        "null",
+        "[]",
+        "42",
+    ] {
+        let source =
+            format!("export const m = import.meta.glob(\"./locales/*.json\", {options});");
+        let out = glob::expand_source(&source, &entry);
+        assert!(
+            compile(Path::new("/verify.mjs"), &out, &CompileOptions::prod()).is_ok(),
+            "options {options} produced invalid code: {out}"
+        );
+    }
+}
+
+#[test]
+fn dynamic_import_var_expansion_stays_inside_the_grammar() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("pages")).unwrap();
+    std::fs::write(dir.path().join("pages/home.js"), "export default 1;").unwrap();
+    std::fs::write(dir.path().join("pages/about.js"), "export default 2;").unwrap();
+    let entry = dir.path().join("src.js");
+
+    for template in [
+        "`./pages/${name}.js`",
+        "`../${name}`",
+        "`./pages/${a}${b}.js`",
+        "`./pages/${name}`",
+        "`/abs/${name}.js`",
+        "`${name}`",
+        "`./pages/${\"literal\"}.js`",
+        "`./pages/${name}.js${extra}`",
+    ] {
+        let source = format!("export const load = (name) => import({template});");
+        let out = glob::expand_dynamic_import_vars_source(&source, &entry);
+        assert!(
+            compile(Path::new("/verify.mjs"), &out, &CompileOptions::prod()).is_ok(),
+            "template {template} produced invalid code: {out}"
+        );
+    }
+}
+
+#[test]
+fn new_url_asset_expansion_stays_inside_the_grammar() {
+    for expression in [
+        "new URL(\"./a.png\", import.meta.url)",
+        "new URL(\"../b.png\", import.meta.url)",
+        "new URL(\"/abs.png\", import.meta.url)",
+        "new URL(\"http://x/y.png\", import.meta.url)",
+        "new URL(name, import.meta.url)",
+        "new URL(\"./a.png\")",
+        "new URL(\"./a.png\", import.meta.url, extra)",
+        "new URL(\"./a.png\", import.meta.env)",
+        "new URL(\"./\\\"; evil(); \\\".png\", import.meta.url)",
+        "new NotURL(\"./a.png\", import.meta.url)",
+    ] {
+        let source = format!("export const u = {expression};");
+        let out = glob::expand_new_url_asset_source(&source, Path::new("/src/app.js"));
+        assert!(
+            compile(Path::new("/verify.mjs"), &out, &CompileOptions::prod()).is_ok(),
+            "expression {expression} produced invalid code: {out}"
+        );
+    }
+}
+
+#[test]
+fn source_expanders_are_the_identity_on_unparsable_input() {
+    let broken = "const a = ( // import.meta.glob import( import.meta.url";
+    let path = Path::new("/src/broken.js");
+    assert_eq!(glob::expand_source(broken, path), broken);
+    assert_eq!(glob::expand_dynamic_import_vars_source(broken, path), broken);
+    assert_eq!(glob::expand_new_url_asset_source(broken, path), broken);
+}
+
+#[test]
+fn cjs_interop_rewriting_is_none_when_there_is_nothing_to_do() {
+    let path = Path::new("/src/App.tsx");
+    let never = |_: &str| None;
+    assert!(interop::rewrite_cjs_interop("import a from \"./a\";", path, &never).is_none());
+    assert!(interop::rewrite_cjs_interop("const a = (", path, &|_| Some("/x".into())).is_none());
+    assert!(interop::rewrite_cjs_interop("", path, &|_| Some("/x".into())).is_none());
+}
+
+#[test]
+fn cjs_interop_rewriting_produces_valid_code_for_every_import_form() {
+    let path = Path::new("/src/App.tsx");
+    let sources = [
+        "import a from \"cjs-pkg\";",
+        "import * as ns from \"cjs-pkg\";",
+        "import { a, b as c } from \"cjs-pkg\";",
+        "import def, { a } from \"cjs-pkg\";",
+        "import def, * as ns from \"cjs-pkg\";",
+        "import \"cjs-pkg\";",
+        "import type { T } from \"cjs-pkg\";",
+        "import { \"weird name\" as w } from \"cjs-pkg\";",
+        "import a from \"cjs-pkg\";\nimport b from \"cjs-pkg\";",
+    ];
+    for source in sources {
+        let rewritten = interop::rewrite_cjs_interop(source, path, &|spec| {
+            (spec == "cjs-pkg").then(|| "/node_modules/cjs-pkg/index.js".to_string())
+        });
+        let Some(code) = rewritten else { continue };
+        assert!(
+            compile(Path::new("/verify.mjs"), &code, &CompileOptions::prod()).is_ok(),
+            "{source} -> invalid code: {code}"
+        );
+        assert!(!code.contains("\"cjs-pkg\""), "specifier left behind: {code}");
+    }
+}

--- a/crates/oj_compiler/tests/edge_cases.rs
+++ b/crates/oj_compiler/tests/edge_cases.rs
@@ -1,0 +1,466 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+//! Boundary behaviour: the shapes that are unusual but entirely valid, where a
+//! pipeline built around the common case quietly does the wrong thing. Empty
+//! files, byte-order marks, syntax that only one extension allows, and the
+//! points where dev and prod are supposed to differ.
+
+use std::path::Path;
+
+use oj_compiler::{
+    bundle, cjs, compile, compile_module, exports, json, CompileError, CompileOptions,
+};
+
+fn dev(path: &str, source: &str) -> Result<oj_compiler::CompileOutput, CompileError> {
+    compile(Path::new(path), source, &CompileOptions::dev())
+}
+
+fn prod(path: &str, source: &str) -> Result<oj_compiler::CompileOutput, CompileError> {
+    compile(Path::new(path), source, &CompileOptions::prod())
+}
+
+#[test]
+fn empty_and_trivial_modules_compile_to_nothing() {
+    for source in ["", " ", "\n\n\n", "\u{feff}"] {
+        let out = dev("/src/empty.ts", source).unwrap();
+        assert!(
+            out.code.trim().is_empty(),
+            "{source:?} produced {:?}",
+            out.code
+        );
+        assert!(out.imports.is_empty());
+        assert!(!out.is_refresh_boundary);
+        assert!(exports(source, Path::new("/src/empty.ts")).is_empty());
+    }
+}
+
+#[test]
+fn comments_are_carried_through_to_the_output() {
+    for source in ["// just a comment", "/* block */", "/** @license MIT */"] {
+        let out = dev("/src/comment.ts", source).unwrap();
+        assert!(out.code.contains(source.trim()), "{source:?} -> {:?}", out.code);
+        assert!(out.imports.is_empty());
+    }
+}
+
+#[test]
+fn a_byte_order_mark_does_not_become_part_of_the_first_statement() {
+    let out = dev("/src/App.ts", "\u{feff}export const a = 1;").unwrap();
+    assert!(out.code.contains("export const a = 1"), "{}", out.code);
+    assert!(!out.code.starts_with('\u{feff}'), "BOM copied into output");
+    assert_eq!(exports("\u{feff}export const a = 1;", Path::new("/src/App.ts")), ["a"]);
+}
+
+#[test]
+fn a_shebang_is_preserved_and_a_hash_bang_elsewhere_is_an_error() {
+    let out = dev("/src/cli.ts", "#!/usr/bin/env node\nexport const a = 1;").unwrap();
+    assert!(out.code.starts_with("#!"), "shebang dropped: {}", out.code);
+    assert!(dev("/src/cli.ts", "const a = 1;\n#!/usr/bin/env node").is_err());
+}
+
+#[test]
+fn crlf_and_lone_cr_line_endings_are_accepted() {
+    for (label, source) in [
+        ("crlf", "export const a = 1;\r\nexport const b = 2;\r\n"),
+        ("cr", "export const a = 1;\rexport const b = 2;\r"),
+        ("mixed", "export const a = 1;\r\nexport const b = 2;\n"),
+        ("no trailing newline", "export const a = 1;"),
+    ] {
+        let mut names = exports(source, Path::new("/src/App.ts"));
+        names.sort();
+        let expected: &[&str] = if source.contains("b = 2") {
+            &["a", "b"]
+        } else {
+            &["a"]
+        };
+        assert_eq!(names, expected, "{label}");
+        assert!(dev("/src/App.ts", source).is_ok(), "{label}");
+    }
+}
+
+#[test]
+fn typescript_enums_are_lowered_rather_than_dropped() {
+    // The TypeScript transform needs `with_enum_eval`; without it, an `enum`
+    // aborts the process instead of compiling.
+    let out = dev("/src/App.ts", "export enum Direction { Up, Down }").unwrap();
+    assert!(out.code.contains("Direction"), "{}", out.code);
+    assert!(out.code.contains("\"Up\""), "reverse mapping: {}", out.code);
+    assert!(!out.code.contains("enum "), "not lowered: {}", out.code);
+
+    let out = dev("/src/App.ts", "export const enum Flag { On = 1 }").unwrap();
+    assert!(out.code.contains("Flag"), "{}", out.code);
+
+    let out = dev("/src/App.ts", "enum S { A = \"a\", B = \"b\" }\nexport const s = S.A;").unwrap();
+    assert!(out.code.contains("\"a\""), "{}", out.code);
+
+    // Ambient declarations still vanish.
+    let out = dev("/src/App.ts", "declare enum D { A }").unwrap();
+    assert!(out.code.trim().is_empty(), "{}", out.code);
+
+    // And in bundle mode, which runs the same transform through its own path.
+    let mut resolve = |spec: &str| Some(format!("/resolved/{spec}"));
+    let factory = bundle::compile_factory(
+        Path::new("/src/App.ts"),
+        "/src/App.ts",
+        "export enum Direction { Up, Down }",
+        &mut resolve,
+    )
+    .unwrap();
+    assert!(factory.code.contains("Direction"), "{}", factory.code);
+}
+
+#[test]
+fn typescript_only_syntax_is_erased_everywhere_it_can_appear() {
+    let source = "\
+import type { Only } from \"./types\";
+export type { Only };
+export interface I { a: string }
+type Alias = I;
+declare global { interface Window { x: number } }
+declare const ambient: number;
+export abstract class A<T extends object = {}> implements I {
+  a!: string;
+  private readonly p?: number;
+  constructor(public q: number) { super(); }
+  abstract m(): void;
+  n<U>(x: U): U { return x as U; }
+}
+export const assertion = (<Alias>{}) satisfies I;
+export const nonNull = ambient!;
+function overloaded(a: string): void;
+function overloaded(a: number): void;
+function overloaded(a: unknown): void {}
+export { overloaded };
+export const generic = <T,>(x: T) => x;
+namespace NS { export const inner = 1; }
+export const used = NS.inner;
+";
+    let out = prod("/src/App.ts", source).unwrap();
+    for leftover in [
+        "interface",
+        "declare",
+        "abstract",
+        "satisfies",
+        " as U",
+        "import type",
+    ] {
+        assert!(
+            !out.code.contains(leftover),
+            "{leftover:?} survived: {}",
+            out.code
+        );
+    }
+    // A type-only import is not a module edge.
+    assert!(
+        !out.imports.contains(&"./types".to_string()),
+        "{:?}",
+        out.imports
+    );
+}
+
+#[test]
+fn jsx_is_only_valid_where_the_extension_allows_it() {
+    let jsx = "export const a = <div />;";
+    assert!(dev("/src/App.tsx", jsx).is_ok());
+    assert!(dev("/src/App.jsx", jsx).is_ok());
+    // JSX in a plain `.js` file is a syntax error, as it is under Vite: the
+    // file has to be named `.jsx`.
+    assert!(dev("/src/App.js", jsx).is_err());
+    // In `.ts`, `<div />` reads as a type assertion, so the JSX is an error too.
+    assert!(dev("/src/App.ts", jsx).is_err());
+}
+
+#[test]
+fn each_extension_gets_the_right_module_or_script_treatment() {
+    // CommonJS syntax is accepted everywhere: `module.exports` is just a member
+    // assignment, and oj decides how to treat it from the url, not the parse.
+    assert!(dev("/src/a.cjs", "module.exports = 1;").is_ok());
+    assert!(dev("/src/a.mjs", "export const a = 1;").is_ok());
+    // `.mts`/`.cts` carry TypeScript.
+    assert!(dev("/src/a.mts", "export const a: number = 1;").is_ok());
+    assert!(dev("/src/a.cts", "const a: number = 1;").is_ok());
+    // TypeScript syntax in a plain `.js` file is not.
+    assert!(dev("/src/a.js", "const a: number = 1;").is_err());
+    // Strict-mode-only errors such as `with` are not reported by the parser;
+    // they are the browser's to report, like the other early errors above.
+    assert!(dev("/src/a.mjs", "with (x) {}").is_ok());
+}
+
+#[test]
+fn top_level_await_is_accepted_in_a_module() {
+    let out = dev("/src/App.ts", "export const a = await Promise.resolve(1);").unwrap();
+    assert!(out.code.contains("await"), "{}", out.code);
+}
+
+#[test]
+fn every_export_form_is_reported_by_name() {
+    let source = "\
+export const named = 1;
+export let mutable = 2;
+export var legacy = 3;
+export function fn() {}
+export function* gen() {}
+export async function afn() {}
+export class Cls {}
+export default class Def {}
+const local = 4;
+export { local, local as aliased, local as \"string name\" };
+export * as namespaced from \"./m\";
+export { other } from \"./n\";
+export { other as renamed } from \"./n\";
+";
+    let mut names = exports(source, Path::new("/src/App.ts"));
+    names.sort();
+    assert_eq!(
+        names,
+        [
+            "Cls",
+            "afn",
+            "aliased",
+            "default",
+            "fn",
+            "gen",
+            "legacy",
+            "local",
+            "mutable",
+            "named",
+            "namespaced",
+            "other",
+            "renamed",
+            "string name",
+        ]
+    );
+}
+
+#[test]
+fn export_star_without_a_name_contributes_no_names() {
+    assert!(exports("export * from \"./m\";", Path::new("/src/App.ts")).is_empty());
+}
+
+#[test]
+fn exports_of_an_unparsable_or_unknown_file_is_empty_not_a_panic() {
+    assert!(exports("const a = (", Path::new("/src/App.ts")).is_empty());
+    assert!(exports("export const a = 1;", Path::new("/src/App.css")).is_empty());
+}
+
+#[test]
+fn dynamic_imports_are_tracked_separately_from_static_ones() {
+    let source = "\
+import statik from \"./statik\";
+const lazy = () => import(\"./lazy\");
+const nested = async () => (await import(\"./nested\")).default;
+const dynamic = (n) => import(n);
+export { statik, lazy, nested, dynamic };
+";
+    let mut rewriter = |spec: &str| Some(format!("/@id/{spec}"));
+    let out = compile_module(
+        Path::new("/src/App.ts"),
+        source,
+        &CompileOptions::dev(),
+        Some(&mut rewriter),
+    )
+    .unwrap();
+    assert_eq!(out.imports, vec!["/@id/./statik".to_string()]);
+    assert_eq!(
+        out.dynamic_imports,
+        vec!["/@id/./lazy".to_string(), "/@id/./nested".to_string()],
+        "a non-literal import() cannot be tracked"
+    );
+}
+
+#[test]
+fn dynamic_imports_are_only_collected_when_a_rewriter_is_present() {
+    // The crawler passes a rewriter; a plain `compile` does not, and then only
+    // static imports are known.
+    let source = "const lazy = () => import(\"./lazy\");";
+    let out = dev("/src/App.ts", source).unwrap();
+    assert!(out.dynamic_imports.is_empty());
+}
+
+#[test]
+fn refresh_instrumentation_only_happens_in_dev_and_only_for_components() {
+    let component = "export function Counter() { return <div />; }";
+    let dev_out = dev("/src/Counter.tsx", component).unwrap();
+    assert!(dev_out.is_refresh_boundary, "{}", dev_out.code);
+    assert!(dev_out.has_refresh_registrations());
+
+    let prod_out = prod("/src/Counter.tsx", component).unwrap();
+    assert!(!prod_out.is_refresh_boundary);
+    assert!(!prod_out.code.contains("$RefreshReg$"), "{}", prod_out.code);
+
+    // Not a component: no boundary, so a change forces a reload upstream.
+    let plain = dev("/src/util.ts", "export const add = (a, b) => a + b;").unwrap();
+    assert!(!plain.is_refresh_boundary);
+
+    // Dev without refresh: the JSX dev runtime, but no registration.
+    let no_refresh = compile(
+        Path::new("/src/Counter.tsx"),
+        component,
+        &CompileOptions {
+            dev: true,
+            refresh: false,
+            sourcemap: false,
+        },
+    )
+    .unwrap();
+    assert!(!no_refresh.is_refresh_boundary);
+    assert!(!no_refresh.code.contains("$RefreshReg$"));
+}
+
+#[test]
+fn a_source_map_is_omitted_when_a_module_gains_synthesized_nodes() {
+    // Glob and dynamic-import-vars expansions splice generated spans, which the
+    // source map builder cannot represent.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("locales")).unwrap();
+    std::fs::write(dir.path().join("locales/en.json"), "{}").unwrap();
+    let entry = dir.path().join("src.ts");
+
+    let plain = compile(&entry, "export const a = 1;", &CompileOptions::dev()).unwrap();
+    assert!(plain.map_data_url.is_some(), "a normal module has a map");
+
+    let globbed = compile(
+        &entry,
+        "export const m = import.meta.glob(\"./locales/*.json\");",
+        &CompileOptions::dev(),
+    )
+    .unwrap();
+    assert!(
+        globbed.map_data_url.is_none(),
+        "a synthesized module must not claim a map"
+    );
+    assert_eq!(
+        globbed.code_with_inline_map(),
+        globbed.code,
+        "no sourceMappingURL comment without a map"
+    );
+}
+
+#[test]
+fn sourcemap_can_be_turned_off_entirely() {
+    let out = compile(
+        Path::new("/src/App.ts"),
+        "export const a = 1;",
+        &CompileOptions {
+            dev: true,
+            refresh: true,
+            sourcemap: false,
+        },
+    )
+    .unwrap();
+    assert!(out.map_data_url.is_none());
+}
+
+#[test]
+fn a_json_module_with_no_keys_still_has_a_default_export() {
+    for source in ["{}", "[]", "null", "0", "\"\""] {
+        let esm = json::to_esm(source, "/data.json").unwrap();
+        assert!(esm.contains("export default __oj_json"), "{source}: {esm}");
+        assert_eq!(esm.matches("export const").count(), 0, "{source}: {esm}");
+    }
+}
+
+#[test]
+fn json_arrays_and_nested_objects_export_only_the_top_level_keys() {
+    let esm = json::to_esm(r#"{"a":{"b":1},"list":[1,2]}"#, "/data.json").unwrap();
+    assert!(esm.contains("export const a ="));
+    assert!(esm.contains("export const list ="));
+    assert_eq!(esm.matches("export const").count(), 2, "{esm}");
+}
+
+#[test]
+fn a_cjs_dep_with_module_syntax_is_treated_as_esm() {
+    let mut resolve = |spec: &str| Some(format!("/@id/{spec}"));
+    let out = cjs::compile_dep(
+        Path::new("/node_modules/pkg/index.js"),
+        "/node_modules/pkg/index.js",
+        "export const a = 1;\nimport b from \"./b\";",
+        &mut resolve,
+    )
+    .unwrap();
+    assert_eq!(out.imports, vec!["/@id/./b".to_string()]);
+    assert!(out.code.contains("export"), "{}", out.code);
+}
+
+#[test]
+fn a_cjs_dep_without_module_syntax_is_wrapped() {
+    let mut resolve = |spec: &str| Some(format!("/@id/{spec}"));
+    let out = cjs::compile_dep(
+        Path::new("/node_modules/pkg/index.js"),
+        "/node_modules/pkg/index.js",
+        "const dep = require(\"./dep\");\nmodule.exports = dep;",
+        &mut resolve,
+    )
+    .unwrap();
+    assert!(out.imports.contains(&"/@id/./dep".to_string()), "{:?}", out.imports);
+    // The body keeps its `require("./dep")` call, but it now resolves through a
+    // local shim over the statically imported dependency map.
+    assert!(out.code.contains("__oj_deps"), "{}", out.code);
+    assert!(
+        out.code.contains("import { __cjs_exports as"),
+        "the dep must become a static import: {}",
+        out.code
+    );
+    assert!(out.code.contains("function require(id)"), "{}", out.code);
+}
+
+#[test]
+fn an_unresolvable_require_does_not_fail_the_module() {
+    let mut resolve = |_: &str| None;
+    let out = cjs::wrap_cjs(
+        Path::new("/node_modules/pkg/index.js"),
+        "/node_modules/pkg/index.js",
+        "const missing = require(\"./missing\");\nmodule.exports = missing;",
+        &mut resolve,
+    )
+    .unwrap();
+    assert!(out.imports.is_empty(), "{:?}", out.imports);
+    assert!(!out.code.is_empty());
+}
+
+#[test]
+fn a_bundle_factory_of_an_app_module_is_an_esm_factory() {
+    let mut resolve = |spec: &str| Some(format!("/@id/{spec}"));
+    let factory = bundle::compile_factory(
+        Path::new("/src/App.tsx"),
+        "/src/App.tsx",
+        "import React from \"react\";\nexport function App() { return <div />; }",
+        &mut resolve,
+    )
+    .unwrap();
+    assert_eq!(factory.kind, bundle::FactoryKind::Esm);
+    assert!(factory.is_boundary(), "a component is a refresh boundary");
+    assert!(factory.require_map.is_empty());
+}
+
+#[test]
+fn a_bundle_factory_of_a_cjs_dep_is_a_cjs_factory() {
+    let mut resolve = |spec: &str| Some(format!("/@id/{spec}"));
+    let factory = bundle::compile_factory(
+        Path::new("/node_modules/pkg/index.js"),
+        "/node_modules/pkg/index.js",
+        "module.exports = require(\"./inner\");",
+        &mut resolve,
+    )
+    .unwrap();
+    assert_eq!(factory.kind, bundle::FactoryKind::Cjs);
+    assert!(!factory.is_boundary(), "a CJS dep is never a boundary");
+    assert_eq!(
+        factory.require_map,
+        vec![("./inner".to_string(), "/@id/./inner".to_string())]
+    );
+}
+
+#[test]
+fn a_dep_reached_through_at_fs_is_still_a_dep() {
+    let mut resolve = |spec: &str| Some(format!("/@id/{spec}"));
+    let factory = bundle::compile_factory(
+        Path::new("/link/node_modules/pkg/index.js"),
+        "/@fs/link/node_modules/pkg/index.js",
+        "module.exports = 1;",
+        &mut resolve,
+    )
+    .unwrap();
+    assert_eq!(factory.kind, bundle::FactoryKind::Cjs);
+}

--- a/crates/oj_compiler/tests/properties.rs
+++ b/crates/oj_compiler/tests/properties.rs
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+//! Properties of the per-file pipeline. Three invariants carry most of the
+//! weight: the compiler is total over arbitrary bytes, whatever it emits is
+//! valid JavaScript, and the same input always produces the same output (the
+//! cache keys everything on the input alone).
+
+use std::path::Path;
+
+use oj_compiler::{compile, compile_module, exports, json, CompileOptions};
+use proptest::prelude::*;
+
+/// Fragments that combine into plausible-but-strange module source. Each is
+/// used at most once per case: repeating one would produce a duplicate
+/// declaration, which is an early error rather than an interesting input.
+const FRAGMENTS: &[&str] = &[
+    "export const a = 1;",
+    "export default function () {}",
+    "import x from \"./x\";",
+    "import * as ns from \"pkg\";",
+    "export * from \"./y\";",
+    "export * as ns2 from \"./z\";",
+    "import(\"./dyn\");",
+    "import.meta.env.MODE;",
+    "import.meta.url;",
+    "import.meta.glob(\"./*.json\");",
+    "interface I { a: string }",
+    "type T = I | null;",
+    "enum E { A, B }",
+    "const enum CE { A }",
+    "declare module \"m\" {}",
+    "abstract class C { abstract m(): void }",
+    "export const C2 = () => <div className=\"x\">{1}</div>;",
+    "function F() { return <><span/></>; }",
+    "const g = async function* () { yield 1; };",
+    "label: for (;;) { break label; }",
+    "using r = getResource();",
+    "class D { #p = 1; static { D.x = 1; } }",
+    "const o = { ...spread, [computed]: 1 };",
+    "const [x = 1, ...rest] = arr;",
+    "try { throw 1; } catch { } finally { }",
+    "const t = `a${b}c`;",
+    "const re = /a[b-c]+/gu;",
+    "const n = 1_000n;",
+    "a?.b?.[c]?.();",
+    "x ??= 1;",
+    "export { };",
+];
+
+fn module_source() -> impl Strategy<Value = String> {
+    proptest::sample::subsequence(FRAGMENTS, 0..FRAGMENTS.len())
+        .prop_map(|parts| parts.join("\n"))
+}
+
+fn extension() -> impl Strategy<Value = &'static str> {
+    prop_oneof![
+        Just("ts"),
+        Just("tsx"),
+        Just("js"),
+        Just("jsx"),
+        Just("mjs"),
+        Just("cjs"),
+    ]
+}
+
+/// Whatever oj emits must be parseable JavaScript. `.mjs` accepts module
+/// syntax and rejects TS, which is what the output should be.
+fn output_parses(code: &str) -> bool {
+    compile(Path::new("/verify.mjs"), code, &CompileOptions::prod()).is_ok()
+}
+
+proptest! {
+    /// Arbitrary bytes are a legal file on disk: compiling them is total.
+    #[test]
+    fn compiling_arbitrary_bytes_never_panics(source in ".{0,300}", ext in extension()) {
+        let path = format!("/src/App.{ext}");
+        let _ = compile(Path::new(&path), &source, &CompileOptions::dev());
+        let _ = compile(Path::new(&path), &source, &CompileOptions::prod());
+        let _ = exports(&source, Path::new(&path));
+    }
+
+    /// Same for `.json`.
+    #[test]
+    fn json_conversion_is_total(source in ".{0,200}") {
+        let _ = json::to_esm(&source, "/data.json");
+        let _ = json::to_factory_body(&source, "/data.json");
+    }
+
+    /// Anything the compiler accepts, it emits as valid JavaScript -- in dev
+    /// and in prod, with and without a source map.
+    #[test]
+    fn accepted_modules_emit_valid_javascript(source in module_source(), ext in extension()) {
+        let path = format!("/src/App.{ext}");
+        for opts in [
+            CompileOptions::dev(),
+            CompileOptions::prod(),
+            CompileOptions { dev: true, refresh: false, sourcemap: false },
+            CompileOptions { dev: false, refresh: true, sourcemap: false },
+        ] {
+            if let Ok(out) = compile(Path::new(&path), &source, &opts) {
+                prop_assert!(output_parses(&out.code), "{source}\n->\n{}", out.code);
+                prop_assert!(!out.code.contains("interface "), "types left in {}", out.code);
+            }
+        }
+    }
+
+    /// Compilation is a pure function of (path, source, options): the cache
+    /// keys entries on exactly that.
+    #[test]
+    fn compilation_is_deterministic(source in module_source(), ext in extension()) {
+        let path = format!("/src/App.{ext}");
+        let opts = CompileOptions::dev();
+        let Ok(first) = compile(Path::new(&path), &source, &opts) else { return Ok(()) };
+        for _ in 0..3 {
+            let again = compile(Path::new(&path), &source, &opts).unwrap();
+            prop_assert_eq!(&first.code, &again.code);
+            prop_assert_eq!(&first.map_data_url, &again.map_data_url);
+            prop_assert_eq!(&first.imports, &again.imports);
+            prop_assert_eq!(&first.dynamic_imports, &again.dynamic_imports);
+            prop_assert_eq!(first.is_refresh_boundary, again.is_refresh_boundary);
+        }
+    }
+
+    /// Compiled output is a fixed point of the parser: re-compiling it as
+    /// `.mjs` produces something that still parses.
+    #[test]
+    fn output_survives_a_second_pass(source in module_source(), ext in extension()) {
+        let path = format!("/src/App.{ext}");
+        let Ok(first) = compile(Path::new(&path), &source, &CompileOptions::prod()) else {
+            return Ok(());
+        };
+        let Ok(second) = compile(Path::new("/src/App.mjs"), &first.code, &CompileOptions::prod()) else {
+            return Err(TestCaseError::fail(format!("second pass rejected: {}", first.code)));
+        };
+        prop_assert!(output_parses(&second.code));
+    }
+
+    /// Every static import in the source is reported once, in source order,
+    /// and a rewriter sees exactly the same list.
+    #[test]
+    fn imports_are_reported_once_and_in_order(
+        specs in proptest::collection::vec("\\./[a-z]{1,6}", 0..8),
+    ) {
+        let source: String = specs
+            .iter()
+            .enumerate()
+            .map(|(i, spec)| format!("import d{i} from {spec:?};\n"))
+            .chain(std::iter::once(format!(
+                "export const all = [{}];\n",
+                (0..specs.len()).map(|i| format!("d{i}")).collect::<Vec<_>>().join(",")
+            )))
+            .collect();
+        let out = compile(Path::new("/src/App.js"), &source, &CompileOptions::dev()).unwrap();
+        prop_assert_eq!(&out.imports, &specs);
+
+        let mut seen = Vec::new();
+        let mut rewriter = |spec: &str| {
+            seen.push(spec.to_string());
+            None
+        };
+        let out = compile_module(
+            Path::new("/src/App.js"),
+            &source,
+            &CompileOptions::dev(),
+            Some(&mut rewriter),
+        )
+        .unwrap();
+        prop_assert_eq!(&seen, &specs);
+        prop_assert_eq!(&out.imports, &specs);
+    }
+
+    /// A rewriter's answer is what lands in the output, verbatim, however
+    /// unpleasant the string.
+    #[test]
+    fn rewritten_specifiers_are_escaped_not_interpolated(replacement in ".{0,20}") {
+        let source = "import a from \"./a\";\nexport { a };";
+        let mut rewriter = |_: &str| Some(replacement.clone());
+        let out = compile_module(
+            Path::new("/src/App.js"),
+            source,
+            &CompileOptions::dev(),
+            Some(&mut rewriter),
+        )
+        .unwrap();
+        prop_assert!(output_parses(&out.code), "{}", out.code);
+        prop_assert_eq!(out.imports, vec![replacement]);
+    }
+
+    /// `exports` reports names, never syntax: whatever it returns is usable as
+    /// an export name.
+    #[test]
+    fn exported_names_are_well_formed(source in module_source(), ext in extension()) {
+        let path = format!("/src/App.{ext}");
+        for name in exports(&source, Path::new(&path)) {
+            prop_assert!(!name.is_empty());
+            prop_assert!(!name.contains(char::is_whitespace), "{name:?}");
+        }
+    }
+
+    /// A JSON document always yields a module whose default export is the
+    /// document, and whose named exports are a subset of its keys.
+    #[test]
+    fn json_modules_export_their_keys(
+        entries in proptest::collection::btree_map("[a-zA-Z_$][a-zA-Z0-9_$]{0,6}", 0i32..100, 0..6),
+    ) {
+        let source = serde_json::to_string(&entries).unwrap();
+        let esm = json::to_esm(&source, "/data.json").unwrap();
+        prop_assert!(output_parses(&esm), "{esm}");
+        prop_assert_eq!(esm.matches("export default").count(), 1);
+        for key in entries.keys() {
+            // Reserved words and `__proto__` are default-only, everything else
+            // gets a named export.
+            let exported = esm.contains(&format!("export const {key} ="));
+            let reserved = !esm.contains(&format!("export const {key} "));
+            prop_assert!(exported || reserved, "{key} in {esm}");
+        }
+        let factory = json::to_factory_body(&source, "/data.json").unwrap();
+        prop_assert!(factory.contains("\"default\": () => __oj_json"));
+    }
+
+    /// The dev/prod split never changes what a module imports, only how it is
+    /// instrumented -- with one deliberate exception, the JSX runtime, which is
+    /// the development build in dev.
+    #[test]
+    fn the_module_graph_does_not_depend_on_the_mode(source in module_source()) {
+        let path = Path::new("/src/App.tsx");
+        let dev = compile(path, &source, &CompileOptions::dev());
+        let prod = compile(path, &source, &CompileOptions::prod());
+        let normalize = |imports: &[String]| -> Vec<String> {
+            imports
+                .iter()
+                .map(|i| i.replace("react/jsx-dev-runtime", "react/jsx-runtime"))
+                .collect()
+        };
+        match (dev, prod) {
+            (Ok(dev), Ok(prod)) => {
+                prop_assert_eq!(normalize(&dev.imports), normalize(&prod.imports));
+                prop_assert_eq!(&dev.dynamic_imports, &prod.dynamic_imports);
+                prop_assert!(!prod.is_refresh_boundary, "prod never instruments refresh");
+            }
+            (Err(_), Err(_)) => {}
+            (dev, prod) => prop_assert!(
+                false,
+                "dev and prod disagree on validity: {:?} vs {:?}",
+                dev.is_ok(),
+                prod.is_ok()
+            ),
+        }
+    }
+
+    /// A source map, when emitted, is a well-formed data URL for a JSON map.
+    #[test]
+    fn source_maps_are_well_formed(source in module_source()) {
+        let out = compile(Path::new("/src/App.tsx"), &source, &CompileOptions::dev());
+        let Ok(out) = out else { return Ok(()) };
+        let Some(url) = out.map_data_url.clone() else { return Ok(()) };
+        prop_assert!(url.starts_with("data:application/json;"), "{url}");
+        let inlined = out.code_with_inline_map();
+        prop_assert!(inlined.contains("//# sourceMappingURL="));
+    }
+}

--- a/crates/oj_config/src/lib.rs
+++ b/crates/oj_config/src/lib.rs
@@ -239,6 +239,9 @@ fn strip_types(path: &Path, source: &str) -> Result<String, ConfigError> {
     }
     let mut program = parsed.program;
     let scoping = SemanticBuilder::new()
+        // The TypeScript transform needs this to lower `enum` instead of
+        // panicking; a config file is allowed to declare one.
+        .with_enum_eval(true)
         .build(&program)
         .semantic
         .into_scoping();
@@ -278,6 +281,30 @@ fn to_script(js: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    /// A config may declare a TypeScript `enum`, and lowering one needs scoping
+    /// built with `with_enum_eval`: without it the transform aborts the process
+    /// instead of loading the config.
+    #[test]
+    fn a_config_that_declares_an_enum_loads() {
+        static SEQ: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "oj-config-enum-{}-{seq}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("oj.config.ts"),
+            "enum Port { Dev = 5199 }\nexport default { server: { port: Port.Dev as number } };",
+        )
+        .unwrap();
+
+        let config = super::load(&dir).expect("a config with an enum must load");
+        assert_eq!(config.server.unwrap().port, Some(5199));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     use super::*;
 
     fn eval_config_in(label: &str, src: &str) -> OjConfig {


### PR DESCRIPTION
Three ways the per-file pipeline could fail a whole command instead of one file.
Each was found by an adverse or property test, and each test is in the PR.

**A TypeScript `enum` panicked the compiler.** oxc's TS transform needs scoping
built with `SemanticBuilder::with_enum_eval(true)` to lower an enum, and panics
without it. So this took `oj` down, in dev and in build:

```ts
export enum Direction { Up, Down }
```

Same for a bundle-mode factory and for an `oj.config.ts` that declares one.
Enabled on all three transform paths.

**A `__proto__` key in a JSON import set the prototype instead of a property.**
`json::to_esm` splices the document straight into an object literal, where
`{"__proto__": x}` is special — so `import data from './d.json'` disagreed with
`JSON.parse` on the same bytes, and `data.polluted` came back `true` for
`{"__proto__":{"polluted":true}}`. In the factory path the `__proto__` getter
replaced the namespace object's prototype outright. Documents containing the key
now go through `JSON.parse`, and it is never emitted as a named export.

**Deep nesting aborted the process.** Parsing, transforming and printing each
recurse once per bracket level, and a stack overflow aborts rather than failing
the file — a generated or minified module could take the dev server with it. It
went over below 1000 levels on the 2 MiB a runtime thread gets by default. The
CLI now installs `oj_compiler::COMPILE_STACK_SIZE` as the runtime's thread stack
size, which is also the size the new tests exercise. There is no depth that is
safe for every stack; this makes the envelope explicit and far above anything
hand-written.

### Tests

`crates/oj_compiler/tests/`, 64 tests in three suites:

- **adverse** — malformed and hostile source (unterminated everything, deep
  nesting, unicode and bidi identifiers, lone surrogates), hostile import
  specifiers, a rewriter that returns junk, JSON that is not JSON, `__proto__`
  keys, every `require` shape, glob and dynamic-import patterns that try to
  escape.
- **edge_cases** — empty files, BOMs, shebangs, CRLF, TypeScript-only syntax
  including `enum`, JSX per extension, top-level await, every export form,
  dev-vs-prod instrumentation, sourcemap omission for synthesized modules.
- **properties** — totality over arbitrary bytes, output validity by re-parsing
  what was emitted, determinism, output as a parser fixed point, import order
  and one-shot rewriting, mode-independence of the module graph.

`cargo test --workspace` and `node e2e/run.mjs` (both modes) pass, as does the
`playground` production build with every CI assertion.
---

One of eleven independent PRs from the same pass over the test suite. Each stands
alone (its own tests pass on `main` without the others) and all eleven merge
together cleanly — I verified both. Each also carries the same two-line
`tmp()` fix in `crates/oj/src/start_dev.rs`, because without it
`app_uses_tailwind_detects_postcss_vite_and_bare` flakes on any PR CI run; the
hunks are identical, so they merge as one.


