### PR TITLE
fix(css): classify modules by filename, and pin the target matrix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +866,12 @@ checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -1861,6 +1882,8 @@ version = "0.0.45"
 dependencies = [
  "grass",
  "lightningcss",
+ "proptest",
+ "tempfile",
 ]
 
 [[package]]
@@ -2746,6 +2769,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2764,6 +2806,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -2942,6 +2990,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3705,6 +3762,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4087,6 +4156,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4382,6 +4464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-id-start"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4502,6 +4590,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,10 @@ axum = { version = "0.8.9", features = ["ws"] }
 notify = "8.2.0"
 clap = { version = "4.6.6", features = ["derive"] }
 
+# test-only
+proptest = "1.9.0"
+tempfile = "3.24.0"
+
 [profile.release]
 lto = "thin"
 codegen-units = 1

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -689,7 +689,15 @@ mod tests {
     use super::*;
 
     fn tmp(label: &str) -> PathBuf {
-        let d = std::env::temp_dir().join(format!("oj-startdev-{}-{label}", std::process::id()));
+        // A fresh directory per call: this wipes the path before creating it, so
+        // two tests that pass the same label would race -- one clearing the
+        // other's fixture out from under it, in whichever order they interleave.
+        static SEQ: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let d = std::env::temp_dir().join(format!(
+            "oj-startdev-{}-{label}-{seq}",
+            std::process::id()
+        ));
         let _ = std::fs::remove_dir_all(&d);
         std::fs::create_dir_all(&d).unwrap();
         d

--- a/crates/oj_css/Cargo.toml
+++ b/crates/oj_css/Cargo.toml
@@ -8,3 +8,7 @@ description = "CSS pipeline: Lightning CSS transforms, CSS Modules scoping"
 [dependencies]
 lightningcss = "1.0.0-alpha.72"
 grass = "0.13.4"
+
+[dev-dependencies]
+proptest.workspace = true
+tempfile.workspace = true

--- a/crates/oj_css/src/lib.rs
+++ b/crates/oj_css/src/lib.rs
@@ -15,7 +15,10 @@ pub struct CssOutput {
 }
 
 pub fn is_css_module(url: &str) -> bool {
-    url.rsplit('/')
+    // The query is not part of the filename: `styles.css?x=.module.` is a plain
+    // stylesheet, and `a.module.css?used` is still a module.
+    let path = url.split('?').next().unwrap_or(url);
+    path.rsplit('/')
         .next()
         .is_some_and(|f| f.contains(".module."))
 }
@@ -157,6 +160,65 @@ mod tests {
             "autoprefixed: {}",
             out.css
         );
+    }
+
+    #[test]
+    fn the_browser_matrix_keeps_modern_syntax_and_downlevels_the_rest() {
+        // The target matrix is the compatibility contract of every stylesheet oj
+        // emits. Asserted through behaviour: syntax the configured versions
+        // support has to survive, and syntax they do not has to be lowered. A
+        // matrix that decoded to version 0 would downlevel everything.
+        let out = compile_css(
+            "/p.css",
+            ".a { width: clamp(1px, 2vw, 3px); color: rgb(0 0 0 / 50%); aspect-ratio: 1/2 }",
+            true,
+        )
+        .unwrap()
+        .css;
+        assert!(out.contains("clamp("), "clamp is supported: {out}");
+        assert!(out.contains("#00000080"), "modern color syntax: {out}");
+        assert!(out.contains("aspect-ratio"), "aspect-ratio is supported: {out}");
+        assert!(!out.contains("max(1px"), "clamp must not be lowered: {out}");
+
+        // Nesting and logical properties are not supported by the oldest target,
+        // so they are lowered.
+        let nested = compile_css("/p.css", ".a { .b { color: red } }", true).unwrap().css;
+        assert_eq!(nested, ".a .b{color:red}");
+        let logical = compile_css("/p.css", ".a { inset-inline-start: 1px }", true)
+            .unwrap()
+            .css;
+        assert!(logical.contains("left:1px"), "logical props lowered: {logical}");
+    }
+
+    #[test]
+    fn scoped_class_names_follow_the_name_local_hash_pattern() {
+        // The scoped name shows up in devtools, in snapshots and in the exports
+        // map, so its shape is part of the contract.
+        let out = compile_css("/src/Counter.module.css", ".button { color: red }", false).unwrap();
+        let (local, scoped) = out.exports.expect("exports").into_iter().next().unwrap();
+        assert_eq!(local, "button");
+        // `[name]` is the file stem with its dots flattened.
+        let prefix = "Counter-module_button_";
+        assert!(
+            scoped.starts_with(prefix),
+            "expected [name]_[local]_[hash], got {scoped}"
+        );
+        let hash = &scoped[prefix.len()..];
+        assert!(!hash.is_empty(), "no hash in {scoped}");
+        assert!(
+            hash.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-'),
+            "hash is not a plain token: {scoped}"
+        );
+        // The hash is derived from the path, not the contents: editing a
+        // stylesheet must not rename its classes, or every edit would invalidate
+        // the markup that already references them.
+        let after_edit = compile_css("/src/Counter.module.css", ".button { color: blue }", false)
+            .unwrap()
+            .exports
+            .expect("exports")
+            .remove(0)
+            .1;
+        assert_eq!(scoped, after_edit, "an edit must not rename a class");
     }
 
     #[test]

--- a/crates/oj_css/tests/adverse.rs
+++ b/crates/oj_css/tests/adverse.rs
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+//! Adversarial stylesheets. CSS and Sass come from the same untrusted place as
+//! the JavaScript, and both go through parsers with their own recursion and
+//! their own idea of what a file is allowed to reach.
+
+use std::path::Path;
+
+use oj_css::{compile_css, compile_sass, is_css_module, is_sass};
+
+/// The stack the CLI gives every thread that compiles a file. Mirrored rather
+/// than imported: the CSS pipeline has no reason to depend on the JavaScript
+/// one. The value itself lives in `oj_compiler::COMPILE_STACK_SIZE`.
+const COMPILE_THREAD_STACK: usize = 16 * 1024 * 1024;
+
+#[test]
+fn malformed_css_is_an_error_not_a_panic() {
+    for source in [
+        "!!not-css!!",
+        "@",
+        "@media",
+        "@media {",
+        ".a { color: }",
+        "}",
+        ":::",
+        "@import;",
+        "\0\0\0",
+        "@charset \"nope\"",
+    ] {
+        // Accepted or rejected -- never a panic, and never silent garbage.
+        if let Ok(out) = compile_css("/x.css", source, true) {
+            assert!(
+                !out.css.contains("!!not-css!!"),
+                "{source:?} passed through verbatim: {}",
+                out.css
+            );
+        }
+    }
+}
+
+#[test]
+fn truncated_and_unterminated_constructs_are_handled() {
+    for source in [
+        ".a { color: red",
+        "/* unterminated",
+        ".a { background: url(\"unterminated",
+        "@media (min-width: 100px) { .a { color: red }",
+        ".a[attr=\"unterminated",
+    ] {
+        let _ = compile_css("/x.css", source, true);
+        let _ = compile_css("/x.module.css", source, false);
+    }
+}
+
+#[test]
+fn empty_stylesheets_are_valid_and_empty() {
+    for source in ["", " ", "\n", "/* only a comment */"] {
+        let out = compile_css("/x.css", source, true).unwrap();
+        assert_eq!(out.css.trim(), "", "{source:?} -> {:?}", out.css);
+        assert!(out.exports.is_none());
+    }
+    // A module with no classes exports an empty map, not `None`.
+    let out = compile_css("/x.module.css", "", false).unwrap();
+    assert_eq!(out.exports.as_deref(), Some(&[][..]));
+}
+
+#[test]
+fn very_large_stylesheets_stay_linear() {
+    let many_rules: String = (0..20_000).map(|i| format!(".c{i} {{ color: #fff }}\n")).collect();
+    let out = compile_css("/big.css", &many_rules, true).unwrap();
+    assert!(out.css.contains(".c19999"));
+
+    let one_huge_selector = format!(
+        "{} {{ color: red }}",
+        (0..20_000).map(|i| format!(".c{i}")).collect::<Vec<_>>().join(",")
+    );
+    assert!(compile_css("/wide.css", &one_huge_selector, true).is_ok());
+
+    let long_value = format!(".a {{ content: \"{}\" }}", "x".repeat(1_000_000));
+    assert!(compile_css("/long.css", &long_value, true).is_ok());
+}
+
+#[test]
+fn deeply_nested_rules_within_the_supported_envelope_compile() {
+    // Both parsers recurse per nesting level. Real stylesheets stay in single
+    // digits; this pins a wide margin above that, on the stack a compile thread
+    // gets. Past a couple of thousand levels the recursion outruns any stack --
+    // see `docs/development/testing.md`.
+    let handle = std::thread::Builder::new()
+        .stack_size(COMPILE_THREAD_STACK)
+        .spawn(|| {
+            for depth in [8usize, 64, 500] {
+                let nested = format!("{}color:red;{}", ".a{".repeat(depth), "}".repeat(depth));
+                let css = compile_sass(&nested, None).unwrap();
+                assert!(compile_css("/deep.css", &css, true).is_ok(), "depth {depth}");
+                let flat = format!("{}color:red;{}", ".a{".repeat(depth), "}".repeat(depth));
+                let _ = compile_css("/deep.css", &flat, true);
+            }
+        })
+        .unwrap();
+    handle.join().expect("no overflow within the envelope");
+}
+
+#[test]
+fn hostile_urls_do_not_change_the_module_classification() {
+    // Classification is by filename, so a query, a fragment or a directory
+    // named `.module.` must not flip it.
+    assert!(is_css_module("/a/b.module.css"));
+    assert!(is_css_module("/a/b.module.css?used"));
+    assert!(is_css_module("/a/b.module.css#frag"));
+    assert!(!is_css_module("/a.module.css/b.css"));
+    assert!(!is_css_module("/a/b.css?x=.module."));
+    assert!(!is_css_module(""));
+    assert!(!is_css_module("/"));
+    assert!(!is_css_module("module.css"));
+
+    assert!(is_sass("/a/b.scss"));
+    assert!(is_sass("/a/b.scss?inline"));
+    assert!(!is_sass("/a/b.scss/c.css"));
+    assert!(!is_sass("/a/b.css?x=.scss"));
+    assert!(!is_sass(""));
+}
+
+#[test]
+fn css_module_class_names_are_scoped_even_when_they_collide() {
+    // Two files with the same class name must not produce the same scoped name,
+    // or one stylesheet silently restyles the other.
+    let source = ".button { color: red }";
+    let a = compile_css("/src/A.module.css", source, false).unwrap();
+    let b = compile_css("/src/B.module.css", source, false).unwrap();
+    let (a_name, b_name) = (&a.exports.unwrap()[0].1, &b.exports.unwrap()[0].1);
+    assert_ne!(a_name, b_name, "same scoped name in two modules");
+
+    // The same file twice is stable, or a warm cache would serve stale names.
+    let again = compile_css("/src/A.module.css", source, false).unwrap();
+    assert_eq!(&again.exports.unwrap()[0].1, a_name);
+}
+
+#[test]
+fn css_module_exports_are_sorted_and_complete() {
+    let out = compile_css(
+        "/src/A.module.css",
+        ".z { color: red } .a { color: red } .m { color: red } \
+         .a:hover { color: blue } #id { color: red } .with-dash { color: red }",
+        false,
+    )
+    .unwrap();
+    let exports = out.exports.expect("module exports");
+    let names: Vec<&str> = exports.iter().map(|(k, _)| k.as_str()).collect();
+    // Ids are scoped and exported too, as the CSS Modules spec requires.
+    assert_eq!(names, ["a", "id", "m", "with-dash", "z"], "sorted, deduped");
+    for (name, scoped) in &exports {
+        assert_ne!(name, scoped, "{name} not scoped");
+    }
+}
+
+#[test]
+fn a_css_module_with_hostile_class_names_still_exports_them() {
+    let out = compile_css(
+        "/src/A.module.css",
+        ".\\31 numeric { color: red } .a\\.b { color: red } \
+         .with\\ space { color: red } .émoji { color: red }",
+        false,
+    );
+    if let Ok(out) = out {
+        let exports = out.exports.expect("module exports");
+        for (name, scoped) in &exports {
+            assert!(!name.is_empty());
+            assert!(!scoped.is_empty());
+        }
+    }
+}
+
+#[test]
+fn sass_errors_are_reported_with_a_message() {
+    for source in [
+        ".a { @include missing-mixin; }",
+        "@use \"nonexistent\";",
+        "@import \"nonexistent\";",
+        ".a { width: 1px + ; }",
+        "$x: ;",
+        "@if { }",
+    ] {
+        let err = compile_sass(source, None).unwrap_err();
+        assert!(err.starts_with("sass error:"), "{source:?} -> {err}");
+    }
+}
+
+#[test]
+fn a_sass_import_cannot_be_resolved_without_a_load_path() {
+    // With no load path, nothing outside the source string is reachable.
+    for source in [
+        "@import \"../../../../../../etc/passwd\";",
+        "@use \"/etc/passwd\";",
+        "@import \"/etc/hosts\";",
+    ] {
+        assert!(
+            compile_sass(source, None).is_err(),
+            "{source:?} resolved without a load path"
+        );
+    }
+}
+
+#[test]
+fn a_sass_load_path_confines_imports_to_files_that_parse_as_sass() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("_vars.scss"), "$pad: 1rem;\n").unwrap();
+    let outside = dir.path().join("outside.txt");
+    std::fs::write(&outside, "definitely not sass {{{\n").unwrap();
+
+    let ok = compile_sass("@use \"vars\";\n.a { padding: vars.$pad }", Some(dir.path())).unwrap();
+    assert!(ok.contains("1rem"), "{ok}");
+
+    // A traversal that lands on a real file still has to parse as Sass, and the
+    // failure names the file rather than leaking its contents.
+    let escaped = format!("@import \"{}\";", outside.display());
+    let err = compile_sass(&escaped, Some(dir.path())).unwrap_err();
+    assert!(
+        !err.contains("definitely not sass"),
+        "file contents leaked into the error: {err}"
+    );
+}
+
+#[test]
+fn sass_and_lightningcss_agree_on_a_pipeline_result() {
+    let scss = "$c: red;\n.a { color: $c; .b { color: darken($c, 10%) } }";
+    let css = compile_sass(scss, None).unwrap();
+    let out = compile_css("/x.scss", &css, true).unwrap();
+    assert!(out.css.contains(".a .b"), "{}", out.css);
+    assert!(out.exports.is_none(), "a .scss url is not a module");
+
+    // The same source through the module path gets scoped exports.
+    let module = compile_css("/x.module.scss", &css, true).unwrap();
+    assert!(module.exports.is_some());
+}
+
+#[test]
+fn minification_is_only_a_formatting_choice() {
+    let source = ".a { color: #ff0000; padding: 0px }";
+    let pretty = compile_css("/x.css", source, false).unwrap().css;
+    let minified = compile_css("/x.css", source, true).unwrap().css;
+    assert!(pretty.len() >= minified.len());
+    // Re-parsing either form yields the same minified output.
+    let round_trip = compile_css("/x.css", &pretty, true).unwrap().css;
+    assert_eq!(round_trip, minified);
+}
+
+#[test]
+fn unicode_and_escapes_survive_the_pipeline() {
+    let source = ".café::after { content: \"日本語 🚀\\A\" }";
+    let out = compile_css("/x.css", source, true).unwrap();
+    assert!(out.css.contains("café"), "{}", out.css);
+    assert!(out.css.contains("日本語"), "{}", out.css);
+}
+
+#[test]
+fn a_url_that_is_not_a_path_is_still_usable_as_a_filename() {
+    for url in ["", "/", "?query-only", "\u{0}", "a".repeat(4096).as_str()] {
+        let out = compile_css(url, ".a { color: red }", true).unwrap();
+        assert_eq!(out.css, ".a{color:red}");
+    }
+    // The url appears in the error message for a parse failure.
+    let err = compile_css("/src/Weird Name.css", "!!!", false).unwrap_err();
+    assert!(err.contains("Weird Name.css"), "{err}");
+}
+
+#[test]
+fn compile_css_never_reads_the_filesystem() {
+    // The url is a label, not a path: a stylesheet for a file that does not
+    // exist compiles, and one whose url points at a real file is not read.
+    let dir = tempfile::tempdir().unwrap();
+    let real = dir.path().join("real.css");
+    std::fs::write(&real, ".from-disk { color: red }").unwrap();
+    let out = compile_css(&real.to_string_lossy(), ".a { color: blue }", true).unwrap();
+    assert!(!out.css.contains("from-disk"), "{}", out.css);
+    assert!(Path::new(&real).exists());
+}
+
+/// Unbounded Sass recursion aborts the process: `grass` has no call-depth limit
+/// and Rust cannot catch a stack overflow, so containing this needs process
+/// isolation rather than a bigger stack. Kept runnable (`--ignored`) so the
+/// behaviour can be re-checked after a `grass` upgrade, and out of CI because
+/// it takes the test binary down with it.
+#[test]
+#[ignore = "aborts the process: unbounded recursion in grass"]
+fn recursive_sass_definitions_abort_the_process() {
+    let _ = compile_sass("@mixin a { @include a; } .x { @include a; }", None);
+    let _ = compile_sass("@function f($n) { @return f($n); } .x { width: f(1) }", None);
+}


### PR DESCRIPTION
`is_css_module` matched `.module.` anywhere in the last path segment, query
included, so `styles.css?x=.module.` was compiled as a CSS module — scoped class
names and an exports map for a plain stylesheet. It now strips the query first,
the way `is_sass` next to it already did.

The other half of this PR is two behaviours that had no test at all, which
mutation testing surfaced (every mutant of them survived):

- **the browser target matrix** — it decides what is downlevelled for whom, and a
  matrix that decoded to version 0 would downlevel everything. Asserted through
  behaviour: `clamp()`, modern color syntax and `aspect-ratio` survive because
  the configured versions support them, while nesting and logical properties are
  lowered because the oldest target does not.
- **the CSS Modules naming pattern** — the scoped name shows up in devtools, in
  snapshots and in the exports map. Also pinned: the hash comes from the path,
  not the contents, so editing a stylesheet does not rename its classes.

### Tests

`crates/oj_css/tests/adverse.rs` (17 tests) plus the two unit tests above:
malformed and truncated stylesheets, 20k-rule and 1MB-value files, nesting within
the supported envelope, module scoping collisions across files, Sass error
reporting, import confinement with and without a load path, and minification as
a formatting choice only (re-parsing either form gives the same output).

One case is `#[ignore]`d rather than pretended away: unbounded Sass recursion
(`@mixin a { @include a; }`) aborts the process. `grass` has no call-depth limit
and Rust cannot catch a stack overflow, so containing it needs process isolation,
not a bigger stack. The test stays runnable under `--ignored` so the behaviour can
be re-checked after a `grass` upgrade.
---

One of eleven independent PRs from the same pass over the test suite. Each stands
alone (its own tests pass on `main` without the others) and all eleven merge
together cleanly — I verified both. Each also carries the same two-line
`tmp()` fix in `crates/oj/src/start_dev.rs`, because without it
`app_uses_tailwind_detects_postcss_vite_and_bare` flakes on any PR CI run; the
hunks are identical, so they merge as one.


