### PR TITLE
fix(server): decode request paths, key the dep optimizer per list, name the sidecars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
           node e2e/memory-cache.mjs
           node e2e/mtime-fastpath.mjs
           node e2e/hmr-hook-skip.mjs
+      - name: request paths (encoded filenames, traversal containment)
+        if: matrix.mode == 'unbundled'
+        run: node e2e/awkward-paths.mjs
 
   # i need to fix this or automate
   build:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,6 +1900,7 @@ dependencies = [
  "reqwest",
  "serde_json",
  "simdutf8",
+ "tempfile",
  "tokio",
 ]
 
@@ -4085,6 +4086,19 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,10 @@ axum = { version = "0.8.9", features = ["ws"] }
 notify = "8.2.0"
 clap = { version = "4.6.6", features = ["derive"] }
 
+# test-only
+proptest = "1.9.0"
+tempfile = "3.24.0"
+
 [profile.release]
 lto = "thin"
 codegen-units = 1

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -689,7 +689,15 @@ mod tests {
     use super::*;
 
     fn tmp(label: &str) -> PathBuf {
-        let d = std::env::temp_dir().join(format!("oj-startdev-{}-{label}", std::process::id()));
+        // A fresh directory per call: this wipes the path before creating it, so
+        // two tests that pass the same label would race -- one clearing the
+        // other's fixture out from under it, in whichever order they interleave.
+        static SEQ: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let d = std::env::temp_dir().join(format!(
+            "oj-startdev-{}-{label}-{seq}",
+            std::process::id()
+        ));
         let _ = std::fs::remove_dir_all(&d);
         std::fs::create_dir_all(&d).unwrap();
         d

--- a/crates/oj_server/Cargo.toml
+++ b/crates/oj_server/Cargo.toml
@@ -21,3 +21,6 @@ serde_json.workspace = true
 blake3.workspace = true
 simdutf8.workspace = true
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -795,18 +795,20 @@ pub async fn preview(
     Ok(())
 }
 
-fn preview_rel<'a>(path: &'a str, base: &str) -> Option<String> {
+fn preview_rel(path: &str, base: &str) -> Option<String> {
     let trimmed = path
         .strip_prefix(base.trim_end_matches('/'))
         .unwrap_or(path);
-    let rel = trimmed.trim_start_matches('/');
+    // Decode first, so `%2e%2e` is rejected by the same check as `..` and a file
+    // with a space in its name is still found.
+    let rel = urldecode(trimmed.trim_start_matches('/'));
     if rel.split('/').any(|seg| seg == "..") {
         return None;
     }
     Some(if rel.is_empty() {
         "index.html".to_string()
     } else {
-        rel.to_string()
+        rel
     })
 }
 
@@ -1206,8 +1208,16 @@ async fn serve_path(
         .as_deref()
         .and_then(|b| uri.path().strip_prefix(b.trim_end_matches('/')))
         .unwrap_or_else(|| uri.path());
-    let rel = path.trim_start_matches('/');
-    let rel = if rel.is_empty() { "index.html" } else { rel };
+    // A request path is percent-encoded: a file called `Cool Button.tsx` arrives
+    // as `Cool%20Button.tsx`. Decode before it is treated as a path -- and
+    // therefore before the traversal check in `locate`, so an encoded `..` is
+    // caught rather than smuggled through.
+    let decoded = urldecode(path.trim_start_matches('/'));
+    let rel = if decoded.is_empty() {
+        "index.html"
+    } else {
+        decoded.as_str()
+    };
 
     if let Some(name) = uri.path().strip_prefix("/@oj-deps/") {
         if name.contains('/') || name.contains("..") {
@@ -1261,7 +1271,7 @@ async fn serve_path(
     }
 
     let file = if let Some(abs) = uri.path().strip_prefix("/@fs") {
-        let candidate = PathBuf::from(abs);
+        let candidate = PathBuf::from(urldecode(abs));
         let allowed = {
             let allow = state.fs_allow.lock().unwrap();
             allow.iter().any(|root| candidate.starts_with(root))
@@ -4045,6 +4055,146 @@ mod adapter_tests {
         assert_eq!(locate(&root, &public, "img/missing.webp"), None);
         assert_eq!(locate(&root, &public, "../secret"), None);
         let _ = std::fs::remove_dir_all(&base);
+    }
+
+    // --- adverse: request paths are attacker-shaped strings ---
+
+    #[test]
+    fn urldecode_handles_every_malformed_escape() {
+        assert_eq!(urldecode("plain/path.tsx"), "plain/path.tsx");
+        assert_eq!(urldecode("a%20b"), "a b");
+        assert_eq!(urldecode("a%2Fb"), "a/b");
+        assert_eq!(urldecode("caf%C3%A9.css"), "café.css");
+        assert_eq!(urldecode("100%25.css"), "100%.css");
+        // Truncated and non-hex escapes are left alone rather than dropped.
+        assert_eq!(urldecode("a%"), "a%");
+        assert_eq!(urldecode("a%2"), "a%2");
+        assert_eq!(urldecode("a%zz"), "a%zz");
+        assert_eq!(urldecode("a%%20"), "a% ");
+        assert_eq!(urldecode(""), "");
+        // A single pass only: an encoded escape stays encoded once decoded.
+        assert_eq!(urldecode("a%2520b"), "a%20b");
+        // Invalid UTF-8 becomes replacement characters instead of panicking.
+        assert!(!urldecode("%ff%fe").is_empty());
+    }
+
+    #[test]
+    fn locate_rejects_traversal_in_every_spelling_after_decoding() {
+        let base = tmp("traversal");
+        let root = base.join("root");
+        let public = base.join("public");
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(&public).unwrap();
+        std::fs::write(base.join("secret.txt"), "s3cret").unwrap();
+        std::fs::write(root.join("src").join("App.tsx"), "x").unwrap();
+
+        for hostile in [
+            "../secret.txt",
+            "src/../../secret.txt",
+            "./../secret.txt",
+            "src/../../../etc/passwd",
+        ] {
+            assert_eq!(locate(&root, &public, hostile), None, "{hostile}");
+            // ...and through the decoding the request handler applies first.
+            let encoded = hostile.replace("..", "%2e%2e");
+            assert_eq!(
+                locate(&root, &public, &urldecode(&encoded)),
+                None,
+                "{encoded}"
+            );
+        }
+        // A name that merely contains dots is not traversal.
+        std::fs::write(root.join("src").join("..dotted.tsx"), "x").unwrap();
+        assert!(locate(&root, &public, "src/..dotted.tsx").is_some());
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn locate_finds_files_whose_names_need_encoding() {
+        let base = tmp("encoded-names");
+        let root = base.join("root");
+        let public = base.join("public");
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(&public).unwrap();
+        for name in ["Cool Button.tsx", "café.css", "100%.css", "a+b.tsx"] {
+            std::fs::write(root.join("src").join(name), "x").unwrap();
+        }
+
+        // What a browser actually requests for each of those files.
+        for (requested, name) in [
+            ("src/Cool%20Button.tsx", "Cool Button.tsx"),
+            ("src/caf%C3%A9.css", "café.css"),
+            ("src/100%25.css", "100%.css"),
+            ("src/a+b.tsx", "a+b.tsx"),
+        ] {
+            let decoded = urldecode(requested);
+            assert_eq!(
+                locate(&root, &public, &decoded),
+                Some(root.join("src").join(name)),
+                "{requested}"
+            );
+        }
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn preview_rel_decodes_before_guarding_traversal() {
+        assert_eq!(
+            preview_rel("/assets/Cool%20Button.js", "/").as_deref(),
+            Some("assets/Cool Button.js")
+        );
+        assert_eq!(preview_rel("/%2e%2e/etc/passwd", "/"), None);
+        assert_eq!(preview_rel("/a/%2e%2e/%2e%2e/etc/passwd", "/"), None);
+        assert_eq!(preview_rel("/%2E%2E/etc/passwd", "/"), None);
+        // Not traversal: `..` inside a segment.
+        assert_eq!(
+            preview_rel("/a..b/x.js", "/").as_deref(),
+            Some("a..b/x.js")
+        );
+    }
+
+    #[test]
+    fn html_entry_src_rejects_everything_that_is_not_a_local_path() {
+        for external in [
+            "",
+            "   ",
+            "http://cdn.example/x.js",
+            "https://cdn.example/x.js",
+            "//cdn.example/x.js",
+            "data:text/javascript,alert(1)",
+        ] {
+            assert_eq!(html_entry_src(external), None, "{external:?}");
+        }
+        assert_eq!(html_entry_src("./src/main.tsx").as_deref(), Some("/src/main.tsx"));
+        assert_eq!(html_entry_src("src/main.tsx").as_deref(), Some("/src/main.tsx"));
+        assert_eq!(html_entry_src("/src/main.tsx").as_deref(), Some("/src/main.tsx"));
+        assert_eq!(html_entry_src("  src/main.tsx  ").as_deref(), Some("/src/main.tsx"));
+        // A traversal in an entry src stays a path; `locate` is what refuses it.
+        assert_eq!(
+            html_entry_src("../../etc/passwd").as_deref(),
+            Some("/../../etc/passwd")
+        );
+    }
+
+    #[test]
+    fn gate_relevance_ignores_generated_directories() {
+        assert!(gate_relevant(Path::new("/app/src/App.tsx")));
+        assert!(!gate_relevant(Path::new("/app/node_modules/react/index.js")));
+        assert!(!gate_relevant(Path::new("/app/.oj-cache/ab/cd.json")));
+        assert!(!gate_relevant(Path::new("/app/dist/assets/x.js")));
+        // Only a whole path component counts.
+        assert!(gate_relevant(Path::new("/app/src/dist-helper.ts")));
+        assert!(gate_relevant(Path::new("/app/src/my-node_modules-thing.ts")));
+    }
+
+    #[test]
+    fn query_classification_only_matches_whole_flags() {
+        assert!(is_worker_query("/w.ts?worker"));
+        assert!(is_worker_query("/w.ts?sharedworker"));
+        assert!(!is_worker_query("/w.ts?workerish"));
+        assert!(!is_worker_query("/w.ts?x=worker"));
+        assert!(!is_worker_query("/w.ts"));
+        assert!(!is_worker_query(""));
     }
 
     #[test]

--- a/crates/oj_server/src/optimize.rs
+++ b/crates/oj_server/src/optimize.rs
@@ -95,16 +95,19 @@ fn lockfile_hash(root: &Path, version: &str, input: &OptimizeInput) -> String {
         }
     }
     // Fold the optimizer config into the key so include/exclude/entries/dedupe/alias
-    // changes invalidate a stale prebundle.
-    for s in input
-        .include
-        .iter()
-        .chain(&input.exclude)
-        .chain(&input.entries)
-        .chain(&input.dedupe)
-    {
-        hasher.update(b"\0");
-        hasher.update(s.as_bytes());
+    // changes invalidate a stale prebundle. Each list gets its own tag: without
+    // one, moving a package from `include` to `exclude` would leave the key --
+    // and therefore the prebundle -- unchanged.
+    for (tag, list) in [
+        (b"\0i".as_slice(), &input.include),
+        (b"\0x".as_slice(), &input.exclude),
+        (b"\0e".as_slice(), &input.entries),
+        (b"\0d".as_slice(), &input.dedupe),
+    ] {
+        for entry in list {
+            hasher.update(tag);
+            hasher.update(entry.as_bytes());
+        }
     }
     for (find, replacement) in &input.alias {
         hasher.update(b"\0a");
@@ -199,4 +202,157 @@ async fn run_optimizer(
     let manifest = serde_json::json!({ "hash": hash, "metadata": metadata });
     let _ = std::fs::write(dir.join("manifest.json"), manifest.to_string());
     Some(map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input(include: &[&str], exclude: &[&str], entries: &[&str], dedupe: &[&str]) -> OptimizeInput {
+        OptimizeInput {
+            include: include.iter().map(|s| s.to_string()).collect(),
+            exclude: exclude.iter().map(|s| s.to_string()).collect(),
+            entries: entries.iter().map(|s| s.to_string()).collect(),
+            dedupe: dedupe.iter().map(|s| s.to_string()).collect(),
+            alias: Vec::new(),
+        }
+    }
+
+    fn project(files: &[(&str, &str)]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        for (name, contents) in files {
+            std::fs::write(dir.path().join(name), contents).unwrap();
+        }
+        dir
+    }
+
+    #[test]
+    fn every_optimizer_list_is_distinguishable_in_the_key() {
+        let dir = project(&[("package.json", r#"{"name":"app"}"#)]);
+        let root = dir.path();
+        let key = |i: &OptimizeInput| lockfile_hash(root, "0.0.1", i);
+
+        // The same package in a different list must not reuse a prebundle: an
+        // excluded dep is not a prebundled one.
+        let base = key(&input(&["react"], &[], &[], &[]));
+        assert_ne!(base, key(&input(&[], &["react"], &[], &[])), "include vs exclude");
+        assert_ne!(base, key(&input(&[], &[], &["react"], &[])), "include vs entries");
+        assert_ne!(base, key(&input(&[], &[], &[], &["react"])), "include vs dedupe");
+        // ...and neither may a list boundary that merely moves an item across it.
+        assert_ne!(
+            key(&input(&["a"], &["b"], &[], &[])),
+            key(&input(&["a", "b"], &[], &[], &[])),
+            "moving an entry across the include/exclude boundary"
+        );
+        assert_ne!(
+            key(&input(&[], &[], &["a", "b"], &[])),
+            key(&input(&[], &[], &["a"], &["b"])),
+            "moving an entry across the entries/dedupe boundary"
+        );
+    }
+
+    #[test]
+    fn the_key_covers_the_lockfiles_the_version_and_the_aliases() {
+        let dir = project(&[
+            ("package.json", r#"{"name":"app","dependencies":{"react":"18"}}"#),
+            ("package-lock.json", r#"{"lockfileVersion":3}"#),
+        ]);
+        let root = dir.path();
+        let empty = OptimizeInput::default();
+        let base = lockfile_hash(root, "0.0.1", &empty);
+
+        assert_eq!(base, lockfile_hash(root, "0.0.1", &empty), "deterministic");
+        assert_ne!(base, lockfile_hash(root, "0.0.2", &empty), "tool version");
+
+        std::fs::write(root.join("package-lock.json"), r#"{"lockfileVersion":4}"#).unwrap();
+        let after_lock = lockfile_hash(root, "0.0.1", &empty);
+        assert_ne!(base, after_lock, "a lockfile change must invalidate");
+
+        let aliased = OptimizeInput {
+            alias: vec![("~".into(), "./src".into())],
+            ..OptimizeInput::default()
+        };
+        assert_ne!(after_lock, lockfile_hash(root, "0.0.1", &aliased), "alias");
+        let swapped = OptimizeInput {
+            alias: vec![("./src".into(), "~".into())],
+            ..OptimizeInput::default()
+        };
+        assert_ne!(
+            lockfile_hash(root, "0.0.1", &aliased),
+            lockfile_hash(root, "0.0.1", &swapped),
+            "an alias is directional"
+        );
+    }
+
+    #[test]
+    fn a_manifest_is_only_reused_when_its_hash_and_its_files_are_there() {
+        let dir = tempfile::tempdir().unwrap();
+        let deps = dir.path().join("deps");
+        std::fs::create_dir_all(&deps).unwrap();
+        std::fs::write(deps.join("react.js"), "export default 1;").unwrap();
+        std::fs::write(
+            deps.join("manifest.json"),
+            r#"{"hash":"abc","metadata":{"react":{"file":"react.js","needsInterop":false}}}"#,
+        )
+        .unwrap();
+
+        let map = load_manifest(&deps, "abc").expect("matching hash loads");
+        assert_eq!(map["react"].file, "react.js");
+        assert!(!map["react"].needs_interop);
+
+        assert!(load_manifest(&deps, "different").is_none(), "stale hash");
+
+        // A manifest whose prebundle is gone is not a warm cache.
+        std::fs::remove_file(deps.join("react.js")).unwrap();
+        assert!(load_manifest(&deps, "abc").is_none(), "missing dep file");
+    }
+
+    #[test]
+    fn a_malformed_manifest_is_a_miss_not_a_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let deps = dir.path().join("deps");
+        std::fs::create_dir_all(&deps).unwrap();
+        for contents in [
+            "",
+            "{",
+            "null",
+            "[]",
+            r#"{"metadata":{}}"#,
+            r#"{"hash":"abc"}"#,
+            r#"{"hash":123,"metadata":{}}"#,
+            r#"{"hash":"abc","metadata":[]}"#,
+            r#"{"hash":"abc","metadata":{"react":{}}}"#,
+            r#"{"hash":"abc","metadata":{"react":{"file":42}}}"#,
+        ] {
+            std::fs::write(deps.join("manifest.json"), contents).unwrap();
+            assert!(
+                load_manifest(&deps, "abc").is_none(),
+                "accepted {contents:?}"
+            );
+        }
+        // An empty metadata object is a legitimate warm cache with no deps.
+        std::fs::write(
+            deps.join("manifest.json"),
+            r#"{"hash":"abc","metadata":{}}"#,
+        )
+        .unwrap();
+        assert!(load_manifest(&deps, "abc").expect("empty is valid").is_empty());
+    }
+
+    #[test]
+    fn needs_interop_defaults_to_true_when_the_optimizer_does_not_say() {
+        // Interop is the safe default: assuming an ESM dep needs none would
+        // break `import x from "cjs-dep"` at runtime.
+        let v: serde_json::Value =
+            serde_json::from_str(r#"{"dep":{"file":"dep.js"}}"#).unwrap();
+        let map = parse_metadata(&v).unwrap();
+        assert!(map["dep"].needs_interop);
+    }
+
+    #[tokio::test]
+    async fn a_disabled_optimizer_is_ready_immediately_and_empty() {
+        let deps = OptimizedDeps::disabled();
+        assert!(deps.ready().await.is_empty());
+        assert_eq!(deps.dir(), Path::new(""));
+    }
 }

--- a/crates/oj_server/src/sidecar.rs
+++ b/crates/oj_server/src/sidecar.rs
@@ -10,6 +10,9 @@ use std::sync::Mutex;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::oneshot;
 
+/// How long one sidecar request may take before it is abandoned.
+const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+
 pub const SIDECAR_JS: &str = include_str!("assets/tailwind-sidecar.mjs");
 pub const PREPROCESS_JS: &str = include_str!("assets/css-preprocess.mjs");
 pub const SVELTE_COMPILE_JS: &str = include_str!("assets/svelte-compile.mjs");
@@ -30,12 +33,59 @@ pub fn is_stylus(url: &str) -> bool {
     f.ends_with(".styl") || f.ends_with(".stylus")
 }
 
-#[inline]
+/// Whether a stylesheet has to go through the Tailwind sidecar.
+///
+/// Both halves of this matter. A false negative silently drops every utility
+/// class from the page; a false positive runs Tailwind over a plain stylesheet
+/// and fails the build with "is tailwindcss installed?". So an import of
+/// `tailwindcss` counts whatever follows the package name (`tailwindcss/theme`,
+/// `... layer(base)`), and `@theme`/`@tailwind` count only where a directive can
+/// actually start -- not inside a comment, a string, or a longer word.
 pub fn is_tailwind_css(source: &str) -> bool {
-    source.contains("@import \"tailwindcss\"")
-        || source.contains("@import 'tailwindcss'")
-        || source.contains("@tailwind ")
-        || source.contains("@theme")
+    for (index, _) in source.match_indices('@') {
+        let rest = &source[index..];
+        if !at_directive_position(source, index) {
+            continue;
+        }
+        if let Some(after) = rest.strip_prefix("@import") {
+            let target = after.trim_start().trim_start_matches(['"', '\'']);
+            if let Some(tail) = target.strip_prefix("tailwindcss") {
+                // The package name has to end here: `tailwindcss-animate` is a
+                // different package, `tailwindcss/theme` is a subpath of this one.
+                if tail
+                    .chars()
+                    .next()
+                    .is_none_or(|c| matches!(c, '"' | '\'' | '/') || c.is_whitespace())
+                {
+                    return true;
+                }
+            }
+            continue;
+        }
+        for directive in ["@tailwind", "@theme", "@utility", "@apply", "@source"] {
+            if let Some(after) = rest.strip_prefix(directive) {
+                // `@themes` is not `@theme`.
+                if after
+                    .chars()
+                    .next()
+                    .is_none_or(|c| !c.is_alphanumeric() && c != '-' && c != '_')
+                {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Whether the `@` at `index` can begin an at-rule: only whitespace, a block or
+/// statement boundary may precede it on its line.
+fn at_directive_position(source: &str, index: usize) -> bool {
+    source[..index]
+        .chars()
+        .rev()
+        .find(|c| !matches!(c, ' ' | '\t'))
+        .is_none_or(|c| matches!(c, '\n' | '\r' | '}' | '{' | ';'))
 }
 
 pub struct Sidecar {
@@ -43,26 +93,47 @@ pub struct Sidecar {
     pending: Mutex<HashMap<u64, oneshot::Sender<Result<String, String>>>>,
     counter: AtomicU64,
     base: String,
+    /// What this sidecar is, for error messages: three kinds share this type,
+    /// and "is tailwindcss installed?" is unhelpful when Less failed to compile.
+    kind: &'static str,
+    /// What to suggest installing when it cannot be reached.
+    package: &'static str,
     _child: tokio::process::Child,
 }
 
 impl Sidecar {
     pub async fn spawn(root: &Path) -> anyhow::Result<std::sync::Arc<Sidecar>> {
-        Self::spawn_named(root, "tailwind-sidecar.mjs", SIDECAR_JS).await
+        Self::spawn_named(root, "tailwind-sidecar.mjs", SIDECAR_JS, "tailwind", "tailwindcss").await
     }
 
     pub async fn spawn_preprocess(root: &Path) -> anyhow::Result<std::sync::Arc<Sidecar>> {
-        Self::spawn_named(root, "css-preprocess.mjs", PREPROCESS_JS).await
+        Self::spawn_named(
+            root,
+            "css-preprocess.mjs",
+            PREPROCESS_JS,
+            "css preprocessor",
+            "less or stylus",
+        )
+        .await
     }
 
     pub async fn spawn_svelte(root: &Path) -> anyhow::Result<std::sync::Arc<Sidecar>> {
-        Self::spawn_named(root, "svelte-compile.mjs", SVELTE_COMPILE_JS).await
+        Self::spawn_named(
+            root,
+            "svelte-compile.mjs",
+            SVELTE_COMPILE_JS,
+            "svelte compiler",
+            "svelte",
+        )
+        .await
     }
 
     async fn spawn_named(
         root: &Path,
         name: &str,
         js: &str,
+        kind: &'static str,
+        package: &'static str,
     ) -> anyhow::Result<std::sync::Arc<Sidecar>> {
         let script = root.join(".oj-cache").join(name);
         if let Some(parent) = script.parent() {
@@ -77,7 +148,7 @@ impl Sidecar {
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
             .spawn()
-            .map_err(|e| anyhow::anyhow!("cannot spawn node for css sidecar: {e}"))?;
+            .map_err(|e| anyhow::anyhow!("cannot spawn node for the {kind} sidecar: {e}"))?;
         let stdin = child.stdin.take().expect("piped stdin");
         let stdout = child.stdout.take().expect("piped stdout");
 
@@ -86,6 +157,8 @@ impl Sidecar {
             pending: Mutex::new(HashMap::new()),
             counter: AtomicU64::new(1),
             base: root.display().to_string(),
+            kind,
+            package,
             _child: child,
         });
 
@@ -123,12 +196,132 @@ impl Sidecar {
                 .await
                 .is_err()
             {
-                return Err("tailwind sidecar died (is tailwindcss installed?)".into());
+                self.pending.lock().unwrap().remove(&id);
+                return Err(format!(
+                    "{} sidecar died (is {} installed?)",
+                    self.kind, self.package
+                ));
             }
         }
-        match tokio::time::timeout(std::time::Duration::from_secs(20), rx).await {
+        match tokio::time::timeout(REQUEST_TIMEOUT, rx).await {
             Ok(Ok(result)) => result,
-            _ => Err("tailwind sidecar timed out".into()),
+            other => {
+                // Nothing will answer this id: drop it, or a sidecar that stalls
+                // once leaks a waiter for the lifetime of the server.
+                self.pending.lock().unwrap().remove(&id);
+                Err(match other {
+                    Ok(Err(_)) => format!("{} sidecar closed the connection", self.kind),
+                    _ => format!(
+                        "{} sidecar timed out after {}s",
+                        self.kind,
+                        REQUEST_TIMEOUT.as_secs()
+                    ),
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tailwind_imports_are_detected_in_every_written_form() {
+        for source in [
+            "@import \"tailwindcss\";",
+            "@import 'tailwindcss';",
+            "@import \"tailwindcss\"",
+            "  @import \"tailwindcss\";",
+            "\n\n@import \"tailwindcss\";\n",
+            // v4 subpath and layer forms.
+            "@import \"tailwindcss/preflight\" layer(base);",
+            "@import \"tailwindcss/theme\" layer(theme);",
+            "@import \"tailwindcss/utilities\" layer(utilities);",
+            // Other statements around it.
+            "@charset \"utf-8\";\n@import \"tailwindcss\";",
+            ".a { color: red }\n@import \"tailwindcss\";",
+        ] {
+            assert!(is_tailwind_css(source), "missed: {source:?}");
+        }
+    }
+
+    #[test]
+    fn tailwind_directives_are_detected_only_where_a_directive_can_start() {
+        for source in [
+            "@tailwind base;",
+            "@tailwind utilities;",
+            "@theme { --color-brand: red }",
+            "@theme inline { --x: 1 }",
+            ".btn {\n  @apply underline;\n}",
+            "@utility tab-4 { tab-size: 4 }",
+            "@source \"./src/**/*.tsx\";",
+            "}\n@theme { --x: 1 }",
+        ] {
+            assert!(is_tailwind_css(source), "missed: {source:?}");
+        }
+    }
+
+    #[test]
+    fn a_plain_stylesheet_never_reaches_the_tailwind_sidecar() {
+        // A false positive here fails the build with "is tailwindcss installed?"
+        // on a stylesheet that has nothing to do with Tailwind.
+        for source in [
+            "",
+            ".a { color: red }",
+            "@media (min-width: 1px) { .a { color: red } }",
+            "@supports (display: grid) { .a { display: grid } }",
+            "@font-face { font-family: X; src: url(x.woff2) }",
+            "@keyframes spin { to { transform: rotate(1turn) } }",
+            "@layer base { .a { color: red } }",
+            "@import \"./other.css\";",
+            "@import \"@acme/design/tokens.css\";",
+            // The word appears, but not as a directive.
+            "/* @theme is not used here */",
+            "/* @tailwind base; */",
+            ".a { content: \"@theme\" }",
+            ".a { content: \"@import \\\"tailwindcss\\\"\" }",
+            "@themes { --x: 1 }",
+            "@theming { --x: 1 }",
+            ".a[data-x=\"@apply\"] { color: red }",
+            "/* see @source for details */",
+            "@import \"tailwindcss-is-not-this-package\";",
+        ] {
+            assert!(!is_tailwind_css(source), "false positive: {source:?}");
+        }
+    }
+
+    #[test]
+    fn an_import_of_a_package_named_after_tailwind_is_not_tailwind() {
+        // The prefix has to end at a boundary the package itself uses.
+        assert!(is_tailwind_css("@import \"tailwindcss\";"));
+        assert!(is_tailwind_css("@import \"tailwindcss/theme\";"));
+        assert!(!is_tailwind_css("@import \"tailwindcss-animate\";"));
+        assert!(!is_tailwind_css("@import \"my-tailwindcss\";"));
+    }
+
+    #[test]
+    fn style_dialects_are_classified_by_extension_not_by_query() {
+        assert!(is_less("/src/a.less"));
+        assert!(is_less("/src/a.less?inline"));
+        assert!(!is_less("/src/a.less/b.css"));
+        assert!(!is_less("/src/a.css?x=.less"));
+
+        assert!(is_stylus("/src/a.styl"));
+        assert!(is_stylus("/src/a.stylus"));
+        assert!(is_stylus("/src/a.styl?raw"));
+        assert!(!is_stylus("/src/a.style"));
+        assert!(!is_stylus("/src/a.css?x=.styl"));
+
+        assert!(is_svelte("/src/A.svelte"));
+        assert!(is_svelte("/src/A.svelte?raw"));
+        assert!(!is_svelte("/src/A.svelte.ts"));
+        assert!(!is_svelte("/src/a.ts?x=.svelte"));
+
+        for predicate in [is_less, is_stylus, is_svelte] {
+            assert!(!predicate(""));
+            assert!(!predicate("?"));
+            assert!(!predicate("/"));
         }
     }
 }

--- a/e2e/awkward-paths.mjs
+++ b/e2e/awkward-paths.mjs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+// A request path is percent-encoded, so a file with a space or a non-ASCII
+// character in its name arrives as `%20`/`%C3%A9`. Serving it means decoding the
+// path -- and decoding means the traversal guard has to run on the decoded form,
+// not the raw one. Both halves are checked here against a real dev server, in
+// dev and in preview.
+
+import { spawn, execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repo = path.join(here, "..");
+const oj = path.join(repo, "target", "debug", "oj");
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+execSync("cargo build -p oj", { cwd: repo, stdio: "inherit" });
+
+const app = fs.mkdtempSync(path.join(os.tmpdir(), "oj-awkward-"));
+const outside = fs.mkdtempSync(path.join(os.tmpdir(), "oj-outside-"));
+const secret = "SECRET-OUTSIDE-THE-APP";
+fs.writeFileSync(path.join(outside, "secret.txt"), secret);
+
+fs.mkdirSync(path.join(app, "src"), { recursive: true });
+fs.writeFileSync(path.join(app, "package.json"), JSON.stringify({ name: "awkward-app", version: "1.0.0" }));
+fs.writeFileSync(path.join(app, "src", "Cool Button.tsx"), `export const label = "spaced-module-loaded";\n`);
+fs.writeFileSync(path.join(app, "src", "café.css"), `.unicode-name { color: rgb(1, 2, 3) }\n`);
+fs.writeFileSync(path.join(app, "src", "100%.txt"), `percent-in-the-name\n`);
+fs.writeFileSync(
+  path.join(app, "src", "main.tsx"),
+  `import { label } from "./Cool Button";\nimport "./café.css";\nwindow.__LABEL = label;\n`,
+);
+fs.writeFileSync(
+  path.join(app, "index.html"),
+  `<!doctype html><html><head><title>t</title></head><body><script type="module" src="/src/main.tsx"></script></body></html>`,
+);
+
+async function get(port, urlPath) {
+  const res = await fetch(`http://127.0.0.1:${port}${urlPath}`, { signal: AbortSignal.timeout(5000) });
+  return { status: res.status, body: await res.text() };
+}
+
+async function reachable(port) {
+  for (let i = 0; i < 60; i++) {
+    try {
+      const r = await fetch(`http://127.0.0.1:${port}/`, { signal: AbortSignal.timeout(1500) });
+      if (r.ok) return true;
+    } catch {}
+    await sleep(200);
+  }
+  return false;
+}
+
+// Every spelling of "read a file outside the app" that a browser or a script
+// can put on the wire.
+const traversals = [
+  "/../../../../etc/passwd",
+  "/%2e%2e/%2e%2e/%2e%2e/%2e%2e/etc/passwd",
+  "/%2E%2E%2F%2E%2E%2Fetc/passwd",
+  "/src/../../../../etc/passwd",
+  `/@fs${path.join(outside, "secret.txt")}`,
+  `/@fs${path.join(outside, "secret.txt").replace(/\//g, "%2f")}`,
+  `/..${outside}/secret.txt`,
+];
+
+let failed = false;
+try {
+  {
+    const srv = spawn(oj, ["dev", app, "--port", "5486"], { stdio: "ignore" });
+    try {
+      assert.ok(await reachable(5486), "dev server reachable");
+
+      const spaced = await get(5486, "/src/Cool%20Button.tsx");
+      assert.equal(spaced.status, 200, "a spaced filename must be served");
+      assert.match(spaced.body, /spaced-module-loaded/, "spaced module body");
+
+      const unicode = await get(5486, "/src/caf%C3%A9.css");
+      assert.equal(unicode.status, 200, "a non-ASCII filename must be served");
+      assert.match(unicode.body, /unicode-name/, "unicode module body");
+
+      const percent = await get(5486, "/src/100%25.txt");
+      assert.equal(percent.status, 200, "a percent in a filename must be served");
+      assert.match(percent.body, /percent-in-the-name/, "percent module body");
+
+      for (const target of traversals) {
+        const res = await get(5486, target);
+        assert.ok(!res.body.includes(secret), `dev leaked a file outside the app: ${target}`);
+        assert.ok(!res.body.includes("root:"), `dev leaked /etc/passwd: ${target}`);
+      }
+      console.log("[dev] awkward filenames served, traversal contained OK");
+    } finally {
+      srv.kill("SIGKILL");
+      await sleep(300);
+    }
+  }
+
+  {
+    execSync(`${oj} build ${app}`, { stdio: "ignore" });
+    fs.writeFileSync(path.join(app, "dist", "Cool Asset.txt"), "spaced-asset-served\n");
+    const srv = spawn(oj, ["preview", app, "--port", "5487"], { stdio: "ignore" });
+    try {
+      assert.ok(await reachable(5487), "preview server reachable");
+
+      const asset = await get(5487, "/Cool%20Asset.txt");
+      assert.equal(asset.status, 200, "preview must serve a spaced filename");
+      assert.match(asset.body, /spaced-asset-served/, "spaced asset body");
+
+      for (const target of traversals) {
+        const res = await get(5487, target);
+        assert.ok(!res.body.includes(secret), `preview leaked a file outside the app: ${target}`);
+        assert.ok(!res.body.includes("root:"), `preview leaked /etc/passwd: ${target}`);
+      }
+      console.log("[preview] awkward filenames served, traversal contained OK");
+    } finally {
+      srv.kill("SIGKILL");
+      await sleep(300);
+    }
+  }
+
+  console.log("AWKWARD-PATHS E2E PASSED");
+} catch (err) {
+  failed = true;
+  console.error("AWKWARD-PATHS E2E FAILED:", err.message);
+} finally {
+  fs.rmSync(app, { recursive: true, force: true });
+  fs.rmSync(outside, { recursive: true, force: true });
+}
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Four bugs on the request path and around the node sidecars.

**Request paths were never percent-decoded.** A component named `Cool Button.tsx`
arrives as `Cool%20Button.tsx`; a stylesheet named `café.css` arrives as
`caf%C3%A9.css`. Both 404'd in `oj dev` **and** `oj preview` — files the app
imports, unreachable. Decoding now happens before the path is treated as a path,
which also puts it before the traversal guard, so `%2e%2e` is caught by the same
check as `..` instead of passing through as a literal segment. `/@fs` decodes too
and stays allow-listed.

**The dep optimizer's cache key could not tell its lists apart.** `include`,
`exclude`, `entries` and `dedupe` were folded into one flat sequence, so moving a
package from `include` to `exclude` left the key unchanged and the stale prebundle
in place — excluding a dep did nothing until something else invalidated the cache.
Each list is now tagged.

**All three sidecars said "tailwind".** A Less file that failed to compile
reported `tailwind sidecar died (is tailwindcss installed?)`. Each sidecar now
names itself and the package to install. A request that times out also drops its
pending entry, which used to leak a waiter per timeout.

**`is_tailwind_css` was wrong in both directions.** It matched `@theme` anywhere,
so a comment mentioning `@theme` or a rule with `content: "@theme"` routed a plain
stylesheet through Tailwind and failed the build. Meanwhile
`@import "tailwindcss/preflight" layer(base);` — the documented v4 form — was not
matched at all, which silently drops every utility class from the page. Directives
now count only where a directive can start, and the import matches the package
rather than an exact string (`tailwindcss/theme` yes, `tailwindcss-animate` no).

### Tests

`e2e/awkward-paths.mjs` drives a real dev server and a real preview server: files
whose names need encoding are served, and seven spellings of a traversal (raw,
`%2e%2e`, `%2E%2E%2F`, `/@fs` with and without encoding) never return a file from
outside the app. I checked it fails against the unfixed code. Added to CI.

Unit tests for percent-decoding (including malformed escapes and double-encoding),
traversal rejection after decoding, filenames that need encoding, `html_entry_src`,
gate relevance, query classification, the optimizer's key and its manifest
handling, and 5 tests over the Tailwind detection in both directions.
---

One of eleven independent PRs from the same pass over the test suite. Each stands
alone (its own tests pass on `main` without the others) and all eleven merge
together cleanly — I verified both. Each also carries the same two-line
`tmp()` fix in `crates/oj/src/start_dev.rs`, because without it
`app_uses_tailwind_detects_postcss_vite_and_bare` flakes on any PR CI run; the
hunks are identical, so they merge as one.


