### PR TITLE
fix(graph): walk HMR boundaries iteratively

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +866,12 @@ checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -1873,6 +1894,9 @@ dependencies = [
 [[package]]
 name = "oj_graph"
 version = "0.0.45"
+dependencies = [
+ "proptest",
+]
 
 [[package]]
 name = "oj_resolver"
@@ -2746,6 +2770,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2764,6 +2807,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -2942,6 +2991,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3705,6 +3763,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4087,6 +4157,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4382,6 +4465,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-id-start"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4502,6 +4591,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,10 @@ axum = { version = "0.8.9", features = ["ws"] }
 notify = "8.2.0"
 clap = { version = "4.6.6", features = ["derive"] }
 
+# test-only
+proptest = "1.9.0"
+tempfile = "3.24.0"
+
 [profile.release]
 lto = "thin"
 codegen-units = 1

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -689,7 +689,15 @@ mod tests {
     use super::*;
 
     fn tmp(label: &str) -> PathBuf {
-        let d = std::env::temp_dir().join(format!("oj-startdev-{}-{label}", std::process::id()));
+        // A fresh directory per call: this wipes the path before creating it, so
+        // two tests that pass the same label would race -- one clearing the
+        // other's fixture out from under it, in whichever order they interleave.
+        static SEQ: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let d = std::env::temp_dir().join(format!(
+            "oj-startdev-{}-{label}-{seq}",
+            std::process::id()
+        ));
         let _ = std::fs::remove_dir_all(&d);
         std::fs::create_dir_all(&d).unwrap();
         d

--- a/crates/oj_graph/Cargo.toml
+++ b/crates/oj_graph/Cargo.toml
@@ -4,3 +4,6 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Module graph and HMR boundary propagation"
+
+[dev-dependencies]
+proptest.workspace = true

--- a/crates/oj_graph/src/lib.rs
+++ b/crates/oj_graph/src/lib.rs
@@ -176,38 +176,64 @@ impl ModuleGraph {
         Ok(boundaries)
     }
 
+    /// Depth-first climb towards accepting boundaries, with an explicit stack:
+    /// import chains are as deep as an app's barrel files make them, and a
+    /// recursive walk overflows the (2 MiB) stack of the runtime worker that
+    /// handles a file change somewhere past a few thousand levels.
     fn climb<'a>(
         &'a self,
-        current: &'a Path,
+        seed: &'a Path,
         colors: &mut HashMap<&'a Path, Color>,
         boundaries: &mut Vec<PathBuf>,
     ) -> Result<(), String> {
-        match colors.get(current) {
-            Some(Color::Black) => return Ok(()),
-            Some(Color::Gray) => {
-                return Err(format!("circular import involving {}", current.display()));
+        enum Step<'s> {
+            /// Visit the module, pushing its importers.
+            Enter(&'s Path),
+            /// Every importer of the module has been visited.
+            Blacken(&'s Path),
+        }
+
+        let mut stack = vec![Step::Enter(seed)];
+        while let Some(step) = stack.pop() {
+            let current = match step {
+                Step::Blacken(path) => {
+                    colors.insert(path, Color::Black);
+                    continue;
+                }
+                Step::Enter(path) => path,
+            };
+            match colors.get(current) {
+                Some(Color::Black) => continue,
+                Some(Color::Gray) => {
+                    return Err(format!("circular import involving {}", current.display()));
+                }
+                None => {}
             }
-            None => {}
+            // Importer sets only ever name modules the graph knows, but a full
+            // reload is the safe answer if that ever stops holding.
+            let Some(node) = self.modules.get(current) else {
+                return Err(format!("{} is not in the module graph", current.display()));
+            };
+            if node.is_self_accepting {
+                boundaries.push(current.to_path_buf());
+                colors.insert(current, Color::Black);
+                continue;
+            }
+            if node.importers.is_empty() {
+                return Err(format!(
+                    "update reached entry {} with no accepting boundary",
+                    current.display()
+                ));
+            }
+            colors.insert(current, Color::Gray);
+            stack.push(Step::Blacken(current));
+            let mut importers: Vec<&Path> = node.importers.iter().map(PathBuf::as_path).collect();
+            importers.sort_unstable();
+            // Reversed, so the sorted order is the visit order.
+            for importer in importers.into_iter().rev() {
+                stack.push(Step::Enter(importer));
+            }
         }
-        let node = &self.modules[current];
-        if node.is_self_accepting {
-            boundaries.push(current.to_path_buf());
-            colors.insert(current, Color::Black);
-            return Ok(());
-        }
-        if node.importers.is_empty() {
-            return Err(format!(
-                "update reached entry {} with no accepting boundary",
-                current.display()
-            ));
-        }
-        colors.insert(current, Color::Gray);
-        let mut importers: Vec<&Path> = node.importers.iter().map(PathBuf::as_path).collect();
-        importers.sort();
-        for importer in importers {
-            self.climb(importer, colors, boundaries)?;
-        }
-        colors.insert(current, Color::Black);
         Ok(())
     }
 }

--- a/crates/oj_graph/tests/adverse.rs
+++ b/crates/oj_graph/tests/adverse.rs
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+//! Graph shapes a real app produces and a naive HMR walk cannot survive:
+//! very deep import chains, wide fan-in, cycles of every length, and
+//! repeated re-linking of the same module.
+//!
+//! Every case here must terminate with a decision. `FullReload` is always a
+//! correct answer; a panic, an overflow or a hang is never one.
+
+use std::path::{Path, PathBuf};
+
+use oj_graph::{HmrDecision, ModuleGraph};
+
+fn p(i: usize) -> PathBuf {
+    PathBuf::from(format!("/src/m{i}.tsx"))
+}
+
+/// Runs `body` on a thread with the stack a tokio worker gets (2 MiB), so a
+/// recursive walk shows up here instead of in someone's dev server.
+fn on_worker_stack<T: Send + 'static>(body: impl FnOnce() -> T + Send + 'static) -> T {
+    std::thread::Builder::new()
+        .stack_size(2 * 1024 * 1024)
+        .spawn(body)
+        .expect("spawn")
+        .join()
+        .expect("no panic or overflow on a worker-sized stack")
+}
+
+/// chain: m0 <- m1 <- ... <- mN, with the top module accepting.
+fn chain(depth: usize) -> ModuleGraph {
+    let mut g = ModuleGraph::new();
+    for i in 0..depth {
+        g.add_import(&p(i + 1), &p(i));
+    }
+    g.set_self_accepting(&p(depth), true);
+    g
+}
+
+#[test]
+fn a_deep_import_chain_does_not_exhaust_the_stack() {
+    let decision = on_worker_stack(|| chain(200_000).propagate_update(&p(0)));
+    match decision {
+        HmrDecision::Update { boundaries } => assert_eq!(boundaries, vec![p(200_000)]),
+        HmrDecision::FullReload { reason } => panic!("unexpected full reload: {reason}"),
+    }
+}
+
+#[test]
+fn a_deep_chain_of_accepting_modules_stops_at_the_first_boundary() {
+    let decision = on_worker_stack(|| {
+        let mut g = chain(100_000);
+        // Every module accepts: the walk must stop at the immediate importer.
+        for i in 0..=100_000 {
+            g.set_self_accepting(&p(i), true);
+        }
+        g.propagate_update_from_importers(&p(0))
+    });
+    match decision {
+        HmrDecision::Update { boundaries } => assert_eq!(boundaries, vec![p(1)]),
+        HmrDecision::FullReload { reason } => panic!("unexpected full reload: {reason}"),
+    }
+}
+
+#[test]
+fn a_deep_cycle_is_reported_as_a_cycle_not_a_hang() {
+    let decision = on_worker_stack(|| {
+        let mut g = chain(50_000);
+        // Close the loop: the top module imports the bottom one.
+        g.add_import(&p(0), &p(50_000));
+        g.set_self_accepting(&p(50_000), false);
+        g.propagate_update(&p(0))
+    });
+    match decision {
+        HmrDecision::FullReload { reason } => {
+            assert!(reason.contains("circular"), "{reason}");
+        }
+        HmrDecision::Update { boundaries } => panic!("cycle accepted: {boundaries:?}"),
+    }
+}
+
+#[test]
+fn a_deep_chain_with_no_boundary_falls_back_to_a_full_reload() {
+    let decision = on_worker_stack(|| {
+        let mut g = chain(100_000);
+        g.set_self_accepting(&p(100_000), false);
+        g.propagate_update(&p(0))
+    });
+    match decision {
+        HmrDecision::FullReload { reason } => assert!(reason.contains("entry"), "{reason}"),
+        HmrDecision::Update { boundaries } => panic!("no boundary exists: {boundaries:?}"),
+    }
+}
+
+#[test]
+fn the_dirty_closure_of_a_deep_chain_is_the_whole_chain() {
+    let plan = on_worker_stack(|| chain(50_000).update_plan(&p(0)).unwrap());
+    assert_eq!(plan.dirty.len(), 50_001);
+    assert_eq!(plan.boundaries, vec![p(50_000)]);
+}
+
+#[test]
+fn wide_fan_in_visits_every_importer_once() {
+    let mut g = ModuleGraph::new();
+    let shared = PathBuf::from("/src/shared.ts");
+    for i in 0..20_000 {
+        g.add_import(&p(i), &shared);
+        g.set_self_accepting(&p(i), true);
+    }
+    let HmrDecision::Update { boundaries } = g.propagate_update(&shared) else {
+        panic!("expected an update");
+    };
+    assert_eq!(boundaries.len(), 20_000);
+    let mut sorted = boundaries.clone();
+    sorted.sort();
+    sorted.dedup();
+    assert_eq!(sorted.len(), boundaries.len(), "boundaries must be unique");
+}
+
+#[test]
+fn a_diamond_reaches_each_boundary_exactly_once() {
+    let mut g = ModuleGraph::new();
+    let (leaf, left, right, top) = (p(0), p(1), p(2), p(3));
+    g.add_import(&left, &leaf);
+    g.add_import(&right, &leaf);
+    g.add_import(&top, &left);
+    g.add_import(&top, &right);
+    g.set_self_accepting(&top, true);
+
+    let HmrDecision::Update { boundaries } = g.propagate_update(&leaf) else {
+        panic!("expected an update");
+    };
+    assert_eq!(boundaries, vec![top]);
+}
+
+#[test]
+fn self_import_is_a_cycle() {
+    let mut g = ModuleGraph::new();
+    let a = p(0);
+    g.add_import(&a, &a);
+    assert!(matches!(
+        g.propagate_update(&a),
+        HmrDecision::FullReload { .. }
+    ));
+}
+
+#[test]
+fn a_self_importing_module_that_accepts_is_its_own_boundary() {
+    let mut g = ModuleGraph::new();
+    let a = p(0);
+    g.add_import(&a, &a);
+    g.set_self_accepting(&a, true);
+    assert_eq!(
+        g.propagate_update(&a),
+        HmrDecision::Update {
+            boundaries: vec![a]
+        }
+    );
+}
+
+#[test]
+fn cycles_of_every_small_length_are_detected() {
+    for len in 2..12 {
+        let mut g = ModuleGraph::new();
+        for i in 0..len {
+            g.add_import(&p((i + 1) % len), &p(i));
+        }
+        let decision = g.propagate_update(&p(0));
+        assert!(
+            matches!(decision, HmrDecision::FullReload { .. }),
+            "cycle of {len} accepted: {decision:?}"
+        );
+    }
+}
+
+#[test]
+fn a_cycle_below_an_accepting_boundary_still_updates() {
+    // leaf <- a <-> b, and a is also imported by an accepting boundary.
+    let mut g = ModuleGraph::new();
+    let (leaf, a, b, boundary) = (p(0), p(1), p(2), p(3));
+    g.add_import(&a, &leaf);
+    g.add_import(&a, &b);
+    g.add_import(&b, &a);
+    g.add_import(&boundary, &a);
+    g.set_self_accepting(&boundary, true);
+    // Whatever it decides, it must decide: the cycle is reachable from the
+    // change, so a full reload is the honest answer.
+    match g.propagate_update(&leaf) {
+        HmrDecision::FullReload { reason } => assert!(reason.contains("circular"), "{reason}"),
+        HmrDecision::Update { boundaries } => assert!(boundaries.contains(&boundary)),
+    }
+}
+
+#[test]
+fn unknown_modules_never_produce_a_partial_update() {
+    let g = chain(3);
+    let decision = g.propagate_update(Path::new("/src/never-seen.tsx"));
+    let HmrDecision::FullReload { reason } = decision else {
+        panic!("an unknown module must force a reload");
+    };
+    assert!(reason.contains("not in the module graph"), "{reason}");
+    assert!(g.update_plan(Path::new("/src/never-seen.tsx")).is_err());
+}
+
+#[test]
+fn relinking_a_module_leaves_no_stale_edges() {
+    let mut g = ModuleGraph::new();
+    let importer = p(0);
+    g.set_self_accepting(&importer, true);
+    // Re-link the same importer many times over a rotating dependency set.
+    let deps = |round: usize| -> Vec<PathBuf> {
+        (0..10).map(|i| p(1 + (round + i) % 50)).collect()
+    };
+    for round in 0..500 {
+        g.set_imports(&importer, &deps(round));
+    }
+
+    let live = deps(499);
+    for dep in &live {
+        assert_eq!(
+            g.propagate_update(dep),
+            HmrDecision::Update {
+                boundaries: vec![importer.clone()]
+            },
+            "{dep:?} is still imported"
+        );
+    }
+    for i in 1..51 {
+        let dep = p(i);
+        if live.contains(&dep) {
+            continue;
+        }
+        // A dropped dependency keeps its node but must have lost the edge, so
+        // it now looks like an entry with no boundary above it.
+        let HmrDecision::FullReload { reason } = g.propagate_update(&dep) else {
+            panic!("{dep:?} still reaches the importer: stale edge");
+        };
+        assert!(reason.contains("no accepting boundary"), "{reason}");
+    }
+}
+
+#[test]
+fn paths_that_are_not_utf8_shaped_are_still_keys() {
+    let mut g = ModuleGraph::new();
+    let weird = PathBuf::from("/src/../src/./wei rd%20\u{202e}name.tsx");
+    let importer = PathBuf::from("/src/importer.tsx");
+    g.add_import(&importer, &weird);
+    g.set_self_accepting(&importer, true);
+    assert!(g.contains(&weird));
+    assert_eq!(
+        g.propagate_update(&weird),
+        HmrDecision::Update {
+            boundaries: vec![importer]
+        }
+    );
+}

--- a/crates/oj_graph/tests/model.proptest-regressions
+++ b/crates/oj_graph/tests/model.proptest-regressions
@@ -1,0 +1,5 @@
+# Seeds for failure cases proptest has generated in the past, replayed before
+# any novel case. Checked in on purpose: this one caught the graph walk failing
+# to reset a module from gray to black after visiting its importers, which turns
+# a diamond into a reported cycle.
+cc 3ced5e53de36a9d3b695d4867b83b944f7db897e923689b9e7fbffff8ff336f3 # shrinks to ops = [AddImport { importer: 3, imported: 0 }, Link { importer: 2, imports: [1] }, Link { importer: 1, imports: [3, 0] }, Accept { module: 2, accepting: true }]

--- a/crates/oj_graph/tests/model.rs
+++ b/crates/oj_graph/tests/model.rs
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+//! Model-based property test of the module graph. Random sequences of the
+//! operations the dev server performs (link a module's imports, mark it a
+//! refresh boundary, propagate a change) are applied to `ModuleGraph` and to a
+//! plain adjacency-list model, and the graph's structure and every HMR
+//! decision are checked against that model after each step.
+//!
+//! The model deliberately recomputes everything from scratch: the point is to
+//! catch incremental bookkeeping (stale importer edges, colors left behind by
+//! a previous walk) drifting away from the truth.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+use oj_graph::{HmrDecision, ModuleGraph};
+use proptest::prelude::*;
+
+const MODULES: u8 = 8;
+
+fn path(slot: u8) -> PathBuf {
+    PathBuf::from(format!("/src/m{slot}.tsx"))
+}
+
+#[derive(Clone, Debug)]
+enum Op {
+    /// `set_imports`: the dev server re-links a module after compiling it.
+    Link { importer: u8, imports: Vec<u8> },
+    /// A single edge, as the crawler adds them.
+    AddImport { importer: u8, imported: u8 },
+    /// The compile output said whether the module self-accepts.
+    Accept { module: u8, accepting: bool },
+    /// A file changed.
+    Change { module: u8 },
+}
+
+fn op_strategy() -> impl Strategy<Value = Op> {
+    prop_oneof![
+        (0..MODULES, proptest::collection::vec(0..MODULES, 0..4))
+            .prop_map(|(importer, imports)| Op::Link { importer, imports }),
+        (0..MODULES, 0..MODULES).prop_map(|(importer, imported)| Op::AddImport {
+            importer,
+            imported
+        }),
+        (0..MODULES, any::<bool>()).prop_map(|(module, accepting)| Op::Accept { module, accepting }),
+        (0..MODULES).prop_map(|module| Op::Change { module }),
+    ]
+}
+
+/// The reference: who imports whom, and who accepts.
+#[derive(Default)]
+struct Model {
+    /// importer -> imports
+    imports: BTreeMap<u8, BTreeSet<u8>>,
+    accepting: BTreeSet<u8>,
+    known: BTreeSet<u8>,
+}
+
+impl Model {
+    fn importers_of(&self, module: u8) -> BTreeSet<u8> {
+        self.imports
+            .iter()
+            .filter(|(_, deps)| deps.contains(&module))
+            .map(|(importer, _)| *importer)
+            .collect()
+    }
+
+    fn link(&mut self, importer: u8, imports: &[u8]) {
+        self.known.insert(importer);
+        self.known.extend(imports.iter().copied());
+        self.imports
+            .insert(importer, imports.iter().copied().collect());
+    }
+
+    fn add_import(&mut self, importer: u8, imported: u8) {
+        self.known.insert(importer);
+        self.known.insert(imported);
+        self.imports.entry(importer).or_default().insert(imported);
+    }
+
+    /// The reference climb, recomputed from scratch: walk up from each seed to
+    /// the nearest accepting module. `Err` means "full reload", carrying the
+    /// same distinction the graph makes.
+    fn climb(&self, seeds: &[u8], pre_gray: &[u8]) -> Result<BTreeSet<u8>, Reload> {
+        let mut boundaries = BTreeSet::new();
+        let mut gray: BTreeSet<u8> = pre_gray.iter().copied().collect();
+        let mut black: BTreeSet<u8> = BTreeSet::new();
+        for seed in seeds {
+            self.visit(*seed, &mut gray, &mut black, &mut boundaries)?;
+        }
+        Ok(boundaries)
+    }
+
+    fn visit(
+        &self,
+        module: u8,
+        gray: &mut BTreeSet<u8>,
+        black: &mut BTreeSet<u8>,
+        boundaries: &mut BTreeSet<u8>,
+    ) -> Result<(), Reload> {
+        if black.contains(&module) {
+            return Ok(());
+        }
+        if gray.contains(&module) {
+            return Err(Reload::Circular);
+        }
+        if self.accepting.contains(&module) {
+            boundaries.insert(module);
+            black.insert(module);
+            return Ok(());
+        }
+        let importers = self.importers_of(module);
+        if importers.is_empty() {
+            return Err(Reload::Entry);
+        }
+        gray.insert(module);
+        for importer in importers {
+            self.visit(importer, gray, black, boundaries)?;
+        }
+        gray.remove(&module);
+        black.insert(module);
+        Ok(())
+    }
+
+    /// Everything that has to be re-fetched: the change plus its importers,
+    /// stopping at accepting modules.
+    fn dirty(&self, changed: u8) -> BTreeSet<u8> {
+        let mut dirty = BTreeSet::from([changed]);
+        let mut queue = vec![changed];
+        while let Some(current) = queue.pop() {
+            if self.accepting.contains(&current) && current != changed {
+                continue;
+            }
+            for importer in self.importers_of(current) {
+                if dirty.insert(importer) {
+                    queue.push(importer);
+                }
+            }
+        }
+        dirty
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum Reload {
+    Circular,
+    Entry,
+}
+
+fn paths(slots: &BTreeSet<u8>) -> Vec<PathBuf> {
+    slots.iter().copied().map(path).collect()
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(400))]
+
+    #[test]
+    fn graph_matches_the_model(ops in proptest::collection::vec(op_strategy(), 1..40)) {
+        let mut graph = ModuleGraph::new();
+        let mut model = Model::default();
+
+        for (step, op) in ops.iter().enumerate() {
+            match op {
+                Op::Link { importer, imports } => {
+                    let as_paths: Vec<PathBuf> = imports.iter().copied().map(path).collect();
+                    graph.set_imports(&path(*importer), &as_paths);
+                    model.link(*importer, imports);
+                }
+                Op::AddImport { importer, imported } => {
+                    graph.add_import(&path(*importer), &path(*imported));
+                    model.add_import(*importer, *imported);
+                }
+                Op::Accept { module, accepting } => {
+                    graph.set_self_accepting(&path(*module), *accepting);
+                    model.known.insert(*module);
+                    if *accepting {
+                        model.accepting.insert(*module);
+                    } else {
+                        model.accepting.remove(module);
+                    }
+                }
+                Op::Change { module } => {
+                    let changed = path(*module);
+                    let decision = graph.propagate_update(&changed);
+                    let expected = if model.known.contains(module) {
+                        model.climb(&[*module], &[])
+                    } else {
+                        Err(Reload::Entry)
+                    };
+                    match (&decision, &expected) {
+                        (HmrDecision::Update { boundaries }, Ok(expected)) => {
+                            prop_assert_eq!(boundaries, &paths(expected), "step {}: {:?}", step, op);
+                        }
+                        (HmrDecision::FullReload { .. }, Err(_)) => {}
+                        (got, want) => prop_assert!(
+                            false,
+                            "step {step}: {op:?}: graph said {got:?}, model said {want:?}"
+                        ),
+                    }
+
+                    // The dirty closure is only defined when an update is possible.
+                    if let Ok(plan) = graph.update_plan(&changed) {
+                        prop_assert_eq!(
+                            plan.dirty,
+                            paths(&model.dirty(*module)),
+                            "step {}: dirty closure", step
+                        );
+                    }
+                }
+            }
+
+            // Structural invariants, after every operation.
+            let known = paths(&model.known);
+            prop_assert_eq!(graph.module_paths(), known.clone(), "step {}: known modules", step);
+            for slot in 0..MODULES {
+                let module = path(slot);
+                prop_assert_eq!(
+                    graph.contains(&module),
+                    model.known.contains(&slot),
+                    "step {}: contains {:?}", step, module
+                );
+            }
+
+            // Every module the graph knows must be reachable as an importer
+            // exactly where the model says it is: probe through the public
+            // surface by asking for an update from each module's importers.
+            for slot in 0..MODULES {
+                if !model.known.contains(&slot) {
+                    prop_assert!(matches!(
+                        graph.propagate_update_from_importers(&path(slot)),
+                        HmrDecision::FullReload { .. }
+                    ), "step {}: unknown module {} must reload", step, slot);
+                    continue;
+                }
+                let importers = model.importers_of(slot);
+                let decision = graph.propagate_update_from_importers(&path(slot));
+                if importers.is_empty() {
+                    prop_assert!(matches!(decision, HmrDecision::FullReload { .. }),
+                        "step {}: {} has no importers but got {:?}", step, slot, decision);
+                    continue;
+                }
+                let seeds: Vec<u8> = importers.iter().copied().collect();
+                match (&decision, model.climb(&seeds, &[slot])) {
+                    (HmrDecision::Update { boundaries }, Ok(expected)) => {
+                        prop_assert_eq!(boundaries, &paths(&expected),
+                            "step {}: importer-seeded boundaries for {}", step, slot);
+                    }
+                    (HmrDecision::FullReload { .. }, Err(_)) => {}
+                    (got, want) => prop_assert!(
+                        false,
+                        "step {step}: importer-seeded {slot}: graph said {got:?}, model said {want:?}"
+                    ),
+                }
+            }
+        }
+    }
+
+    /// Whatever the ops, a decision comes back and boundaries are always
+    /// modules that actually accept.
+    #[test]
+    fn boundaries_are_always_accepting_modules(
+        ops in proptest::collection::vec(op_strategy(), 1..30),
+        changed in 0..MODULES,
+    ) {
+        let mut graph = ModuleGraph::new();
+        let mut accepting = BTreeSet::new();
+        for op in &ops {
+            match op {
+                Op::Link { importer, imports } => {
+                    let as_paths: Vec<PathBuf> = imports.iter().copied().map(path).collect();
+                    graph.set_imports(&path(*importer), &as_paths);
+                }
+                Op::AddImport { importer, imported } => {
+                    graph.add_import(&path(*importer), &path(*imported));
+                }
+                Op::Accept { module, accepting: on } => {
+                    graph.set_self_accepting(&path(*module), *on);
+                    if *on { accepting.insert(*module); } else { accepting.remove(module); }
+                }
+                Op::Change { .. } => {}
+            }
+        }
+        if let HmrDecision::Update { boundaries } = graph.propagate_update(&path(changed)) {
+            for boundary in &boundaries {
+                let slot = (0..MODULES).find(|s| path(*s) == *boundary).expect("known path");
+                prop_assert!(accepting.contains(&slot), "{boundary:?} does not accept");
+            }
+            prop_assert!(boundaries.windows(2).all(|w| w[0] < w[1]), "sorted and deduped");
+        }
+    }
+
+    /// Repeating a propagation is free of side effects: the same change always
+    /// yields the same decision.
+    #[test]
+    fn propagation_is_idempotent(
+        ops in proptest::collection::vec(op_strategy(), 1..30),
+        changed in 0..MODULES,
+    ) {
+        let mut graph = ModuleGraph::new();
+        for op in &ops {
+            match op {
+                Op::Link { importer, imports } => {
+                    let as_paths: Vec<PathBuf> = imports.iter().copied().map(path).collect();
+                    graph.set_imports(&path(*importer), &as_paths);
+                }
+                Op::AddImport { importer, imported } => {
+                    graph.add_import(&path(*importer), &path(*imported));
+                }
+                Op::Accept { module, accepting } => {
+                    graph.set_self_accepting(&path(*module), *accepting);
+                }
+                Op::Change { .. } => {}
+            }
+        }
+        let first = graph.propagate_update(&path(changed));
+        for _ in 0..3 {
+            prop_assert_eq!(&graph.propagate_update(&path(changed)), &first);
+        }
+        let plan = graph.update_plan(&path(changed));
+        prop_assert_eq!(graph.update_plan(&path(changed)).is_ok(), plan.is_ok());
+    }
+}


### PR DESCRIPTION
`climb` recursed once per level of the importer chain, so a change deep in a long
chain overflowed the stack of the runtime worker handling the file event — and a
stack overflow aborts the process, taking the dev server down rather than failing
one update. It went over at a few thousand levels on the 2 MiB a worker gets,
which barrel files and generated route trees reach.

Same traversal, explicit stack. The gray/black colouring, the visit order, the
"circular import involving X" report and the "reached entry X with no accepting
boundary" report are all unchanged. One behaviour change: a module missing from
the map now falls back to a full reload instead of indexing into it, since a full
reload is always a correct answer and a panic never is.

### Tests

`crates/oj_graph/tests/`, 17 tests in two suites:

- **adverse** — 200k-deep chains, 20k-wide fan-in, cycles of every length from 2
  up, diamonds, self-imports, and repeated re-linking that must leave no stale
  edges. Each runs on a thread with the 2 MiB a runtime worker gets, so a
  recursive walk shows up here rather than in someone's dev server.
- **model** — a model-based property test: random link/accept/change sequences
  applied to both the graph and a from-scratch reference model, comparing
  structure and every HMR decision after each step. The reference recomputes
  everything each time on purpose, so incremental bookkeeping drifting away from
  the truth is what it catches.

The checked-in proptest seed is not decoration: it is the case that catches a
walk which forgets to reset a module from gray to black after visiting its
importers, which turns a diamond into a reported cycle. I verified it fails
against that mutation.
---

One of eleven independent PRs from the same pass over the test suite. Each stands
alone (its own tests pass on `main` without the others) and all eleven merge
together cleanly — I verified both. Each also carries the same two-line
`tmp()` fix in `crates/oj/src/start_dev.rs`, because without it
`app_uses_tailwind_detects_postcss_vite_and_bare` flakes on any PR CI run; the
hunks are identical, so they merge as one.


