### PR TITLE
docs: testing strategy, fuzz targets, mutation config, nightly CI

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,14 @@
+# cargo-mutants configuration. Informational, run on demand rather than in CI:
+# it is a check on the suites, not a gate on a change.
+#
+# Scoped to the pure, correctness-critical crates. The dev server and the CLI
+# are covered end to end from `e2e/`, which cargo-mutants cannot drive.
+examine_globs = [
+    "crates/oj_env/src/**",
+    "crates/oj_graph/src/**",
+    "crates/oj_cache/src/**",
+    "crates/oj_css/src/**",
+    "crates/oj_compiler/src/json.rs",
+]
+timeout_multiplier = 4.0
+minimum_test_timeout = 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
+      # The fuzz crate is outside the workspace; keep its targets compiling so
+      # they cannot rot between nightly fuzzing runs.
+      - name: fuzz targets still build
+        run: cargo check --manifest-path fuzz/Cargo.toml --all-targets
 
   e2e:
     name: e2e (${{ matrix.mode }})

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,50 @@
+name: nightly
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fuzz:
+    name: fuzz ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - fuzz_compile
+          - fuzz_dotenv
+          - fuzz_json_module
+          - fuzz_html_env
+          - fuzz_cache_entry
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: fuzz
+      - run: cargo install cargo-fuzz --locked
+      - name: fuzz for 10 minutes
+        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=600
+      - name: upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-artifacts-${{ matrix.target }}
+          path: fuzz/artifacts
+
+  ignored:
+    name: process-aborting tier
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      # These are `#[ignore]`d because they abort the test binary on purpose
+      # (see docs/development/testing.md). Nightly runs them so a change
+      # upstream that fixes -- or worsens -- one of them is noticed.
+      - name: run the ignored tier, reporting rather than failing
+        run: cargo test --workspace -- --ignored || echo "the ignored tier still aborts, as documented"

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ dist*/
 bench/oj-benchmarks.png
 bench/card.html
 e2e/.ssr-stderr.log
+
+# cargo-mutants scratch output
+mutants.out/
+mutants.out.old/

--- a/README.md
+++ b/README.md
@@ -127,7 +127,21 @@ node e2e/plugin-middleware.mjs                     # configureServer post body f
 node e2e/hmr-gate.mjs                              # hmr gate holds updates until POST /__hmr_flush
 node e2e/config-flag.mjs                           # oj dev --config <path> loads an override config
 node e2e/config-wrapper.mjs                        # vite.config that calls an external defineConfig wrapper
+node e2e/awkward-paths.mjs                         # percent-encoded filenames served, traversal contained
 node bench/generate.mjs 1000                      # generate a benchmark app (then npm i inside it)
 node bench/run.mjs 1000                           # p50/p95 benchmark vs vite
 node bench/card.mjs                               # render bench/card.html to oj-benchmarks.png
 ```
+
+## Testing
+
+```sh
+cargo test --workspace                            # unit + integration suites
+node e2e/run.mjs                                  # the end-to-end suite
+```
+
+The suite is organized by failure mode rather than by module -- adversarial
+input, boundary shapes, contention, injected faults, and properties that hold
+for every input -- and `docs/development/testing.md` describes the layers, the
+fuzz targets, and the behaviours that are deliberate boundaries rather than
+gaps.

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -689,7 +689,15 @@ mod tests {
     use super::*;
 
     fn tmp(label: &str) -> PathBuf {
-        let d = std::env::temp_dir().join(format!("oj-startdev-{}-{label}", std::process::id()));
+        // A fresh directory per call: this wipes the path before creating it, so
+        // two tests that pass the same label would race -- one clearing the
+        // other's fixture out from under it, in whichever order they interleave.
+        static SEQ: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let d = std::env::temp_dir().join(format!(
+            "oj-startdev-{}-{label}-{seq}",
+            std::process::id()
+        ));
         let _ = std::fs::remove_dir_all(&d);
         std::fs::create_dir_all(&d).unwrap();
         d

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,0 +1,163 @@
+# Testing strategy
+
+oj runs other people's source code. Everything it reads -- modules, stylesheets,
+`.env` files, `package.json`, `tsconfig.json`, `oj.config.ts`, cache entries on
+disk, request paths off the wire -- is input it did not write, and much of it is
+machine-generated. So the suite is organized around *how a thing can go wrong*
+rather than around modules: adversarial input, boundary shapes, contention,
+injected faults, and properties that have to hold for every input.
+
+The rules that shape it:
+
+- **Totality.** Arbitrary bytes are a legal file. Every entry point returns a
+  described error or a result -- never a panic, never a hang.
+- **Output validity.** Anything the compiler emits parses as JavaScript. Tests
+  assert that by re-parsing the output, not by matching strings.
+- **Confinement.** An unprefixed environment variable never reaches the client.
+  A request path never reaches a file outside the project.
+- **Determinism.** Compilation is a pure function of (path, source, options);
+  the cache keys entries on exactly that, so a warm cache cannot be wrong.
+- **Degradation.** The cache is an optimization: every failure mode costs a
+  recompile and nothing else.
+
+## Layers
+
+### Unit tests (in `crates/*/src/`)
+
+Next to the code, for the logic that has no interesting failure surface of its
+own: define construction, HMR boundary rules, CJS lowering shapes, the dev
+server's private path helpers (percent-decoding, traversal rejection, url
+classification, HMR gate relevance).
+
+### Integration suites (in `crates/*/tests/`)
+
+| Suite | Proves |
+| --- | --- |
+| `oj_compiler/tests/adverse.rs` | Malformed, hostile and enormous source: unterminated everything, deep nesting on a compile-sized stack, unicode and bidi identifiers, lone surrogates, hostile import specifiers, a rewriter that returns junk, JSON that is not JSON, `__proto__` keys, every `require` shape, glob and dynamic-import-vars patterns that try to escape |
+| `oj_compiler/tests/edge_cases.rs` | Empty files, BOMs, shebangs, CRLF, TypeScript-only syntax (including `enum`), JSX per extension, top-level await, every export form, dev-vs-prod instrumentation, sourcemap omission for synthesized modules, CJS/ESM factory selection |
+| `oj_compiler/tests/properties.rs` | Totality over arbitrary bytes, output validity, determinism, output as a parser fixed point, import order and one-shot rewriting, mode-independence of the module graph |
+| `oj_env/tests/adverse.rs` | Malformed `.env` lines, self-referential and mutual expansion, unterminated quotes and braces, non-ASCII values byte for byte, `%`-soup in HTML, secret confinement including near-miss prefixes and values that try to break out of the JSON literal |
+| `oj_env/tests/properties.rs` | Parsing is total; single-quoted and metacharacter-free values are byte-exact; the defines and the aggregate `import.meta.env` object always agree; no unprefixed variable is ever exposed |
+| `oj_graph/tests/model.rs` | Model-based property test: random link/accept/change sequences checked against a from-scratch reference model after every operation, plus boundary-set and idempotence invariants |
+| `oj_graph/tests/adverse.rs` | 200k-deep import chains, 20k-wide fan-in, cycles of every length, diamonds, self-imports, repeated re-linking leaving no stale edges -- all on a runtime-worker-sized stack |
+| `oj_cache/tests/faults.rs` | Garbage, truncated, wrong-schema and older-schema entries; read-only directories; a cache dir that is a file; keys that are not digests; version isolation |
+| `oj_cache/tests/concurrency.rs` | Several builds sharing one `.oj-cache`: concurrent writers publish a complete entry, a reader never observes a partial one, distinct keys all land, eviction races safely with rewriting |
+| `oj_cache/tests/properties.rs` | Keys are hex digests, deterministic, and injective over (source, url, mode, version); entries round trip exactly; non-digest keys are refused |
+| `oj_css/tests/adverse.rs` | Malformed and truncated stylesheets, 20k-rule and 1MB-value files, nesting within the supported envelope, module scoping collisions, Sass errors, import confinement, minification as formatting only |
+| `oj_resolver/tests/adverse.rs` | Degenerate specifiers, traversal out of the project (allowed by design -- see below), malformed `package.json` and `tsconfig.json`, exports-map encapsulation, private `#imports`, symlinks and symlink cycles, dedupe and alias policy, non-file schemes |
+| `oj_config/tests/adverse.rs` | A config that never finishes, allocates without bound, recurses, throws, is cyclic, exports nothing, or is not an object; TypeScript stripping including `enum`; the sandbox's reach; candidate precedence |
+
+### End-to-end (in `e2e/`)
+
+Node scripts driving the real CLI, some with Playwright. `e2e/run.mjs` is the
+main suite; the standalone scripts cover one seam each. `e2e/awkward-paths.mjs`
+is the request-path pair: filenames that need percent-encoding must be served,
+and every spelling of a traversal (raw, `%2e%2e`, `%2f`, `/@fs`) must not reach
+a file outside the app, in both `oj dev` and `oj preview`.
+
+### Fuzzing (`fuzz/`)
+
+cargo-fuzz targets over the untrusted-input surfaces, asserting the invariants
+above rather than merely "does not crash":
+
+| Target | Asserts |
+| --- | --- |
+| `fuzz_compile` | Output re-parses, specifiers are well-formed, compilation is deterministic |
+| `fuzz_dotenv` | Keys are well-formed; the defines and the aggregate object agree; no unprefixed variable or value leaks |
+| `fuzz_json_module` | Valid JSON always yields a valid module with exactly one default export and no bare `__proto__` key |
+| `fuzz_html_env` | Substitution is total, only touches known keys, never re-scans its own output |
+| `fuzz_cache_entry` | Any entry the cache accepts round trips unchanged |
+
+```sh
+cargo install cargo-fuzz                       # needs a nightly toolchain
+cargo +nightly fuzz run fuzz_compile -- -max_total_time=300
+```
+
+`fuzz_compile` skips inputs nested deeper than 200 brackets: recursion depth is
+governed by the stack a compile thread gets, which is a separate contract (see
+below), and without the filter the fuzzer spends all its time rediscovering that
+parsers recurse.
+
+### Mutation testing (`.cargo/mutants.toml`)
+
+Run on demand, not in CI: it is a check on the suites, not a gate on a change.
+Scoped to the pure crates -- the dev server and the CLI are covered from `e2e/`,
+which cargo-mutants cannot drive.
+
+```sh
+cargo mutants --test-workspace false -j 4 -p oj_env -p oj_graph -p oj_cache -p oj_css
+```
+
+The survivors that mattered were killed by adding tests: the CSS browser-target
+matrix (a matrix decoding to version 0 downlevels everything, so the tests now
+assert that supported syntax survives) and the CSS module naming pattern. One
+survivor was a dead expression rather than an untested one -- the index computed
+for an unclosed `${` in `oj_env::expand` was never read -- and was removed. A
+timeout counts as caught: those mutants turn a loop counter into a
+multiplication and hang, which the suite catches as a hang.
+
+`oj_env` and `oj_css` now come back 95 caught / 6 timed out / 6 missed of 108,
+and all six survivors are equivalent mutants rather than gaps:
+
+- deleting any *single* browser from the target matrix (five of them): the
+  remaining entries still drive the same output, since downleveling follows the
+  oldest target;
+- flipping the `env.is_empty() || !html.contains('%')` fast path in
+  `replace_html_env`: without it the loop reaches the same answer, only slower.
+
+New survivors in these crates mean a real gap, not noise.
+
+## Deliberate boundaries
+
+Things that look like gaps and are not, pinned by a test so they stay decisions:
+
+- **Recursion depth is a stack-size contract.** Parsing, transforming and
+  printing all recurse once per nesting level, and a stack overflow aborts the
+  process rather than failing one file. `oj_compiler::COMPILE_STACK_SIZE` is what
+  the CLI installs as the runtime's thread stack size, and the adverse suites
+  test at that size. There is no depth at which recursion is safe for every
+  stack; there is a documented envelope, far above anything hand-written.
+- **Unbounded Sass recursion aborts the process.** `grass` has no call-depth
+  limit and Rust cannot catch a stack overflow, so `@mixin a { @include a; }`
+  takes the process down. Containing it needs process isolation, not a bigger
+  stack. `oj_css/tests/adverse.rs` keeps the case runnable under `--ignored` so
+  it can be re-checked after a `grass` upgrade.
+- **Early errors are the browser's to report.** Duplicate bindings, assignment
+  to a `const`, `with` in a module: oj does not run oxc's semantic checker on
+  every file in dev. The emitted code is exactly as wrong as the input, never
+  silently repaired.
+- **Resolution is not confinement.** A linked package or a monorepo sibling
+  lives outside the project root, so resolution deliberately returns absolute
+  paths outside it -- including through a `file://` specifier. The dev server's
+  `/@fs` allow-list is what decides whether such a path may be served, and
+  `e2e/awkward-paths.mjs` tests that half.
+- **A broken `tsconfig.json` fails every resolution.** Guessing the alias table
+  would resolve imports to the wrong files, so the error is reported instead --
+  and every message names the tsconfig.
+- **`%%KEY%%` differs from Vite.** Vite's `/%(\S+?)%/g` consumes `%%KEY%` as an
+  unknown key and leaves the text alone; oj rescans from the inner `%` and
+  substitutes. Only adjacent percents differ.
+
+## Commands
+
+```sh
+cargo test --workspace                 # unit + integration, all crates
+cargo test -p oj_graph --test model    # one suite
+cargo test --workspace -- --ignored    # the process-aborting tier, deliberately
+cargo check --manifest-path fuzz/Cargo.toml   # fuzz targets still build
+node e2e/run.mjs                       # the main end-to-end suite
+node e2e/awkward-paths.mjs             # one seam
+```
+
+## Conventions
+
+- Name a test after the property it defends, not the function it calls.
+- Assert the invariant, not the shape: re-parse emitted code, compare against a
+  reference model, check that a secret is absent -- rather than matching output
+  text that a harmless refactor will change.
+- Adverse input goes in the suite that owns the seam. A new failure mode gets a
+  test there, not a new suite.
+- Randomness is seeded (proptest). Failures reproduce from the seed alone, and
+  proptest writes a regression file next to the suite -- commit it.
+- When a test documents a divergence or a limitation rather than a requirement,
+  say so in a comment and list it under **Deliberate boundaries** above.

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target/
+corpus/
+artifacts/
+coverage/
+Cargo.lock

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Raphael Amorim
+[package]
+name = "oj-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+serde_json = "1"
+oj_compiler = { path = "../crates/oj_compiler" }
+oj_cache = { path = "../crates/oj_cache" }
+oj_env = { path = "../crates/oj_env" }
+
+[[bin]]
+name = "fuzz_compile"
+path = "fuzz_targets/fuzz_compile.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_dotenv"
+path = "fuzz_targets/fuzz_dotenv.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_json_module"
+path = "fuzz_targets/fuzz_json_module.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_html_env"
+path = "fuzz_targets/fuzz_html_env.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_cache_entry"
+path = "fuzz_targets/fuzz_cache_entry.rs"
+test = false
+doc = false
+bench = false
+
+# Detached from the workspace so fuzzing dependencies and profiles never leak
+# into the product build.
+[workspace]

--- a/fuzz/fuzz_targets/fuzz_cache_entry.rs
+++ b/fuzz/fuzz_targets/fuzz_cache_entry.rs
@@ -1,0 +1,18 @@
+//! A `.oj-cache` entry is a file on disk that another process, another oj
+//! version, or a crash mid-write produced. Reading one must never panic, and
+//! whatever it deserializes into must round trip byte for byte.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use oj_cache::CachedModule;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(entry) = serde_json::from_slice::<CachedModule>(data) else {
+        return;
+    };
+    // Anything the cache accepts, it must be able to write back and re-read
+    // unchanged: a lossy round trip would serve one module and cache another.
+    let bytes = serde_json::to_vec(&entry).expect("an entry always serializes");
+    let again: CachedModule = serde_json::from_slice(&bytes).expect("round trip");
+    assert_eq!(entry, again, "entry changed across a round trip");
+});

--- a/fuzz/fuzz_targets/fuzz_compile.rs
+++ b/fuzz/fuzz_targets/fuzz_compile.rs
@@ -1,0 +1,75 @@
+//! The per-file pipeline is oj's only contact with source it did not write: it
+//! must never panic, and anything it accepts must come back out as parseable
+//! JavaScript with a module graph that matches what it emitted.
+#![no_main]
+
+use std::path::Path;
+
+use libfuzzer_sys::fuzz_target;
+use oj_compiler::{compile, exports, CompileOptions};
+
+/// Bracket nesting, over-approximated over raw bytes (brackets inside strings
+/// count). Used only to skip inputs, never to assert: nesting depth is bounded
+/// by the stack oj gives a compile thread, which `COMPILE_STACK_SIZE` and the
+/// `adverse` suite cover directly. Without this the fuzzer spends all its time
+/// rediscovering that a parser recurses.
+fn bracket_depth(data: &[u8]) -> usize {
+    let mut depth = 0usize;
+    let mut max = 0usize;
+    for byte in data {
+        match byte {
+            b'(' | b'[' | b'{' => {
+                depth += 1;
+                max = max.max(depth);
+            }
+            b')' | b']' | b'}' => depth = depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+    max
+}
+
+const EXTENSIONS: [&str; 6] = ["ts", "tsx", "js", "jsx", "mjs", "cjs"];
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(source) = std::str::from_utf8(data) else {
+        return;
+    };
+    if bracket_depth(data) > 200 {
+        return;
+    }
+    // The first byte picks the extension, so one corpus entry can explore every
+    // source type without the fuzzer having to guess filenames.
+    let extension = EXTENSIONS[data.first().copied().unwrap_or(0) as usize % EXTENSIONS.len()];
+    let path = std::path::PathBuf::from(format!("/src/fuzz.{extension}"));
+
+    // Names are names, whatever the input.
+    for name in exports(source, &path) {
+        assert!(!name.is_empty(), "empty export name");
+    }
+
+    for options in [CompileOptions::dev(), CompileOptions::prod()] {
+        let Ok(out) = compile(&path, source, &options) else {
+            continue;
+        };
+        // Whatever was emitted is valid JavaScript.
+        let reparsed = compile(Path::new("/src/verify.mjs"), &out.code, &CompileOptions::prod());
+        assert!(
+            reparsed.is_ok(),
+            "emitted invalid code for {extension}: {:?}\n---\n{}",
+            source,
+            out.code
+        );
+        // Every import reported is a real specifier, and the map, if any, is a
+        // data URL.
+        for import in out.imports.iter().chain(out.dynamic_imports.iter()) {
+            assert!(!import.contains('\n'), "specifier with a newline: {import:?}");
+        }
+        if let Some(url) = &out.map_data_url {
+            assert!(url.starts_with("data:application/json;"), "{url}");
+        }
+        // Compilation is a pure function of its inputs.
+        let again = compile(&path, source, &options).expect("second compile");
+        assert_eq!(out.code, again.code, "nondeterministic output");
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_dotenv.rs
+++ b/fuzz/fuzz_targets/fuzz_dotenv.rs
@@ -1,0 +1,83 @@
+//! `.env` files are untrusted text that a build reads without asking, and the
+//! defines derived from them are shipped to the browser. Parsing must be total,
+//! and confinement -- no unprefixed variable in anything the client sees -- must
+//! hold for every input.
+#![no_main]
+
+use std::collections::BTreeMap;
+
+use libfuzzer_sys::fuzz_target;
+use oj_env::{html_env_map, import_meta_env_defines, parse};
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(contents) = std::str::from_utf8(data) else {
+        return;
+    };
+    let mut base = BTreeMap::new();
+    base.insert("PRESET".to_string(), "preset-value".to_string());
+
+    let loaded = parse(contents, &base);
+    for (key, _) in &loaded {
+        assert!(!key.is_empty(), "empty key");
+        assert_eq!(key.trim(), key, "untrimmed key: {key:?}");
+        assert!(!key.contains('='), "key holds an '=': {key:?}");
+        assert!(!key.contains('\n'), "key holds a newline: {key:?}");
+    }
+
+    let prefix = "VITE_";
+    let defines = import_meta_env_defines(&loaded, "production", false, "/", prefix);
+
+    // The aggregate object is always valid JSON, and its keys are exactly the
+    // individual defines.
+    let aggregate = defines
+        .iter()
+        .find(|(k, _)| k == "import.meta.env")
+        .map(|(_, v)| v.clone())
+        .expect("aggregate define");
+    let json: serde_json::Value = serde_json::from_str(&aggregate).expect("valid JSON object");
+    let object = json.as_object().expect("object");
+    let mut individual: Vec<&str> = defines
+        .iter()
+        .filter_map(|(k, _)| k.strip_prefix("import.meta.env."))
+        .collect();
+    individual.sort_unstable();
+    let mut aggregated: Vec<&str> = object.keys().map(String::as_str).collect();
+    aggregated.sort_unstable();
+    assert_eq!(individual, aggregated, "defines disagree with the object");
+
+    // Confinement: only builtins and prefixed variables may appear.
+    const BUILTINS: [&str; 5] = ["MODE", "BASE_URL", "DEV", "PROD", "SSR"];
+    for key in object.keys() {
+        assert!(
+            key.starts_with(prefix) || BUILTINS.contains(&key.as_str()),
+            "unprefixed variable exposed: {key:?}"
+        );
+    }
+    // A variable in the file but not in the defines must not appear by value
+    // either, unless some prefixed variable legitimately holds the same text.
+    let public: Vec<&String> = loaded
+        .iter()
+        .filter(|(k, _)| k.starts_with(prefix))
+        .map(|(_, v)| v)
+        .collect();
+    for (key, value) in &loaded {
+        if key.starts_with(prefix) || value.is_empty() {
+            continue;
+        }
+        if public.iter().any(|v| *v == value) {
+            continue;
+        }
+        assert!(
+            !aggregate.contains(value.as_str()),
+            "value of {key:?} leaked into the defines"
+        );
+    }
+
+    // The html substitution map round trips the string values.
+    let env = html_env_map(&defines);
+    for (key, value) in &loaded {
+        if key.starts_with(prefix) {
+            assert_eq!(env.get(key.as_str()), Some(value), "{key:?} not recoverable");
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_html_env.rs
+++ b/fuzz/fuzz_targets/fuzz_html_env.rs
@@ -1,0 +1,44 @@
+//! `%KEY%` substitution runs over an `index.html` nobody validated, against a
+//! map derived from a `.env` nobody validated. It must be total, must never
+//! substitute a key it was not given, and must never re-scan what it produced.
+#![no_main]
+
+use std::collections::BTreeMap;
+
+use libfuzzer_sys::fuzz_target;
+use oj_env::replace_html_env;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(html) = std::str::from_utf8(data) else {
+        return;
+    };
+
+    // With nothing to substitute, substitution is the identity.
+    assert_eq!(replace_html_env(html, &BTreeMap::new()), html);
+
+    let mut env = BTreeMap::new();
+    env.insert("KNOWN".to_string(), "value".to_string());
+    env.insert("RECURSIVE".to_string(), "%KNOWN%".to_string());
+    env.insert("EMPTY".to_string(), String::new());
+    let out = replace_html_env(html, &env);
+
+    // Only the keys in the map may have been consumed.
+    let substitutions = html.matches("%KNOWN%").count()
+        + html.matches("%RECURSIVE%").count()
+        + html.matches("%EMPTY%").count();
+    if substitutions == 0 {
+        assert_eq!(out, html, "substituted something that was not in the map");
+    }
+    // A substituted value is never scanned again.
+    if html.contains("%RECURSIVE%") {
+        assert!(
+            out.contains("%KNOWN%"),
+            "a substituted value was expanded again:\n{out}"
+        );
+    }
+    // Substitution is a fixed point of itself once the placeholders are gone.
+    let twice = replace_html_env(&out, &env);
+    if !out.contains("%KNOWN%") && !out.contains("%RECURSIVE%") && !out.contains("%EMPTY%") {
+        assert_eq!(twice, out, "not idempotent");
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_json_module.rs
+++ b/fuzz/fuzz_targets/fuzz_json_module.rs
@@ -1,0 +1,65 @@
+//! A `.json` import is turned into JavaScript by splicing the document into a
+//! module. Anything that parses as JSON must therefore come out as valid JS,
+//! with a single default export and named exports that are real identifiers.
+#![no_main]
+
+use std::path::Path;
+
+use libfuzzer_sys::fuzz_target;
+use oj_compiler::{compile, json, CompileOptions};
+
+fn parses_as_js(code: &str) -> bool {
+    compile(Path::new("/src/verify.mjs"), code, &CompileOptions::prod()).is_ok()
+}
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(source) = std::str::from_utf8(data) else {
+        return;
+    };
+    // Only well-formed JSON reaches the interesting code; the error path is
+    // covered by the assertion that both entry points agree below.
+    let value: serde_json::Value = match serde_json::from_str(source) {
+        Ok(value) => value,
+        Err(_) => {
+            assert!(json::to_esm(source, "/data.json").is_err());
+            assert!(json::to_factory_body(source, "/data.json").is_err());
+            return;
+        }
+    };
+
+    let esm = json::to_esm(source, "/data.json").expect("valid JSON converts");
+    assert!(parses_as_js(&esm), "invalid module for {source:?}:\n{esm}");
+    assert_eq!(
+        esm.matches("export default").count(),
+        1,
+        "exactly one default export:\n{esm}"
+    );
+
+    let factory = json::to_factory_body(source, "/data.json").expect("valid JSON converts");
+    assert!(
+        factory.contains("\"default\": () => __oj_json"),
+        "factory without a default export:\n{factory}"
+    );
+
+    // `__proto__` in an object literal would set the prototype instead of
+    // defining a property, so it must never appear as a bare key or as an
+    // export name.
+    if json_has_proto(&value) {
+        assert!(
+            !esm.contains("\"__proto__\":") || esm.contains("JSON.parse("),
+            "a bare __proto__ key reached an object literal:\n{esm}"
+        );
+    }
+    assert!(!esm.contains("export const __proto__"), "{esm}");
+    assert!(!factory.contains("\"__proto__\": ()"), "{factory}");
+});
+
+fn json_has_proto(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Object(map) => {
+            map.contains_key("__proto__") || map.values().any(json_has_proto)
+        }
+        serde_json::Value::Array(items) => items.iter().any(json_has_proto),
+        _ => false,
+    }
+}


### PR DESCRIPTION
Writes down what the other eight PRs were found by, so the method outlives the
bugs.

**`docs/development/testing.md`** maps the layers and lists what each suite
proves. The organizing idea is that suites are named after *how a thing can go
wrong* rather than after the module they cover — adverse input, boundary shapes,
contention, injected faults, properties — with five invariants doing most of the
work: totality (arbitrary bytes are a legal file), output validity (assert by
re-parsing, not by matching strings), confinement (no unprefixed variable reaches
the client, no request path reaches outside the project), determinism, and
degradation (the cache is an optimization; every failure costs a recompile and
nothing else).

Its **Deliberate boundaries** section is the part I would read twice: six
behaviours that look like gaps and are decisions, each pinned by a test —
recursion depth as a stack-size contract, unbounded Sass recursion aborting the
process (`grass` has no depth limit and Rust cannot catch a stack overflow),
early errors left for the browser to report, resolution deliberately not being
confinement, a broken tsconfig failing loudly, and one documented divergence from
Vite's `%%KEY%%` handling.

**`fuzz/`** adds five cargo-fuzz targets over the untrusted-input surfaces. Each
asserts an invariant rather than merely "does not crash": compiled output
re-parses and is deterministic; the dotenv defines never leak an unprefixed
variable; valid JSON always yields a valid module with one default export and no
bare `__proto__` key; `%KEY%` substitution only touches known keys and never
rescans its own output; any cache entry that deserializes round trips unchanged.
`fuzz_compile` skips inputs nested past 200 brackets, since depth is the
stack-size contract above and without the filter the fuzzer spends all its time
rediscovering that parsers recurse.

**CI** keeps the fuzz targets compiling on every PR (they are outside the
workspace, so they would rot silently). A nightly workflow runs each for ten
minutes, uploads crash artifacts, and runs the `#[ignore]`d tier that aborts on
purpose.

**`.cargo/mutants.toml`** scopes cargo-mutants to the pure crates — the dev
server and CLI are covered from `e2e/`, which it cannot drive. It is what
surfaced the untested CSS target matrix and module naming pattern (#5) and one
dead expression (#2). `oj_env` and `oj_css` now come back 95 caught / 6 timed out
/ 6 missed of 108, and all six survivors are equivalent mutants — documented, so
a new survivor there means a real gap rather than noise.

Caveat worth stating: the fuzz targets are compile-checked, not run. cargo-fuzz
needs a nightly toolchain, which the machine I wrote this on does not have; the
nightly workflow is where they would first actually execute.
---

One of eleven independent PRs from the same pass over the test suite. Each stands
alone (its own tests pass on `main` without the others) and all eleven merge
together cleanly — I verified both. Each also carries the same two-line
`tmp()` fix in `crates/oj/src/start_dev.rs`, because without it
`app_uses_tailwind_detects_postcss_vite_and_bare` flakes on any PR CI run; the
hunks are identical, so they merge as one.


