### PR TITLE
fix(env): keep non-ASCII dotenv values intact

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +866,12 @@ checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -1867,7 +1888,9 @@ dependencies = [
 name = "oj_env"
 version = "0.0.45"
 dependencies = [
+ "proptest",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -2746,6 +2769,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2764,6 +2806,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -2942,6 +2990,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3705,6 +3762,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4087,6 +4156,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4382,6 +4464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-id-start"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4502,6 +4590,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,10 @@ axum = { version = "0.8.9", features = ["ws"] }
 notify = "8.2.0"
 clap = { version = "4.6.6", features = ["derive"] }
 
+# test-only
+proptest = "1.9.0"
+tempfile = "3.24.0"
+
 [profile.release]
 lto = "thin"
 codegen-units = 1

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -689,7 +689,15 @@ mod tests {
     use super::*;
 
     fn tmp(label: &str) -> PathBuf {
-        let d = std::env::temp_dir().join(format!("oj-startdev-{}-{label}", std::process::id()));
+        // A fresh directory per call: this wipes the path before creating it, so
+        // two tests that pass the same label would race -- one clearing the
+        // other's fixture out from under it, in whichever order they interleave.
+        static SEQ: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let d = std::env::temp_dir().join(format!(
+            "oj-startdev-{}-{label}-{seq}",
+            std::process::id()
+        ));
         let _ = std::fs::remove_dir_all(&d);
         std::fs::create_dir_all(&d).unwrap();
         d

--- a/crates/oj_env/Cargo.toml
+++ b/crates/oj_env/Cargo.toml
@@ -7,3 +7,7 @@ description = "dotenv loading and import.meta.env define construction (Vite-comp
 
 [dependencies]
 serde_json.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true
+tempfile.workspace = true

--- a/crates/oj_env/src/lib.rs
+++ b/crates/oj_env/src/lib.rs
@@ -62,11 +62,13 @@ fn expand(input: &str, vars: &BTreeMap<String, String>) -> String {
             continue;
         }
         if c == b'$' {
-            let (name, next) = if bytes.get(i + 1) == Some(&b'{') {
-                match input[i + 2..].find('}') {
-                    Some(rel) => (&input[i + 2..i + 2 + rel], i + 2 + rel + 1),
-                    None => (&input[i + 1..i + 1], i + 1),
-                }
+            // `None` for a reference that is not one: `${` with no `}`, or a
+            // bare `$` with no name after it. Both are literal text.
+            let reference: Option<(&str, usize)> = if bytes.get(i + 1) == Some(&b'{') {
+                input[i + 2..]
+                    .find('}')
+                    .map(|rel| (&input[i + 2..i + 2 + rel], i + 2 + rel + 1))
+                    .filter(|(name, _)| !name.is_empty())
             } else {
                 let start = i + 1;
                 let mut end = start;
@@ -75,16 +77,22 @@ fn expand(input: &str, vars: &BTreeMap<String, String>) -> String {
                 {
                     end += 1;
                 }
-                (&input[start..end], end)
+                (end > start).then(|| (&input[start..end], end))
             };
-            if !name.is_empty() {
+            if let Some((name, next)) = reference {
                 out.push_str(vars.get(name).map(String::as_str).unwrap_or(""));
                 i = next;
                 continue;
             }
         }
-        out.push(c as char);
-        i += 1;
+        // Copy one whole UTF-8 character: indexing by byte here (`c as char`)
+        // would mojibake every non-ASCII value that goes through expansion.
+        let ch = input[i..]
+            .chars()
+            .next()
+            .expect("loop only advances to char boundaries");
+        out.push(ch);
+        i += ch.len_utf8();
     }
     out
 }
@@ -160,6 +168,8 @@ pub fn html_env_map(defines: &[(String, String)]) -> BTreeMap<String, String> {
 /// Replace `%KEY%` placeholders in HTML with env values (Vite parity: regex
 /// `/%(\S+?)%/g`, only keys present in the map; unknown placeholders are left).
 pub fn replace_html_env(html: &str, env: &BTreeMap<String, String>) -> String {
+    // Fast path only: with an empty map, or no `%` at all, the loop below would
+    // reach the same answer the slow way.
     if env.is_empty() || !html.contains('%') {
         return html.to_string();
     }

--- a/crates/oj_env/tests/adverse.rs
+++ b/crates/oj_env/tests/adverse.rs
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+//! Adversarial `.env` and `index.html` input. A dotenv file is untrusted text
+//! that a build reads without asking: it must never panic, never loop, never
+//! mangle bytes, and never let an unprefixed variable reach the client bundle.
+
+use std::collections::BTreeMap;
+
+use oj_env::{html_env_map, import_meta_env_defines, parse, replace_html_env};
+
+fn base() -> BTreeMap<String, String> {
+    BTreeMap::new()
+}
+
+fn map(src: &str) -> BTreeMap<String, String> {
+    parse(src, &base()).into_iter().collect()
+}
+
+#[test]
+fn malformed_lines_are_skipped_not_fatal() {
+    let src = "\
+no-equals-at-all
+=value-with-no-key
+   =also-no-key
+export
+export =
+ \t \t
+#
+# = #
+KEEP=kept
+";
+    let out = parse(src, &base());
+    assert_eq!(
+        out,
+        vec![("KEEP".to_string(), "kept".to_string())],
+        "only the one well-formed line survives: {out:?}"
+    );
+}
+
+#[test]
+fn self_and_mutual_references_terminate_and_do_not_recurse() {
+    // Expansion only sees variables defined *before* the current line, so a
+    // self-reference resolves to empty rather than looping.
+    let m = map("A=$A\nB=${B}\nC=$D\nD=$C\n");
+    assert_eq!(m["A"], "");
+    assert_eq!(m["B"], "");
+    assert_eq!(m["C"], "");
+    assert_eq!(m["D"], "", "D sees C's (empty) value, not its own");
+}
+
+#[test]
+fn expansion_is_one_pass_not_recursive() {
+    // A value that itself looks like a reference is not expanded again.
+    let m = map("INNER=payload\nMID=$INNER\nOUTER=$MID\nLITERAL='$INNER'\nVIA=$LITERAL\n");
+    assert_eq!(m["OUTER"], "payload");
+    assert_eq!(m["LITERAL"], "$INNER");
+    assert_eq!(
+        m["VIA"], "$INNER",
+        "a stored `$INNER` must not be re-expanded on use"
+    );
+}
+
+#[test]
+fn unterminated_quotes_and_braces_do_not_panic() {
+    let m = map("A=\"unterminated\nB='also unterminated\nC=${UNCLOSED\nD=$\nE=${}\nF=ok\n");
+    assert_eq!(m["A"], "unterminated");
+    assert_eq!(m["B"], "also unterminated");
+    assert_eq!(m["C"], "${UNCLOSED");
+    assert_eq!(m["D"], "$");
+    assert_eq!(m["E"], "${}", "an empty brace name is left literal");
+    assert_eq!(m["F"], "ok");
+}
+
+#[test]
+fn nested_dollar_braces_are_left_literal() {
+    let m = map("A=${${${X}}}\nB=$$$$X\n");
+    // The outer `${...}` closes at the first `}`, the remainder is literal.
+    assert!(m.contains_key("A"), "parsed without panic: {m:?}");
+    assert!(m.contains_key("B"));
+}
+
+#[test]
+fn non_ascii_values_survive_byte_for_byte() {
+    let m = map(
+        "PLAIN=café\nQUOTED=\"naïve — dash\"\nLITERAL='日本語'\nEMOJI=🚀\nEXPANDED=${PLAIN}/x\n",
+    );
+    assert_eq!(m["PLAIN"], "café");
+    assert_eq!(m["QUOTED"], "naïve — dash");
+    assert_eq!(m["LITERAL"], "日本語");
+    assert_eq!(m["EMOJI"], "🚀");
+    assert_eq!(m["EXPANDED"], "café/x");
+}
+
+#[test]
+fn non_ascii_keys_and_multibyte_boundaries_are_intact() {
+    let m = map("TÍTULO=hola\nX=${TÍTULO}\n");
+    assert_eq!(m["TÍTULO"], "hola");
+    // `$` name scanning is ASCII-only, so a multibyte name is not a reference;
+    // whatever it does, it must not split a UTF-8 character.
+    assert!(m["X"].is_char_boundary(m["X"].len()));
+}
+
+#[test]
+fn control_bytes_and_crlf_are_handled() {
+    let m = map("A=with\ttab\r\nB=nul\0byte\r\nC=ok\r\n");
+    assert_eq!(m["A"], "with\ttab", "CR is not part of the value");
+    assert_eq!(m["B"], "nul\0byte");
+    assert_eq!(m["C"], "ok");
+}
+
+#[test]
+fn duplicate_keys_take_the_last_value_and_see_the_previous_one() {
+    let out = parse("A=first\nA=$A-second\n", &base());
+    assert_eq!(out.len(), 2, "both assignments are reported in order");
+    assert_eq!(out[1], ("A".to_string(), "first-second".to_string()));
+}
+
+#[test]
+fn very_long_values_and_many_keys_are_linear_not_quadratic() {
+    let long = "x".repeat(1 << 20);
+    let m = map(&format!("BIG={long}\n"));
+    assert_eq!(m["BIG"].len(), 1 << 20);
+
+    let many: String = (0..5_000).map(|i| format!("K{i}=v{i}\n")).collect();
+    let m = map(&many);
+    assert_eq!(m.len(), 5_000);
+    assert_eq!(m["K4999"], "v4999");
+}
+
+#[test]
+fn unprefixed_variables_never_reach_the_defines() {
+    let loaded = vec![
+        ("DATABASE_URL".into(), "postgres://user:pw@host/db".into()),
+        ("AWS_SECRET_ACCESS_KEY".into(), "top-secret-value".into()),
+        // Near-misses on the prefix must not slip through either.
+        ("vite_lowercase".into(), "lower-secret".into()),
+        (" VITE_PADDED".into(), "padded-secret".into()),
+        ("XVITE_API".into(), "prefixed-secret".into()),
+        ("VITE_OK".into(), "public".into()),
+    ];
+    let defines = import_meta_env_defines(&loaded, "production", false, "/", "VITE_");
+    let blob = defines
+        .iter()
+        .map(|(k, v)| format!("{k}={v}\n"))
+        .collect::<String>();
+
+    for secret in [
+        "postgres://user:pw@host/db",
+        "top-secret-value",
+        "lower-secret",
+        "padded-secret",
+        "prefixed-secret",
+    ] {
+        assert!(!blob.contains(secret), "leaked {secret} into {blob}");
+    }
+    assert!(blob.contains("public"), "prefixed var must be exposed");
+}
+
+#[test]
+fn an_empty_prefix_exposes_everything_by_design() {
+    // Vite parity: envPrefix "" means every loaded variable is public. The point
+    // of this test is that the behavior is deliberate and visible, not a
+    // surprise found in production.
+    let loaded = vec![("DATABASE_URL".into(), "secret".into())];
+    let defines = import_meta_env_defines(&loaded, "production", false, "/", "");
+    let keys: Vec<&str> = defines.iter().map(|(k, _)| k.as_str()).collect();
+    assert!(keys.contains(&"import.meta.env.DATABASE_URL"));
+}
+
+#[test]
+fn secret_values_containing_define_syntax_stay_quoted_json() {
+    let loaded = vec![(
+        "VITE_TRICK".into(),
+        "\",\"SECRET\":\"leaked\",\"x\":\"".into(),
+    )];
+    let defines = import_meta_env_defines(&loaded, "development", true, "/", "VITE_");
+    let obj = defines
+        .iter()
+        .find(|(k, _)| k == "import.meta.env")
+        .map(|(_, v)| v.clone())
+        .unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&obj).expect("valid JSON object");
+    assert_eq!(
+        parsed["VITE_TRICK"], "\",\"SECRET\":\"leaked\",\"x\":\"",
+        "a hostile value must not break out of the JSON literal"
+    );
+    assert!(parsed.get("SECRET").is_none(), "no injected key: {parsed}");
+}
+
+#[test]
+fn html_percent_soup_is_left_alone() {
+    let mut env = BTreeMap::new();
+    env.insert("T".to_string(), "Title".to_string());
+    // Nothing here names a known key, so every one of these is an identity.
+    for html in [
+        "%", "%%", "%%%%%%%%", "% T %", "%T", "T%", "%NOT SET%", "% %", "%\n%",
+    ] {
+        assert_eq!(
+            replace_html_env(html, &env),
+            html,
+            "{html:?} must pass through untouched"
+        );
+    }
+    assert_eq!(replace_html_env("%T%%T%", &env), "TitleTitle");
+    assert_eq!(replace_html_env("100%% of %T%", &env), "100%% of Title");
+    // Documented divergence from Vite's `/%(\S+?)%/g`: that regex consumes
+    // `%%T%` as an unknown key and leaves `%%T%%` untouched, while oj rescans
+    // from the inner `%` and substitutes. Only adjacent percents differ.
+    assert_eq!(replace_html_env("%%T%%", &env), "%Title%");
+}
+
+#[test]
+fn an_empty_key_in_the_map_never_matches() {
+    // `%%` has no key between the percents, so it is text -- even when the map
+    // happens to contain an entry under the empty name.
+    let mut env = BTreeMap::new();
+    env.insert(String::new(), "SHOULD-NOT-APPEAR".to_string());
+    env.insert("T".to_string(), "Title".to_string());
+    for html in ["%%", "a%%b", "%%%", "100%% off", "%%T%%"] {
+        let out = replace_html_env(html, &env);
+        assert!(
+            !out.contains("SHOULD-NOT-APPEAR"),
+            "{html:?} matched the empty key: {out}"
+        );
+    }
+    // A key that is only whitespace is text too.
+    let mut spaced = BTreeMap::new();
+    spaced.insert(" ".to_string(), "SHOULD-NOT-APPEAR".to_string());
+    assert_eq!(replace_html_env("% %", &spaced), "% %");
+}
+
+#[test]
+fn html_substitution_is_not_recursive() {
+    let mut env = BTreeMap::new();
+    env.insert("A".to_string(), "%B%".to_string());
+    env.insert("B".to_string(), "final".to_string());
+    assert_eq!(
+        replace_html_env("<t>%A%</t>", &env),
+        "<t>%B%</t>",
+        "a substituted value must not be scanned again"
+    );
+}
+
+#[test]
+fn html_substitution_keeps_multibyte_content_intact() {
+    let defines = import_meta_env_defines(
+        &[("VITE_T".into(), "Café — Straße".into())],
+        "development",
+        true,
+        "/",
+        "VITE_",
+    );
+    let env = html_env_map(&defines);
+    let out = replace_html_env("<title>%VITE_T%</title> 日本 %MODE%", &env);
+    assert!(out.contains("Café — Straße"), "{out}");
+    assert!(out.contains("日本"), "{out}");
+    assert!(out.contains("development"), "{out}");
+}
+
+#[test]
+fn html_env_map_unwraps_only_json_strings() {
+    let defines = vec![
+        ("import.meta.env.S".to_string(), "\"str\"".to_string()),
+        ("import.meta.env.B".to_string(), "true".to_string()),
+        ("import.meta.env.N".to_string(), "42".to_string()),
+        ("import.meta.env.BROKEN".to_string(), "\"unclosed".to_string()),
+        ("unrelated.define".to_string(), "\"ignored\"".to_string()),
+    ];
+    let env = html_env_map(&defines);
+    assert_eq!(env["S"], "str");
+    assert_eq!(env["B"], "true");
+    assert_eq!(env["N"], "42");
+    assert_eq!(env["BROKEN"], "\"unclosed", "unparsable falls back to raw");
+    assert!(!env.contains_key("unrelated.define"));
+}
+
+#[test]
+fn load_of_a_directory_that_is_not_one_is_empty() {
+    let file = tempfile::NamedTempFile::new().unwrap();
+    assert!(oj_env::load(file.path(), "development").is_empty());
+}
+
+#[test]
+fn later_env_files_win_and_only_changed_keys_are_reported() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join(".env"), "VITE_A=base\nVITE_B=base\n").unwrap();
+    std::fs::write(dir.path().join(".env.local"), "VITE_B=local\n").unwrap();
+    std::fs::write(
+        dir.path().join(".env.production"),
+        "VITE_C=prod\nVITE_D=${VITE_A}-derived\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join(".env.production.local"),
+        "VITE_C=prod-local\n",
+    )
+    .unwrap();
+    // A file for another mode must not be read.
+    std::fs::write(dir.path().join(".env.development"), "VITE_DEV_ONLY=nope\n").unwrap();
+
+    let loaded: BTreeMap<String, String> = oj_env::load(dir.path(), "production")
+        .into_iter()
+        .collect();
+    assert_eq!(loaded["VITE_A"], "base");
+    assert_eq!(loaded["VITE_B"], "local");
+    assert_eq!(loaded["VITE_C"], "prod-local");
+    assert_eq!(
+        loaded["VITE_D"], "base-derived",
+        "expansion sees keys from earlier files"
+    );
+    assert!(!loaded.contains_key("VITE_DEV_ONLY"));
+}
+
+#[test]
+fn a_dotenv_cannot_shadow_the_builtin_env_fields() {
+    let loaded = vec![
+        ("VITE_X".into(), "x".into()),
+        ("MODE".into(), "hacked".into()),
+        ("DEV".into(), "hacked".into()),
+    ];
+    let defines = import_meta_env_defines(&loaded, "production", false, "/base/", "VITE_");
+    let m: BTreeMap<_, _> = defines.into_iter().collect();
+    assert_eq!(m["import.meta.env.MODE"], "\"production\"");
+    assert_eq!(m["import.meta.env.DEV"], "false");
+    assert_eq!(m["import.meta.env.PROD"], "true");
+    assert_eq!(m["import.meta.env.BASE_URL"], "\"/base/\"");
+}

--- a/crates/oj_env/tests/properties.rs
+++ b/crates/oj_env/tests/properties.rs
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+//! Property tests over the dotenv surface. The invariants that matter are
+//! total-ness (arbitrary bytes in, no panic), byte fidelity (a value reaches
+//! the app exactly as written), and confinement (an unprefixed variable can
+//! never appear in anything shipped to the client).
+
+use std::collections::BTreeMap;
+
+use oj_env::{html_env_map, import_meta_env_defines, parse, replace_html_env};
+use proptest::prelude::*;
+
+/// Text that looks like a dotenv file: mostly assignment-shaped, with quotes,
+/// comments, expansions and junk mixed in.
+fn dotenv_line() -> impl Strategy<Value = String> {
+    let key = "[A-Za-z_][A-Za-z0-9_]{0,8}";
+    let value = prop_oneof![
+        Just(String::new()),
+        "[^\\n]{0,20}",
+        r#"\$\{[A-Za-z_]{1,6}\}"#.prop_map(|s| s),
+        "'[^'\\n]{0,10}'".prop_map(|s| s),
+        "\"[^\"\\n]{0,10}\"".prop_map(|s| s),
+    ];
+    prop_oneof![
+        8 => (key, value).prop_map(|(k, v)| format!("{k}={v}")),
+        1 => Just("# comment".to_string()),
+        1 => "[^\\n]{0,20}".prop_map(|s| s),
+    ]
+}
+
+fn dotenv_file() -> impl Strategy<Value = String> {
+    proptest::collection::vec(dotenv_line(), 0..12).prop_map(|lines| lines.join("\n"))
+}
+
+proptest! {
+    /// Arbitrary bytes are a legal `.env`: parsing is total.
+    #[test]
+    fn parse_is_total(src in ".{0,400}") {
+        let out = parse(&src, &BTreeMap::new());
+        for (key, _) in &out {
+            prop_assert!(!key.is_empty(), "empty key from {src:?}");
+            prop_assert_eq!(key.trim(), key.as_str(), "key not trimmed: {:?}", key);
+            prop_assert!(!key.contains('='), "key contains '=': {:?}", key);
+        }
+    }
+
+    #[test]
+    fn parse_is_total_over_dotenv_shaped_input(src in dotenv_file()) {
+        let out = parse(&src, &BTreeMap::new());
+        // Every assignment reported must come from a line that had an '='.
+        prop_assert!(out.len() <= src.lines().filter(|l| l.contains('=')).count());
+    }
+
+    /// Assignments come back in file order, one per line, unchanged: a build
+    /// applies them in sequence, so both the order and the count matter.
+    #[test]
+    fn well_formed_assignments_round_trip_in_order(
+        lines in proptest::collection::vec(
+            ("[A-Z][A-Z0-9_]{0,6}", "[^\\s$\\\\#'\"]{0,16}"),
+            0..8,
+        ),
+    ) {
+        let file: String = lines
+            .iter()
+            .map(|(k, v)| format!("{k}={v}\n"))
+            .collect();
+        prop_assert_eq!(parse(&file, &BTreeMap::new()), lines);
+    }
+
+    /// Single quotes are literal: the value is exactly the bytes between them,
+    /// whatever they are.
+    #[test]
+    fn single_quoted_values_are_byte_exact(raw in "[^'\\n]{0,40}") {
+        let out = parse(&format!("K='{raw}'\n"), &BTreeMap::new());
+        prop_assert_eq!(out, vec![("K".to_string(), raw)]);
+    }
+
+    /// Values with no dotenv metacharacters survive verbatim, including
+    /// multi-byte UTF-8.
+    #[test]
+    fn plain_values_survive_expansion_verbatim(raw in "[^\\s$\\\\#'\"]{0,40}") {
+        let out = parse(&format!("K={raw}\n"), &BTreeMap::new());
+        prop_assert_eq!(out, vec![("K".to_string(), raw)]);
+    }
+
+    /// Confinement: no unprefixed key or value can appear anywhere in the
+    /// defines a build hands to the client.
+    #[test]
+    fn unprefixed_variables_are_never_exposed(
+        public in proptest::collection::vec(("[A-Z]{1,6}", "[a-z]{1,8}"), 0..5),
+        secret in proptest::collection::vec(("[A-Z]{1,6}", "[a-z]{8,16}"), 0..5),
+    ) {
+        let mut loaded: Vec<(String, String)> = public
+            .iter()
+            .map(|(k, v)| (format!("VITE_{k}"), v.clone()))
+            .collect();
+        // Secret names deliberately avoid the prefix.
+        loaded.extend(secret.iter().map(|(k, v)| (format!("SECRET_{k}"), v.clone())));
+
+        let defines = import_meta_env_defines(&loaded, "production", false, "/", "VITE_");
+        let blob: String = defines.iter().map(|(k, v)| format!("{k}={v};")).collect();
+        for (k, v) in &secret {
+            prop_assert!(!blob.contains(&format!("SECRET_{k}")), "leaked key in {blob}");
+            // A secret value could coincide with a public one; only flag it
+            // when it is genuinely absent from the public set.
+            if !public.iter().any(|(_, pv)| pv == v) {
+                prop_assert!(!blob.contains(v.as_str()), "leaked value in {blob}");
+            }
+        }
+    }
+
+    /// Every define is either a builtin or a prefixed variable, and the
+    /// aggregate `import.meta.env` object always parses as JSON with exactly
+    /// the same keys as the individual defines.
+    #[test]
+    fn defines_and_the_aggregate_object_agree(
+        vars in proptest::collection::btree_map("VITE_[A-Z]{1,6}", "[^\"\\\\]{0,12}", 0..6),
+        dev in any::<bool>(),
+    ) {
+        let vars: Vec<(String, String)> = vars.into_iter().collect();
+        let defines = import_meta_env_defines(&vars, if dev { "development" } else { "production" }, dev, "/b/", "VITE_");
+        let object = defines.iter().find(|(k, _)| k == "import.meta.env").unwrap();
+        let json: serde_json::Value = serde_json::from_str(&object.1).unwrap();
+        let obj = json.as_object().unwrap();
+
+        let mut individual: Vec<&str> = defines
+            .iter()
+            .filter_map(|(k, _)| k.strip_prefix("import.meta.env."))
+            .collect();
+        individual.sort_unstable();
+        let mut aggregate: Vec<&str> = obj.keys().map(String::as_str).collect();
+        aggregate.sort_unstable();
+        prop_assert_eq!(individual, aggregate);
+
+        prop_assert_eq!(&obj["DEV"], &serde_json::Value::Bool(dev));
+        prop_assert_eq!(&obj["PROD"], &serde_json::Value::Bool(!dev));
+        prop_assert_eq!(&obj["SSR"], &serde_json::Value::Bool(false));
+        for (k, v) in &vars {
+            prop_assert_eq!(&obj[k.as_str()], &serde_json::Value::String(v.clone()));
+        }
+    }
+
+    /// `html_env_map` recovers exactly the string values that went in.
+    #[test]
+    fn html_env_map_roundtrips_string_values(
+        vars in proptest::collection::btree_map("VITE_[A-Z]{1,6}", ".{0,12}", 0..6),
+    ) {
+        let vars: Vec<(String, String)> = vars.into_iter().collect();
+        let defines = import_meta_env_defines(&vars, "development", true, "/", "VITE_");
+        let env = html_env_map(&defines);
+        for (k, v) in &vars {
+            prop_assert_eq!(env.get(k.as_str()), Some(v));
+        }
+        prop_assert_eq!(env.get("MODE").map(String::as_str), Some("development"));
+    }
+
+    /// Substitution is total, and with nothing to substitute it is the identity.
+    #[test]
+    fn html_substitution_is_total(html in ".{0,200}") {
+        prop_assert_eq!(replace_html_env(&html, &BTreeMap::new()), html.clone());
+        let mut env = BTreeMap::new();
+        env.insert("KEY".to_string(), "value".to_string());
+        let out = replace_html_env(&html, &env);
+        // Only `%KEY%` occurrences may change, and each shortens the text.
+        prop_assert!(out.len() <= html.len() + html.matches("%KEY%").count() * 5);
+    }
+
+    /// Placeholders are only recognised for keys that exist; unknown ones are
+    /// preserved byte for byte.
+    #[test]
+    fn unknown_placeholders_are_preserved(key in "[A-Z]{1,8}", other in "[A-Z]{1,8}") {
+        prop_assume!(key != other);
+        let mut env = BTreeMap::new();
+        env.insert(key.clone(), "V".to_string());
+        let html = format!("<p>%{other}%</p>");
+        prop_assert_eq!(replace_html_env(&html, &env), html.clone());
+    }
+}


### PR DESCRIPTION
`expand` walked the value byte by byte and pushed each byte as a `char`, so every
multi-byte character in an expanded value came out mojibaked:

```sh
# .env
VITE_TITLE=café
```

reached the app as `cafÃ©`. Single-quoted values escaped it only because they
skip expansion entirely, which is why this hid for a while: `'café'` was fine and
`café` was not. Fixed by copying whole characters.

Also drops a dead index. The unclosed-`\${` branch computed a `next` position
nothing could read; mutation testing flagged it as an unkillable mutant, which is
the tell. The branch now says what it means with `Option`.

### Tests

`crates/oj_env/tests/`, 31 tests in two suites:

- **adverse** — malformed lines, self-referential and mutual expansion,
  unterminated quotes and braces, control bytes and CRLF, non-ASCII values byte
  for byte, `%`-soup in HTML, and secret confinement: near-miss prefixes
  (`vite_`, ` VITE_`, `XVITE_`), and a value that tries to break out of the JSON
  literal it is embedded in.
- **properties** — parsing is total over arbitrary bytes; single-quoted and
  metacharacter-free values are byte-exact; the individual `import.meta.env.*`
  defines and the aggregate object always have the same keys; no unprefixed
  variable is ever exposed, by name or by value.

One documented divergence is pinned rather than silently carried: Vite's
`/%(\S+?)%/g` leaves `%%KEY%%` untouched, where oj rescans from the inner `%` and
substitutes. Only adjacent percents differ.
---

One of eleven independent PRs from the same pass over the test suite. Each stands
alone (its own tests pass on `main` without the others) and all eleven merge
together cleanly — I verified both. Each also carries the same two-line
`tmp()` fix in `crates/oj/src/start_dev.rs`, because without it
`app_uses_tailwind_detects_postcss_vite_and_bare` flakes on any PR CI run; the
hunks are identical, so they merge as one.


