### PR TITLE
fix(ssr): confine the module runner's reads and server-function calls

### DIFF
--- a/crates/oj/src/ssr_dev.rs
+++ b/crates/oj/src/ssr_dev.rs
@@ -80,6 +80,65 @@ pub async fn ssr_dev(
     Ok(())
 }
 
+/// Resolve the `module` field of a server-function call to a file oj is willing
+/// to import.
+///
+/// The field comes off the request body, so it is attacker-controlled -- and a
+/// browser can POST here cross-origin without a preflight, since a JSON body
+/// with `content-type: text/plain` is a simple request. Unchecked, that is
+/// "import and run any module on the developer's machine" from any page they
+/// have open. Two conditions, matching what the production dispatch table
+/// allows: inside the project, and named like a server module.
+fn server_fn_module(root: &Path, module_url: &str) -> Option<PathBuf> {
+    const SERVER_SUFFIXES: [&str; 8] = [
+        ".server.ts",
+        ".server.tsx",
+        ".server.js",
+        ".server.jsx",
+        ".server.mts",
+        ".server.mjs",
+        ".server.cts",
+        ".server.cjs",
+    ];
+
+    let rel = module_url.split('?').next().unwrap_or(module_url);
+    let rel = rel.trim_start_matches('/');
+    if rel.is_empty() {
+        return None;
+    }
+    let candidate = normalize_path(&root.join(rel));
+    if !candidate.starts_with(normalize_path(root)) {
+        return None;
+    }
+    let name = candidate.file_name().and_then(|n| n.to_str())?;
+    if !SERVER_SUFFIXES.iter().any(|s| name.ends_with(s)) {
+        return None;
+    }
+    // Every server module is a real file in the project (production dispatches
+    // through a table globbed from them), so a name that is not one is refused
+    // here rather than sent to the runner to fail with a stack trace.
+    if !candidate.is_file() {
+        return None;
+    }
+    Some(candidate)
+}
+
+/// Resolve `.` and `..` without touching the filesystem, so a path that does not
+/// exist yet is still confined.
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::ParentDir => {
+                out.pop();
+            }
+            std::path::Component::CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
 async fn spawn_runner(root: &Path, base: &str, entry_abs: &Path) -> anyhow::Result<Runner> {
     let dir = root.join(".oj-cache").join("ssr");
     std::fs::create_dir_all(&dir)?;
@@ -123,7 +182,13 @@ async fn ssr_route(State(state): State<Arc<SsrState>>, req: Request, next: Next)
             .unwrap_or_default();
         let payload: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or_default();
         let module_url = payload.get("module").and_then(|m| m.as_str()).unwrap_or("");
-        let abs = state.root.join(module_url.trim_start_matches('/'));
+        let Some(abs) = server_fn_module(&state.root, module_url) else {
+            return (
+                StatusCode::FORBIDDEN,
+                format!("oj: not a server module: {module_url}"),
+            )
+                .into_response();
+        };
         let cmd = serde_json::json!({
             "cmd": "call",
             "module": abs.to_string_lossy(),
@@ -337,4 +402,137 @@ fn html_escape(s: &str) -> String {
     s.replace('&', "&amp;")
         .replace('<', "&lt;")
         .replace('>', "&gt;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A project with one server module and one ordinary module, plus a sibling
+    /// directory outside it.
+    fn fixture() -> (PathBuf, PathBuf) {
+        static SEQ: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let base = std::env::temp_dir().join(format!("oj-serverfn-{}-{seq}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        let root = base.join("app");
+        std::fs::create_dir_all(root.join("src/api")).unwrap();
+        std::fs::create_dir_all(base.join("outside")).unwrap();
+        for name in [
+            "src/greeting.server.ts",
+            "src/greeting.server.tsx",
+            "src/api/user.server.js",
+            "src/api/user.server.mjs",
+            "src/App.tsx",
+            "src/main.tsx",
+            "src/server.ts",
+            "src/serverish.ts",
+            "src/greeting.server",
+            "src/greeting.server.css",
+            "package.json",
+        ] {
+            std::fs::write(root.join(name), "x").unwrap();
+        }
+        std::fs::write(base.join("outside/secrets.server.ts"), "x").unwrap();
+        (base, root)
+    }
+
+    #[test]
+    fn a_server_function_call_names_a_server_module_inside_the_project() {
+        let (base, root) = fixture();
+        for ok in [
+            "src/greeting.server.ts",
+            "/src/greeting.server.ts",
+            "src/greeting.server.tsx",
+            "src/api/user.server.js",
+            "src/api/user.server.mjs",
+            "src/greeting.server.ts?t=123",
+            // `..` that lands back inside is still inside.
+            "src/../src/greeting.server.ts",
+        ] {
+            let resolved = server_fn_module(&root, ok).unwrap_or_else(|| panic!("{ok} rejected"));
+            assert!(resolved.starts_with(&root), "{ok} -> {resolved:?}");
+        }
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn a_server_function_call_cannot_name_a_module_outside_the_project() {
+        let (base, root) = fixture();
+        // The `module` field comes off the request body, and a browser can POST
+        // here cross-origin without a preflight. Unchecked, this is "import and
+        // run any module on the machine" from any page the developer has open.
+        for hostile in [
+            "../outside/secrets.server.ts",
+            "../../../../etc/evil.server.js",
+            "src/../../outside/secrets.server.ts",
+            "/etc/passwd",
+            "/Users/someone/.ssh/id_rsa",
+            "..",
+            "/",
+            "",
+            " ",
+        ] {
+            assert!(
+                server_fn_module(&root, hostile).is_none(),
+                "{hostile:?} accepted"
+            );
+        }
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn a_server_function_call_cannot_name_an_ordinary_module() {
+        let (base, root) = fixture();
+        // Production dispatches through a table built from `**/*.server.*`; dev
+        // must not be able to reach further than that.
+        for not_a_server_module in [
+            "src/App.tsx",
+            "src/main.tsx",
+            "package.json",
+            "src/server.ts",
+            "src/greeting.server",
+            "src/greeting.server.css",
+            "src/serverish.ts",
+            "node_modules/react/index.js",
+        ] {
+            assert!(
+                server_fn_module(&root, not_a_server_module).is_none(),
+                "{not_a_server_module:?} accepted"
+            );
+        }
+        // A server module that does not exist is refused too.
+        assert!(server_fn_module(&root, "src/missing.server.ts").is_none());
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn path_normalization_does_not_touch_the_filesystem() {
+        assert_eq!(
+            normalize_path(Path::new("/a/b/../c/./d.ts")),
+            PathBuf::from("/a/c/d.ts")
+        );
+        assert_eq!(normalize_path(Path::new("/a/../..")), PathBuf::from("/"));
+        assert_eq!(normalize_path(Path::new("a/b/../b")), PathBuf::from("a/b"));
+    }
+
+    #[test]
+    fn requests_for_assets_and_internals_are_passed_through() {
+        let prefixes: Vec<String> = vec!["/api".to_string()];
+        let route = |method: &str, path: &str| {
+            let req = axum::http::Request::builder()
+                .method(method)
+                .uri(path)
+                .body(axum::body::Body::empty())
+                .unwrap();
+            matches!(classify(&req, &prefixes), Route::Pass)
+        };
+        assert!(route("GET", "/@oj/client.js"), "internal urls pass through");
+        assert!(route("GET", "/__oj_fn"), "double-underscore urls pass through");
+        assert!(route("GET", "/src/App.tsx"), "a file url passes through");
+        assert!(route("GET", "/api/users"), "a proxied prefix passes through");
+        assert!(route("PUT", "/dashboard"), "an unhandled method passes through");
+        assert!(!route("GET", "/dashboard"), "a route is a document");
+        assert!(!route("POST", "/dashboard"), "a post is an action");
+    }
 }

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -689,7 +689,15 @@ mod tests {
     use super::*;
 
     fn tmp(label: &str) -> PathBuf {
-        let d = std::env::temp_dir().join(format!("oj-startdev-{}-{label}", std::process::id()));
+        // A fresh directory per call: this wipes the path before creating it, so
+        // two tests that pass the same label would race -- one clearing the
+        // other's fixture out from under it, in whichever order they interleave.
+        static SEQ: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let d = std::env::temp_dir().join(format!(
+            "oj-startdev-{}-{label}-{seq}",
+            std::process::id()
+        ));
         let _ = std::fs::remove_dir_all(&d);
         std::fs::create_dir_all(&d).unwrap();
         d

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -653,6 +653,46 @@ fn js_response_json(v: serde_json::Value) -> Response {
     ([(header::CONTENT_TYPE, "application/json")], v.to_string()).into_response()
 }
 
+/// Whether the SSR runner may load `path`, given what the server allows.
+///
+/// The runner asks for modules by absolute path, and `id` arrives on a request,
+/// so the set has to be bounded by something other than the caller's honesty.
+/// Anything that is not a real file is not a filesystem read at all -- a virtual
+/// id can only be resolved by the plugin host, and only to what a plugin
+/// generated -- so those pass through. A real file has to be the project's, a
+/// dependency's, or something `server.fs.allow` named. That leaves out what this
+/// endpoint has no business reading: `~/.ssh`, `~/.aws`, `/etc`.
+fn module_read_allowed(
+    root: &Path,
+    allow: &std::collections::HashSet<PathBuf>,
+    path: &Path,
+) -> bool {
+    let Ok(candidate) = std::fs::canonicalize(path) else {
+        return true;
+    };
+    let real = |p: &Path| std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+    if candidate.starts_with(real(root)) {
+        return true;
+    }
+    // A dependency, wherever it is installed (a pnpm store, a workspace root, a
+    // linked package): dependencies are not secrets, and this is the path every
+    // real SSR import takes.
+    if candidate
+        .components()
+        .any(|c| c.as_os_str() == "node_modules")
+    {
+        return true;
+    }
+    allow
+        .iter()
+        .any(|allowed| candidate.starts_with(real(allowed)))
+}
+
+fn ssr_module_allowed(state: &ServerState, path: &Path) -> bool {
+    let allow = state.fs_allow.lock().unwrap().clone();
+    module_read_allowed(&state.root, &allow, path)
+}
+
 async fn ssr_module(
     State(state): State<Arc<ServerState>>,
     Query(q): Query<HashMap<String, String>>,
@@ -661,6 +701,11 @@ async fn ssr_module(
         return (StatusCode::BAD_REQUEST, "id required").into_response();
     };
     let path = PathBuf::from(id);
+    // `id` arrives on a request, so it is attacker-controlled: without this the
+    // endpoint hands back the contents of any compilable file on the machine.
+    if !ssr_module_allowed(&state, &path) {
+        return (StatusCode::FORBIDDEN, "oj: module not allow-listed").into_response();
+    }
     let (source, from_plugin) = match std::fs::read(&path).and_then(bytes_to_string) {
         Ok(s) => (s, false),
         Err(read_err) => match ssr_plugin_host(&state).await {
@@ -4021,6 +4066,73 @@ mod adapter_tests {
         )
         .unwrap();
         assert!(!is_tanstack_start_app(&app2));
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn the_ssr_module_endpoint_only_reads_the_project_and_its_dependencies() {
+        let base = tmp("ssr-allow");
+        let root = base.join("app");
+        let outside = base.join("elsewhere");
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(root.join("node_modules/react")).unwrap();
+        std::fs::create_dir_all(outside.join("secrets")).unwrap();
+        std::fs::create_dir_all(base.join("linked/node_modules/dep")).unwrap();
+        std::fs::create_dir_all(base.join("allowed")).unwrap();
+        std::fs::write(root.join("src/App.tsx"), "x").unwrap();
+        std::fs::write(root.join("node_modules/react/index.js"), "x").unwrap();
+        std::fs::write(outside.join("secrets/id_rsa"), "x").unwrap();
+        std::fs::write(base.join("linked/node_modules/dep/index.js"), "x").unwrap();
+        std::fs::write(base.join("allowed/shared.ts"), "x").unwrap();
+
+        let mut allow = std::collections::HashSet::new();
+        allow.insert(base.join("allowed"));
+
+        // The project, its dependencies, and what `server.fs.allow` named.
+        for ok in [
+            root.join("src/App.tsx"),
+            root.join("node_modules/react/index.js"),
+            base.join("linked/node_modules/dep/index.js"),
+            base.join("allowed/shared.ts"),
+        ] {
+            assert!(module_read_allowed(&root, &allow, &ok), "{ok:?} denied");
+        }
+
+        // Everything else, however it is spelled.
+        for denied in [
+            outside.join("secrets/id_rsa"),
+            root.join("../elsewhere/secrets/id_rsa"),
+            root.join("src/../../elsewhere/secrets/id_rsa"),
+        ] {
+            assert!(
+                !module_read_allowed(&root, &allow, &denied),
+                "{denied:?} allowed"
+            );
+        }
+
+        // A virtual id is not a filesystem read: the plugin host is the only
+        // thing that can resolve it, so it passes through.
+        for virtual_id in ["virtual:oj-routes", "\0virtual:x", "plugin:generated"] {
+            assert!(module_read_allowed(&root, &allow, Path::new(virtual_id)));
+        }
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlink_out_of_the_project_does_not_widen_what_can_be_read() {
+        let base = tmp("ssr-symlink");
+        let root = base.join("app");
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(base.join("secrets")).unwrap();
+        std::fs::write(base.join("secrets/id_rsa"), "x").unwrap();
+        let link = root.join("src/escape.ts");
+        if std::os::unix::fs::symlink(base.join("secrets/id_rsa"), &link).is_ok() {
+            assert!(
+                !module_read_allowed(&root, &std::collections::HashSet::new(), &link),
+                "a symlink inside the project must not expose its target"
+            );
+        }
         let _ = std::fs::remove_dir_all(&base);
     }
 

--- a/e2e/ssr-dev.mjs
+++ b/e2e/ssr-dev.mjs
@@ -4,6 +4,7 @@
 import { spawn, execSync } from "node:child_process";
 import fs from "node:fs";
 import http from "node:http";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -174,6 +175,58 @@ try {
       throw new Error("ssr load did not return the plugin virtual module source: " + mod);
     }
     console.log("ssr-dev: plugin resolveId + load ok (virtual module resolves/loads server-side)");
+  }
+
+  {
+    // The SSR module endpoint and the server-function endpoint both take a path
+    // from the request. Neither may reach a file outside the project: a browser
+    // can POST to /__oj_fn cross-origin without a preflight (a JSON body with
+    // content-type text/plain is a simple request), so "any module on the
+    // developer's machine" would be reachable from any page they have open.
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "oj-ssr-outside-"));
+    const outside = path.join(outsideDir, "outside.server.mjs");
+    fs.writeFileSync(outside, `export function leak() { return "PWNED"; }\n`);
+    const rel = path.relative(path.join(repo, "playground"), outside);
+
+    const call = async (module) => {
+      const res = await fetch(`${base}/__oj_fn`, {
+        method: "POST",
+        headers: { "content-type": "text/plain" },
+        body: JSON.stringify({ module, name: "leak", args: [] }),
+      });
+      return { status: res.status, body: await res.text() };
+    };
+    for (const hostile of [rel, outside, "../../../etc/passwd", "src/App.tsx"]) {
+      const r = await call(hostile);
+      if (r.status !== 403 || r.body.includes("PWNED")) {
+        throw new Error(`server fn accepted ${hostile}: ${r.status} ${r.body.slice(0, 120)}`);
+      }
+    }
+    const good = await fetch(`${base}/__oj_fn`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ module: "/src/greeting.server.ts", name: "greet", args: ["oj"] }),
+    });
+    const greeting = await good.text();
+    if (good.status !== 200 || !greeting.includes("server=true")) {
+      throw new Error(`a real server function stopped working: ${good.status} ${greeting}`);
+    }
+
+    const read = async (id) =>
+      await fetch(`${base}/@ssr-module?id=${encodeURIComponent(id)}`);
+    for (const hostile of [outside, path.join(outsideDir, "..", path.basename(outsideDir), "outside.server.mjs")]) {
+      const r = await read(hostile);
+      if (r.status !== 403) {
+        throw new Error(`ssr-module served ${hostile}: ${r.status} ${(await r.text()).slice(0, 120)}`);
+      }
+    }
+    const inRoot = await read(path.join(repo, "playground", "src", "App.tsx"));
+    if (inRoot.status !== 200) throw new Error("ssr-module stopped serving project files");
+    const dep = await read(path.join(repo, "playground", "node_modules", "react", "index.js"));
+    if (dep.status !== 200) throw new Error("ssr-module stopped serving dependencies");
+
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+    console.log("ssr-dev: module + server-fn endpoints confined to the project ok");
   }
 
   let pw = null;


### PR DESCRIPTION
Two endpoints that `oj dev --ssr` adds take a path straight from the request.

**`GET /@ssr-module?id=<path>`** read whatever `id` named:

```
$ curl 'http://127.0.0.1:5199/@ssr-module?id=%2FUsers%2Fme%2F.claude%2Fnotes.mjs'
200  <the file's source>
```

Any compilable file on the machine came back with its contents in the body.

**`POST /__oj_fn`** joined the body's `module` field onto the project root
without normalising it, so `../../../../x.server.mjs` resolved outside the
project — and the module runner imported it and called the named export:

```
$ curl -X POST http://127.0.0.1:5199/__oj_fn -H 'content-type: text/plain' \
    -d '{"module":"../../../../tmp/outside.server.mjs","name":"leak","args":[]}'
200 "PWNED"
```

That `content-type: text/plain` matters: a JSON body sent with it is a CORS
*simple* request, so a browser sends it cross-origin with no preflight. Any page
a developer had open could import and execute a module from their filesystem,
and anything on the LAN could when the server was started with `--host`. I
confirmed both against a real dev server, before and after.

Neither affects the production server. `__ojDispatch` there resolves against a
table globbed from `**/*.server.*` at build time, which is a closed set. The fix
gives dev the same bound:

- a server-function call must name an existing `*.server.*` file that stays
  inside the project after normalisation;
- the module endpoint serves the project, anything under a `node_modules` (a
  dependency is not a secret, and it is the path every real SSR import takes),
  and whatever `server.fs.allow` names.

Paths that are not real files pass through untouched — a virtual id is not a
filesystem read, and only the plugin host can resolve one, to what a plugin
generated. That keeps `virtual:` modules and plugin-provided ids working, which
is what the first version of this patch broke and the existing SSR e2e caught.
Canonicalisation means a symlink planted inside the project does not widen it
either.

### Tests

Unit tests over both policies — the project/dependency/allow-list cases, the
denied spellings, the virtual-id pass-through, and a symlink escape.

`e2e/ssr-dev.mjs` now drives both endpoints against a real dev server: a module
outside the project, a relative traversal, an ordinary non-server module, and
`/etc/passwd`, all of which must be refused, while a genuine server function,
project files and dependencies must still work. It reports `200 "PWNED"` against
the unfixed code — I checked by stashing only the Rust changes.

---

One of eleven independent PRs from the same pass over the test suite. Each stands
alone (its own tests pass on `main` without the others) and all eleven merge
together cleanly — I verified both. Each also carries the same two-line `tmp()`
fix in `crates/oj/src/start_dev.rs`, because without it
`app_uses_tailwind_detects_postcss_vite_and_bare` flakes on any PR CI run; the
hunks are identical, so they merge as one.
