### PR TITLE
exit child processes when the parent oj process dies

### DIFF
--- a/crates/oj_server/src/assets/css-preprocess.mjs
+++ b/crates/oj_server/src/assets/css-preprocess.mjs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Raphael Amorim
 
 import { createRequire } from "node:module";
+import { fstatSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import path from "node:path";
 import readline from "node:readline";
@@ -28,6 +29,14 @@ async function stylus(base, css, from) {
 }
 
 const rl = readline.createInterface({ input: process.stdin });
+// stdin EOF means the parent is gone (SIGKILL skips its teardown) or the
+// one-shot build path closed it: exit once no reply is in flight.
+let inflight = 0;
+let stdinClosed = false;
+const maybeExit = () => { if (stdinClosed && inflight === 0) process.exit(0); };
+try {
+  if (fstatSync(0).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
+} catch {}
 rl.on("line", async (line) => {
   let msg;
   try {
@@ -37,6 +46,7 @@ rl.on("line", async (line) => {
   }
   const { id, base, css, from } = msg;
   const ext = String(from || "").split("?")[0].split(".").pop().toLowerCase();
+  inflight += 1;
   try {
     let out = css;
     if (ext === "less") out = await less(base, css, from);
@@ -44,5 +54,8 @@ rl.on("line", async (line) => {
     process.stdout.write(JSON.stringify({ id, css: out }) + "\n");
   } catch (e) {
     process.stdout.write(JSON.stringify({ id, error: String((e && e.message) || e) }) + "\n");
+  } finally {
+    inflight -= 1;
+    maybeExit();
   }
 });

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 Raphael Amorim
 
 import http from "node:http";
-import { writeFileSync } from "node:fs";
+import { fstatSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { pathToFileURL } from "node:url";
 import { dirname } from "node:path";
@@ -595,6 +595,15 @@ async function run(hook, args) {
   }
   return null;
 }
+
+// stdin EOF means oj died without tearing us down (SIGKILL skips
+// kill_on_drop): exit instead of idling as an orphan.
+try {
+  if (fstatSync(0).isFIFO()) {
+    process.stdin.once("end", () => process.exit(0));
+    process.stdin.once("close", () => process.exit(0));
+  }
+} catch {}
 
 const rl = readline.createInterface({ input: process.stdin });
 rl.on("line", async (line) => {

--- a/crates/oj_server/src/assets/ssr-runner.mjs
+++ b/crates/oj_server/src/assets/ssr-runner.mjs
@@ -3,7 +3,7 @@
 
 import vm from "node:vm";
 import readline from "node:readline";
-import { statSync } from "node:fs";
+import { fstatSync, statSync } from "node:fs";
 
 const [BASE, ENTRY] = process.argv.slice(2);
 
@@ -247,6 +247,15 @@ function connectHmr() {
   ws.addEventListener("error", () => {});
 }
 connectHmr();
+
+// stdin EOF means oj died without tearing us down (the HMR reconnect timer
+// would otherwise keep an orphaned runner alive forever): exit.
+try {
+  if (fstatSync(0).isFIFO()) {
+    process.stdin.once("end", () => process.exit(0));
+    process.stdin.once("close", () => process.exit(0));
+  }
+} catch {}
 
 const rl = readline.createInterface({ input: process.stdin });
 rl.on("line", (line) => {

--- a/crates/oj_server/src/assets/start/css-host.mjs
+++ b/crates/oj_server/src/assets/start/css-host.mjs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-import { createRequire } from "node:module";
-import { existsSync, readFileSync } from "node:fs";
+import module, { createRequire } from "node:module";
+import { existsSync, fstatSync, readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import readline from "node:readline";
 
@@ -69,6 +69,19 @@ async function compile(path) {
 const _ojTTY = process.stderr.isTTY && !process.env.NO_COLOR;
 const OJ = _ojTTY ? "\x1b[48;2;255;255;255m\x1b[1;38;2;42;51;212m oj \x1b[0m" : "oj";
 process.stderr.write(`${OJ} css host: ready\n`);
+// stdin EOF means oj died without tearing us down (SIGKILL skips
+// kill_on_drop): exit instead of idling as an orphan.
+const onParentGone = () => {
+  try { module.flushCompileCache?.(); } catch {}
+  process.exit(0);
+};
+try {
+  if (fstatSync(0).isFIFO()) {
+    process.stdin.once("end", onParentGone);
+    process.stdin.once("close", onParentGone);
+  }
+} catch {}
+
 const rl = readline.createInterface({ input: process.stdin });
 for await (const line of rl) {
   let msg;

--- a/crates/oj_server/src/assets/start/runner.mjs
+++ b/crates/oj_server/src/assets/start/runner.mjs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-import { register } from "node:module";
+import module, { register } from "node:module";
+import { fstatSync } from "node:fs";
 import { pathToFileURL, fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { MessageChannel } from "node:worker_threads";
@@ -26,6 +27,19 @@ let handler = (await import(ENTRY)).default;
 const _ojTTY = process.stderr.isTTY && !process.env.NO_COLOR;
 const OJ = _ojTTY ? "\x1b[48;2;255;255;255m\x1b[1;38;2;42;51;212m oj \x1b[0m" : "oj";
 process.stderr.write(`${OJ} start runner: ready\n`);
+
+// stdin EOF means oj died without tearing us down (SIGKILL skips
+// kill_on_drop): exit instead of idling as an orphan.
+const onParentGone = () => {
+  try { module.flushCompileCache?.(); } catch {}
+  process.exit(0);
+};
+try {
+  if (fstatSync(0).isFIFO()) {
+    process.stdin.once("end", onParentGone);
+    process.stdin.once("close", onParentGone);
+  }
+} catch {}
 
 const rl = readline.createInterface({ input: process.stdin });
 for await (const line of rl) {

--- a/crates/oj_server/src/assets/svelte-compile.mjs
+++ b/crates/oj_server/src/assets/svelte-compile.mjs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Raphael Amorim
 
 import { createRequire } from "node:module";
+import { fstatSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import path from "node:path";
 import readline from "node:readline";
@@ -24,6 +25,14 @@ async function toolchain(base) {
 }
 
 const rl = readline.createInterface({ input: process.stdin });
+// stdin EOF means the parent is gone (SIGKILL skips its teardown) or the
+// one-shot build path closed it: exit once no reply is in flight.
+let inflight = 0;
+let stdinClosed = false;
+const maybeExit = () => { if (stdinClosed && inflight === 0) process.exit(0); };
+try {
+  if (fstatSync(0).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
+} catch {}
 rl.on("line", async (line) => {
   let msg;
   try {
@@ -33,6 +42,7 @@ rl.on("line", async (line) => {
   }
   const { id, base, css: source, from } = msg;
   const dev = msg.dev !== false;
+  inflight += 1;
   try {
     const { compile, preprocess, preprocessors } = await toolchain(base);
     let code = source;
@@ -50,5 +60,8 @@ rl.on("line", async (line) => {
     process.stdout.write(JSON.stringify({ id, css: out.js.code }) + "\n");
   } catch (e) {
     process.stdout.write(JSON.stringify({ id, error: String((e && e.message) || e) }) + "\n");
+  } finally {
+    inflight -= 1;
+    maybeExit();
   }
 });

--- a/crates/oj_server/src/assets/tailwind-sidecar.mjs
+++ b/crates/oj_server/src/assets/tailwind-sidecar.mjs
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 Raphael Amorim
 
 import { createRequire } from "node:module";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, fstatSync, readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import readline from "node:readline";
 
@@ -69,14 +69,26 @@ if (process.argv[2] === "--once") {
     .catch((err) => { console.error(String(err)); process.exit(1); });
 } else {
   const rl = readline.createInterface({ input: process.stdin });
+  // stdin EOF means the parent is gone (SIGKILL skips its teardown): exit
+  // once no reply is in flight instead of idling as an orphan.
+  let inflight = 0;
+  let stdinClosed = false;
+  const maybeExit = () => { if (stdinClosed && inflight === 0) process.exit(0); };
+  try {
+    if (fstatSync(0).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
+  } catch {}
   rl.on("line", async (line) => {
     let msg;
     try { msg = JSON.parse(line); } catch { return; }
+    inflight += 1;
     try {
       const css = await compileCss(msg.base, msg.css, msg.from);
       process.stdout.write(JSON.stringify({ id: msg.id, css }) + "\n");
     } catch (err) {
       process.stdout.write(JSON.stringify({ id: msg.id, error: String(err) }) + "\n");
+    } finally {
+      inflight -= 1;
+      maybeExit();
     }
   });
 }


### PR DESCRIPTION
This PR is part 1 of a 16-part series that makes `oj dev` correct and fast on a large real-world TanStack Start application (approximately 18,600 client modules, 2,500 SSR modules, and a 788-line Vite config that registers 53 plugins); every number in the series was measured on that app. The series fixes three correctness bugs (orphaned child processes, unserved code-split chunks, mis-routed connect error middlewares) and hardens the first fix against a Node `fs.realpathSync` stale-cache interaction, then removes repeated boot work with persistent content-addressed caches, then restructures the SSR loader and the plugin host, and finally hardens the cache formats against corruption and version skew. The branches form a linear chain: each PR is based on the previous one, so each PR's GitHub diff includes the commits of the PRs below it, and each PR links a compare view that shows only its own part. The recommended merge order is bottom-up, starting with this PR. Each branch builds green on its own (`cargo check` at every point in the chain), and the full test battery passes at the tip (102/102 Rust unit tests, 77/77 node unit tests). The 16 parts: orphan hardening, rolldown hook filters, serve all client chunks, connect error-middleware routing, realpath-cache stdin hardening, codegen cache, client-bundle cache, SSR loader caches, early runner spawn, in-thread loader hooks, config-extract cache, runner memory pass, single plugin host, speculative plugin answers, pack integrity framing, cache-root versioning.

The full series, in merge order:

1. #12 — exit child processes when the parent oj process dies
2. #13 — add rolldown hook filters to the start client-bundle plugins
3. #14 — serve every chunk of the code-split client bundle
4. #26 — route connect error middlewares per their arity
5. #27 — stat stdin with bigint to avoid corrupting the realpath cache
6. #15 — cache start-mode codegen, enable the V8 compile cache on node children
7. #16 — add a persistent cache for the start client bundle
8. #17 — persist SSR loader resolutions and load results across boots
9. #18 — spawn the start runner concurrently with the client bundle
10. #19 — run SSR loader hooks in-thread via module.registerHooks
11. #20 — cache the vite config extract, keyed by the config's import graph
12. #21 — serve SSR load-pack hits by file offset to bound runner memory
13. #22 — host the SSR plugin container in the plugin host process
14. #23 — serve recorded plugin container answers during the boot module walk
15. #24 — frame loader pack records with a length and hash prefix
16. #25 — namespace the cache root by format version (.oj-cache/v1)

---

### Problem

oj spawns Node.js child processes and talks to them over pipes:

- The start runner (`crates/oj_server/src/assets/start/runner.mjs`) executes the app's server code in start mode. `crates/oj/src/start_dev.rs` spawns it.
- The css host (`crates/oj_server/src/assets/start/css-host.mjs`) compiles Tailwind and PostCSS in start mode. `crates/oj/src/start_dev.rs` spawns it.
- The plugin host (`crates/oj_server/src/assets/plugin-host.mjs`) runs the hooks of the app's Vite plugins. `crates/oj_server/src/plugins.rs` spawns it.
- The SSR runner (`crates/oj_server/src/assets/ssr-runner.mjs`) renders pages in SSR dev mode. `crates/oj/src/ssr_dev.rs` spawns it.
- Three css sidecars (`crates/oj_server/src/assets/tailwind-sidecar.mjs`, `css-preprocess.mjs`, `svelte-compile.mjs`) answer JSON requests over stdin/stdout. `crates/oj_server/src/sidecar.rs` spawns them long-lived. `crates/oj/src/build.rs` also runs `css-preprocess.mjs` and `svelte-compile.mjs` as one-shots during builds.

Every spawn uses tokio's `kill_on_drop(true)`. `kill_on_drop` kills the child only when the Rust `Child` value drops. SIGKILL terminates oj without running any destructor, so the children receive nothing. This also happens when oj crashes or when the OOM killer picks it. The children reparent to init and wait on stdin forever. The SSR runner is worse: its HMR reconnect timer keeps its event loop alive with no stdin read at all.

Interactive Ctrl+C hides the bug because the shell signals the whole foreground process group. Any supervised or scripted use hits it.

Measured cost per killed oj instance: one orphaned plugin host holds 639 MB RSS and one orphaned start runner holds 892 MB to 1.04 GB RSS, indefinitely. We measured on a large real-world app: a TanStack Start application with approximately 18,600 client modules, approximately 2,500 SSR modules, and a 788-line Vite config that registers 53 plugins. Hardware: macOS arm64 (M-series), release build of oj. Repeated kill/restart cycles accumulated orphans until they exhausted a 64 GB machine.

### Change

Every child process already receives a reliable parent-death signal. oj spawns each long-lived child with `stdin(Stdio::piped())` and holds the write end for the child's lifetime. When the oj process dies — by any means, including SIGKILL — the kernel closes the write end. The child then sees end-of-file (EOF) on stdin. This PR makes each child act on that signal. It changes only the seven embedded `.mjs` assets. It changes no Rust code.

1. At startup, each child calls `fstatSync(0).isFIFO()`. This checks that file descriptor 0 is a pipe.
2. If stdin is not a pipe (a TTY, `/dev/null`, or a file), the child installs nothing and keeps its old behavior. This protects manual runs of the scripts.
3. If stdin is a pipe, the child installs an EOF handler.
4. The start runner, css host, plugin host, and SSR runner exit immediately on EOF. oj never closes their stdin while it is alive, so EOF always means the parent is gone.
5. Before exit, the start runner and the css host call `module.flushCompileCache?.()`. The call writes Node's V8 compile cache to disk when the user set `NODE_COMPILE_CACHE`. The optional chaining makes it a no-op on Node older than 22.10.
6. The three sidecars cannot exit on EOF alone. The build path in `crates/oj/src/build.rs` writes one request, closes stdin, and then reads the reply. An immediate exit on EOF would truncate that reply. Each sidecar therefore counts in-flight requests. It exits when stdin has closed and the count is zero. The count increments synchronously at the start of each `line` handler, and readline emits `close` after pending `line` events, so the counter cannot miss a request.

Files changed:

| Path | Change |
| --- | --- |
| `crates/oj_server/src/assets/start/runner.mjs` | Exit on stdin EOF; flush the V8 compile cache first. |
| `crates/oj_server/src/assets/start/css-host.mjs` | Exit on stdin EOF; flush the V8 compile cache first. |
| `crates/oj_server/src/assets/plugin-host.mjs` | Exit on stdin EOF. |
| `crates/oj_server/src/assets/ssr-runner.mjs` | Exit on stdin EOF. Removes the orphan the HMR reconnect timer kept alive. |
| `crates/oj_server/src/assets/tailwind-sidecar.mjs` | Exit on stdin EOF once no reply is in flight (long-lived mode only; `--once` mode is unchanged). |
| `crates/oj_server/src/assets/css-preprocess.mjs` | Exit on stdin EOF once no reply is in flight. |
| `crates/oj_server/src/assets/svelte-compile.mjs` | Exit on stdin EOF once no reply is in flight. |

### Correctness

- Graceful teardown is unchanged. `kill_on_drop` still kills the children when oj shuts down normally. The EOF handler is a second, independent path.
- The `isFIFO()` guard prevents false triggers. A developer who runs `node runner.mjs` in a terminal has a TTY on stdin; the handler never arms. The `fstatSync` call sits in a `try/catch`, so a missing or strange fd 0 degrades to the old behavior.
- The one-shot build path stays correct. The parent closes stdin before it reads the reply. The sidecar's in-flight counter defers the exit until the reply is written, then exits with status 0. The parent's `wait_with_output` sees the full reply.
- Each handler listens for both `end` and `close` on stdin. Whichever fires first wins; `process.exit(0)` makes the second a no-op.
- The loader worker thread inside the start runner needs no handler. Worker threads die with their process.
- Intentionally not covered: helpers the parent already awaits to completion (`optimize-deps`, `vite-extract`, prerender). They are short-lived by construction and exit on their own.

### Performance

- Steady-state cost: one `fstat` call per child at startup. The sidecars add one integer increment and decrement per request. Nothing else runs until EOF.
- Validation, on the test app described above (approximately 18,600 client modules, macOS arm64, release build): we booted the dev server, then sent SIGKILL to the oj pid only. Every child exited within 1 second. The control build (without this change) left the children alive indefinitely. A 210-second idle run produced no premature exits, and edit/reload worked normally. Time to first content (TTFC: wall-clock time from `oj dev` start until `GET /` returns HTTP 200 with HTML) was unchanged against the same tree without this patch.

### How to test

1. Run `oj dev` in a TanStack Start app. Wait for the first page load.
2. List the Node.js children: `pgrep -fl 'runner.mjs|css-host.mjs|plugin-host.mjs'` (or `ps -o pid,ppid,rss,command | grep node`).
3. Send SIGKILL to the oj pid only: `kill -9 <oj pid>`.
4. Without this change, the children remain, reparented to init (ppid 1). With this change, they exit within about 1 second.
5. One-shot check: run `oj build` on an app that has a `.less` or `.styl` file, or a Svelte component with preprocessed styles. The build must succeed and the emitted CSS must be complete.
6. Regression check: leave `oj dev` idle for several minutes, then edit a file. The children must stay alive while oj is alive, and the reload must work.



