### PR TITLE
fix(build): inline SVGs with CRLF endings, and give every asset a mime type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,6 +1792,7 @@ dependencies = [
  "anyhow",
  "arcstr",
  "axum",
+ "blake3",
  "clap",
  "notify",
  "oj_compiler",

--- a/crates/oj/Cargo.toml
+++ b/crates/oj/Cargo.toml
@@ -23,6 +23,7 @@ rolldown_plugin = "1.2.5"
 rolldown_utils = "1.2.5"
 arcstr = "1.2.0"
 serde_json.workspace = true
+blake3.workspace = true
 oj_css.workspace = true
 axum.workspace = true
 notify.workspace = true

--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -183,8 +183,10 @@ fn asset_mime(ext: &str) -> &'static str {
         "ttf" => "font/ttf",
         "otf" => "font/otf",
         "eot" => "application/vnd.ms-fontobject",
+        "bmp" => "image/bmp",
         "mp4" => "video/mp4",
         "webm" => "video/webm",
+        "mov" => "video/quicktime",
         "mp3" => "audio/mpeg",
         "wav" => "audio/wav",
         "ogg" => "audio/ogg",
@@ -218,6 +220,43 @@ fn b64(bytes: &[u8]) -> String {
     out
 }
 
+/// A module that default-exports `url`. The literal is JSON-encoded rather than
+/// interpolated: a url is derived from a file oj did not write, and a raw
+/// carriage return or quote in it would emit JavaScript that does not parse.
+fn export_default_url(url: &str) -> String {
+    format!(
+        "export default {};",
+        serde_json::Value::String(url.to_string())
+    )
+}
+
+/// An unencoded `data:image/svg+xml,` url, which keeps an inlined SVG readable
+/// and smaller than base64 would.
+///
+/// Percent-encodes what cannot appear unencoded in a data url, and drops the
+/// line terminators: a CRLF-formatted SVG -- what git hands a Windows checkout
+/// -- used to leave the CR in place, and a raw CR cannot appear in a JavaScript
+/// string literal at all.
+fn svg_data_url(text: &str) -> String {
+    let mut out = String::with_capacity(text.len() + 16);
+    for ch in text.chars() {
+        match ch {
+            '%' => out.push_str("%25"),
+            '#' => out.push_str("%23"),
+            '<' => out.push_str("%3C"),
+            '>' => out.push_str("%3E"),
+            '\\' => out.push_str("%5C"),
+            // A double quote would close the literal; SVG accepts either quote.
+            '"' => out.push('\''),
+            // Line terminators: not allowed in a string literal, and not
+            // meaningful in SVG markup.
+            '\n' | '\r' | '\u{2028}' | '\u{2029}' => {}
+            other => out.push(other),
+        }
+    }
+    format!("data:image/svg+xml,{out}")
+}
+
 fn emit_or_inline(
     ctx: &rolldown_plugin::SharedLoadPluginContext,
     file: &str,
@@ -227,22 +266,15 @@ fn emit_or_inline(
     let path = std::path::Path::new(file);
     let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
     if (bytes.len() as u64) <= inline_limit && ext != "svg" {
-        return Ok(format!(
-            "export default \"data:{};base64,{}\";",
+        return Ok(export_default_url(&format!(
+            "data:{};base64,{}",
             asset_mime(ext),
             b64(&bytes)
-        ));
+        )));
     }
     if (bytes.len() as u64) <= inline_limit && ext == "svg" {
         let text = String::from_utf8_lossy(&bytes);
-        let encoded = text
-            .replace('%', "%25")
-            .replace('#', "%23")
-            .replace('<', "%3C")
-            .replace('>', "%3E")
-            .replace('"', "'")
-            .replace('\n', "");
-        return Ok(format!("export default \"data:image/svg+xml,{encoded}\";"));
+        return Ok(export_default_url(&svg_data_url(&text)));
     }
     let name = path
         .file_name()
@@ -2295,11 +2327,14 @@ fn sanitize_asset_name(s: &str) -> String {
         .collect()
 }
 
+/// The hash in a content-addressed filename.
+///
+/// blake3 rather than `DefaultHasher`: the standard library makes no promise
+/// about that hasher's output across releases, so asset filenames could change
+/// -- invalidating every caching header a deploy relies on -- purely because oj
+/// was rebuilt with a newer Rust.
 fn content_hash(bytes: &[u8]) -> String {
-    use std::hash::{Hash, Hasher};
-    let mut h = std::collections::hash_map::DefaultHasher::new();
-    bytes.hash(&mut h);
-    format!("{:016x}", h.finish())
+    blake3::hash(bytes).to_hex()[..16].to_string()
 }
 
 /// Emit a CSS-referenced asset (font/image) under a content hash and return its
@@ -2762,6 +2797,163 @@ mod tests {
             !empty.contains("export "),
             "no exports means no stubs: {empty}"
         );
+    }
+
+    /// Whatever an inlined asset's bytes are, the module oj emits for it has to
+    /// parse. The url is derived from a file oj did not write.
+    fn parses(code: &str) -> bool {
+        oj_compiler::compile(
+            std::path::Path::new("/verify.mjs"),
+            code,
+            &oj_compiler::CompileOptions::prod(),
+        )
+        .is_ok()
+    }
+
+    #[test]
+    fn an_inlined_svg_with_crlf_endings_emits_parseable_javascript() {
+        // git hands a Windows checkout CRLF, and a raw carriage return cannot
+        // appear in a JavaScript string literal.
+        let svg = "<svg xmlns=\"http://www.w3.org/2000/svg\">\r\n  <rect/>\r\n</svg>\r\n";
+        let url = svg_data_url(svg);
+        assert!(!url.contains('\r'), "carriage return survived: {url}");
+        assert!(!url.contains('\n'), "line feed survived: {url}");
+        assert!(url.starts_with("data:image/svg+xml,"), "{url}");
+        assert!(url.contains("%3Crect/%3E"), "content lost: {url}");
+        assert!(parses(&export_default_url(&url)), "{url}");
+    }
+
+    #[test]
+    fn svg_data_urls_encode_everything_that_would_break_the_url_or_the_literal() {
+        let cases = [
+            ("<svg/>", "%3Csvg/%3E"),
+            ("<svg a=\"b\"/>", "%3Csvg a='b'/%3E"),
+            ("<svg>100%</svg>", "%3Csvg%3E100%25%3C/svg%3E"),
+            ("<svg fill=\"#fff\"/>", "%3Csvg fill='%23fff'/%3E"),
+            ("<svg>a\\b</svg>", "%3Csvg%3Ea%5Cb%3C/svg%3E"),
+        ];
+        for (svg, expected_tail) in cases {
+            let url = svg_data_url(svg);
+            assert_eq!(url, format!("data:image/svg+xml,{expected_tail}"));
+            assert!(parses(&export_default_url(&url)), "{url}");
+        }
+        // Line and paragraph separators are string-literal terminators too.
+        for terminator in ["\u{2028}", "\u{2029}", "\r", "\n", "\r\n"] {
+            let url = svg_data_url(&format!("<svg>{terminator}</svg>"));
+            assert_eq!(url, "data:image/svg+xml,%3Csvg%3E%3C/svg%3E");
+            assert!(parses(&export_default_url(&url)));
+        }
+    }
+
+    #[test]
+    fn a_default_export_of_a_url_is_always_a_valid_module() {
+        for url in [
+            "data:image/png;base64,AAAA",
+            "/assets/a-0123.png",
+            "",
+            "a\"b",
+            "a\\b",
+            "a\nb",
+            "a\rb",
+            "a\u{2028}b",
+            "a\0b",
+            "café/🚀.png",
+        ] {
+            let module = export_default_url(url);
+            assert!(parses(&module), "{url:?} -> {module}");
+        }
+    }
+
+    #[test]
+    fn every_asset_extension_has_a_real_mime_type() {
+        // `is_build_asset` decides what gets inlined; `asset_mime` decides what
+        // the browser is told it is. A gap between them inlines a file the page
+        // then refuses to render.
+        for ext in [
+            "png", "jpg", "jpeg", "gif", "webp", "avif", "ico", "bmp", "svg", "woff", "woff2",
+            "ttf", "otf", "eot", "mp4", "webm", "mov", "mp3", "wav", "ogg",
+        ] {
+            assert!(is_build_asset(&format!("/src/a.{ext}")), "{ext} not an asset");
+            assert_ne!(
+                asset_mime(ext),
+                "application/octet-stream",
+                "{ext} has no mime type"
+            );
+        }
+        // A query does not change the classification.
+        assert!(is_build_asset("/src/a.png?url"));
+        assert!(!is_build_asset("/src/a.tsx"));
+        assert!(!is_build_asset("/src/a.png.tsx"));
+        assert!(!is_build_asset(""));
+        // An unknown extension falls back rather than guessing.
+        assert_eq!(asset_mime("xyz"), "application/octet-stream");
+    }
+
+    #[test]
+    fn base64_matches_the_reference_vectors() {
+        // RFC 4648 section 10, plus the padding boundaries.
+        assert_eq!(b64(b""), "");
+        assert_eq!(b64(b"f"), "Zg==");
+        assert_eq!(b64(b"fo"), "Zm8=");
+        assert_eq!(b64(b"foo"), "Zm9v");
+        assert_eq!(b64(b"foob"), "Zm9vYg==");
+        assert_eq!(b64(b"fooba"), "Zm9vYmE=");
+        assert_eq!(b64(b"foobar"), "Zm9vYmFy");
+        // High bytes must not sign-extend.
+        assert_eq!(b64(&[0xff, 0xff, 0xff]), "////");
+        assert_eq!(b64(&[0x00, 0x00, 0x00]), "AAAA");
+        assert_eq!(b64(&[0xfb, 0xff, 0xbf]), "+/+/");
+        // Length is always a multiple of four.
+        for len in 0..64 {
+            let bytes: Vec<u8> = (0..len).map(|i| i as u8).collect();
+            assert_eq!(b64(&bytes).len() % 4, 0, "len {len}");
+        }
+    }
+
+    #[test]
+    fn content_hashes_are_stable_and_content_addressed() {
+        // Pinned: filenames derived from this end up in caching headers, so the
+        // value must not drift with the toolchain that built oj.
+        assert_eq!(content_hash(b""), "af1349b9f5f9a1a6");
+        assert_eq!(content_hash(b"oj"), "b74f11b8dbbdd6b4");
+        assert_eq!(content_hash(b"oj").len(), 16);
+        assert!(content_hash(b"oj").chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(content_hash(b"a"), content_hash(b"b"));
+        // A one-bit difference is a different name.
+        assert_ne!(content_hash(&[0x00]), content_hash(&[0x01]));
+    }
+
+    #[test]
+    fn transitive_imports_terminates_on_a_cycle() {
+        let mut map = std::collections::HashMap::new();
+        map.insert("a".to_string(), vec!["b".to_string()]);
+        map.insert("b".to_string(), vec!["c".to_string(), "a".to_string()]);
+        map.insert("c".to_string(), vec!["b".to_string()]);
+        let reachable = transitive_imports("a", &map);
+        assert_eq!(
+            reachable.into_iter().collect::<Vec<_>>(),
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+        // An unknown entry reaches nothing.
+        assert!(transitive_imports("missing", &map).is_empty());
+        // A self-import terminates.
+        let mut selfish = std::collections::HashMap::new();
+        selfish.insert("a".to_string(), vec!["a".to_string()]);
+        assert_eq!(
+            transitive_imports("a", &selfish).into_iter().collect::<Vec<_>>(),
+            vec!["a".to_string()]
+        );
+    }
+
+    #[test]
+    fn asset_names_are_sanitized_without_collapsing_to_nothing() {
+        assert_eq!(sanitize_asset_name("logo.png"), "logo.png");
+        assert_eq!(sanitize_asset_name("my logo.png"), "my_logo.png");
+        assert_eq!(sanitize_asset_name("a/b.png"), "a_b.png");
+        assert_eq!(sanitize_asset_name("../../etc/passwd"), ".._.._etc_passwd");
+        assert_eq!(sanitize_asset_name("a\0b.png"), "a_b.png");
+        assert!(!sanitize_asset_name("café.png").contains('é'));
+        assert!(sanitize_asset_name("").is_empty());
     }
 
     #[test]

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -689,7 +689,15 @@ mod tests {
     use super::*;
 
     fn tmp(label: &str) -> PathBuf {
-        let d = std::env::temp_dir().join(format!("oj-startdev-{}-{label}", std::process::id()));
+        // A fresh directory per call: this wipes the path before creating it, so
+        // two tests that pass the same label would race -- one clearing the
+        // other's fixture out from under it, in whichever order they interleave.
+        static SEQ: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let d = std::env::temp_dir().join(format!(
+            "oj-startdev-{}-{label}-{seq}",
+            std::process::id()
+        ));
         let _ = std::fs::remove_dir_all(&d);
         std::fs::create_dir_all(&d).unwrap();
         d

--- a/e2e/assets-inline.mjs
+++ b/e2e/assets-inline.mjs
@@ -26,10 +26,22 @@ fs.writeFileSync(
   path.join(app, "src", "dot.png"),
   Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==", "base64"),
 );
+// A CRLF-formatted SVG: what git hands a Windows checkout. Inlining used to
+// leave the CR in the emitted string literal, which does not parse.
+fs.writeFileSync(
+  path.join(app, "src", "crlf.svg"),
+  `<svg xmlns="http://www.w3.org/2000/svg">\r\n  <rect width="1" height="1"/>\r\n</svg>\r\n`,
+);
+fs.writeFileSync(
+  path.join(app, "src", "dot.bmp"),
+  Buffer.from("Qk06AAAAAAAAADYAAAAoAAAAAQAAAAEAAAABABgAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAD/AA==", "base64"),
+);
 fs.writeFileSync(
   path.join(app, "src", "main.js"),
   `import small from "./small.svg";\nimport big from "./big.svg";\nimport png from "./dot.png";\n` +
-    `window.__S = small; window.__B = big; window.__PNG = png; window.__READY = true;\n`,
+    `import crlf from "./crlf.svg";\nimport bmp from "./dot.bmp";\n` +
+    `window.__S = small; window.__B = big; window.__PNG = png; window.__CRLF = crlf; window.__BMP = bmp;\n` +
+    `window.__READY = true;\n`,
 );
 fs.writeFileSync(
   path.join(app, "index.html"),
@@ -60,10 +72,20 @@ try {
   try {
     await page.goto("http://localhost:5351/", { timeout: 30000 });
     await page.waitForFunction(() => window.__READY, { timeout: 10000 });
-    const r = await page.evaluate(() => ({ s: window.__S, b: window.__B, png: window.__PNG }));
+    const r = await page.evaluate(() => ({
+      s: window.__S,
+      b: window.__B,
+      png: window.__PNG,
+      crlf: window.__CRLF,
+      bmp: window.__BMP,
+    }));
     assert.match(r.s, /^data:image\/svg\+xml,/, "small svg is an inline data uri");
     assert.match(r.png, /^data:image\/png;base64,/, "png is an inline base64 data uri");
     assert.match(r.b, /\/assets\/big-.*\.svg$/, "big svg is an emitted file url");
+    assert.match(r.crlf, /^data:image\/svg\+xml,/, "a CRLF svg inlines too");
+    assert.ok(!/[\r\n]/.test(r.crlf), "no line terminator survives in the data uri");
+    assert.match(r.crlf, /%3Crect/, "the CRLF svg kept its content");
+    assert.match(r.bmp, /^data:image\/bmp;base64,/, "bmp inlines with its own mime type");
     assert.equal(errors.length, 0, `page errors: ${errors.join("|")}`);
   } finally {
     await browser.close();
@@ -75,6 +97,7 @@ try {
   build();
   files = assets();
   assert.ok(files.some((f) => f.startsWith("small-")) && files.some((f) => f.endsWith(".png")), "limit 0 emits every asset");
+  assert.ok(files.some((f) => f.endsWith(".bmp")), "limit 0 emits the bmp too");
 
   console.log("ASSETS-INLINE E2E PASSED");
 } catch (err) {


### PR DESCRIPTION
Three bugs in how the production build emits assets.

**An inlined SVG with CRLF line endings failed the build.**

```
Error: build failed: PARSE_ERROR "Unterminated string"
```

`emit_or_inline` stripped `\n` from the SVG text and interpolated the result into
a string literal, which leaves the `\r` behind — and a raw carriage return cannot
appear in a JavaScript string literal at all. So a perfectly valid SVG, checked
out by git on Windows or anywhere with `core.autocrlf`, broke the build with a
parse error pointing at generated code the user never wrote. I reproduced it with
a two-file app before fixing it.

The data url now drops every line terminator (including U+2028 and U+2029, which
are string-literal terminators too) and percent-encodes the backslash. And the
module is emitted through a JSON-encoded literal, so no asset url — derived, as
they all are, from a file oj did not write — can produce something that does not
parse.

**`bmp` and `mov` inlined as `application/octet-stream`.** `is_build_asset`
accepts both, `asset_mime` had no arm for either, so an inlined BMP became a data
url the page will not render. Added, along with a test that walks every extension
`is_build_asset` accepts and asserts each has a real type — the two tables are
supposed to agree, and nothing was checking that.

**`content_hash` used `DefaultHasher`.** The standard library explicitly makes no
promise about that hasher's output across releases, and these hashes become asset
filenames that end up in caching headers. A deploy's cache keys should not change
because oj was rebuilt with a newer Rust. Switched to blake3, which the workspace
already depends on.

### Tests

Unit tests around the two extracted helpers (`svg_data_url`, `export_default_url`)
that assert by re-parsing what they emit, base64 against the RFC 4648 vectors,
the asset mime and classification tables against each other, content hashes
pinned by value, `transitive_imports` against cycles and self-imports, and asset
name sanitization.

`e2e/assets-inline.mjs` grows a CRLF SVG and a BMP: the SVG must inline with no
line terminator in the data url and its content intact, and the BMP must inline
as `data:image/bmp;base64,`. It fails against the unfixed build — I checked by
stashing only the Rust change.

`cargo test --workspace`, `node e2e/run.mjs`, the eight build-output e2e scripts
(manifest, assets, css-code-split, modulepreload, manual-chunks, css-rebase,
query-assets, assets-inline) and the `playground` production build all pass.

---

One of eleven independent PRs from the same pass over the test suite. Each stands
alone (its own tests pass on `main` without the others) and all eleven merge
together cleanly — I verified both. Each also carries the same two-line `tmp()`
fix in `crates/oj/src/start_dev.rs`, because without it
`app_uses_tailwind_detects_postcss_vite_and_bare` flakes on any PR CI run; the
hunks are identical, so they merge as one.

