### PR TITLE
fix(config): bound evaluation and check the shape of what it returns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +866,12 @@ checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -1849,9 +1870,11 @@ dependencies = [
  "oxc_semantic",
  "oxc_span",
  "oxc_transformer",
+ "proptest",
  "rquickjs",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
 ]
 
@@ -2746,6 +2769,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2764,6 +2806,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -2942,6 +2990,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3705,6 +3762,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4087,6 +4156,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4382,6 +4464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-id-start"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4502,6 +4590,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,10 @@ axum = { version = "0.8.9", features = ["ws"] }
 notify = "8.2.0"
 clap = { version = "4.6.6", features = ["derive"] }
 
+# test-only
+proptest = "1.9.0"
+tempfile = "3.24.0"
+
 [profile.release]
 lto = "thin"
 codegen-units = 1

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -689,7 +689,15 @@ mod tests {
     use super::*;
 
     fn tmp(label: &str) -> PathBuf {
-        let d = std::env::temp_dir().join(format!("oj-startdev-{}-{label}", std::process::id()));
+        // A fresh directory per call: this wipes the path before creating it, so
+        // two tests that pass the same label would race -- one clearing the
+        // other's fixture out from under it, in whichever order they interleave.
+        static SEQ: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let d = std::env::temp_dir().join(format!(
+            "oj-startdev-{}-{label}-{seq}",
+            std::process::id()
+        ));
         let _ = std::fs::remove_dir_all(&d);
         std::fs::create_dir_all(&d).unwrap();
         d

--- a/crates/oj_config/Cargo.toml
+++ b/crates/oj_config/Cargo.toml
@@ -18,3 +18,7 @@ rquickjs = { version = "0.12.2", features = ["loader"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true
+tempfile.workspace = true

--- a/crates/oj_config/src/lib.rs
+++ b/crates/oj_config/src/lib.rs
@@ -16,6 +16,11 @@ pub enum ConfigError {
     Schema(PathBuf, String),
 }
 
+/// Wall-clock budget for evaluating a config file.
+const EVAL_TIME_LIMIT: std::time::Duration = std::time::Duration::from_secs(5);
+/// Heap budget for evaluating a config file.
+const EVAL_MEMORY_LIMIT: usize = 64 * 1024 * 1024;
+
 const CANDIDATES: &[&str] = &[
     "oj.config.ts",
     "oj.config.mjs",
@@ -161,7 +166,36 @@ pub fn load_with(root: &Path, command: &str, mode: &str) -> Result<OjConfig, Con
     } else {
         evaluate(&path, &source, command, mode)?
     };
-    serde_json::from_str(&json).map_err(|e| ConfigError::Schema(path, e.to_string()))
+
+    // Check the shape before deserializing: every field of `OjConfig` is
+    // optional, and serde will happily read a JSON array as a struct of
+    // defaults, so `export default []` would look like a valid empty config.
+    let value: serde_json::Value =
+        serde_json::from_str(&json).map_err(|e| ConfigError::Schema(path.clone(), e.to_string()))?;
+    match &value {
+        serde_json::Value::Object(_) => {
+            serde_json::from_value(value).map_err(|e| ConfigError::Schema(path, e.to_string()))
+        }
+        serde_json::Value::Null => Err(ConfigError::Eval(
+            path,
+            "no config was exported; a config file must `export default` an object".into(),
+        )),
+        other => Err(ConfigError::Schema(
+            path,
+            format!("expected an object, found {}", json_type_name(other)),
+        )),
+    }
+}
+
+fn json_type_name(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "a boolean",
+        serde_json::Value::Number(_) => "a number",
+        serde_json::Value::String(_) => "a string",
+        serde_json::Value::Array(_) => "an array",
+        serde_json::Value::Object(_) => "an object",
+    }
 }
 
 fn evaluate(path: &Path, source: &str, command: &str, mode: &str) -> Result<String, ConfigError> {
@@ -170,6 +204,13 @@ fn evaluate(path: &Path, source: &str, command: &str, mode: &str) -> Result<Stri
 
     let rt = rquickjs::Runtime::new()
         .map_err(|e| ConfigError::Eval(path.to_path_buf(), e.to_string()))?;
+    // A config is a literal with a little logic around it. These bounds are
+    // what turns a runaway one -- `while (true) {}`, an allocation loop -- into
+    // a failed command with a message instead of a dev server that never
+    // starts, or an out-of-memory kill.
+    rt.set_memory_limit(EVAL_MEMORY_LIMIT);
+    let deadline = std::time::Instant::now() + EVAL_TIME_LIMIT;
+    rt.set_interrupt_handler(Some(Box::new(move || std::time::Instant::now() >= deadline)));
     let ctx = rquickjs::Context::full(&rt)
         .map_err(|e| ConfigError::Eval(path.to_path_buf(), e.to_string()))?;
 
@@ -206,6 +247,13 @@ fn evaluate(path: &Path, source: &str, command: &str, mode: &str) -> Result<Stri
                 .as_exception()
                 .map(|ex| ex.to_string())
                 .unwrap_or_else(|| format!("{e}"));
+            if std::time::Instant::now() >= deadline {
+                detail = format!(
+                    "evaluation exceeded the {}s limit; a config file must not \
+                     block (no infinite loops, no blocking work)",
+                    EVAL_TIME_LIMIT.as_secs()
+                );
+            }
             if detail.contains("is not defined") {
                 detail.push_str(
                     "\nnote: oj.config is evaluated in a sandbox without module imports; \

--- a/crates/oj_config/tests/adverse.rs
+++ b/crates/oj_config/tests/adverse.rs
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+//! `oj.config.{ts,js,mjs,json}` is a file oj executes. The contract for every
+//! shape of it -- malformed, hostile, runaway, or merely surprising -- is a
+//! `ConfigError` naming the file, never a hang, a crash, or a default config
+//! silently standing in for one that failed to load.
+
+use std::path::Path;
+
+use oj_config::{load, load_with, ConfigError};
+
+struct Project(tempfile::TempDir);
+
+impl Project {
+    fn with(name: &str, source: &str) -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(name), source).unwrap();
+        Self(dir)
+    }
+
+    fn ts(source: &str) -> Self {
+        Self::with("oj.config.ts", source)
+    }
+
+    fn path(&self) -> &Path {
+        self.0.path()
+    }
+
+    fn load(&self) -> Result<oj_config::OjConfig, ConfigError> {
+        load(self.path())
+    }
+}
+
+fn assert_error_names_the_file(err: &ConfigError, name: &str) {
+    let text = err.to_string();
+    assert!(text.contains(name), "error does not name {name}: {text}");
+}
+
+#[test]
+fn a_project_with_no_config_gets_the_defaults() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = load(dir.path()).unwrap();
+    assert!(config.server.is_none());
+    assert!(config.build.is_none());
+}
+
+#[test]
+fn a_config_that_never_finishes_is_stopped() {
+    let project = Project::ts("while (true) {}\nexport default {};");
+    let err = project.load().unwrap_err();
+    assert!(matches!(err, ConfigError::Eval(..)), "{err}");
+    assert!(
+        err.to_string().contains("limit"),
+        "the message must explain the limit: {err}"
+    );
+    assert_error_names_the_file(&err, "oj.config.ts");
+}
+
+#[test]
+fn a_config_that_allocates_without_bound_is_stopped() {
+    let project = Project::ts(
+        "const a = [];\nwhile (true) { a.push(new Array(1e6).fill(0)); }\nexport default {};",
+    );
+    assert!(matches!(project.load().unwrap_err(), ConfigError::Eval(..)));
+}
+
+#[test]
+fn a_config_that_recurses_without_bound_is_stopped() {
+    let project = Project::ts("function f() { return f(); }\nexport default f();");
+    assert!(matches!(project.load().unwrap_err(), ConfigError::Eval(..)));
+}
+
+#[test]
+fn a_config_that_throws_reports_the_exception() {
+    let project = Project::ts("throw new Error('deliberate failure');");
+    let err = project.load().unwrap_err();
+    assert!(
+        err.to_string().contains("deliberate failure"),
+        "the thrown message must reach the user: {err}"
+    );
+}
+
+#[test]
+fn a_config_with_a_throwing_getter_is_an_error_not_a_partial_config() {
+    let project = Project::ts(
+        "export default { base: '/ok/', get server() { throw new Error('boom'); } };",
+    );
+    let err = project.load().unwrap_err();
+    assert!(matches!(err, ConfigError::Eval(..)), "{err}");
+}
+
+#[test]
+fn a_cyclic_config_object_is_an_error() {
+    let project = Project::ts("const a = { base: '/x/' };\na.self = a;\nexport default a;");
+    assert!(matches!(project.load().unwrap_err(), ConfigError::Eval(..)));
+}
+
+#[test]
+fn a_config_that_exports_nothing_says_so() {
+    // A file that exists but exports nothing is a mistake, and the message has
+    // to say which mistake -- not "invalid type: null, expected struct".
+    for source in [
+        "const unused = 1;",
+        "export default null;",
+        "export default undefined;",
+        "",
+    ] {
+        let project = Project::ts(source);
+        let err = project.load().unwrap_err();
+        assert!(
+            err.to_string().contains("export default"),
+            "{source:?}: {err}"
+        );
+        assert_error_names_the_file(&err, "oj.config.ts");
+    }
+}
+
+#[test]
+fn a_config_that_is_not_an_object_is_a_schema_error() {
+    for source in [
+        "export default 42;",
+        "export default 'string';",
+        "export default true;",
+        // An array must not be read as a struct of defaults.
+        "export default [];",
+        "export default [{ base: '/x/' }];",
+    ] {
+        let project = Project::ts(source);
+        match project.load() {
+            Err(ConfigError::Schema(..)) => {}
+            Err(other) => panic!("{source:?}: unexpected {other}"),
+            Ok(config) => panic!("{source:?}: accepted as {config:?}"),
+        }
+    }
+}
+
+#[test]
+fn fields_of_the_wrong_type_are_schema_errors_naming_the_file() {
+    for source in [
+        "export default { base: 42 };",
+        "export default { server: 'nope' };",
+        "export default { server: { port: 'not a number' } };",
+        "export default { build: { rollupOptions: 1, outDir: [] } };",
+        "export default { resolve: { alias: 42 } };",
+    ] {
+        let project = Project::ts(source);
+        let err = project.load().unwrap_err();
+        assert!(
+            matches!(err, ConfigError::Schema(..)),
+            "{source:?}: {err}"
+        );
+        assert_error_names_the_file(&err, "oj.config.ts");
+    }
+}
+
+#[test]
+fn unknown_fields_are_ignored_rather_than_fatal() {
+    let project = Project::ts(
+        "export default { base: '/app/', somethingViteHasThatOjDoesNot: { deep: [1, 2] } };",
+    );
+    let config = project.load().unwrap();
+    assert_eq!(config.base.as_deref(), Some("/app/"));
+}
+
+#[test]
+fn a_syntax_error_is_reported_as_a_parse_error() {
+    for source in [
+        "export default {",
+        "const a = (",
+        "export default { base: };",
+        "!!!",
+        "\0\0\0",
+    ] {
+        let project = Project::ts(source);
+        let err = project.load().unwrap_err();
+        assert!(
+            matches!(err, ConfigError::Parse(..) | ConfigError::Eval(..)),
+            "{source:?}: {err}"
+        );
+    }
+}
+
+#[test]
+fn typescript_in_a_config_is_stripped() {
+    let project = Project::ts(
+        "interface Shape { base: string }\n\
+         type Alias = Shape;\n\
+         const config: Alias & { server: { port: number } } = {\n\
+           base: '/ts/',\n\
+           server: { port: 5199 as number },\n\
+         };\n\
+         export default config satisfies Alias;",
+    );
+    let config = project.load().unwrap();
+    assert_eq!(config.base.as_deref(), Some("/ts/"));
+    assert_eq!(config.server.unwrap().port, Some(5199));
+}
+
+#[test]
+fn a_config_function_receives_the_command_and_mode() {
+    let project = Project::ts(
+        "export default ({ command, mode }) => ({ base: `/${command}-${mode}/` });",
+    );
+    assert_eq!(
+        load_with(project.path(), "build", "production")
+            .unwrap()
+            .base
+            .as_deref(),
+        Some("/build-production/")
+    );
+    assert_eq!(
+        load_with(project.path(), "serve", "development")
+            .unwrap()
+            .base
+            .as_deref(),
+        Some("/serve-development/")
+    );
+}
+
+#[test]
+fn define_config_is_available_without_an_import() {
+    // The import line is stripped and `defineConfig` is provided by the
+    // sandbox, so the idiomatic Vite-style config loads as written.
+    let project = Project::ts(
+        "import { defineConfig } from 'vite';\n\
+         export default defineConfig({ base: '/defined/' });",
+    );
+    assert_eq!(project.load().unwrap().base.as_deref(), Some("/defined/"));
+}
+
+#[test]
+fn an_import_of_a_real_module_is_stripped_and_its_use_is_an_error_with_a_hint() {
+    let project = Project::ts(
+        "import react from '@vitejs/plugin-react';\n\
+         export default { plugins: [react()] };",
+    );
+    let err = project.load().unwrap_err();
+    let text = err.to_string();
+    assert!(text.contains("react"), "{text}");
+    assert!(
+        text.contains("oj.plugins.mjs"),
+        "the error should point at the supported alternative: {text}"
+    );
+}
+
+#[test]
+fn a_multiline_import_statement_is_not_mistaken_for_config() {
+    // `to_script` works line by line, so an import spanning lines leaves its
+    // tail behind. Whatever it does, it must not be a crash or a wrong config.
+    let project = Project::ts(
+        "import {\n  defineConfig,\n} from 'vite';\nexport default { base: '/multi/' };",
+    );
+    match project.load() {
+        Ok(config) => assert_eq!(config.base.as_deref(), Some("/multi/")),
+        Err(err) => assert!(matches!(err, ConfigError::Parse(..) | ConfigError::Eval(..)), "{err}"),
+    }
+}
+
+#[test]
+fn a_deeply_nested_config_object_is_an_error_not_a_crash() {
+    let project = Project::ts(
+        "let root = {}; let cursor = root;\n\
+         for (let i = 0; i < 100000; i++) { cursor.next = {}; cursor = cursor.next; }\n\
+         export default { build: { rollupOptions: root } };",
+    );
+    // Either bound (the JSON serializer's or serde's recursion limit) is fine.
+    assert!(project.load().is_err());
+}
+
+#[test]
+fn process_env_is_readable_but_a_missing_variable_is_undefined() {
+    let project = Project::ts(
+        "export default { base: process.env.OJ_TEST_NOT_SET ? '/set/' : '/unset/' };",
+    );
+    assert_eq!(project.load().unwrap().base.as_deref(), Some("/unset/"));
+}
+
+#[test]
+fn a_config_cannot_reach_the_filesystem_or_the_network() {
+    // The sandbox has no module loader and no host bindings: these either throw
+    // or come back undefined.
+    for expression in [
+        "typeof require",
+        "typeof module",
+        "typeof fetch",
+        "typeof process.binding",
+        "typeof process.dlopen",
+        "typeof globalThis.Deno",
+        "typeof new Function('return this')().require",
+    ] {
+        let project = Project::ts(&format!("export default {{ base: String({expression}) }};"));
+        match project.load() {
+            Err(ConfigError::Eval(..)) | Err(ConfigError::Schema(..)) => {}
+            Err(other) => panic!("{expression}: unexpected {other}"),
+            Ok(config) => assert_eq!(
+                config.base.as_deref(),
+                Some("undefined"),
+                "{expression} resolved to something"
+            ),
+        }
+    }
+    // `process` itself exists, but only as the injected environment.
+    let project = Project::ts(
+        "export default { base: Object.keys(process).sort().join(',') };",
+    );
+    assert_eq!(project.load().unwrap().base.as_deref(), Some("env"));
+}
+
+#[test]
+fn the_first_candidate_filename_wins() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("oj.config.json"), r#"{"base":"/json/"}"#).unwrap();
+    assert_eq!(load(dir.path()).unwrap().base.as_deref(), Some("/json/"));
+
+    std::fs::write(dir.path().join("oj.config.js"), "export default { base: '/js/' };").unwrap();
+    assert_eq!(load(dir.path()).unwrap().base.as_deref(), Some("/js/"));
+
+    std::fs::write(dir.path().join("oj.config.ts"), "export default { base: '/ts/' };").unwrap();
+    assert_eq!(load(dir.path()).unwrap().base.as_deref(), Some("/ts/"));
+}
+
+#[test]
+fn a_json_config_is_not_evaluated_as_javascript() {
+    let project = Project::with("oj.config.json", "{\"base\": \"/j/\", \"//\": \"comment\"}");
+    assert_eq!(project.load().unwrap().base.as_deref(), Some("/j/"));
+
+    // JSON with JS in it is a schema error, not code that runs.
+    let hostile = Project::with("oj.config.json", "{\"base\": (function(){ return '/x/' })()}");
+    assert!(matches!(
+        hostile.load().unwrap_err(),
+        ConfigError::Schema(..)
+    ));
+}
+
+#[test]
+fn a_config_directory_instead_of_a_file_is_not_a_config() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir(dir.path().join("oj.config.ts")).unwrap();
+    // Not a file, so it is skipped rather than read.
+    assert!(load(dir.path()).unwrap().base.is_none());
+}
+
+#[test]
+fn invalid_utf8_in_a_config_is_a_parse_error() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("oj.config.ts"), [0xff, 0xfe, 0x00, 0x41]).unwrap();
+    let err = load(dir.path()).unwrap_err();
+    assert!(matches!(err, ConfigError::Parse(..)), "{err}");
+}
+
+#[test]
+fn loading_the_same_config_twice_gives_the_same_result() {
+    let project = Project::ts(
+        "export default { base: '/stable/', server: { port: 1234 }, define: { A: 1 } };",
+    );
+    let first = format!("{:?}", project.load().unwrap());
+    for _ in 0..3 {
+        assert_eq!(format!("{:?}", project.load().unwrap()), first);
+    }
+}


### PR DESCRIPTION
A config file is code oj runs, and it ran unbounded.

```ts
// oj.config.ts
while (true) {}
export default {};
```

`oj dev` hung forever, no output, no timeout. An allocation loop grew until the OS
stepped in. The QuickJS runtime now gets a 5s deadline through an interrupt
handler and a 64 MiB heap cap, and a config that hits the deadline says so
instead of surfacing something from the engine's internals.

Second half: every field of `OjConfig` is optional, so serde read a JSON array as
a struct of defaults — `export default []` was silently accepted as a valid empty
config, which is a config that looks like it worked. And a file that exported
nothing failed with `invalid type: null, expected struct OjConfig`, which tells
the user nothing about what to do. The evaluated value is now checked to be an
object first, and the message names the actual problem
("no config was exported; a config file must `export default` an object").

### Tests

`crates/oj_config/tests/adverse.rs`, 25 tests: a config that never finishes,
allocates without bound, recurses, throws, has a throwing getter, is cyclic,
exports nothing, or is not an object; fields of the wrong type; unknown fields
ignored rather than fatal; TypeScript stripping; the `defineConfig` import being
stripped while the sandbox still provides it; how far the sandbox reaches
(`require`, `fetch`, `process.binding` are all undefined, and `process` has
exactly one key); candidate filename precedence; a config directory instead of a
file; invalid UTF-8; and that loading twice gives the same answer.

The 5s bound is what three of those tests wait on, so the suite takes ~5s wall
clock — they run in parallel, so it is 5s total rather than 15.
---

One of eleven independent PRs from the same pass over the test suite. Each stands
alone (its own tests pass on `main` without the others) and all eleven merge
together cleanly — I verified both. Each also carries the same two-line
`tmp()` fix in `crates/oj/src/start_dev.rs`, because without it
`app_uses_tailwind_detects_postcss_vite_and_bare` flakes on any PR CI run; the
hunks are identical, so they merge as one.


