### PR TITLE
fix(cache): validate keys and publish entries atomically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +866,12 @@ checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -1813,8 +1834,10 @@ name = "oj_cache"
 version = "0.0.45"
 dependencies = [
  "blake3",
+ "proptest",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -2746,6 +2769,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2764,6 +2806,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -2942,6 +2990,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3705,6 +3762,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4087,6 +4156,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4382,6 +4464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-id-start"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4502,6 +4590,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,10 @@ axum = { version = "0.8.9", features = ["ws"] }
 notify = "8.2.0"
 clap = { version = "4.6.6", features = ["derive"] }
 
+# test-only
+proptest = "1.9.0"
+tempfile = "3.24.0"
+
 [profile.release]
 lto = "thin"
 codegen-units = 1

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -689,7 +689,15 @@ mod tests {
     use super::*;
 
     fn tmp(label: &str) -> PathBuf {
-        let d = std::env::temp_dir().join(format!("oj-startdev-{}-{label}", std::process::id()));
+        // A fresh directory per call: this wipes the path before creating it, so
+        // two tests that pass the same label would race -- one clearing the
+        // other's fixture out from under it, in whichever order they interleave.
+        static SEQ: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let d = std::env::temp_dir().join(format!(
+            "oj-startdev-{}-{label}-{seq}",
+            std::process::id()
+        ));
         let _ = std::fs::remove_dir_all(&d);
         std::fs::create_dir_all(&d).unwrap();
         d

--- a/crates/oj_cache/Cargo.toml
+++ b/crates/oj_cache/Cargo.toml
@@ -9,3 +9,7 @@ description = "Content-addressed persistent cache for compiled module outputs"
 blake3.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true
+tempfile.workspace = true

--- a/crates/oj_cache/src/lib.rs
+++ b/crates/oj_cache/src/lib.rs
@@ -3,6 +3,7 @@
 
 use std::fs;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use serde::{Deserialize, Serialize};
 
@@ -52,33 +53,54 @@ impl PersistentCache {
     }
 
     pub fn get(&self, key: &str) -> Option<CachedModule> {
-        let bytes = fs::read(self.path_for(key)).ok()?;
+        let path = self.path_for(key)?;
+        let bytes = fs::read(&path).ok()?;
         match serde_json::from_slice(&bytes) {
             Ok(module) => Some(module),
             Err(_) => {
-                let _ = fs::remove_file(self.path_for(key));
+                let _ = fs::remove_file(&path);
                 None
             }
         }
     }
 
     pub fn put(&self, key: &str, module: &CachedModule) {
-        let path = self.path_for(key);
+        let Some(path) = self.path_for(key) else { return };
         let Some(parent) = path.parent() else { return };
         if fs::create_dir_all(parent).is_err() {
             return;
         }
-        let tmp = path.with_extension("tmp");
+        // A private temp name per writer, so the rename is the only way an
+        // entry becomes visible: concurrent builds sharing one .oj-cache must
+        // never be able to read a half-written entry.
+        let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
+        let tmp = path.with_extension(format!("tmp-{}-{seq}", std::process::id()));
         if fs::write(&tmp, serde_json::to_vec(module).unwrap_or_default()).is_ok() {
-            let _ = fs::rename(&tmp, &path);
+            if fs::rename(&tmp, &path).is_err() {
+                let _ = fs::remove_file(&tmp);
+            }
+        } else {
+            let _ = fs::remove_file(&tmp);
         }
     }
 
-    fn path_for(&self, key: &str) -> PathBuf {
-        let shard = key.get(..2).unwrap_or("00");
-        self.dir.join(shard).join(format!("{key}.json"))
+    /// Keys come from [`Self::key`] and are therefore always a 64-character
+    /// lowercase blake3 digest. Anything else is a caller bug, and letting it
+    /// through would let the key steer reads and writes out of the cache
+    /// directory (`../../..`), so it is refused instead.
+    fn path_for(&self, key: &str) -> Option<PathBuf> {
+        let is_digest = key.len() == 64
+            && key
+                .bytes()
+                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b));
+        if !is_digest {
+            return None;
+        }
+        Some(self.dir.join(&key[..2]).join(format!("{key}.json")))
     }
 }
+
+static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
 
 #[cfg(test)]
 mod tests {
@@ -138,7 +160,7 @@ mod tests {
         let cache = temp_cache("corrupt");
         let key = cache.key(b"s", "/u", "dev");
         cache.put(&key, &sample());
-        let path = cache.path_for(&key);
+        let path = cache.path_for(&key).unwrap();
         std::fs::write(&path, b"{ not json").unwrap();
         assert_eq!(cache.get(&key), None);
         assert!(!path.exists(), "corrupt entry must be removed");
@@ -149,7 +171,7 @@ mod tests {
         let cache = temp_cache("shard");
         let key = cache.key(b"s", "/u", "dev");
         cache.put(&key, &sample());
-        let path = cache.path_for(&key);
+        let path = cache.path_for(&key).unwrap();
         assert_eq!(
             path.parent()
                 .unwrap()
@@ -160,10 +182,14 @@ mod tests {
             &key[..2]
         );
         assert!(path.exists());
-        assert!(
-            !path.with_extension("tmp").exists(),
-            "temp file must be renamed away"
-        );
+        let shard = path.parent().unwrap();
+        let leftovers: Vec<_> = std::fs::read_dir(shard)
+            .unwrap()
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files must be renamed away: {leftovers:?}");
     }
 
     #[test]

--- a/crates/oj_cache/tests/common/mod.rs
+++ b/crates/oj_cache/tests/common/mod.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+//! Shared helpers for the cache suites.
+
+use oj_cache::{CachedModule, PersistentCache};
+
+pub const VERSION: &str = "0.0.0-test";
+
+pub struct Fixture {
+    pub dir: tempfile::TempDir,
+    pub cache: PersistentCache,
+}
+
+pub fn fixture() -> Fixture {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = PersistentCache::new(dir.path().to_path_buf(), VERSION);
+    Fixture { dir, cache }
+}
+
+/// The on-disk location of an entry. `path_for` is private, so the layout is
+/// re-derived here on purpose: it is a compatibility contract between oj
+/// versions sharing a `.oj-cache`.
+pub fn entry_path(dir: &std::path::Path, key: &str) -> std::path::PathBuf {
+    dir.join(&key[..2]).join(format!("{key}.json"))
+}
+
+pub fn module(code: &str) -> CachedModule {
+    CachedModule {
+        code: code.to_string(),
+        map_data_url: Some("data:application/json;base64,e30=".into()),
+        imports: vec!["/node_modules/react/index.js".into()],
+        is_boundary: true,
+        kind: "esm".into(),
+        require_map: vec![("react".into(), "/node_modules/react/index.js".into())],
+        css_exports: vec![("button".into(), "button_x1".into())],
+        fs_allow: vec!["/node_modules/react".into()],
+        watch_files: vec!["/tailwind.config.ts".into()],
+    }
+}
+
+/// Every file under `dir`, relative and sorted.
+pub fn walk(dir: &std::path::Path) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(current) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&current) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else {
+                out.push(
+                    path.strip_prefix(dir)
+                        .unwrap_or(&path)
+                        .to_string_lossy()
+                        .replace('\\', "/"),
+                );
+            }
+        }
+    }
+    out.sort();
+    out
+}

--- a/crates/oj_cache/tests/concurrency.rs
+++ b/crates/oj_cache/tests/concurrency.rs
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+//! oj exists to make many builds cheap, so several of them share one
+//! `.oj-cache` at the same time — threads within a build, and separate
+//! processes in CI or an agent fleet. The rule under contention is the same as
+//! everywhere else in the cache: a read returns the exact entry or nothing.
+//! Never a torn entry, never a leftover temp file, never a panic.
+
+mod common;
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier};
+
+use common::*;
+use oj_cache::PersistentCache;
+
+/// Big enough that a write is several syscalls, so a torn read is reachable if
+/// publication is not atomic.
+fn big_module(tag: &str) -> oj_cache::CachedModule {
+    let mut m = module(&format!("/*{tag}*/ export const big = \"{}\";", "x".repeat(400_000)));
+    m.imports = (0..2_000).map(|i| format!("/src/dep{i}.tsx")).collect();
+    m
+}
+
+#[test]
+fn concurrent_writers_of_one_key_publish_a_complete_entry() {
+    let f = fixture();
+    let dir = f.dir.path().to_path_buf();
+    let key = f.cache.key(b"source", "/src/App.tsx", "dev");
+    let expected = big_module("same");
+
+    let barrier = Arc::new(Barrier::new(8));
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let (dir, key, barrier) = (dir.clone(), key.clone(), Arc::clone(&barrier));
+        let expected = expected.clone();
+        handles.push(std::thread::spawn(move || {
+            let cache = PersistentCache::new(dir, VERSION);
+            barrier.wait();
+            for _ in 0..20 {
+                cache.put(&key, &expected);
+            }
+        }));
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    assert_eq!(f.cache.get(&key), Some(expected));
+    assert_eq!(
+        walk(f.dir.path()),
+        vec![format!("{}/{key}.json", &key[..2])],
+        "no temp files may survive"
+    );
+}
+
+#[test]
+fn a_reader_never_observes_a_partial_entry() {
+    let f = fixture();
+    let dir = f.dir.path().to_path_buf();
+    let key = f.cache.key(b"source", "/src/App.tsx", "dev");
+    let expected = big_module("torn");
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let hits = Arc::new(AtomicUsize::new(0));
+    let misses = Arc::new(AtomicUsize::new(0));
+
+    let readers: Vec<_> = (0..4)
+        .map(|_| {
+            let (dir, key, stop) = (dir.clone(), key.clone(), Arc::clone(&stop));
+            let (hits, misses, expected) =
+                (Arc::clone(&hits), Arc::clone(&misses), expected.clone());
+            std::thread::spawn(move || {
+                let cache = PersistentCache::new(dir, VERSION);
+                while !stop.load(Ordering::Relaxed) {
+                    match cache.get(&key) {
+                        Some(entry) => {
+                            assert_eq!(entry, expected, "torn entry served");
+                            hits.fetch_add(1, Ordering::Relaxed);
+                        }
+                        None => {
+                            misses.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                }
+            })
+        })
+        .collect();
+
+    let writers: Vec<_> = (0..4)
+        .map(|_| {
+            let (dir, key, expected) = (dir.clone(), key.clone(), expected.clone());
+            std::thread::spawn(move || {
+                let cache = PersistentCache::new(dir, VERSION);
+                for _ in 0..30 {
+                    cache.put(&key, &expected);
+                }
+            })
+        })
+        .collect();
+
+    for w in writers {
+        w.join().unwrap();
+    }
+    stop.store(true, Ordering::Relaxed);
+    for r in readers {
+        r.join().unwrap();
+    }
+
+    assert!(
+        hits.load(Ordering::Relaxed) > 0,
+        "the entry must become readable at some point ({} misses)",
+        misses.load(Ordering::Relaxed)
+    );
+    assert_eq!(f.cache.get(&key), Some(expected));
+}
+
+#[test]
+fn concurrent_writers_of_distinct_keys_all_land() {
+    let f = fixture();
+    let dir = f.dir.path().to_path_buf();
+    let total = 400;
+
+    let barrier = Arc::new(Barrier::new(8));
+    let mut handles = Vec::new();
+    for thread in 0..8 {
+        let (dir, barrier) = (dir.clone(), Arc::clone(&barrier));
+        handles.push(std::thread::spawn(move || {
+            let cache = PersistentCache::new(dir, VERSION);
+            barrier.wait();
+            for i in (thread..total).step_by(8) {
+                let url = format!("/src/m{i}.tsx");
+                let key = cache.key(format!("source {i}").as_bytes(), &url, "dev");
+                cache.put(&key, &module(&format!("export const n = {i};")));
+            }
+        }));
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    for i in 0..total {
+        let url = format!("/src/m{i}.tsx");
+        let key = f.cache.key(format!("source {i}").as_bytes(), &url, "dev");
+        assert_eq!(
+            f.cache.get(&key).map(|m| m.code),
+            Some(format!("export const n = {i};")),
+            "entry {i} is missing"
+        );
+    }
+    assert_eq!(walk(f.dir.path()).len(), total, "one file per entry");
+}
+
+#[test]
+fn a_reader_racing_a_first_write_sees_a_miss_or_the_entry() {
+    // The interesting window is the very first `put` for a key: the shard
+    // directory does not exist yet.
+    for round in 0..40 {
+        let f = fixture();
+        let dir = f.dir.path().to_path_buf();
+        let key = f
+            .cache
+            .key(format!("round {round}").as_bytes(), "/src/App.tsx", "dev");
+        let expected = module(&format!("export const round = {round};"));
+
+        let barrier = Arc::new(Barrier::new(2));
+        let writer = {
+            let (dir, key, expected, barrier) = (
+                dir.clone(),
+                key.clone(),
+                expected.clone(),
+                Arc::clone(&barrier),
+            );
+            std::thread::spawn(move || {
+                let cache = PersistentCache::new(dir, VERSION);
+                barrier.wait();
+                cache.put(&key, &expected);
+            })
+        };
+        let reader = {
+            let (dir, key, expected, barrier) = (dir, key, expected.clone(), barrier);
+            std::thread::spawn(move || {
+                let cache = PersistentCache::new(dir, VERSION);
+                barrier.wait();
+                for _ in 0..50 {
+                    if let Some(entry) = cache.get(&key) {
+                        assert_eq!(entry, expected, "torn first entry");
+                    }
+                }
+            })
+        };
+        writer.join().unwrap();
+        reader.join().unwrap();
+    }
+}
+
+#[test]
+fn eviction_of_a_corrupt_entry_races_safely_with_a_rewrite() {
+    let f = fixture();
+    let dir = f.dir.path().to_path_buf();
+    let key = f.cache.key(b"source", "/src/App.tsx", "dev");
+    let expected = module("export const x = 1;");
+    let path = entry_path(f.dir.path(), &key);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+    // One thread keeps corrupting the entry (a crashed peer), the others keep
+    // reading and rewriting it. Nothing here may panic, and the value that
+    // survives must be the right one.
+    let stop = Arc::new(AtomicBool::new(false));
+    let corrupter = {
+        let (path, stop) = (path.clone(), Arc::clone(&stop));
+        std::thread::spawn(move || {
+            while !stop.load(Ordering::Relaxed) {
+                let _ = std::fs::write(&path, b"{ truncated");
+            }
+        })
+    };
+    let workers: Vec<_> = (0..4)
+        .map(|_| {
+            let (dir, key, expected) = (dir.clone(), key.clone(), expected.clone());
+            std::thread::spawn(move || {
+                let cache = PersistentCache::new(dir, VERSION);
+                for _ in 0..200 {
+                    if let Some(entry) = cache.get(&key) {
+                        assert_eq!(entry.kind, expected.kind);
+                    }
+                    cache.put(&key, &expected);
+                }
+            })
+        })
+        .collect();
+    for w in workers {
+        w.join().unwrap();
+    }
+    stop.store(true, Ordering::Relaxed);
+    corrupter.join().unwrap();
+
+    f.cache.put(&key, &expected);
+    assert_eq!(f.cache.get(&key), Some(expected));
+}

--- a/crates/oj_cache/tests/faults.rs
+++ b/crates/oj_cache/tests/faults.rs
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+//! The cache is an optimization, so every failure mode has exactly one correct
+//! outcome: a miss. A crashed build, a half-written file, a read-only checkout
+//! or an entry from another oj version must all cost a recompile and nothing
+//! else — never a panic, and never a wrong module served from disk.
+
+mod common;
+
+use common::*;
+use oj_cache::{CachedModule, PersistentCache};
+
+fn corrupt_entry_is_a_miss(label: &str, contents: &[u8]) {
+    let f = fixture();
+    let key = f.cache.key(b"source", "/src/App.tsx", "dev");
+    f.cache.put(&key, &module("export const ok = 1;"));
+    let path = entry_path(f.dir.path(), &key);
+    std::fs::write(&path, contents).unwrap();
+
+    assert_eq!(f.cache.get(&key), None, "{label} must be a miss");
+    assert!(!path.exists(), "{label} must be evicted, not left to rot");
+    // And the cache is usable again afterwards.
+    f.cache.put(&key, &module("export const ok = 2;"));
+    assert_eq!(
+        f.cache.get(&key).map(|m| m.code),
+        Some("export const ok = 2;".to_string())
+    );
+}
+
+#[test]
+fn garbage_and_truncated_entries_are_misses() {
+    let full = serde_json::to_vec(&module("export const x = 1;")).unwrap();
+    corrupt_entry_is_a_miss("empty file", b"");
+    corrupt_entry_is_a_miss("not json", b"{ not json");
+    corrupt_entry_is_a_miss("truncated json", &full[..full.len() / 2]);
+    corrupt_entry_is_a_miss("json of the wrong type", b"[]");
+    corrupt_entry_is_a_miss("json null", b"null");
+    corrupt_entry_is_a_miss("missing required field", br#"{"imports":[],"is_boundary":false}"#);
+    corrupt_entry_is_a_miss("wrong field type", br#"{"code":42,"imports":[],"is_boundary":false}"#);
+    corrupt_entry_is_a_miss("nul bytes", b"\0\0\0\0");
+    corrupt_entry_is_a_miss("utf16 bom", b"\xff\xfe{\0}\0");
+}
+
+#[test]
+fn an_entry_from_an_older_schema_still_loads() {
+    // Fields added since a `.oj-cache` was written must default, not fail: the
+    // cache is shared across oj versions with the same CACHE_FORMAT.
+    let f = fixture();
+    let key = f.cache.key(b"source", "/src/App.tsx", "dev");
+    let path = entry_path(f.dir.path(), &key);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &path,
+        br#"{"code":"export const a = 1;","map_data_url":null,"imports":["./b.ts"],"is_boundary":true}"#,
+    )
+    .unwrap();
+
+    let hit = f.cache.get(&key).expect("older entries still load");
+    assert_eq!(hit.code, "export const a = 1;");
+    assert_eq!(hit.imports, vec!["./b.ts".to_string()]);
+    assert_eq!(hit.kind, "", "absent fields take their default");
+    assert!(hit.require_map.is_empty());
+    assert!(hit.css_exports.is_empty());
+    assert!(hit.fs_allow.is_empty());
+    assert!(hit.watch_files.is_empty());
+}
+
+#[test]
+fn unknown_fields_from_a_newer_oj_are_ignored() {
+    let f = fixture();
+    let key = f.cache.key(b"source", "/src/App.tsx", "dev");
+    let path = entry_path(f.dir.path(), &key);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &path,
+        br#"{"code":"x","imports":[],"is_boundary":false,"future_field":{"deep":[1,2]}}"#,
+    )
+    .unwrap();
+    assert_eq!(f.cache.get(&key).map(|m| m.code), Some("x".to_string()));
+}
+
+#[test]
+fn a_directory_where_an_entry_should_be_is_a_miss() {
+    let f = fixture();
+    let key = f.cache.key(b"source", "/src/App.tsx", "dev");
+    let path = entry_path(f.dir.path(), &key);
+    std::fs::create_dir_all(&path).unwrap();
+    assert_eq!(f.cache.get(&key), None);
+}
+
+#[test]
+fn a_leftover_temp_file_is_never_served_and_never_blocks_a_write() {
+    let f = fixture();
+    let key = f.cache.key(b"source", "/src/App.tsx", "dev");
+    let path = entry_path(f.dir.path(), &key);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    // A crash mid-`put` leaves a partial temp file behind, named after the
+    // writer that died.
+    std::fs::write(path.with_extension("tmp"), b"{ half written").unwrap();
+    std::fs::write(path.with_extension("tmp-999999-7"), b"{ half written").unwrap();
+
+    assert_eq!(f.cache.get(&key), None, "temp files are not entries");
+    f.cache.put(&key, &module("export const recovered = 1;"));
+    assert_eq!(
+        f.cache.get(&key).map(|m| m.code),
+        Some("export const recovered = 1;".to_string())
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn a_read_only_cache_directory_degrades_to_no_caching() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let cache_dir = dir.path().join("cache");
+    std::fs::create_dir_all(&cache_dir).unwrap();
+    std::fs::set_permissions(&cache_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+    let cache = PersistentCache::new(cache_dir.clone(), VERSION);
+    let key = cache.key(b"source", "/src/App.tsx", "dev");
+    // Must not panic, must not hang, must simply not cache.
+    cache.put(&key, &module("export const x = 1;"));
+    assert_eq!(cache.get(&key), None);
+
+    std::fs::set_permissions(&cache_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn a_read_only_shard_directory_degrades_to_no_caching() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let f = fixture();
+    let key = f.cache.key(b"source", "/src/App.tsx", "dev");
+    f.cache.put(&key, &module("first"));
+    let shard = entry_path(f.dir.path(), &key).parent().unwrap().to_path_buf();
+    std::fs::set_permissions(&shard, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+    f.cache.put(&key, &module("second"));
+    assert_eq!(
+        f.cache.get(&key).map(|m| m.code),
+        Some("first".to_string()),
+        "a failed write must leave the previous entry intact"
+    );
+
+    std::fs::set_permissions(&shard, std::fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+#[test]
+fn a_cache_dir_that_is_a_file_is_inert() {
+    let file = tempfile::NamedTempFile::new().unwrap();
+    let cache = PersistentCache::new(file.path().to_path_buf(), VERSION);
+    let key = cache.key(b"source", "/src/App.tsx", "dev");
+    cache.put(&key, &module("export const x = 1;"));
+    assert_eq!(cache.get(&key), None);
+}
+
+#[test]
+fn a_missing_cache_dir_is_created_on_demand() {
+    let dir = tempfile::tempdir().unwrap();
+    let nested = dir.path().join("a/b/c/.oj-cache");
+    let cache = PersistentCache::new(nested.clone(), VERSION);
+    let key = cache.key(b"source", "/src/App.tsx", "dev");
+    cache.put(&key, &module("export const x = 1;"));
+    assert!(cache.get(&key).is_some());
+    assert!(nested.is_dir());
+}
+
+#[test]
+fn a_different_tool_version_never_reads_the_other_ones_entries() {
+    let dir = tempfile::tempdir().unwrap();
+    let old = PersistentCache::new(dir.path().to_path_buf(), "0.0.1");
+    let new = PersistentCache::new(dir.path().to_path_buf(), "0.0.2");
+
+    let old_key = old.key(b"source", "/src/App.tsx", "dev");
+    old.put(&old_key, &module("compiled by 0.0.1"));
+
+    let new_key = new.key(b"source", "/src/App.tsx", "dev");
+    assert_ne!(old_key, new_key, "the version is part of the key");
+    assert_eq!(new.get(&new_key), None, "a version bump is a cold cache");
+    // ...and the old entry is still there for the old binary.
+    assert!(old.get(&old_key).is_some());
+}
+
+#[test]
+fn keys_that_are_not_valid_paths_do_not_escape_the_cache_dir() {
+    // `get`/`put` take a key as a string; a caller passing something that is
+    // not a cache key must not be able to write outside the cache dir.
+    let f = fixture();
+    for hostile in [
+        "../../../../../../tmp/oj-escape",
+        "..",
+        "/etc/oj-escape",
+        "",
+        "a",
+    ] {
+        f.cache.put(hostile, &module("nope"));
+        let _ = f.cache.get(hostile);
+    }
+    assert!(
+        walk(f.dir.path()).is_empty(),
+        "a malformed key must not become an entry: {:?}",
+        walk(f.dir.path())
+    );
+    for escape in ["/tmp/oj-escape", "/tmp/oj-escape.json"] {
+        assert!(
+            !std::path::Path::new(escape).exists(),
+            "wrote outside the cache directory: {escape}"
+        );
+    }
+}
+
+#[test]
+fn an_entry_is_only_ever_published_whole() {
+    // A hit must carry every field exactly as written: no lossy round trip.
+    let f = fixture();
+    let key = f.cache.key(b"source", "/src/App.tsx", "dev");
+    let written = CachedModule {
+        code: "const s = \"\u{2028}\u{2029}\\n\t\0é🚀\";".into(),
+        map_data_url: None,
+        imports: vec![String::new(), "…/ünïcødé.tsx".into()],
+        is_boundary: false,
+        kind: "cjs".into(),
+        require_map: vec![("".into(), "".into())],
+        css_exports: vec![("a\nb".into(), "c\"d".into())],
+        fs_allow: vec!["/tmp/a b/c".into()],
+        watch_files: vec!["\\\\?\\C:\\x".into()],
+    };
+    f.cache.put(&key, &written);
+    assert_eq!(f.cache.get(&key), Some(written));
+}

--- a/crates/oj_cache/tests/properties.rs
+++ b/crates/oj_cache/tests/properties.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+//! Properties of the cache key and of the entry round trip. The key is the
+//! whole correctness story: if two different compilations can share a key, the
+//! cache serves the wrong code, and no test downstream of it will notice.
+
+mod common;
+
+use common::*;
+use oj_cache::{CachedModule, PersistentCache};
+use proptest::prelude::*;
+
+fn cached_module() -> impl Strategy<Value = CachedModule> {
+    (
+        ".{0,64}",
+        proptest::option::of(".{0,32}"),
+        proptest::collection::vec(".{0,24}", 0..4),
+        any::<bool>(),
+        "(esm|cjs|css|)",
+        proptest::collection::vec((".{0,8}", ".{0,8}"), 0..3),
+    )
+        .prop_map(
+            |(code, map_data_url, imports, is_boundary, kind, pairs)| CachedModule {
+                code,
+                map_data_url,
+                imports,
+                is_boundary,
+                kind: kind.to_string(),
+                require_map: pairs.clone(),
+                css_exports: pairs.clone(),
+                fs_allow: pairs.iter().map(|(a, _)| a.clone()).collect(),
+                watch_files: pairs.iter().map(|(_, b)| b.clone()).collect(),
+            },
+        )
+}
+
+proptest! {
+    /// A key is always a blake3 digest in lowercase hex: the on-disk layout
+    /// (`<first two chars>/<key>.json`) depends on it.
+    #[test]
+    fn keys_are_always_hex_digests(source in proptest::collection::vec(any::<u8>(), 0..64), url in ".{0,40}", mode in ".{0,8}") {
+        let cache = PersistentCache::new(std::env::temp_dir(), "v");
+        let key = cache.key(&source, &url, &mode);
+        prop_assert_eq!(key.len(), 64);
+        prop_assert!(key.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b)), "{}", key);
+    }
+
+    /// Same inputs, same key: a warm cache has to hit.
+    #[test]
+    fn keys_are_deterministic(source in proptest::collection::vec(any::<u8>(), 0..64), url in ".{0,40}", mode in ".{0,8}") {
+        let a = PersistentCache::new(std::env::temp_dir(), "v");
+        let b = PersistentCache::new(std::path::PathBuf::from("/elsewhere"), "v");
+        prop_assert_eq!(a.key(&source, &url, &mode), a.key(&source, &url, &mode));
+        prop_assert_eq!(a.key(&source, &url, &mode), b.key(&source, &url, &mode), "the directory is not part of the key");
+    }
+
+    /// The field separators do their job: no way to shift bytes between the
+    /// mode, the url and the source and land on the same key.
+    #[test]
+    fn no_two_distinct_inputs_share_a_key(
+        source_a in proptest::collection::vec(any::<u8>(), 0..24),
+        url_a in ".{0,16}",
+        mode_a in ".{0,6}",
+        source_b in proptest::collection::vec(any::<u8>(), 0..24),
+        url_b in ".{0,16}",
+        mode_b in ".{0,6}",
+    ) {
+        prop_assume!((&source_a, &url_a, &mode_a) != (&source_b, &url_b, &mode_b));
+        let cache = PersistentCache::new(std::env::temp_dir(), "v");
+        prop_assert_ne!(
+            cache.key(&source_a, &url_a, &mode_a),
+            cache.key(&source_b, &url_b, &mode_b),
+            "({:?}, {:?}, {:?}) collided with ({:?}, {:?}, {:?})",
+            source_a, url_a, mode_a, source_b, url_b, mode_b
+        );
+    }
+
+    /// A tool-version change is always a cache miss, never a silent hit.
+    #[test]
+    fn the_tool_version_is_part_of_every_key(a in ".{0,12}", b in ".{0,12}") {
+        prop_assume!(a != b);
+        let one = PersistentCache::new(std::env::temp_dir(), &a);
+        let two = PersistentCache::new(std::env::temp_dir(), &b);
+        prop_assert_ne!(one.key(b"source", "/u", "dev"), two.key(b"source", "/u", "dev"));
+    }
+
+    /// Whatever a compile produced, the cache gives it back unchanged.
+    #[test]
+    fn entries_round_trip_exactly(entry in cached_module()) {
+        let f = fixture();
+        let key = f.cache.key(entry.code.as_bytes(), "/src/App.tsx", "dev");
+        prop_assert_eq!(f.cache.get(&key), None);
+        f.cache.put(&key, &entry);
+        prop_assert_eq!(f.cache.get(&key), Some(entry.clone()));
+        // Overwriting with a new value replaces it wholesale.
+        let mut replaced = entry.clone();
+        replaced.code.push_str("/* v2 */");
+        f.cache.put(&key, &replaced);
+        prop_assert_eq!(f.cache.get(&key), Some(replaced));
+    }
+
+    /// Anything that is not a digest is refused rather than resolved against
+    /// the filesystem.
+    #[test]
+    fn non_digest_keys_are_never_written(key in ".{0,80}") {
+        prop_assume!(
+            key.len() != 64
+                || !key.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+        );
+        let f = fixture();
+        f.cache.put(&key, &module("side effect"));
+        prop_assert!(walk(f.dir.path()).is_empty(), "wrote for key {:?}", key);
+        prop_assert_eq!(f.cache.get(&key), None);
+    }
+
+    /// Every entry lands in the shard named by its own first two characters.
+    #[test]
+    fn entries_are_sharded_by_key_prefix(source in ".{0,32}", url in ".{0,32}") {
+        let f = fixture();
+        let key = f.cache.key(source.as_bytes(), &url, "dev");
+        f.cache.put(&key, &module("export const x = 1;"));
+        prop_assert_eq!(walk(f.dir.path()), vec![format!("{}/{key}.json", &key[..2])]);
+    }
+}


### PR DESCRIPTION
Two things about how entries reach and leave the disk.

**A key that was not a digest steered the path.** `path_for` built a path out of
whatever string it was handed, so `cache.put("../../../../tmp/x", …)` wrote
outside the cache directory — my test wrote `/tmp/oj-escape.json` before the fix.
Every key in the tree comes from `key()` and is therefore a 64-character blake3
digest, so anything else is a caller bug and is now refused rather than resolved.
Latent today, but a cache is exactly the component someone later hands a
URL-derived key.

**Publication was not atomic under contention.** The temp file a `put` writes
through was named after the entry, so two builds sharing one `.oj-cache` — CI, an
agent fleet, the workloads oj exists for — could have one writer's rename publish
the file while another was still writing into it. A reader then sees a short entry
and evicts a good one. Each writer now gets its own temp name, so the rename is
the only way an entry becomes visible, and a failed write cleans up after itself.

### Tests

`crates/oj_cache/tests/`, 24 tests in three suites plus a shared harness:

- **faults** — garbage, truncated, wrong-type and wrong-schema entries; an entry
  written by an older schema (fields must default, not fail); unknown fields from
  a newer oj; a read-only cache dir and a read-only shard; a cache dir that is a
  file; keys that are not digests; version isolation. Every one has the same
  correct outcome: a miss, and a cache that still works afterwards.
- **concurrency** — 8 writers on one key publish a complete entry; readers racing
  writers see the exact entry or nothing, never a torn one; 400 distinct keys all
  land with one file each; corruption by a crashed peer races safely with
  rewriting.
- **properties** — keys are hex digests, deterministic, independent of the cache
  directory, and injective over (source, url, mode, version); entries round trip
  exactly, including `\u{2028}`, NUL and emoji; non-digest keys never write.
---

One of eleven independent PRs from the same pass over the test suite. Each stands
alone (its own tests pass on `main` without the others) and all eleven merge
together cleanly — I verified both. Each also carries the same two-line
`tmp()` fix in `crates/oj/src/start_dev.rs`, because without it
`app_uses_tailwind_detects_postcss_vite_and_bare` flakes on any PR CI run; the
hunks are identical, so they merge as one.


