### PR TITLE
serve SSR load-pack hits by file offset to bound runner memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1794,6 +1794,7 @@ dependencies = [
  "axum",
  "clap",
  "notify",
+ "oj_cache",
  "oj_compiler",
  "oj_config",
  "oj_css",

--- a/crates/oj/Cargo.toml
+++ b/crates/oj/Cargo.toml
@@ -10,6 +10,7 @@ name = "oj"
 path = "src/main.rs"
 
 [dependencies]
+oj_cache.workspace = true
 oj_compiler.workspace = true
 oj_env.workspace = true
 oj_config.workspace = true

--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -583,6 +583,7 @@ fn expand_css_via_sidecar(root: &Path, css_file: &Path) -> anyhow::Result<String
             css_file.to_str().unwrap(),
             root.to_str().unwrap(),
         ])
+        .env("NODE_COMPILE_CACHE", oj_server::node_compile_cache(root))
         .current_dir(root)
         .output()
         .context("node not found for tailwind/postcss build")?;
@@ -614,6 +615,7 @@ fn svelte_via_sidecar(root: &Path, file: &Path) -> anyhow::Result<String> {
     .to_string();
     let mut child = std::process::Command::new("node")
         .arg(&script)
+        .env("NODE_COMPILE_CACHE", oj_server::node_compile_cache(root))
         .current_dir(root)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
@@ -658,6 +660,7 @@ fn preprocess_via_sidecar(root: &Path, css_file: &Path) -> anyhow::Result<String
     .to_string();
     let mut child = std::process::Command::new("node")
         .arg(&script)
+        .env("NODE_COMPILE_CACHE", oj_server::node_compile_cache(root))
         .current_dir(root)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
@@ -1974,6 +1977,7 @@ pub(crate) async fn build_ssr_app(
         let out = std::process::Command::new("node")
             .arg(&script_path)
             .arg(serde_json::to_string(&paths)?)
+            .env("NODE_COMPILE_CACHE", oj_server::node_compile_cache(root))
             .current_dir(out_dir)
             .output()
             .context("node not found for prerender")?;

--- a/crates/oj/src/ssr_dev.rs
+++ b/crates/oj/src/ssr_dev.rs
@@ -86,17 +86,21 @@ async fn spawn_runner(root: &Path, base: &str, entry_abs: &Path) -> anyhow::Resu
     let script = dir.join("runner.mjs");
     std::fs::write(&script, oj_server::SSR_RUNNER_JS)?;
 
-    let mut child = tokio::process::Command::new("node")
-        .args([
-            "--experimental-vm-modules",
-            &script.to_string_lossy(),
-            base,
-            &entry_abs.to_string_lossy(),
-        ])
-        .current_dir(root)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
+    let mut cmd = tokio::process::Command::new("node");
+    cmd.args([
+        "--experimental-vm-modules",
+        &script.to_string_lossy(),
+        base,
+        &entry_abs.to_string_lossy(),
+    ])
+    .current_dir(root)
+    .stdin(Stdio::piped())
+    .stdout(Stdio::piped())
+    .stderr(Stdio::inherit());
+    if let Some(v8) = oj_server::node_compile_cache_opt_in(root) {
+        cmd.env("NODE_COMPILE_CACHE", v8);
+    }
+    let mut child = cmd
         .spawn()
         .map_err(|e| anyhow::anyhow!("could not spawn SSR runner (node): {e}"))?;
 

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -52,6 +52,20 @@ pub async fn start_dev(
     oj_server::write_start_assets(&cache)?;
     oj_server::boot_phase("start_dev begin");
 
+    // build_app (vite.config extract + plugin host boot) needs only the root;
+    // starting it first overlaps the plugin host's own config evaluation with
+    // route/resolver codegen, the runner spawn, and the client bundle.
+    let built_task = tokio::spawn(
+        oj_server::DevServer {
+            root: root.clone(),
+            port,
+            bundle: false,
+            host,
+            config: None,
+        }
+        .build_app(),
+    );
+
     let route_tree = {
         let (root, cache) = (root.clone(), cache.clone());
         tokio::task::spawn_blocking(move || generate_route_tree(&root, &cache))
@@ -65,14 +79,6 @@ pub async fn start_dev(
         let (root, cache) = (root.clone(), cache.clone());
         tokio::task::spawn_blocking(move || bundle_client_entry_cached(&root, &cache))
     };
-    let built_fut = oj_server::DevServer {
-        root: root.clone(),
-        port,
-        bundle: false,
-        host,
-        config: None,
-    }
-    .build_app();
     resolver.await??;
     // The runner's SSR module-graph walk dominates boot time; start it now so
     // it overlaps the client bundle (the manifest reads CSS lazily, so the
@@ -88,9 +94,9 @@ pub async fn start_dev(
             let _ = forward(&runner, "GET".into(), "/".into(), vec![], None).await;
         });
     }
-    let (bundle_res, built_res) = tokio::join!(bundle, built_fut);
+    let (bundle_res, built_res) = tokio::join!(bundle, built_task);
     let pinned = bundle_res??;
-    let built = built_res?;
+    let built = built_res??;
     let css_host = if app_uses_tailwind(&root) {
         spawn_node_service(&root, &cache.join("css-host.mjs"))
             .await

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -50,6 +50,7 @@ pub async fn start_dev(
         .map_err(|e| anyhow::anyhow!("app root not found: {}: {e}", root.display()))?;
     let cache = root.join(".oj-cache").join("start");
     oj_server::write_start_assets(&cache)?;
+    oj_server::boot_phase("start_dev begin");
 
     let route_tree = {
         let (root, cache) = (root.clone(), cache.clone());
@@ -129,6 +130,7 @@ pub async fn start_dev(
     let listener = tokio::net::TcpListener::bind(addr)
         .await
         .map_err(|e| anyhow::anyhow!("cannot bind {addr}: {e}"))?;
+    oj_server::boot_phase("listening");
     println!("  {} dev (tanstack start)", oj_server::oj_brand());
     let url = format!("http://localhost:{}/", built.port);
     println!("  {}", oj_server::link(&url, &oj_server::cell(&url)));

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -72,11 +72,24 @@ pub async fn start_dev(
         config: None,
     }
     .build_app();
+    resolver.await??;
+    // The runner's SSR module-graph walk dominates boot time; start it now so
+    // it overlaps the client bundle (the manifest reads CSS lazily, so the
+    // runner no longer needs the bundle's output).
+    let runner = Arc::new(tokio::sync::Mutex::new(
+        spawn_start_runner(&root, &cache).await?,
+    ));
+    {
+        // Prewarm: queue one synthetic render so first-request module
+        // evaluation also happens before the listener binds.
+        let runner = Arc::clone(&runner);
+        tokio::spawn(async move {
+            let _ = forward(&runner, "GET".into(), "/".into(), vec![], None).await;
+        });
+    }
     let (bundle_res, built_res) = tokio::join!(bundle, built_fut);
     let pinned = bundle_res??;
-    resolver.await??;
     let built = built_res?;
-    let runner = spawn_start_runner(&root, &cache).await?;
     let css_host = if app_uses_tailwind(&root) {
         spawn_node_service(&root, &cache.join("css-host.mjs"))
             .await
@@ -89,7 +102,7 @@ pub async fn start_dev(
     let state = Arc::new(StartState {
         proxy_prefixes: built.proxy_prefixes.clone(),
         plugin_mw_port: built.plugin_mw_port,
-        runner: Arc::new(tokio::sync::Mutex::new(runner)),
+        runner,
         bundle: std::sync::RwLock::new(Arc::new(pinned)),
         verify: oj_cache::integrity::VerifyMode::from_env(),
         live_reload: cache.join("live-reload.js"),
@@ -649,7 +662,7 @@ async fn start_route(State(state): State<Arc<StartState>>, req: Request, next: N
             .await
             .ok()
             .map(|b| String::from_utf8_lossy(&b).into_owned());
-        return forward(&state, method, url, headers, body).await;
+        return forward(&state.runner, method, url, headers, body).await;
     }
     match classify(&req, &state.proxy_prefixes) {
         Route::Document => {
@@ -670,7 +683,7 @@ async fn start_route(State(state): State<Arc<StartState>>, req: Request, next: N
                     return resp;
                 }
             }
-            forward(&state, "GET".into(), document_url(&raw), vec![], None).await
+            forward(&state.runner, "GET".into(), document_url(&raw), vec![], None).await
         }
         Route::Pass => next.run(req).await,
     }
@@ -838,13 +851,13 @@ fn collect_headers(headers: &header::HeaderMap) -> Vec<(String, String)> {
 }
 
 async fn forward(
-    state: &StartState,
+    runner: &Arc<tokio::sync::Mutex<Runner>>,
     method: String,
     url: String,
     req_headers: Vec<(String, String)>,
     body: Option<String>,
 ) -> Response {
-    let runner = Arc::clone(&state.runner);
+    let runner = Arc::clone(runner);
     let (tx, rx) = tokio::sync::oneshot::channel();
     tokio::spawn(async move {
         let mut guard = runner.lock_owned().await;

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -25,7 +25,10 @@ struct StartState {
     proxy_prefixes: Vec<String>,
     plugin_mw_port: Option<u16>,
     runner: Arc<tokio::sync::Mutex<Runner>>,
-    client_bundle: PathBuf,
+    // The chunk set of the client build this server serves: swapped whole on
+    // watch rebuilds, so every /@oj-start/<chunk> resolves against exactly
+    // one build and a name outside it is a deliberate 404.
+    bundle: std::sync::RwLock<Arc<PinnedBundle>>,
     live_reload: PathBuf,
     workspace_root: PathBuf,
     reload_tx: broadcast::Sender<()>,
@@ -60,7 +63,12 @@ pub async fn start_dev(
     route_tree.await??;
     let bundle = {
         let (root, cache) = (root.clone(), cache.clone());
-        tokio::task::spawn_blocking(move || bundle_client_entry(&root, &cache))
+        tokio::task::spawn_blocking(move || -> anyhow::Result<PinnedBundle> {
+            bundle_client_entry(&root, &cache)?;
+            PinnedBundle::from_build_dir(&cache).ok_or_else(|| {
+                anyhow::anyhow!("client chunk index missing after successful bundle")
+            })
+        })
     };
     let built_fut = oj_server::DevServer {
         root: root.clone(),
@@ -71,7 +79,7 @@ pub async fn start_dev(
     }
     .build_app();
     let (bundle_res, built_res) = tokio::join!(bundle, built_fut);
-    bundle_res??;
+    let pinned = bundle_res??;
     resolver.await??;
     let built = built_res?;
     let runner = spawn_start_runner(&root, &cache).await?;
@@ -88,7 +96,7 @@ pub async fn start_dev(
         proxy_prefixes: built.proxy_prefixes.clone(),
         plugin_mw_port: built.plugin_mw_port,
         runner: Arc::new(tokio::sync::Mutex::new(runner)),
-        client_bundle: cache.join("client-entry.js"),
+        bundle: std::sync::RwLock::new(Arc::new(pinned)),
         live_reload: cache.join("live-reload.js"),
         workspace_root: workspace_root(&root),
         reload_tx: reload_tx.clone(),
@@ -253,9 +261,15 @@ fn spawn_start_watcher(root: PathBuf, cache: PathBuf, state: Arc<StartState>) {
             rt.block_on(async {
                 let (r, c) = (root.clone(), cache.clone());
                 let client = tokio::task::spawn_blocking(move || {
-                    let _ = bundle_client_entry(&r, &c);
+                    if bundle_client_entry(&r, &c).is_err() {
+                        return None;
+                    }
+                    PinnedBundle::from_build_dir(&c)
                 });
-                let (_, _) = tokio::join!(client, reload_runner(&state));
+                let (pinned, _) = tokio::join!(client, reload_runner(&state));
+                if let Ok(Some(pinned)) = pinned {
+                    *state.bundle.write().unwrap() = Arc::new(pinned);
+                }
             });
             let _ = state.reload_tx.send(());
             let modules = client_module_count(&cache);
@@ -316,6 +330,44 @@ fn bundle_client_entry(root: &Path, cache: &Path) -> anyhow::Result<()> {
         &cache.join("bundle-client.mjs"),
         "client entry bundling",
     )
+}
+
+/// The chunk set of one client build: chunk name -> on-disk file. Names
+/// absent from the map do not exist for the serve path.
+#[derive(Debug, Clone, PartialEq)]
+struct PinnedBundle {
+    entry: String,
+    chunks: std::collections::HashMap<String, PinnedChunk>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct PinnedChunk {
+    path: PathBuf,
+}
+
+impl PinnedBundle {
+    fn chunk(&self, name: &str) -> Option<&PinnedChunk> {
+        self.chunks
+            .get(name)
+            .or_else(|| (name == "client-entry.js").then(|| self.chunks.get(&self.entry))?)
+    }
+
+    /// Pin the chunk set a fresh build left in `start_dir/client-chunks`,
+    /// reading the index (`client-chunks.json`) bundle-client.mjs wrote.
+    fn from_build_dir(start_dir: &Path) -> Option<Self> {
+        let raw = std::fs::read_to_string(start_dir.join("client-chunks.json")).ok()?;
+        let index: serde_json::Value = serde_json::from_str(&raw).ok()?;
+        let entry = index.get("entry")?.as_str()?.to_string();
+        let chunk_dir = start_dir.join("client-chunks");
+        let files = index.get("files")?.as_array()?;
+        let mut chunks = std::collections::HashMap::with_capacity(files.len());
+        for f in files {
+            let name = f.get("name")?.as_str()?.to_string();
+            let path = chunk_dir.join(&name);
+            chunks.insert(name, PinnedChunk { path });
+        }
+        Some(Self { entry, chunks })
+    }
 }
 
 // Client module count written by bundle-client.mjs, for update/boot narration.
@@ -451,14 +503,16 @@ async fn start_route(State(state): State<Arc<StartState>>, req: Request, next: N
             Err(e) => e.into_response(),
         };
     }
-    if req.uri().path() == "/@oj-start/client-entry.js" {
-        return serve_js(&state.client_bundle, "client entry").await;
-    }
     if req.uri().path() == "/@oj-start/live-reload.js" {
         return serve_js(&state.live_reload, "live-reload client").await;
     }
-    if let Some(abs) = req.uri().path().strip_prefix("/@oj-start/fs") {
-        return serve_fs_asset(&state, abs).await;
+    // "/fs/" with the trailing slash: a bare "fs" prefix would shadow any
+    // client chunk whose name starts with "fs".
+    if let Some(rest) = req.uri().path().strip_prefix("/@oj-start/fs/") {
+        return serve_fs_asset(&state, &format!("/{rest}")).await;
+    }
+    if let Some(name) = req.uri().path().strip_prefix("/@oj-start/") {
+        return serve_client_chunk(&state, name).await;
     }
     if req.uri().path().starts_with("/_serverFn/") {
         let method = req.method().to_string();
@@ -497,6 +551,43 @@ async fn start_route(State(state): State<Arc<StartState>>, req: Request, next: N
             forward(&state, "GET".into(), document_url(&raw), vec![], None).await
         }
         Route::Pass => next.run(req).await,
+    }
+}
+
+/// Serve one file of the pinned client build. Resolution goes only through
+/// the pinned index: an unknown name is a deliberate 404, so the serve set
+/// can never mix two builds.
+async fn serve_client_chunk(state: &StartState, name: &str) -> Response {
+    let name = percent_decode(name);
+    let bundle = state
+        .bundle
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    let Some(chunk) = bundle.chunk(&name) else {
+        return (
+            StatusCode::NOT_FOUND,
+            format!("oj start: {name} is not in the client bundle manifest"),
+        )
+            .into_response();
+    };
+    match tokio::fs::read(&chunk.path).await {
+        Ok(bytes) => {
+            let ext = name.rsplit('.').next().unwrap_or("");
+            (
+                [
+                    (header::CONTENT_TYPE, asset_mime(ext)),
+                    (header::CACHE_CONTROL, "no-cache"),
+                ],
+                bytes,
+            )
+                .into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("oj start: chunk {name}: {e}"),
+        )
+            .into_response(),
     }
 }
 

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -25,10 +25,11 @@ struct StartState {
     proxy_prefixes: Vec<String>,
     plugin_mw_port: Option<u16>,
     runner: Arc<tokio::sync::Mutex<Runner>>,
-    // The chunk set of the client build this server serves: swapped whole on
+    // The generation of client chunks this server serves: swapped whole on
     // watch rebuilds, so every /@oj-start/<chunk> resolves against exactly
     // one build and a name outside it is a deliberate 404.
-    bundle: std::sync::RwLock<Arc<PinnedBundle>>,
+    bundle: std::sync::RwLock<Arc<oj_cache::start_bundle::PinnedBundle>>,
+    verify: oj_cache::integrity::VerifyMode,
     live_reload: PathBuf,
     workspace_root: PathBuf,
     reload_tx: broadcast::Sender<()>,
@@ -61,12 +62,7 @@ pub async fn start_dev(
     route_tree.await??;
     let bundle = {
         let (root, cache) = (root.clone(), cache.clone());
-        tokio::task::spawn_blocking(move || -> anyhow::Result<PinnedBundle> {
-            bundle_client_entry(&root, &cache)?;
-            PinnedBundle::from_build_dir(&cache).ok_or_else(|| {
-                anyhow::anyhow!("client chunk index missing after successful bundle")
-            })
-        })
+        tokio::task::spawn_blocking(move || bundle_client_entry_cached(&root, &cache))
     };
     let built_fut = oj_server::DevServer {
         root: root.clone(),
@@ -95,6 +91,7 @@ pub async fn start_dev(
         plugin_mw_port: built.plugin_mw_port,
         runner: Arc::new(tokio::sync::Mutex::new(runner)),
         bundle: std::sync::RwLock::new(Arc::new(pinned)),
+        verify: oj_cache::integrity::VerifyMode::from_env(),
         live_reload: cache.join("live-reload.js"),
         workspace_root: workspace_root(&root),
         reload_tx: reload_tx.clone(),
@@ -103,6 +100,12 @@ pub async fn start_dev(
     });
 
     spawn_start_watcher(root.clone(), cache.clone(), Arc::clone(&state));
+    {
+        let root = root.clone();
+        tokio::task::spawn_blocking(move || {
+            start_bundle_store(&root).prune(oj_cache::start_bundle::DEFAULT_PRUNE_BUDGET_BYTES);
+        });
+    }
 
     let app = built.router.layer(axum::middleware::from_fn_with_state(
         Arc::clone(&state),
@@ -262,7 +265,10 @@ fn spawn_start_watcher(root: PathBuf, cache: PathBuf, state: Arc<StartState>) {
                     if bundle_client_entry(&r, &c).is_err() {
                         return None;
                     }
-                    PinnedBundle::from_build_dir(&c)
+                    match start_bundle_store(&r).persist(&c) {
+                        Some((_, pinned)) => Some(pinned),
+                        None => oj_cache::start_bundle::PinnedBundle::from_build_dir(&c),
+                    }
                 });
                 let (pinned, _) = tokio::join!(client, reload_runner(&state));
                 if let Ok(Some(pinned)) = pinned {
@@ -433,42 +439,52 @@ fn bundle_client_entry(root: &Path, cache: &Path) -> anyhow::Result<()> {
     )
 }
 
-/// The chunk set of one client build: chunk name -> on-disk file. Names
-/// absent from the map do not exist for the serve path.
-#[derive(Debug, Clone, PartialEq)]
-struct PinnedBundle {
-    entry: String,
-    chunks: std::collections::HashMap<String, PinnedChunk>,
+fn start_bundle_store(root: &Path) -> oj_cache::start_bundle::StartBundleStore {
+    oj_cache::start_bundle::StartBundleStore::new(
+        root,
+        env!("CARGO_PKG_VERSION"),
+        oj_cache::integrity::VerifyMode::from_env(),
+    )
 }
 
-#[derive(Debug, Clone, PartialEq)]
-struct PinnedChunk {
-    path: PathBuf,
-}
-
-impl PinnedBundle {
-    fn chunk(&self, name: &str) -> Option<&PinnedChunk> {
-        self.chunks
-            .get(name)
-            .or_else(|| (name == "client-entry.js").then(|| self.chunks.get(&self.entry))?)
-    }
-
-    /// Pin the chunk set a fresh build left in `start_dir/client-chunks`,
-    /// reading the index (`client-chunks.json`) bundle-client.mjs wrote.
-    fn from_build_dir(start_dir: &Path) -> Option<Self> {
-        let raw = std::fs::read_to_string(start_dir.join("client-chunks.json")).ok()?;
-        let index: serde_json::Value = serde_json::from_str(&raw).ok()?;
-        let entry = index.get("entry")?.as_str()?.to_string();
-        let chunk_dir = start_dir.join("client-chunks");
-        let files = index.get("files")?.as_array()?;
-        let mut chunks = std::collections::HashMap::with_capacity(files.len());
-        for f in files {
-            let name = f.get("name")?.as_str()?.to_string();
-            let path = chunk_dir.join(&name);
-            chunks.insert(name, PinnedChunk { path });
+// Must run after write_start_assets: it re-stubs the manifest.ts a hit restores.
+fn bundle_client_entry_cached(
+    root: &Path,
+    cache: &Path,
+) -> anyhow::Result<oj_cache::start_bundle::PinnedBundle> {
+    let store = start_bundle_store(root);
+    match store.restore(cache) {
+        Ok((stats, pinned)) => {
+            let rehashed = match stats.rehashed {
+                0 => String::new(),
+                n => format!(", {n} re-hashed"),
+            };
+            println!(
+                "  oj start: client bundle restored from cache (key {}…, {} chunks, {} files verified in {}ms{rehashed})",
+                stats.key.get(..8).unwrap_or(&stats.key),
+                stats.chunks,
+                stats.files,
+                stats.elapsed_ms
+            );
+            return Ok(pinned);
         }
-        Some(Self { entry, chunks })
+        Err(miss) => println!("  oj start: client bundle cache miss ({miss})"),
     }
+    bundle_client_entry(root, cache)?;
+    // Logging the stored key makes key flapping (boot key != persisted key,
+    // i.e. an unstable closure input) visible instead of an eternal miss.
+    if let Some((key, pinned)) = store.persist(cache) {
+        println!(
+            "  oj start: client bundle cached (key {}…, {} chunks)",
+            key.get(..8).unwrap_or(&key),
+            pinned.len()
+        );
+        return Ok(pinned);
+    }
+    // The build succeeded but the store could not take it: serve the build
+    // output directly rather than failing the boot.
+    oj_cache::start_bundle::PinnedBundle::from_build_dir(cache)
+        .ok_or_else(|| anyhow::anyhow!("client chunk index missing after successful bundle"))
 }
 
 // Client module count written by bundle-client.mjs, for update/boot narration.
@@ -660,9 +676,10 @@ async fn start_route(State(state): State<Arc<StartState>>, req: Request, next: N
     }
 }
 
-/// Serve one file of the pinned client build. Resolution goes only through
-/// the pinned index: an unknown name is a deliberate 404, so the serve set
-/// can never mix two builds.
+/// Serve one file of the pinned client-bundle generation. Resolution goes
+/// only through the generation manifest: an unknown name is a 404, and a
+/// stored chunk whose bytes no longer match the manifest is refused, never
+/// served wrong.
 async fn serve_client_chunk(state: &StartState, name: &str) -> Response {
     let name = percent_decode(name);
     let bundle = state
@@ -677,8 +694,23 @@ async fn serve_client_chunk(state: &StartState, name: &str) -> Response {
         )
             .into_response();
     };
-    match tokio::fs::read(&chunk.path).await {
-        Ok(bytes) => {
+    // A chunk pinned straight off a fresh build has no recorded hash yet;
+    // its bytes were written by this process, so size is the only check.
+    let mode = match &chunk.hash {
+        Some(_) => state.verify,
+        None => oj_cache::integrity::VerifyMode::Standard,
+    };
+    let expected = oj_cache::integrity::ExpectedFile {
+        size: chunk.size,
+        hash: chunk.hash.clone().unwrap_or_default(),
+    };
+    let path = chunk.path.clone();
+    let read = tokio::task::spawn_blocking(move || {
+        oj_cache::integrity::verified_read(&path, &expected, mode)
+    })
+    .await;
+    match read {
+        Ok(Ok(bytes)) => {
             let ext = name.rsplit('.').next().unwrap_or("");
             (
                 [
@@ -689,9 +721,17 @@ async fn serve_client_chunk(state: &StartState, name: &str) -> Response {
             )
                 .into_response()
         }
-        Err(e) => (
+        Ok(Err(e)) => {
+            eprintln!("oj start: chunk {name} failed verification ({e}); refusing to serve");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("oj start: chunk {name}: {e}"),
+            )
+                .into_response()
+        }
+        Err(_) => (
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!("oj start: chunk {name}: {e}"),
+            "oj start: chunk read task failed".to_string(),
         )
             .into_response(),
     }
@@ -902,7 +942,7 @@ mod tests {
 
     #[test]
     fn app_uses_tailwind_detects_postcss_vite_and_bare() {
-        let base = tmp("tw");
+        let base = tmp("tw-pkg");
         let cases = [
             (r#"{"devDependencies":{"@tailwindcss/postcss":"4"}}"#, true),
             (r#"{"devDependencies":{"@tailwindcss/vite":"4"}}"#, true),

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -56,9 +56,7 @@ pub async fn start_dev(
     };
     let resolver = {
         let (root, cache) = (root.clone(), cache.clone());
-        tokio::task::spawn_blocking(move || {
-            run_node(&root, &cache.join("gen-resolver.mjs"), "server-fn resolver")
-        })
+        tokio::task::spawn_blocking(move || generate_server_fn_resolver(&root, &cache))
     };
     route_tree.await??;
     let bundle = {
@@ -250,7 +248,7 @@ fn spawn_start_watcher(root: PathBuf, cache: PathBuf, state: Arc<StartState>) {
                         || std::fs::read_to_string(p).is_ok_and(|s| s.contains("createServerFn")))
             });
             if routes_changed || server_fn_changed {
-                let _ = run_node(&root, &cache.join("gen-resolver.mjs"), "server-fn resolver");
+                let _ = generate_server_fn_resolver(&root, &cache);
             }
             // Narrate the compile batch to the editor: "Applying changes…" while
             // it rebuilds, then done so the pill clears.
@@ -293,7 +291,7 @@ pub async fn start_build(root: PathBuf) -> anyhow::Result<()> {
     let cache = root.join(".oj-cache").join("start");
     oj_server::write_start_assets(&cache)?;
     generate_route_tree(&root, &cache)?;
-    run_node(&root, &cache.join("gen-resolver.mjs"), "server-fn resolver")?;
+    generate_server_fn_resolver(&root, &cache)?;
     let prerender = oj_config::load(&root)
         .ok()
         .and_then(|c| c.build)
@@ -305,6 +303,7 @@ pub async fn start_build(root: PathBuf) -> anyhow::Result<()> {
         .env("OJ_APP_ROOT", &root)
         .env("NODE_ENV", "production")
         .env("OJ_PRERENDER", &prerender)
+        .env("NODE_COMPILE_CACHE", oj_server::node_compile_cache(&root))
         .current_dir(&root)
         .status()
         .map_err(|e| anyhow::anyhow!("could not run production build (node): {e}"))?;
@@ -320,8 +319,110 @@ pub async fn start_build(root: PathBuf) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn codegen_store(
+    root: &Path,
+    cache: &Path,
+    kind: &str,
+    script: &str,
+    marker: Option<&str>,
+) -> oj_cache::start_codegen::StartCodegenStore {
+    let mut extra = std::fs::read(cache.join(script)).unwrap_or_default();
+    for name in [
+        "tsr.config.json",
+        "package.json",
+        "package-lock.json",
+        "yarn.lock",
+        "pnpm-lock.yaml",
+        "bun.lockb",
+    ] {
+        if let Ok(bytes) = std::fs::read(root.join(name)) {
+            extra.extend_from_slice(name.as_bytes());
+            extra.push(0);
+            extra.extend_from_slice(&bytes);
+            extra.push(0);
+        }
+    }
+    oj_cache::start_codegen::StartCodegenStore::new(
+        root,
+        kind,
+        env!("CARGO_PKG_VERSION"),
+        &extra,
+        marker,
+    )
+}
+
 fn generate_route_tree(root: &Path, cache: &Path) -> anyhow::Result<()> {
-    run_node(root, &cache.join("generate.mjs"), "route tree generation")
+    let store = codegen_store(root, cache, "route-tree", "generate.mjs", None);
+    let dest = root.join("src").join("routeTree.gen.ts");
+    let outputs = [("routeTree.gen.ts", dest.as_path())];
+    let inputs: Vec<PathBuf> = list_route_files(root).into_iter().collect();
+    match store.restore(&inputs, &outputs) {
+        Ok(stats) => {
+            println!(
+                "  oj start: route tree restored from cache (key {}…, {} route file(s) verified in {}ms)",
+                stats.key.get(..8).unwrap_or(&stats.key),
+                stats.keyed_files,
+                stats.elapsed_ms
+            );
+            return Ok(());
+        }
+        Err(miss) => println!("  oj start: route tree cache miss ({miss})"),
+    }
+    run_node(root, &cache.join("generate.mjs"), "route tree generation")?;
+    // The generator normalizes route files in place, so key over the post-run
+    // (fixed-point) contents; the pre-run state would never be seen again.
+    let inputs: Vec<PathBuf> = list_route_files(root).into_iter().collect();
+    store.persist(&inputs, &outputs);
+    Ok(())
+}
+
+fn generate_server_fn_resolver(root: &Path, cache: &Path) -> anyhow::Result<()> {
+    let store = codegen_store(
+        root,
+        cache,
+        "server-fn",
+        "gen-resolver.mjs",
+        Some("createServerFn"),
+    );
+    let dest = cache.join("server-fn-resolver.mjs");
+    let outputs = [("server-fn-resolver.mjs", dest.as_path())];
+    let inputs = list_src_ts_files(root);
+    match store.restore(&inputs, &outputs) {
+        Ok(stats) => {
+            println!(
+                "  oj start: server-fn resolver restored from cache (key {}…, {} server-fn file(s), {} of {} rehashed, {}ms)",
+                stats.key.get(..8).unwrap_or(&stats.key),
+                stats.keyed_files,
+                stats.rehashed,
+                inputs.len(),
+                stats.elapsed_ms
+            );
+            return Ok(());
+        }
+        Err(miss) => println!("  oj start: server-fn resolver cache miss ({miss})"),
+    }
+    run_node(root, &cache.join("gen-resolver.mjs"), "server-fn resolver")?;
+    store.persist(&inputs, &outputs);
+    Ok(())
+}
+
+fn list_src_ts_files(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for e in entries.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                walk(&p, out);
+            } else if p.extension().is_some_and(|x| x == "ts" || x == "tsx") {
+                out.push(p);
+            }
+        }
+    }
+    walk(&root.join("src"), &mut out);
+    out
 }
 
 fn bundle_client_entry(root: &Path, cache: &Path) -> anyhow::Result<()> {
@@ -383,6 +484,7 @@ fn run_node(root: &Path, script: &Path, what: &str) -> anyhow::Result<()> {
         .arg(script)
         .env("OJ_APP_ROOT", root)
         .env("NODE_ENV", "development")
+        .env("NODE_COMPILE_CACHE", oj_server::node_compile_cache(root))
         .current_dir(root)
         .status()
         .map_err(|e| anyhow::anyhow!("could not run {what} (node): {e}"))?;
@@ -397,15 +499,19 @@ async fn spawn_start_runner(root: &Path, cache: &Path) -> anyhow::Result<Runner>
 }
 
 async fn spawn_node_service(root: &Path, script: &Path) -> anyhow::Result<Runner> {
-    let mut child = tokio::process::Command::new("node")
-        .arg(script)
+    let mut cmd = tokio::process::Command::new("node");
+    cmd.arg(script)
         .env("OJ_APP_ROOT", root)
         .env("NODE_ENV", "development")
         .current_dir(root)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
-        .kill_on_drop(true)
+        .kill_on_drop(true);
+    if let Some(v8) = oj_server::node_compile_cache_opt_in(root) {
+        cmd.env("NODE_COMPILE_CACHE", v8);
+    }
+    let mut child = cmd
         .spawn()
         .map_err(|e| anyhow::anyhow!("could not spawn node service {}: {e}", script.display()))?;
     let stdin = child.stdin.take().expect("piped stdin");
@@ -878,7 +984,7 @@ mod tests {
 
     #[test]
     fn app_uses_tailwind_reads_package_json() {
-        let base = tmp("tw");
+        let base = tmp("tw-pkg");
         std::fs::write(
             base.join("package.json"),
             r#"{"devDependencies":{"@tailwindcss/postcss":"4"}}"#,
@@ -968,6 +1074,21 @@ mod tests {
         assert!(!names
             .iter()
             .any(|n| n.ends_with(".css") || n.ends_with(".json")));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn list_src_ts_files_walks_all_of_src() {
+        let root = tmp("srcwalk");
+        let src = root.join("src");
+        std::fs::create_dir_all(src.join("routes")).unwrap();
+        std::fs::create_dir_all(src.join("lib")).unwrap();
+        std::fs::write(src.join("routes").join("index.tsx"), "").unwrap();
+        std::fs::write(src.join("lib").join("fns.ts"), "").unwrap();
+        std::fs::write(src.join("lib").join("types.d.ts"), "").unwrap();
+        std::fs::write(src.join("styles.css"), "").unwrap();
+        let found = list_src_ts_files(&root);
+        assert_eq!(found.len(), 3, "ts/tsx (incl. .d.ts) only: {found:?}");
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/crates/oj_cache/src/config_extract.rs
+++ b/crates/oj_cache/src/config_extract.rs
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Cache for the vite.config extract subprocess output, keyed by the config
+/// file plus its import graph (as reported by the extract itself), the
+/// lockfiles/.env files, and the env vars a config commonly reads.
+pub struct ConfigExtractStore {
+    dir: PathBuf,
+    root: PathBuf,
+    salt: String,
+}
+
+pub struct CachedExtract {
+    pub output: String,
+    pub stderr: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Entry {
+    env_epoch: String,
+    files: Vec<FileStamp>,
+    output: String,
+    stderr: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct FileStamp {
+    path: String,
+    digest: String,
+}
+
+const ABSENT: &str = "-";
+
+impl ConfigExtractStore {
+    pub fn new(root: &Path, salt: &str) -> Self {
+        Self {
+            dir: root.join(".oj-cache").join("config-extract"),
+            root: root.to_path_buf(),
+            salt: salt.to_string(),
+        }
+    }
+
+    pub fn lookup(&self, config: &Path, command: &str, mode: &str) -> Option<CachedExtract> {
+        let path = self.entry_path(config, command, mode);
+        let bytes = fs::read(&path).ok()?;
+        let entry: Entry = match serde_json::from_slice(&bytes) {
+            Ok(e) => e,
+            Err(_) => {
+                let _ = fs::remove_file(&path);
+                return None;
+            }
+        };
+        if entry.env_epoch != env_epoch(&self.root) {
+            return None;
+        }
+        for f in &entry.files {
+            if file_digest(Path::new(&f.path)) != f.digest {
+                return None;
+            }
+        }
+        Some(CachedExtract {
+            output: entry.output,
+            stderr: entry.stderr,
+        })
+    }
+
+    pub fn store(
+        &self,
+        config: &Path,
+        command: &str,
+        mode: &str,
+        deps: &[PathBuf],
+        output: &str,
+        stderr: &str,
+    ) {
+        if fs::create_dir_all(&self.dir).is_err() {
+            return;
+        }
+        let mut files: Vec<PathBuf> = Vec::with_capacity(deps.len() + 1);
+        files.push(config.to_path_buf());
+        files.extend(deps.iter().cloned());
+        files.sort();
+        files.dedup();
+        let files = files
+            .into_iter()
+            .map(|p| FileStamp {
+                digest: file_digest(&p),
+                path: p.display().to_string(),
+            })
+            .collect();
+        let entry = Entry {
+            env_epoch: env_epoch(&self.root),
+            files,
+            output: output.to_string(),
+            stderr: stderr.to_string(),
+        };
+        let path = self.entry_path(config, command, mode);
+        let tmp = path.with_extension(format!("tmp-{}", std::process::id()));
+        if fs::write(&tmp, serde_json::to_vec(&entry).unwrap_or_default()).is_ok() {
+            let _ = fs::rename(&tmp, &path);
+        }
+    }
+
+    fn entry_path(&self, config: &Path, command: &str, mode: &str) -> PathBuf {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(self.salt.as_bytes());
+        hasher.update(&[0]);
+        hasher.update(config.as_os_str().as_encoded_bytes());
+        hasher.update(&[0]);
+        hasher.update(command.as_bytes());
+        hasher.update(&[0]);
+        hasher.update(mode.as_bytes());
+        self.dir
+            .join(format!("{}.json", hasher.finalize().to_hex()))
+    }
+}
+
+fn file_digest(path: &Path) -> String {
+    match fs::read(path) {
+        Ok(bytes) => blake3::hash(&bytes).to_hex().to_string(),
+        Err(_) => ABSENT.to_string(),
+    }
+}
+
+/// Non-file inputs that can shape the extracted values: dependency lockfiles
+/// (node_modules content), package.json, .env files, and the env vars app
+/// configs commonly branch on. Anything here changing must be a cache miss.
+fn env_epoch(root: &Path) -> String {
+    let mut hasher = blake3::Hasher::new();
+    for name in [
+        "package-lock.json",
+        "yarn.lock",
+        "pnpm-lock.yaml",
+        "bun.lockb",
+        "package.json",
+        ".env",
+        ".env.local",
+        ".env.development",
+        ".env.development.local",
+    ] {
+        if let Ok(bytes) = fs::read(root.join(name)) {
+            hasher.update(name.as_bytes());
+            hasher.update(&[0]);
+            hasher.update(&bytes);
+        }
+    }
+    let mut env: Vec<(String, String)> = std::env::vars()
+        .filter(|(k, _)| {
+            ["VITE_", "LOVABLE_", "LOVBOX_", "TSS_"]
+                .iter()
+                .any(|p| k.starts_with(p))
+                || matches!(k.as_str(), "NODE_ENV" | "CI" | "ANALYZE")
+        })
+        .collect();
+    env.sort();
+    for (k, v) in env {
+        hasher.update(b"\0e");
+        hasher.update(k.as_bytes());
+        hasher.update(&[0]);
+        hasher.update(v.as_bytes());
+    }
+    hasher.finalize().to_hex().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_root(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "oj-config-extract-test-{}-{label}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn roundtrip_hits_until_a_dep_changes() {
+        let root = temp_root("roundtrip");
+        let config = root.join("vite.config.ts");
+        let dep = root.join("plugin.ts");
+        fs::write(&config, "import './plugin'").unwrap();
+        fs::write(&dep, "export const x = 1").unwrap();
+        let store = ConfigExtractStore::new(&root, "s1");
+        assert!(store.lookup(&config, "serve", "development").is_none());
+        store.store(
+            &config,
+            "serve",
+            "development",
+            &[dep.clone()],
+            r#"{"base":"/"}"#,
+            "warn\n",
+        );
+        let hit = store.lookup(&config, "serve", "development").unwrap();
+        assert_eq!(hit.output, r#"{"base":"/"}"#);
+        assert_eq!(hit.stderr, "warn\n");
+        fs::write(&dep, "export const x = 2").unwrap();
+        assert!(store.lookup(&config, "serve", "development").is_none());
+    }
+
+    #[test]
+    fn config_edit_invalidates() {
+        let root = temp_root("config-edit");
+        let config = root.join("vite.config.ts");
+        fs::write(&config, "a").unwrap();
+        let store = ConfigExtractStore::new(&root, "s1");
+        store.store(&config, "serve", "development", &[], "{}", "");
+        assert!(store.lookup(&config, "serve", "development").is_some());
+        fs::write(&config, "b").unwrap();
+        assert!(store.lookup(&config, "serve", "development").is_none());
+    }
+
+    #[test]
+    fn lockfile_and_env_file_changes_invalidate() {
+        let root = temp_root("epoch");
+        let config = root.join("vite.config.ts");
+        fs::write(&config, "a").unwrap();
+        let store = ConfigExtractStore::new(&root, "s1");
+        store.store(&config, "serve", "development", &[], "{}", "");
+        assert!(store.lookup(&config, "serve", "development").is_some());
+        fs::write(root.join("pnpm-lock.yaml"), "lock").unwrap();
+        assert!(store.lookup(&config, "serve", "development").is_none());
+        store.store(&config, "serve", "development", &[], "{}", "");
+        assert!(store.lookup(&config, "serve", "development").is_some());
+        fs::write(root.join(".env.local"), "VITE_X=1").unwrap();
+        assert!(store.lookup(&config, "serve", "development").is_none());
+    }
+
+    #[test]
+    fn dep_deleted_invalidates() {
+        let root = temp_root("dep-del");
+        let config = root.join("vite.config.ts");
+        let dep = root.join("plugin.ts");
+        fs::write(&config, "a").unwrap();
+        fs::write(&dep, "b").unwrap();
+        let store = ConfigExtractStore::new(&root, "s1");
+        store.store(&config, "serve", "development", &[dep.clone()], "{}", "");
+        assert!(store.lookup(&config, "serve", "development").is_some());
+        fs::remove_file(&dep).unwrap();
+        assert!(store.lookup(&config, "serve", "development").is_none());
+    }
+
+    #[test]
+    fn corrupt_entry_is_dropped_not_served() {
+        let root = temp_root("corrupt");
+        let config = root.join("vite.config.ts");
+        fs::write(&config, "a").unwrap();
+        let store = ConfigExtractStore::new(&root, "s1");
+        store.store(&config, "serve", "development", &[], "{}", "");
+        let path = store.entry_path(&config, "serve", "development");
+        fs::write(&path, b"{ not json").unwrap();
+        assert!(store.lookup(&config, "serve", "development").is_none());
+        assert!(!path.exists(), "corrupt entry must be removed");
+    }
+
+    #[test]
+    fn salt_and_command_and_mode_separate_entries() {
+        let root = temp_root("salt");
+        let config = root.join("vite.config.ts");
+        fs::write(&config, "a").unwrap();
+        let store = ConfigExtractStore::new(&root, "s1");
+        store.store(&config, "serve", "development", &[], "{}", "");
+        assert!(ConfigExtractStore::new(&root, "s2")
+            .lookup(&config, "serve", "development")
+            .is_none());
+        assert!(store.lookup(&config, "build", "development").is_none());
+        assert!(store.lookup(&config, "serve", "production").is_none());
+    }
+}

--- a/crates/oj_cache/src/integrity.rs
+++ b/crates/oj_cache/src/integrity.rs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+//! Shared cache-integrity primitives: atomic whole-file writes and
+//! verified reads of content-addressed artifacts. Every store in this
+//! crate is expected to write through `atomic_write` and read stored
+//! artifacts through `verify_file`/`verified_read`, so a torn write or
+//! a corrupted entry degrades to a cache miss, never to wrong output.
+
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+/// How deeply stored artifacts are checked against their recorded
+/// size and hash. `Standard` trusts existence + size (git's trust
+/// model); `Full` re-hashes content on every read. Selected at the
+/// call site, normally via [`VerifyMode::from_env`] (`OJ_CACHE_VERIFY=full`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerifyMode {
+    Standard,
+    Full,
+}
+
+impl VerifyMode {
+    pub fn from_env() -> Self {
+        match std::env::var("OJ_CACHE_VERIFY") {
+            Ok(v) if v.eq_ignore_ascii_case("full") => VerifyMode::Full,
+            _ => VerifyMode::Standard,
+        }
+    }
+}
+
+/// What an artifact on disk must look like: its byte length and the
+/// blake3 hash of its content (hex).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpectedFile {
+    pub size: u64,
+    pub hash: String,
+}
+
+#[derive(Debug)]
+pub enum VerifyError {
+    Io(io::Error),
+    WrongSize { expected: u64, actual: u64 },
+    WrongHash { expected: String, actual: String },
+}
+
+impl fmt::Display for VerifyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            VerifyError::Io(e) => write!(f, "io: {e}"),
+            VerifyError::WrongSize { expected, actual } => {
+                write!(f, "size mismatch: expected {expected} B, found {actual} B")
+            }
+            VerifyError::WrongHash { expected, actual } => {
+                write!(
+                    f,
+                    "hash mismatch: expected {}…, found {}…",
+                    expected.get(..12).unwrap_or(expected),
+                    actual.get(..12).unwrap_or(actual)
+                )
+            }
+        }
+    }
+}
+
+/// Write `bytes` to `path` via a same-directory temp file + rename, so a
+/// concurrent reader sees either the old content or the new, never a tear.
+pub fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let dir = path.parent().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "atomic_write needs a parent dir")
+    })?;
+    let name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("artifact");
+    let tmp = dir.join(format!(".{name}.tmp-{}", std::process::id()));
+    fs::write(&tmp, bytes)?;
+    fs::rename(&tmp, path).inspect_err(|_| {
+        let _ = fs::remove_file(&tmp);
+    })
+}
+
+/// Check an on-disk artifact against `expected` without returning its
+/// content. `Standard`: a stat pass (existence + size). `Full`: also
+/// read and re-hash.
+pub fn verify_file(path: &Path, expected: &ExpectedFile, mode: VerifyMode) -> Result<(), VerifyError> {
+    match mode {
+        VerifyMode::Standard => {
+            let meta = fs::metadata(path).map_err(VerifyError::Io)?;
+            if meta.len() != expected.size {
+                return Err(VerifyError::WrongSize {
+                    expected: expected.size,
+                    actual: meta.len(),
+                });
+            }
+            Ok(())
+        }
+        VerifyMode::Full => verified_read(path, expected, mode).map(|_| ()),
+    }
+}
+
+/// Read an artifact and check it against `expected`. Size is checked in
+/// both modes; `Full` also re-hashes the content.
+pub fn verified_read(
+    path: &Path,
+    expected: &ExpectedFile,
+    mode: VerifyMode,
+) -> Result<Vec<u8>, VerifyError> {
+    let bytes = fs::read(path).map_err(VerifyError::Io)?;
+    if bytes.len() as u64 != expected.size {
+        return Err(VerifyError::WrongSize {
+            expected: expected.size,
+            actual: bytes.len() as u64,
+        });
+    }
+    if mode == VerifyMode::Full {
+        let actual = blake3::hash(&bytes).to_hex().to_string();
+        if actual != expected.hash {
+            return Err(VerifyError::WrongHash {
+                expected: expected.hash.clone(),
+                actual,
+            });
+        }
+    }
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn tmp(label: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!("oj-integrity-{}-{label}", std::process::id()));
+        let _ = fs::remove_dir_all(&d);
+        fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    fn expected_for(bytes: &[u8]) -> ExpectedFile {
+        ExpectedFile {
+            size: bytes.len() as u64,
+            hash: blake3::hash(bytes).to_hex().to_string(),
+        }
+    }
+
+    #[test]
+    fn atomic_write_leaves_no_temp_file() {
+        let d = tmp("atomic");
+        let p = d.join("out.json");
+        atomic_write(&p, b"{}").unwrap();
+        assert_eq!(fs::read(&p).unwrap(), b"{}");
+        let leftovers: Vec<_> = fs::read_dir(&d)
+            .unwrap()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().contains("tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "{leftovers:?}");
+    }
+
+    #[test]
+    fn verified_read_returns_bytes_on_match() {
+        let d = tmp("ok");
+        let p = d.join("blob");
+        fs::write(&p, b"hello").unwrap();
+        let exp = expected_for(b"hello");
+        assert_eq!(verified_read(&p, &exp, VerifyMode::Standard).unwrap(), b"hello");
+        assert_eq!(verified_read(&p, &exp, VerifyMode::Full).unwrap(), b"hello");
+    }
+
+    #[test]
+    fn wrong_size_fails_in_both_modes() {
+        let d = tmp("size");
+        let p = d.join("blob");
+        fs::write(&p, b"hello!").unwrap();
+        let exp = expected_for(b"hello");
+        assert!(matches!(
+            verified_read(&p, &exp, VerifyMode::Standard),
+            Err(VerifyError::WrongSize { expected: 5, actual: 6 })
+        ));
+        assert!(verify_file(&p, &exp, VerifyMode::Standard).is_err());
+    }
+
+    #[test]
+    fn same_size_corruption_needs_full_mode() {
+        let d = tmp("flip");
+        let p = d.join("blob");
+        fs::write(&p, b"hellX").unwrap();
+        let exp = expected_for(b"hello");
+        assert!(verified_read(&p, &exp, VerifyMode::Standard).is_ok());
+        assert!(verify_file(&p, &exp, VerifyMode::Standard).is_ok());
+        assert!(matches!(
+            verified_read(&p, &exp, VerifyMode::Full),
+            Err(VerifyError::WrongHash { .. })
+        ));
+        assert!(verify_file(&p, &exp, VerifyMode::Full).is_err());
+    }
+
+    #[test]
+    fn missing_file_is_io_error() {
+        let d = tmp("missing");
+        let exp = expected_for(b"hello");
+        assert!(matches!(
+            verify_file(&d.join("nope"), &exp, VerifyMode::Standard),
+            Err(VerifyError::Io(_))
+        ));
+    }
+}

--- a/crates/oj_cache/src/lib.rs
+++ b/crates/oj_cache/src/lib.rs
@@ -4,6 +4,9 @@
 use std::fs;
 use std::path::PathBuf;
 
+pub mod integrity;
+pub mod start_bundle;
+
 use serde::{Deserialize, Serialize};
 
 pub mod start_codegen;

--- a/crates/oj_cache/src/lib.rs
+++ b/crates/oj_cache/src/lib.rs
@@ -4,6 +4,7 @@
 use std::fs;
 use std::path::PathBuf;
 
+pub mod config_extract;
 pub mod integrity;
 pub mod start_bundle;
 

--- a/crates/oj_cache/src/lib.rs
+++ b/crates/oj_cache/src/lib.rs
@@ -6,6 +6,8 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+pub mod start_codegen;
+
 pub const CACHE_FORMAT: u32 = 5;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/oj_cache/src/start_bundle.rs
+++ b/crates/oj_cache/src/start_bundle.rs
@@ -1,0 +1,1192 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use crate::integrity::{self, ExpectedFile, VerifyMode};
+
+pub const START_BUNDLE_FORMAT: u32 = 3;
+pub const DEFAULT_PRUNE_BUDGET_BYTES: u64 = 1024 * 1024 * 1024;
+
+// Small per-generation artifacts copied into the start dir on restore.
+// The chunk set itself is not copied: it is served straight out of the
+// blob store through the generation manifest.
+const ARTIFACTS: [&str; 2] = ["client-entry.modules", "manifest.ts"];
+const CLOSURE_FILE: &str = "closure.json";
+const MEMO_FILE: &str = "memo.json";
+const MANIFEST_FILE: &str = "manifest.json";
+const CURRENT_FILE: &str = "current";
+const LEGACY_POINTER_FILE: &str = "latest";
+const TOUCH_FILE: &str = "last-used";
+const BLOBS_DIR: &str = "blobs";
+const CHUNKS_DIR: &str = "client-chunks";
+const CHUNK_INDEX_FILE: &str = "client-chunks.json";
+const CSS_URLS_FILE: &str = "css-urls.json";
+
+// Git's racy-index rule: a file whose mtime is within this window of the
+// memo's write time may have been modified without the stat changing, so it
+// is left out of the memo and re-hashed until a later write sees it settled.
+const MEMO_FRESHNESS_SLACK_NS: u64 = 2_000_000_000;
+
+/// Whole-bundle cache for the TanStack Start client build, keyed by the
+/// content of every module in the previous build's closure. One build =
+/// one generation: chunk bytes live content-addressed under `blobs/`
+/// (shared across generations), and a generation manifest maps every
+/// public chunk name to its blob. A `current` pointer names the pinned
+/// generation; the serve path resolves names only through it.
+pub struct StartBundleStore {
+    dir: PathBuf,
+    salt: String,
+    verify: VerifyMode,
+}
+
+/// The generation the server serves from: chunk name -> on-disk file.
+/// Names absent from the map do not exist for the serve path.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PinnedBundle {
+    pub entry: String,
+    chunks: HashMap<String, PinnedChunk>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PinnedChunk {
+    pub path: PathBuf,
+    pub size: u64,
+    /// blake3 hex of the content; `None` when pinned straight off a fresh
+    /// build (trusted: the bytes were written by this process moments ago).
+    pub hash: Option<String>,
+}
+
+impl PinnedBundle {
+    pub fn chunk(&self, name: &str) -> Option<&PinnedChunk> {
+        self.chunks
+            .get(name)
+            .or_else(|| (name == "client-entry.js").then(|| self.chunks.get(&self.entry))?)
+    }
+
+    pub fn len(&self) -> usize {
+        self.chunks.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.chunks.is_empty()
+    }
+
+    /// Pin the chunk set a fresh build left in `start_dir/client-chunks`,
+    /// bypassing the store. Fallback for when `persist` fails: the server
+    /// still serves the build it just made.
+    pub fn from_build_dir(start_dir: &Path) -> Option<Self> {
+        let index = read_chunk_index(start_dir)?;
+        let chunk_dir = start_dir.join(CHUNKS_DIR);
+        let mut chunks = HashMap::with_capacity(index.files.len());
+        for f in index.files {
+            let path = chunk_dir.join(&f.name);
+            let size = fs::metadata(&path).ok()?.len();
+            chunks.insert(f.name, PinnedChunk { path, size, hash: None });
+        }
+        Some(Self { entry: index.entry, chunks })
+    }
+}
+
+/// On-disk generation manifest (`<entry>/manifest.json`): the single file
+/// that defines which chunk names exist and which bytes they resolve to.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GenerationManifest {
+    format: u32,
+    entry: String,
+    css_urls: Vec<String>,
+    files: BTreeMap<String, ManifestFile>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct ManifestFile {
+    hash: String,
+    size: u64,
+}
+
+/// `client-chunks.json`, written by bundle-client.mjs next to the chunk dir.
+#[derive(Deserialize)]
+struct ChunkIndex {
+    entry: String,
+    files: Vec<ChunkIndexFile>,
+}
+
+#[derive(Deserialize)]
+struct ChunkIndexFile {
+    name: String,
+    #[allow(dead_code)]
+    size: u64,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct RestoreStats {
+    pub key: String,
+    pub files: usize,
+    pub chunks: usize,
+    pub rehashed: usize,
+    pub elapsed_ms: u128,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Miss {
+    NoPreviousBuild,
+    ClosureUnreadable,
+    ClosureFileUnreadable(PathBuf),
+    NoEntryForKey(String),
+    EntryCorrupt(String),
+    ChunkCorrupt {
+        key: String,
+        name: String,
+        detail: String,
+    },
+    ArtifactWriteFailed(String),
+}
+
+impl std::fmt::Display for Miss {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fn short(key: &str) -> &str {
+            key.get(..8).unwrap_or(key)
+        }
+        match self {
+            Miss::NoPreviousBuild => write!(f, "no previous build"),
+            Miss::ClosureUnreadable => write!(f, "previous closure unreadable"),
+            Miss::ClosureFileUnreadable(p) => {
+                write!(f, "closure file unreadable: {}", p.display())
+            }
+            Miss::NoEntryForKey(k) => write!(f, "no cached bundle for key {}…", short(k)),
+            Miss::EntryCorrupt(k) => write!(f, "cached entry {}… corrupt, removed", short(k)),
+            Miss::ChunkCorrupt { key, name, detail } => write!(
+                f,
+                "chunk {name} of entry {}… failed verification ({detail}); entry removed",
+                short(key)
+            ),
+            Miss::ArtifactWriteFailed(name) => {
+                write!(f, "could not write restored artifact {name}")
+            }
+        }
+    }
+}
+
+/// Per-file (size, mtime, digest) memo so verification is a stat pass, not a
+/// read of every closure file. Content stays authoritative: a stat mismatch
+/// falls back to re-hashing, so the memo can cause extra reads, never a
+/// false hit.
+#[derive(Serialize, Deserialize)]
+struct Memo {
+    written_at_ns: u64,
+    files: HashMap<String, MemoFile>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct MemoFile {
+    size: u64,
+    mtime_ns: u64,
+    digest: String,
+}
+
+impl StartBundleStore {
+    pub fn new(root: &Path, tool_version: &str, verify: VerifyMode) -> Self {
+        Self {
+            dir: root.join(".oj-cache").join("start-bundle"),
+            salt: format!(
+                "{tool_version}:{START_BUNDLE_FORMAT}:start-bundle:{}",
+                epoch(root)
+            ),
+            verify,
+        }
+    }
+
+    /// Pin the generation matching the current source state: verify its
+    /// chunk blobs (existence + size; full re-hash under
+    /// `OJ_CACHE_VERIFY=full`), copy the small artifacts into `start_dir`
+    /// (after `write_start_assets`, which stubs manifest.ts), and swap the
+    /// `current` pointer. No chunk bytes are copied.
+    pub fn restore(&self, start_dir: &Path) -> Result<(RestoreStats, PinnedBundle), Miss> {
+        let started = Instant::now();
+        let current = fs::read_to_string(self.dir.join(CURRENT_FILE))
+            .map_err(|_| Miss::NoPreviousBuild)?
+            .trim()
+            .to_string();
+        let current_dir = self.dir.join(&current);
+        let Some(files) = read_closure(&current_dir.join(CLOSURE_FILE)) else {
+            let _ = fs::remove_dir_all(&current_dir);
+            return Err(Miss::ClosureUnreadable);
+        };
+        let memo = read_memo(&current_dir);
+        let (digests, rehashed) = verified_digests(&files, memo.as_ref());
+        let key = self.key_from(&files, &digests)?;
+        let entry = self.dir.join(&key);
+        if !entry.is_dir() {
+            return Err(Miss::NoEntryForKey(key));
+        }
+        let Some(manifest) = read_manifest(&entry) else {
+            let _ = fs::remove_dir_all(&entry);
+            return Err(Miss::EntryCorrupt(key));
+        };
+        if let Err((name, detail)) = self.verify_members(&manifest) {
+            let _ = fs::remove_dir_all(&entry);
+            return Err(Miss::ChunkCorrupt { key, name, detail });
+        }
+        for name in ARTIFACTS {
+            let Ok(bytes) = fs::read(entry.join(name)) else {
+                let _ = fs::remove_dir_all(&entry);
+                return Err(Miss::EntryCorrupt(key));
+            };
+            if integrity::atomic_write(&start_dir.join(name), &bytes).is_err() {
+                return Err(Miss::ArtifactWriteFailed(name.to_string()));
+            }
+        }
+        // css-urls.json is derived from the manifest so the SSR runner's CSS
+        // list can never split from the chunk set it was built with.
+        let css = serde_json::to_vec(&manifest.css_urls).unwrap_or_else(|_| b"[]".to_vec());
+        if integrity::atomic_write(&start_dir.join(CSS_URLS_FILE), &css).is_err() {
+            return Err(Miss::ArtifactWriteFailed(CSS_URLS_FILE.to_string()));
+        }
+        if rehashed > 0 || !entry.join(MEMO_FILE).is_file() {
+            write_memo(&entry, &build_memo(&files, &digests));
+        }
+        touch(&entry);
+        if key != current {
+            self.write_current(&key);
+        }
+        let stats = RestoreStats {
+            key,
+            files: files.len(),
+            chunks: manifest.files.len(),
+            rehashed,
+            elapsed_ms: started.elapsed().as_millis(),
+        };
+        Ok((stats, self.pin(&manifest)))
+    }
+
+    /// Store the build a fresh bundle left in `start_dir`: ingest every
+    /// chunk into the blob store (deduplicated by content hash), write the
+    /// generation manifest, and swap the `current` pointer. Best-effort:
+    /// any failure leaves the store as it was.
+    pub fn persist(&self, start_dir: &Path) -> Option<(String, PinnedBundle)> {
+        let files = read_closure(&start_dir.join(CLOSURE_FILE))?;
+        let digests = par_map(&files, |p| hash_file(p));
+        let key = self.key_from(&files, &digests).ok()?;
+        let index = read_chunk_index(start_dir)?;
+        let css_urls = read_css_urls(start_dir);
+        let chunk_dir = start_dir.join(CHUNKS_DIR);
+        let chunk_paths: Vec<PathBuf> = index.files.iter().map(|f| chunk_dir.join(&f.name)).collect();
+        let chunk_hashes = par_map(&chunk_paths, |p| hash_file(p));
+        let blobs = self.dir.join(BLOBS_DIR);
+        fs::create_dir_all(&blobs).ok()?;
+        let mut manifest_files = BTreeMap::new();
+        for (f, (path, hash)) in index.files.iter().zip(chunk_paths.iter().zip(&chunk_hashes)) {
+            let hex = hash.as_ref()?.to_hex().to_string();
+            let size = fs::metadata(path).ok()?.len();
+            let blob = blobs.join(&hex);
+            if !blob.is_file() {
+                let tmp = blobs.join(format!(".tmp-{}-{}", hex.get(..16)?, std::process::id()));
+                if fs::copy(path, &tmp).is_err() {
+                    let _ = fs::remove_file(&tmp);
+                    return None;
+                }
+                if fs::rename(&tmp, &blob).is_err() {
+                    let _ = fs::remove_file(&tmp);
+                    if !blob.is_file() {
+                        return None;
+                    }
+                }
+            }
+            manifest_files.insert(f.name.clone(), ManifestFile { hash: hex, size });
+        }
+        let manifest = GenerationManifest {
+            format: START_BUNDLE_FORMAT,
+            entry: index.entry,
+            css_urls,
+            files: manifest_files,
+        };
+        let entry = self.dir.join(&key);
+        if !entry.is_dir() {
+            let tmp = self
+                .dir
+                .join(format!(".tmp-{}-{}", key.get(..16)?, std::process::id()));
+            let _ = fs::remove_dir_all(&tmp);
+            fs::create_dir_all(&tmp).ok()?;
+            for name in ARTIFACTS.into_iter().chain([CLOSURE_FILE]) {
+                if fs::copy(start_dir.join(name), tmp.join(name)).is_err() {
+                    let _ = fs::remove_dir_all(&tmp);
+                    return None;
+                }
+            }
+            let bytes = serde_json::to_vec(&manifest).ok()?;
+            if fs::write(tmp.join(MANIFEST_FILE), bytes).is_err() {
+                let _ = fs::remove_dir_all(&tmp);
+                return None;
+            }
+            if fs::rename(&tmp, &entry).is_err() {
+                let _ = fs::remove_dir_all(&tmp);
+                if !entry.is_dir() {
+                    return None;
+                }
+            }
+        }
+        write_memo(&entry, &build_memo(&files, &digests));
+        touch(&entry);
+        self.write_current(&key);
+        Some((key, self.pin(&manifest)))
+    }
+
+    /// LRU eviction of whole generations down to `budget_bytes`, counting
+    /// each blob once (generations share blobs), followed by a sweep of
+    /// blobs no surviving generation references. The `current` generation
+    /// always survives.
+    pub fn prune(&self, budget_bytes: u64) {
+        let _ = fs::remove_file(self.dir.join(LEGACY_POINTER_FILE));
+        let Ok(entries) = fs::read_dir(&self.dir) else {
+            return;
+        };
+        let keep = fs::read_to_string(self.dir.join(CURRENT_FILE))
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default();
+        struct Gen {
+            path: PathBuf,
+            stamp: SystemTime,
+            own_size: u64,
+            refs: Vec<String>,
+            is_current: bool,
+        }
+        let mut gens = Vec::new();
+        for e in entries.flatten() {
+            let path = e.path();
+            let name = e.file_name().to_string_lossy().into_owned();
+            if name == BLOBS_DIR || !path.is_dir() {
+                continue;
+            }
+            if name.starts_with(".tmp-") {
+                let _ = fs::remove_dir_all(&path);
+                continue;
+            }
+            let refs = read_manifest(&path)
+                .map(|m| m.files.into_values().map(|f| f.hash).collect())
+                .unwrap_or_default();
+            let stamp = fs::metadata(path.join(TOUCH_FILE))
+                .or_else(|_| fs::metadata(&path))
+                .and_then(|m| m.modified())
+                .unwrap_or(UNIX_EPOCH);
+            gens.push(Gen {
+                own_size: entry_size(&path),
+                is_current: name == keep,
+                path,
+                stamp,
+                refs,
+            });
+        }
+        let blobs_dir = self.dir.join(BLOBS_DIR);
+        let mut blob_sizes: HashMap<String, u64> = HashMap::new();
+        if let Ok(entries) = fs::read_dir(&blobs_dir) {
+            for e in entries.flatten() {
+                let name = e.file_name().to_string_lossy().into_owned();
+                if name.starts_with(".tmp-") {
+                    let _ = fs::remove_file(e.path());
+                    continue;
+                }
+                if let Ok(meta) = e.metadata() {
+                    blob_sizes.insert(name, meta.len());
+                }
+            }
+        }
+        let mut refcount: HashMap<String, usize> = HashMap::new();
+        for g in &gens {
+            for h in &g.refs {
+                *refcount.entry(h.clone()).or_default() += 1;
+            }
+        }
+        let mut total: u64 = gens.iter().map(|g| g.own_size).sum();
+        for (hash, count) in &refcount {
+            if *count > 0 {
+                total += blob_sizes.get(hash).copied().unwrap_or(0);
+            }
+        }
+        gens.sort_by_key(|g| g.stamp);
+        for g in &gens {
+            if total <= budget_bytes {
+                break;
+            }
+            if g.is_current {
+                continue;
+            }
+            if fs::remove_dir_all(&g.path).is_err() {
+                continue;
+            }
+            total = total.saturating_sub(g.own_size);
+            for h in &g.refs {
+                if let Some(c) = refcount.get_mut(h.as_str()) {
+                    *c -= 1;
+                    if *c == 0 {
+                        total = total.saturating_sub(blob_sizes.get(h).copied().unwrap_or(0));
+                    }
+                }
+            }
+        }
+        // Sweep unreferenced blobs. A generation persisted while this scan
+        // ran is invisible to `refcount`, so re-read the pointer and spare
+        // whatever the now-current generation references.
+        let mut live: HashSet<String> = refcount
+            .into_iter()
+            .filter(|&(_, c)| c > 0)
+            .map(|(h, _)| h)
+            .collect();
+        if let Ok(now_current) = fs::read_to_string(self.dir.join(CURRENT_FILE)) {
+            if let Some(m) = read_manifest(&self.dir.join(now_current.trim())) {
+                live.extend(m.files.into_values().map(|f| f.hash));
+            }
+        }
+        for hash in blob_sizes.keys() {
+            if !live.contains(hash) {
+                let _ = fs::remove_file(blobs_dir.join(hash));
+            }
+        }
+    }
+
+    fn pin(&self, manifest: &GenerationManifest) -> PinnedBundle {
+        let blobs = self.dir.join(BLOBS_DIR);
+        let chunks = manifest
+            .files
+            .iter()
+            .map(|(name, f)| {
+                (
+                    name.clone(),
+                    PinnedChunk {
+                        path: blobs.join(&f.hash),
+                        size: f.size,
+                        hash: Some(f.hash.clone()),
+                    },
+                )
+            })
+            .collect();
+        PinnedBundle {
+            entry: manifest.entry.clone(),
+            chunks,
+        }
+    }
+
+    fn verify_members(&self, manifest: &GenerationManifest) -> Result<(), (String, String)> {
+        let blobs = self.dir.join(BLOBS_DIR);
+        let items: Vec<(String, PathBuf, ExpectedFile)> = manifest
+            .files
+            .iter()
+            .map(|(name, f)| {
+                (
+                    name.clone(),
+                    blobs.join(&f.hash),
+                    ExpectedFile {
+                        size: f.size,
+                        hash: f.hash.clone(),
+                    },
+                )
+            })
+            .collect();
+        let mode = self.verify;
+        let results = par_map(&items, |(name, path, expected)| {
+            Some(match integrity::verify_file(path, expected, mode) {
+                Ok(()) => Ok(()),
+                Err(e) => {
+                    if !matches!(e, integrity::VerifyError::Io(_)) {
+                        let _ = fs::remove_file(path);
+                    }
+                    Err((name.clone(), e.to_string()))
+                }
+            })
+        });
+        for r in results.into_iter().flatten() {
+            r?;
+        }
+        Ok(())
+    }
+
+    fn key_from(
+        &self,
+        files: &[PathBuf],
+        digests: &[Option<blake3::Hash>],
+    ) -> Result<String, Miss> {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(self.salt.as_bytes());
+        for (path, digest) in files.iter().zip(digests) {
+            let Some(digest) = digest else {
+                return Err(Miss::ClosureFileUnreadable(path.clone()));
+            };
+            hasher.update(&[0]);
+            hasher.update(path.as_os_str().as_encoded_bytes());
+            hasher.update(&[0]);
+            hasher.update(digest.as_bytes());
+        }
+        Ok(hasher.finalize().to_hex().to_string())
+    }
+
+    fn write_current(&self, key: &str) {
+        let _ = integrity::atomic_write(&self.dir.join(CURRENT_FILE), key.as_bytes());
+    }
+}
+
+/// Everything that shapes the bundle without being a module in its closure:
+/// dependency lockfiles, vite/oj config, env files, and the env vars the
+/// bundler inlines (`VITE_*` via import.meta.env, TSS_SERVER_FN_BASE).
+fn epoch(root: &Path) -> String {
+    let mut hasher = blake3::Hasher::new();
+    for name in [
+        "package-lock.json",
+        "yarn.lock",
+        "pnpm-lock.yaml",
+        "bun.lockb",
+        "package.json",
+        "vite.config.ts",
+        "vite.config.js",
+        "vite.config.mjs",
+        "vite.config.mts",
+        "oj.config.ts",
+        "oj.config.js",
+        "oj.config.mjs",
+        ".env",
+        ".env.local",
+        ".env.development",
+        ".env.development.local",
+    ] {
+        if let Ok(bytes) = fs::read(root.join(name)) {
+            hasher.update(name.as_bytes());
+            hasher.update(&[0]);
+            hasher.update(&bytes);
+        }
+    }
+    let mut env: Vec<(String, String)> = std::env::vars()
+        .filter(|(k, _)| k.starts_with("VITE_") || k == "TSS_SERVER_FN_BASE")
+        .collect();
+    env.sort();
+    for (k, v) in env {
+        hasher.update(b"\0e");
+        hasher.update(k.as_bytes());
+        hasher.update(&[0]);
+        hasher.update(v.as_bytes());
+    }
+    hasher.finalize().to_hex().to_string()
+}
+
+fn read_closure(path: &Path) -> Option<Vec<PathBuf>> {
+    let bytes = fs::read(path).ok()?;
+    let files: Vec<String> = serde_json::from_slice(&bytes).ok()?;
+    if files.is_empty() {
+        return None;
+    }
+    let mut files: Vec<PathBuf> = files.into_iter().map(PathBuf::from).collect();
+    files.sort();
+    files.dedup();
+    Some(files)
+}
+
+fn read_manifest(entry: &Path) -> Option<GenerationManifest> {
+    let bytes = fs::read(entry.join(MANIFEST_FILE)).ok()?;
+    let manifest: GenerationManifest = serde_json::from_slice(&bytes).ok()?;
+    if manifest.format != START_BUNDLE_FORMAT || manifest.files.is_empty() {
+        return None;
+    }
+    Some(manifest)
+}
+
+fn read_chunk_index(start_dir: &Path) -> Option<ChunkIndex> {
+    let bytes = fs::read(start_dir.join(CHUNK_INDEX_FILE)).ok()?;
+    let index: ChunkIndex = serde_json::from_slice(&bytes).ok()?;
+    if index.files.is_empty() {
+        return None;
+    }
+    Some(index)
+}
+
+fn read_css_urls(start_dir: &Path) -> Vec<String> {
+    fs::read(start_dir.join(CSS_URLS_FILE))
+        .ok()
+        .and_then(|b| serde_json::from_slice(&b).ok())
+        .unwrap_or_default()
+}
+
+fn read_memo(entry: &Path) -> Option<Memo> {
+    let path = entry.join(MEMO_FILE);
+    let bytes = fs::read(&path).ok()?;
+    match serde_json::from_slice(&bytes) {
+        Ok(memo) => Some(memo),
+        Err(_) => {
+            let _ = fs::remove_file(&path);
+            None
+        }
+    }
+}
+
+fn write_memo(entry: &Path, memo: &Memo) {
+    let Ok(bytes) = serde_json::to_vec(memo) else {
+        return;
+    };
+    let _ = integrity::atomic_write(&entry.join(MEMO_FILE), &bytes);
+}
+
+/// Stats are taken after the digests were computed, so a file modified in
+/// between carries an mtime close to `written_at_ns` and the freshness rule
+/// below keeps it out of the memo.
+fn build_memo(files: &[PathBuf], digests: &[Option<blake3::Hash>]) -> Memo {
+    let written_at_ns = now_ns();
+    let stats = par_map(files, |p| {
+        let meta = fs::metadata(p).ok()?;
+        Some((meta.len(), mtime_ns(&meta)?))
+    });
+    let mut map = HashMap::new();
+    for ((path, digest), stat) in files.iter().zip(digests).zip(&stats) {
+        let (Some(digest), Some((size, mtime_ns)), Some(path)) = (digest, stat, path.to_str())
+        else {
+            continue;
+        };
+        if mtime_ns.saturating_add(MEMO_FRESHNESS_SLACK_NS) > written_at_ns {
+            continue;
+        }
+        map.insert(
+            path.to_string(),
+            MemoFile {
+                size: *size,
+                mtime_ns: *mtime_ns,
+                digest: digest.to_hex().to_string(),
+            },
+        );
+    }
+    Memo {
+        written_at_ns,
+        files: map,
+    }
+}
+
+fn verified_digests(files: &[PathBuf], memo: Option<&Memo>) -> (Vec<Option<blake3::Hash>>, usize) {
+    let rehashed = AtomicUsize::new(0);
+    let digests = par_map(files, |p| {
+        if let Some(known) = memo.and_then(|m| p.to_str().and_then(|s| m.files.get(s))) {
+            if let Ok(meta) = fs::metadata(p) {
+                if meta.len() == known.size && mtime_ns(&meta) == Some(known.mtime_ns) {
+                    if let Ok(digest) = blake3::Hash::from_hex(&known.digest) {
+                        return Some(digest);
+                    }
+                }
+            }
+        }
+        rehashed.fetch_add(1, Ordering::Relaxed);
+        hash_file(p)
+    });
+    (digests, rehashed.into_inner())
+}
+
+fn hash_file(p: &Path) -> Option<blake3::Hash> {
+    fs::read(p).ok().map(|bytes| blake3::hash(&bytes))
+}
+
+fn mtime_ns(meta: &fs::Metadata) -> Option<u64> {
+    let t = meta.modified().ok()?;
+    u64::try_from(t.duration_since(UNIX_EPOCH).ok()?.as_nanos()).ok()
+}
+
+fn now_ns() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|d| u64::try_from(d.as_nanos()).ok())
+        .unwrap_or(0)
+}
+
+fn par_map<I: Sync, T: Send>(items: &[I], f: impl Fn(&I) -> Option<T> + Sync) -> Vec<Option<T>> {
+    let threads = std::thread::available_parallelism()
+        .map_or(1, |n| n.get())
+        .min(items.len().max(1));
+    if threads <= 1 {
+        return items.iter().map(|p| f(p)).collect();
+    }
+    let chunk = items.len().div_ceil(threads);
+    let mut out: Vec<Option<T>> = Vec::new();
+    out.resize_with(items.len(), || None);
+    std::thread::scope(|s| {
+        for (part, slots) in items.chunks(chunk).zip(out.chunks_mut(chunk)) {
+            let f = &f;
+            s.spawn(move || {
+                for (p, slot) in part.iter().zip(slots) {
+                    *slot = f(p);
+                }
+            });
+        }
+    });
+    out
+}
+
+fn touch(entry: &Path) {
+    let _ = fs::write(entry.join(TOUCH_FILE), b"");
+}
+
+fn entry_size(dir: &Path) -> u64 {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return 0;
+    };
+    entries
+        .flatten()
+        .filter_map(|e| e.metadata().ok())
+        .filter(|m| m.is_file())
+        .map(|m| m.len())
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    struct Fixture {
+        root: PathBuf,
+        start: PathBuf,
+    }
+
+    impl Fixture {
+        fn new(label: &str) -> Self {
+            let root = std::env::temp_dir().join(format!(
+                "oj-start-bundle-test-{}-{label}",
+                std::process::id()
+            ));
+            let _ = fs::remove_dir_all(&root);
+            let start = root.join(".oj-cache").join("start");
+            fs::create_dir_all(root.join("src")).unwrap();
+            fs::create_dir_all(&start).unwrap();
+            fs::write(root.join("package.json"), b"{}").unwrap();
+            let fx = Self { root, start };
+            fx.write_module("a.tsx", "export const a = 1;");
+            fx.write_module("b.tsx", "export const b = 2;");
+            fx.write_build("bundle-v1");
+            fx
+        }
+
+        fn store(&self) -> StartBundleStore {
+            StartBundleStore::new(&self.root, "0.0.1-test", VerifyMode::Standard)
+        }
+
+        fn full_store(&self) -> StartBundleStore {
+            StartBundleStore::new(&self.root, "0.0.1-test", VerifyMode::Full)
+        }
+
+        fn module(&self, name: &str) -> PathBuf {
+            self.root.join("src").join(name)
+        }
+
+        fn write_module(&self, name: &str, code: &str) {
+            fs::write(self.module(name), code).unwrap();
+        }
+
+        /// Backdate module mtimes past the memo freshness window so persist
+        /// records them (freshly written files are deliberately left out).
+        fn settle_modules(&self) {
+            let old = SystemTime::now() - Duration::from_secs(3600);
+            for name in ["a.tsx", "b.tsx"] {
+                set_mtime(&self.module(name), old);
+            }
+        }
+
+        /// Simulate what bundle-client.mjs leaves in .oj-cache/start:
+        /// the chunk dir, its index, and the small artifacts. The
+        /// `shared.js` chunk keeps the same bytes across builds so blob
+        /// dedupe is observable; the entry chunk carries the marker.
+        fn write_build(&self, marker: &str) {
+            let closure = vec![
+                self.module("a.tsx").display().to_string(),
+                self.module("b.tsx").display().to_string(),
+            ];
+            fs::write(
+                self.start.join(CLOSURE_FILE),
+                serde_json::to_vec(&closure).unwrap(),
+            )
+            .unwrap();
+            let chunks = self.start.join(CHUNKS_DIR);
+            let _ = fs::remove_dir_all(&chunks);
+            fs::create_dir_all(&chunks).unwrap();
+            fs::write(chunks.join("client-entry.js"), marker).unwrap();
+            fs::write(chunks.join("shared-x.js"), "shared bytes").unwrap();
+            let index = serde_json::json!({
+                "entry": "client-entry.js",
+                "files": [
+                    { "name": "client-entry.js", "size": marker.len() },
+                    { "name": "shared-x.js", "size": "shared bytes".len() },
+                ],
+            });
+            fs::write(self.start.join(CHUNK_INDEX_FILE), index.to_string()).unwrap();
+            fs::write(self.start.join(CSS_URLS_FILE), br#"["/@oj-start/fs/a.css"]"#).unwrap();
+            fs::write(self.start.join("client-entry.modules"), "2").unwrap();
+            fs::write(self.start.join("manifest.ts"), format!("// {marker}")).unwrap();
+        }
+
+        fn clear_start_dir(&self) {
+            for name in ARTIFACTS.into_iter().chain([CSS_URLS_FILE]) {
+                let _ = fs::remove_file(self.start.join(name));
+            }
+            let _ = fs::remove_dir_all(self.start.join(CHUNKS_DIR));
+        }
+
+        fn entry_dir(&self, key: &str) -> PathBuf {
+            self.root.join(".oj-cache/start-bundle").join(key)
+        }
+
+        fn blob_dir(&self) -> PathBuf {
+            self.root.join(".oj-cache/start-bundle").join(BLOBS_DIR)
+        }
+
+        fn blob_count(&self) -> usize {
+            fs::read_dir(self.blob_dir())
+                .map(|d| d.flatten().count())
+                .unwrap_or(0)
+        }
+
+        fn entry_bytes(&self, pinned: &PinnedBundle) -> String {
+            let chunk = pinned.chunk("client-entry.js").unwrap();
+            String::from_utf8(fs::read(&chunk.path).unwrap()).unwrap()
+        }
+    }
+
+    fn set_mtime(path: &Path, t: SystemTime) {
+        let f = fs::OpenOptions::new().append(true).open(path).unwrap();
+        f.set_times(fs::FileTimes::new().set_modified(t)).unwrap();
+    }
+
+    #[test]
+    fn restore_misses_without_previous_build() {
+        let fx = Fixture::new("nolatest");
+        assert!(matches!(
+            fx.store().restore(&fx.start),
+            Err(Miss::NoPreviousBuild)
+        ));
+    }
+
+    #[test]
+    fn persist_then_restore_roundtrips_artifacts() {
+        let fx = Fixture::new("roundtrip");
+        let (key, _) = fx.store().persist(&fx.start).unwrap();
+        fx.clear_start_dir();
+        let (stats, pinned) = fx.store().restore(&fx.start).unwrap();
+        assert_eq!(stats.key, key);
+        assert_eq!(stats.files, 2);
+        assert_eq!(stats.chunks, 2);
+        assert_eq!(fx.entry_bytes(&pinned), "bundle-v1");
+        assert_eq!(
+            fs::read_to_string(&pinned.chunk("shared-x.js").unwrap().path).unwrap(),
+            "shared bytes"
+        );
+        assert_eq!(
+            fs::read_to_string(fx.start.join("manifest.ts")).unwrap(),
+            "// bundle-v1"
+        );
+        assert_eq!(
+            fs::read_to_string(fx.start.join(CSS_URLS_FILE)).unwrap(),
+            r#"["/@oj-start/fs/a.css"]"#
+        );
+        assert!(
+            !fx.start.join(CHUNKS_DIR).exists(),
+            "restore must not copy chunk bytes back into the start dir"
+        );
+    }
+
+    #[test]
+    fn names_absent_from_the_manifest_do_not_resolve() {
+        let fx = Fixture::new("absent");
+        let (_, pinned) = fx.store().persist(&fx.start).unwrap();
+        assert!(pinned.chunk("client-entry.js").is_some());
+        assert!(pinned.chunk("shared-x.js").is_some());
+        assert!(pinned.chunk("other-chunk.js").is_none());
+        assert!(pinned.chunk("../../../etc/passwd").is_none());
+    }
+
+    #[test]
+    fn pinned_bundle_comes_from_the_blob_store_not_the_build_dir() {
+        let fx = Fixture::new("blobpaths");
+        let (_, pinned) = fx.store().persist(&fx.start).unwrap();
+        let chunk = pinned.chunk("client-entry.js").unwrap();
+        assert!(
+            chunk.path.starts_with(fx.blob_dir()),
+            "{:?}",
+            chunk.path
+        );
+        assert_eq!(chunk.hash.as_deref(), Some(blake3::hash(b"bundle-v1").to_hex().as_str()));
+    }
+
+    #[test]
+    fn from_build_dir_pins_the_fresh_build() {
+        let fx = Fixture::new("builddir");
+        let pinned = PinnedBundle::from_build_dir(&fx.start).unwrap();
+        assert_eq!(pinned.entry, "client-entry.js");
+        assert_eq!(pinned.len(), 2);
+        let chunk = pinned.chunk("shared-x.js").unwrap();
+        assert!(chunk.path.starts_with(fx.start.join(CHUNKS_DIR)));
+        assert_eq!(chunk.hash, None);
+        assert!(pinned.chunk("missing.js").is_none());
+    }
+
+    #[test]
+    fn source_edit_changes_key_and_misses_until_repersisted() {
+        let fx = Fixture::new("edit");
+        fx.settle_modules();
+        let (key, _) = fx.store().persist(&fx.start).unwrap();
+        fx.write_module("a.tsx", "export const a = 99;");
+        match fx.store().restore(&fx.start) {
+            Err(Miss::NoEntryForKey(k)) => assert_ne!(k, key),
+            other => panic!("expected key miss, got {other:?}"),
+        }
+        fx.write_build("bundle-v2");
+        let (key2, _) = fx.store().persist(&fx.start).unwrap();
+        assert_ne!(key2, key);
+        fx.clear_start_dir();
+        assert_eq!(fx.store().restore(&fx.start).unwrap().0.key, key2);
+    }
+
+    #[test]
+    fn reverting_an_edit_pins_the_older_generation() {
+        let fx = Fixture::new("revert");
+        let (key, _) = fx.store().persist(&fx.start).unwrap();
+        fx.write_module("a.tsx", "export const a = 99;");
+        fx.write_build("bundle-v2");
+        fx.store().persist(&fx.start).unwrap();
+        fx.write_module("a.tsx", "export const a = 1;");
+        // current points at v2, whose closure lists the same files; the
+        // recomputed key lands back on the v1 generation, and the pointer
+        // swings back to it.
+        let (stats, pinned) = fx.store().restore(&fx.start).unwrap();
+        assert_eq!(stats.key, key);
+        assert_eq!(fx.entry_bytes(&pinned), "bundle-v1");
+        let current = fs::read_to_string(
+            fx.root.join(".oj-cache/start-bundle").join(CURRENT_FILE),
+        )
+        .unwrap();
+        assert_eq!(current.trim(), key, "pointer swaps to the pinned generation");
+    }
+
+    #[test]
+    fn generations_share_identical_chunks_in_the_blob_store() {
+        let fx = Fixture::new("dedupe");
+        fx.store().persist(&fx.start).unwrap();
+        assert_eq!(fx.blob_count(), 2, "entry + shared chunk");
+        fx.write_module("a.tsx", "export const a = 99;");
+        fx.write_build("bundle-v2");
+        fx.store().persist(&fx.start).unwrap();
+        // Second generation adds a new entry blob; shared-x.js dedupes.
+        assert_eq!(fx.blob_count(), 3, "shared chunk stored once");
+    }
+
+    #[test]
+    fn deleted_closure_file_is_a_miss_not_a_panic() {
+        let fx = Fixture::new("deleted");
+        fx.store().persist(&fx.start).unwrap();
+        fs::remove_file(fx.module("b.tsx")).unwrap();
+        assert!(matches!(
+            fx.store().restore(&fx.start),
+            Err(Miss::ClosureFileUnreadable(_))
+        ));
+    }
+
+    #[test]
+    fn epoch_input_changes_the_key() {
+        let fx = Fixture::new("epoch");
+        let (key, _) = fx.store().persist(&fx.start).unwrap();
+        fs::write(fx.root.join("package.json"), b"{\"name\":\"x\"}").unwrap();
+        match fx.store().restore(&fx.start) {
+            Err(Miss::NoEntryForKey(k)) => assert_ne!(k, key),
+            other => panic!("expected key miss, got {other:?}"),
+        }
+        let other_version =
+            StartBundleStore::new(&fx.root, "9.9.9", VerifyMode::Standard).persist(&fx.start);
+        assert_ne!(other_version.unwrap().0, key, "tool version salts the key");
+    }
+
+    #[test]
+    fn missing_blob_fails_verification_and_removes_the_entry() {
+        let fx = Fixture::new("missing-blob");
+        let (key, pinned) = fx.store().persist(&fx.start).unwrap();
+        fs::remove_file(&pinned.chunk("shared-x.js").unwrap().path).unwrap();
+        match fx.store().restore(&fx.start) {
+            Err(Miss::ChunkCorrupt { key: k, name, .. }) => {
+                assert_eq!(k, key);
+                assert_eq!(name, "shared-x.js");
+            }
+            other => panic!("expected chunk corruption, got {other:?}"),
+        }
+        assert!(!fx.entry_dir(&key).exists(), "corrupt entry must be removed");
+    }
+
+    #[test]
+    fn wrong_size_blob_is_caught_in_standard_mode() {
+        let fx = Fixture::new("truncated-blob");
+        let (key, pinned) = fx.store().persist(&fx.start).unwrap();
+        let blob = &pinned.chunk("client-entry.js").unwrap().path;
+        fs::write(blob, b"bundle").unwrap();
+        assert!(matches!(
+            fx.store().restore(&fx.start),
+            Err(Miss::ChunkCorrupt { .. })
+        ));
+        assert!(!fx.entry_dir(&key).exists());
+        assert!(!blob.exists(), "corrupt blob must be removed");
+    }
+
+    #[test]
+    fn same_size_bitflip_is_caught_only_in_full_mode() {
+        let fx = Fixture::new("bitflip");
+        let (key, pinned) = fx.store().persist(&fx.start).unwrap();
+        let blob = pinned.chunk("client-entry.js").unwrap().path.clone();
+        fs::write(&blob, b"bundle-vX").unwrap();
+        // Standard mode trusts existence + size: the flip passes restore.
+        assert!(fx.store().restore(&fx.start).is_ok());
+        // Full mode re-hashes, detects, removes blob + entry, and misses.
+        match fx.full_store().restore(&fx.start) {
+            Err(Miss::ChunkCorrupt { name, detail, .. }) => {
+                assert_eq!(name, "client-entry.js");
+                assert!(detail.contains("hash mismatch"), "{detail}");
+            }
+            other => panic!("expected hash mismatch, got {other:?}"),
+        }
+        assert!(!fx.entry_dir(&key).exists());
+        assert!(!blob.exists());
+        // The rebuild path (persist) heals the store.
+        fx.write_build("bundle-v1");
+        let (key2, pinned2) = fx.full_store().persist(&fx.start).unwrap();
+        assert_eq!(key2, key);
+        assert_eq!(fx.entry_bytes(&pinned2), "bundle-v1");
+        assert!(fx.full_store().restore(&fx.start).is_ok());
+    }
+
+    #[test]
+    fn foreign_format_manifest_is_invalid_by_version() {
+        let fx = Fixture::new("format");
+        let (key, _) = fx.store().persist(&fx.start).unwrap();
+        let manifest_path = fx.entry_dir(&key).join(MANIFEST_FILE);
+        let mut v: serde_json::Value =
+            serde_json::from_slice(&fs::read(&manifest_path).unwrap()).unwrap();
+        v["format"] = serde_json::json!(START_BUNDLE_FORMAT - 1);
+        fs::write(&manifest_path, v.to_string()).unwrap();
+        assert!(matches!(
+            fx.store().restore(&fx.start),
+            Err(Miss::EntryCorrupt(_))
+        ));
+        assert!(!fx.entry_dir(&key).exists());
+    }
+
+    #[test]
+    fn legacy_entry_without_manifest_is_a_miss() {
+        let fx = Fixture::new("legacy");
+        let (key, _) = fx.store().persist(&fx.start).unwrap();
+        fs::remove_file(fx.entry_dir(&key).join(MANIFEST_FILE)).unwrap();
+        assert!(matches!(
+            fx.store().restore(&fx.start),
+            Err(Miss::EntryCorrupt(_))
+        ));
+        assert!(!fx.entry_dir(&key).exists(), "legacy entry removed");
+    }
+
+    #[test]
+    fn prune_evicts_lru_generations_and_sweeps_unreferenced_blobs() {
+        let fx = Fixture::new("prune");
+        let store = fx.store();
+        let (key1, _) = store.persist(&fx.start).unwrap();
+        std::thread::sleep(Duration::from_millis(20));
+        fx.write_module("a.tsx", "export const a = 2;");
+        fx.write_build("bundle-v2");
+        let (key2, _) = store.persist(&fx.start).unwrap();
+        std::thread::sleep(Duration::from_millis(20));
+        fx.write_module("a.tsx", "export const a = 3;");
+        fx.write_build("bundle-v3");
+        let (key3, _) = store.persist(&fx.start).unwrap();
+        assert_eq!(fx.blob_count(), 4, "3 entry blobs + 1 shared blob");
+
+        let dir = fx.root.join(".oj-cache/start-bundle");
+        store.prune(u64::MAX);
+        assert!(dir.join(&key1).is_dir(), "under budget: nothing evicted");
+        assert_eq!(fx.blob_count(), 4, "all blobs still referenced");
+        store.prune(0);
+        assert!(!dir.join(&key1).is_dir(), "oldest generation evicted first");
+        assert!(!dir.join(&key2).is_dir());
+        assert!(
+            dir.join(&key3).is_dir(),
+            "current generation survives zero budget"
+        );
+        assert_eq!(
+            fx.blob_count(),
+            2,
+            "evicted generations' unshared blobs swept; shared blob kept"
+        );
+        assert!(fx.store().restore(&fx.start).is_ok(), "survivor still restores");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn memo_verifies_settled_files_without_reading_them() {
+        use std::os::unix::fs::PermissionsExt;
+        let fx = Fixture::new("memo-noread");
+        fx.settle_modules();
+        let (key, _) = fx.store().persist(&fx.start).unwrap();
+        for name in ["a.tsx", "b.tsx"] {
+            fs::set_permissions(fx.module(name), fs::Permissions::from_mode(0o000)).unwrap();
+        }
+        let (stats, _) = fx.store().restore(&fx.start).unwrap();
+        assert_eq!(stats.key, key);
+        assert_eq!(stats.rehashed, 0, "memo hit must not read file contents");
+        for name in ["a.tsx", "b.tsx"] {
+            fs::set_permissions(fx.module(name), fs::Permissions::from_mode(0o644)).unwrap();
+        }
+    }
+
+    #[test]
+    fn touched_but_unchanged_file_rehashes_to_the_same_key() {
+        let fx = Fixture::new("memo-touch");
+        fx.settle_modules();
+        let (key, _) = fx.store().persist(&fx.start).unwrap();
+        fx.write_module("a.tsx", "export const a = 1;");
+        let (stats, _) = fx.store().restore(&fx.start).unwrap();
+        assert_eq!(stats.key, key, "same content must reach the same key");
+        assert!(stats.rehashed >= 1, "stat mismatch must force a re-hash");
+    }
+
+    #[test]
+    fn racy_fresh_files_are_not_memoized() {
+        let fx = Fixture::new("memo-racy");
+        // Modules were written moments ago: inside the freshness window, so
+        // persist must leave them out of the memo.
+        fx.store().persist(&fx.start).unwrap();
+        let orig_mtime = fs::metadata(fx.module("a.tsx"))
+            .unwrap()
+            .modified()
+            .unwrap();
+        // Same length, same mtime, different content: only a re-hash can see it.
+        fx.write_module("a.tsx", "export const a = 9;");
+        set_mtime(&fx.module("a.tsx"), orig_mtime);
+        assert!(
+            matches!(fx.store().restore(&fx.start), Err(Miss::NoEntryForKey(_))),
+            "stat-identical edit within the racy window must still miss"
+        );
+    }
+
+    #[test]
+    fn missing_memo_falls_back_to_full_hash_and_heals() {
+        let fx = Fixture::new("memo-fallback");
+        fx.settle_modules();
+        let (key, _) = fx.store().persist(&fx.start).unwrap();
+        let memo_path = fx.entry_dir(&key).join(MEMO_FILE);
+        fs::remove_file(&memo_path).unwrap();
+        let (stats, _) = fx.store().restore(&fx.start).unwrap();
+        assert_eq!(stats.key, key);
+        assert_eq!(stats.rehashed, 2, "no memo: every file is hashed");
+        assert!(memo_path.is_file(), "successful restore rewrites the memo");
+        let (again, _) = fx.store().restore(&fx.start).unwrap();
+        assert_eq!(again.rehashed, 0, "healed memo verifies by stat alone");
+    }
+
+    #[test]
+    fn corrupt_memo_is_dropped_and_falls_back() {
+        let fx = Fixture::new("memo-corrupt");
+        fx.settle_modules();
+        let (key, _) = fx.store().persist(&fx.start).unwrap();
+        let memo_path = fx.entry_dir(&key).join(MEMO_FILE);
+        fs::write(&memo_path, b"{ not json").unwrap();
+        let (stats, _) = fx.store().restore(&fx.start).unwrap();
+        assert_eq!(stats.key, key);
+        assert_eq!(stats.rehashed, 2);
+    }
+}

--- a/crates/oj_cache/src/start_codegen.rs
+++ b/crates/oj_cache/src/start_codegen.rs
@@ -1,0 +1,693 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+pub const START_CODEGEN_FORMAT: u32 = 1;
+pub const DEFAULT_KEEP_ENTRIES: usize = 8;
+
+const MEMO_FILE: &str = "memo.json";
+const TOUCH_FILE: &str = "last-used";
+
+// Git's racy-index rule: a file whose mtime is within this window of the
+// memo's write time may have been modified without the stat changing, so it
+// is left out of the memo and re-hashed until a later write sees it settled.
+const MEMO_FRESHNESS_SLACK_NS: u64 = 2_000_000_000;
+
+/// Output cache for the TanStack Start codegen node scripts (route tree,
+/// server-fn resolver), keyed by the content of the generator's input files.
+/// With a `marker`, only files containing it feed the key: adding, removing,
+/// or editing a marked file changes the key; other files are free to change.
+pub struct StartCodegenStore {
+    root: PathBuf,
+    dir: PathBuf,
+    salt: String,
+    marker: Option<String>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct RestoreStats {
+    pub key: String,
+    pub keyed_files: usize,
+    pub rehashed: usize,
+    pub elapsed_ms: u128,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Miss {
+    InputUnreadable(PathBuf),
+    NoEntryForKey(String),
+    EntryCorrupt(String),
+}
+
+impl std::fmt::Display for Miss {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fn short(key: &str) -> &str {
+            key.get(..8).unwrap_or(key)
+        }
+        match self {
+            Miss::InputUnreadable(p) => write!(f, "input unreadable: {}", p.display()),
+            Miss::NoEntryForKey(k) => write!(f, "no cached output for key {}…", short(k)),
+            Miss::EntryCorrupt(k) => write!(f, "cached entry {}… corrupt, removed", short(k)),
+        }
+    }
+}
+
+/// Per-file (size, mtime, digest, marked) memo so verification is a stat
+/// pass, not a read of every input. Content stays authoritative: a stat
+/// mismatch falls back to re-hashing, so the memo can cause extra reads,
+/// never a false hit.
+#[derive(Serialize, Deserialize)]
+struct Memo {
+    written_at_ns: u64,
+    files: HashMap<String, MemoFile>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct MemoFile {
+    size: u64,
+    mtime_ns: u64,
+    digest: String,
+    marked: bool,
+}
+
+#[derive(Clone)]
+struct FileInfo {
+    digest: blake3::Hash,
+    marked: bool,
+}
+
+impl StartCodegenStore {
+    pub fn new(
+        root: &Path,
+        kind: &str,
+        tool_version: &str,
+        extra_salt: &[u8],
+        marker: Option<&str>,
+    ) -> Self {
+        Self {
+            root: root.to_path_buf(),
+            dir: root.join(".oj-cache").join("start-codegen").join(kind),
+            salt: format!(
+                "{tool_version}:{START_CODEGEN_FORMAT}:{kind}:{}",
+                blake3::hash(extra_salt).to_hex()
+            ),
+            marker: marker.map(str::to_owned),
+        }
+    }
+
+    /// Copy the cached outputs for the current input state to their
+    /// destinations. `inputs` is the full candidate set (the store applies
+    /// the marker filter itself); `outputs` maps entry file names to the
+    /// paths the generator would have written.
+    pub fn restore(
+        &self,
+        inputs: &[PathBuf],
+        outputs: &[(&str, &Path)],
+    ) -> Result<RestoreStats, Miss> {
+        let started = Instant::now();
+        let inputs = sorted(inputs);
+        let memo = self.read_memo();
+        let (infos, rehashed) = self.verified_infos(&inputs, memo.as_ref());
+        let (key, keyed_files) = self.key_from(&inputs, &infos)?;
+        let entry = self.dir.join(&key);
+        if !entry.is_dir() {
+            return Err(Miss::NoEntryForKey(key));
+        }
+        for (name, dest) in outputs {
+            if copy_atomic(&entry.join(name), dest).is_err() {
+                let _ = fs::remove_dir_all(&entry);
+                return Err(Miss::EntryCorrupt(key));
+            }
+        }
+        if rehashed > 0 || !self.dir.join(MEMO_FILE).is_file() {
+            self.write_memo(&build_memo(&self.root, &inputs, &infos));
+        }
+        touch(&entry);
+        Ok(RestoreStats {
+            key,
+            keyed_files,
+            rehashed,
+            elapsed_ms: started.elapsed().as_millis(),
+        })
+    }
+
+    /// Store the outputs a fresh generator run left at their destinations.
+    /// Best-effort: any failure leaves the store as it was.
+    pub fn persist(&self, inputs: &[PathBuf], outputs: &[(&str, &Path)]) -> Option<String> {
+        let inputs = sorted(inputs);
+        let memo = self.read_memo();
+        let (infos, _) = self.verified_infos(&inputs, memo.as_ref());
+        let (key, _) = self.key_from(&inputs, &infos).ok()?;
+        let entry = self.dir.join(&key);
+        if !entry.is_dir() {
+            let tmp = self
+                .dir
+                .join(format!(".tmp-{}-{}", key.get(..16)?, std::process::id()));
+            let _ = fs::remove_dir_all(&tmp);
+            fs::create_dir_all(&tmp).ok()?;
+            for (name, src) in outputs {
+                if fs::copy(src, tmp.join(name)).is_err() {
+                    let _ = fs::remove_dir_all(&tmp);
+                    return None;
+                }
+            }
+            if fs::rename(&tmp, &entry).is_err() {
+                let _ = fs::remove_dir_all(&tmp);
+                if !entry.is_dir() {
+                    return None;
+                }
+            }
+        }
+        self.write_memo(&build_memo(&self.root, &inputs, &infos));
+        touch(&entry);
+        self.prune(DEFAULT_KEEP_ENTRIES);
+        Some(key)
+    }
+
+    /// Touch-LRU eviction down to `keep` entries.
+    pub fn prune(&self, keep: usize) {
+        let Ok(entries) = fs::read_dir(&self.dir) else {
+            return;
+        };
+        let mut stamped = Vec::new();
+        for e in entries.flatten() {
+            let path = e.path();
+            if !path.is_dir() {
+                continue;
+            }
+            if e.file_name().to_string_lossy().starts_with(".tmp-") {
+                let _ = fs::remove_dir_all(&path);
+                continue;
+            }
+            let stamp = fs::metadata(path.join(TOUCH_FILE))
+                .or_else(|_| fs::metadata(&path))
+                .and_then(|m| m.modified())
+                .unwrap_or(UNIX_EPOCH);
+            stamped.push((path, stamp));
+        }
+        stamped.sort_by_key(|&(_, stamp)| std::cmp::Reverse(stamp));
+        for (path, _) in stamped.into_iter().skip(keep) {
+            let _ = fs::remove_dir_all(&path);
+        }
+    }
+
+    fn key_from(
+        &self,
+        inputs: &[PathBuf],
+        infos: &[Option<FileInfo>],
+    ) -> Result<(String, usize), Miss> {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(self.salt.as_bytes());
+        let mut keyed = 0usize;
+        for (path, info) in inputs.iter().zip(infos) {
+            let Some(info) = info else {
+                return Err(Miss::InputUnreadable(path.clone()));
+            };
+            if !info.marked {
+                continue;
+            }
+            keyed += 1;
+            hasher.update(&[0]);
+            hasher.update(rel_key(&self.root, path).as_bytes());
+            hasher.update(&[0]);
+            hasher.update(info.digest.as_bytes());
+        }
+        Ok((hasher.finalize().to_hex().to_string(), keyed))
+    }
+
+    fn verified_infos(
+        &self,
+        inputs: &[PathBuf],
+        memo: Option<&Memo>,
+    ) -> (Vec<Option<FileInfo>>, usize) {
+        let rehashed = AtomicUsize::new(0);
+        let infos = par_map(inputs, |p| {
+            let rel = rel_key(&self.root, p);
+            if let Some(known) = memo.and_then(|m| m.files.get(&rel)) {
+                if let Ok(meta) = fs::metadata(p) {
+                    if meta.len() == known.size && mtime_ns(&meta) == Some(known.mtime_ns) {
+                        if let Ok(digest) = blake3::Hash::from_hex(&known.digest) {
+                            return Some(FileInfo {
+                                digest,
+                                marked: known.marked,
+                            });
+                        }
+                    }
+                }
+            }
+            rehashed.fetch_add(1, Ordering::Relaxed);
+            let bytes = fs::read(p).ok()?;
+            Some(FileInfo {
+                digest: blake3::hash(&bytes),
+                marked: self
+                    .marker
+                    .as_ref()
+                    .is_none_or(|m| contains(&bytes, m.as_bytes())),
+            })
+        });
+        (infos, rehashed.into_inner())
+    }
+
+    fn read_memo(&self) -> Option<Memo> {
+        let path = self.dir.join(MEMO_FILE);
+        let bytes = fs::read(&path).ok()?;
+        match serde_json::from_slice(&bytes) {
+            Ok(memo) => Some(memo),
+            Err(_) => {
+                let _ = fs::remove_file(&path);
+                None
+            }
+        }
+    }
+
+    fn write_memo(&self, memo: &Memo) {
+        let Ok(bytes) = serde_json::to_vec(memo) else {
+            return;
+        };
+        if fs::create_dir_all(&self.dir).is_err() {
+            return;
+        }
+        let tmp = self.dir.join(".memo.tmp");
+        if fs::write(&tmp, bytes).is_ok() {
+            let _ = fs::rename(&tmp, self.dir.join(MEMO_FILE));
+        }
+    }
+}
+
+fn sorted(inputs: &[PathBuf]) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = inputs.to_vec();
+    out.sort();
+    out.dedup();
+    out
+}
+
+fn rel_key(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn contains(hay: &[u8], needle: &[u8]) -> bool {
+    !needle.is_empty() && hay.windows(needle.len()).any(|w| w == needle)
+}
+
+fn copy_atomic(src: &Path, dest: &Path) -> std::io::Result<()> {
+    let bytes = fs::read(src)?;
+    // An unchanged destination keeps its mtime, so other stat-memo caches
+    // that treat it as an input stay settled across boots.
+    if fs::read(dest).is_ok_and(|cur| cur == bytes) {
+        return Ok(());
+    }
+    let dir = dest.parent().unwrap_or(Path::new("."));
+    fs::create_dir_all(dir)?;
+    let tmp = dir.join(format!(
+        ".oj-codegen-restore-{}-{}.tmp",
+        std::process::id(),
+        dest.file_name().unwrap_or_default().to_string_lossy()
+    ));
+    fs::write(&tmp, &bytes)
+        .and_then(|_| fs::rename(&tmp, dest))
+        .inspect_err(|_| {
+            let _ = fs::remove_file(&tmp);
+        })
+}
+
+/// Stats are taken after the digests were computed, so a file modified in
+/// between carries an mtime close to `written_at_ns` and the freshness rule
+/// below keeps it out of the memo.
+fn build_memo(root: &Path, inputs: &[PathBuf], infos: &[Option<FileInfo>]) -> Memo {
+    let written_at_ns = now_ns();
+    let stats = par_map(inputs, |p| {
+        let meta = fs::metadata(p).ok()?;
+        Some((meta.len(), mtime_ns(&meta)?))
+    });
+    let mut map = HashMap::new();
+    for ((path, info), stat) in inputs.iter().zip(infos).zip(&stats) {
+        let (Some(info), Some((size, mtime_ns))) = (info, stat) else {
+            continue;
+        };
+        if mtime_ns.saturating_add(MEMO_FRESHNESS_SLACK_NS) > written_at_ns {
+            continue;
+        }
+        map.insert(
+            rel_key(root, path),
+            MemoFile {
+                size: *size,
+                mtime_ns: *mtime_ns,
+                digest: info.digest.to_hex().to_string(),
+                marked: info.marked,
+            },
+        );
+    }
+    Memo {
+        written_at_ns,
+        files: map,
+    }
+}
+
+fn mtime_ns(meta: &fs::Metadata) -> Option<u64> {
+    let t = meta.modified().ok()?;
+    u64::try_from(t.duration_since(UNIX_EPOCH).ok()?.as_nanos()).ok()
+}
+
+fn now_ns() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|d| u64::try_from(d.as_nanos()).ok())
+        .unwrap_or(0)
+}
+
+fn par_map<T: Send>(files: &[PathBuf], f: impl Fn(&Path) -> Option<T> + Sync) -> Vec<Option<T>> {
+    let threads = std::thread::available_parallelism()
+        .map_or(1, |n| n.get())
+        .min(files.len().max(1));
+    if threads <= 1 {
+        return files.iter().map(|p| f(p)).collect();
+    }
+    let chunk = files.len().div_ceil(threads);
+    let mut out: Vec<Option<T>> = Vec::new();
+    out.resize_with(files.len(), || None);
+    std::thread::scope(|s| {
+        for (paths, slots) in files.chunks(chunk).zip(out.chunks_mut(chunk)) {
+            let f = &f;
+            s.spawn(move || {
+                for (p, slot) in paths.iter().zip(slots) {
+                    *slot = f(p);
+                }
+            });
+        }
+    });
+    out
+}
+
+fn touch(entry: &Path) {
+    let _ = fs::write(entry.join(TOUCH_FILE), b"");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    struct Fixture {
+        root: PathBuf,
+    }
+
+    impl Fixture {
+        fn new(label: &str) -> Self {
+            let root = std::env::temp_dir().join(format!(
+                "oj-start-codegen-test-{}-{label}",
+                std::process::id()
+            ));
+            let _ = fs::remove_dir_all(&root);
+            fs::create_dir_all(root.join("src/routes")).unwrap();
+            let fx = Self { root };
+            fx.write("src/routes/index.tsx", "export const Route = 1;");
+            fx.write("src/routes/about.tsx", "export const Route = 2;");
+            fx.write("src/routeTree.gen.ts", "// tree-v1");
+            fx
+        }
+
+        fn store(&self) -> StartCodegenStore {
+            StartCodegenStore::new(&self.root, "route-tree", "0.0.1-test", b"script-v1", None)
+        }
+
+        fn marked_store(&self) -> StartCodegenStore {
+            StartCodegenStore::new(
+                &self.root,
+                "server-fn",
+                "0.0.1-test",
+                b"script-v1",
+                Some("createServerFn"),
+            )
+        }
+
+        fn path(&self, rel: &str) -> PathBuf {
+            self.root.join(rel)
+        }
+
+        fn write(&self, rel: &str, content: &str) {
+            let p = self.path(rel);
+            fs::create_dir_all(p.parent().unwrap()).unwrap();
+            fs::write(p, content).unwrap();
+        }
+
+        fn inputs(&self) -> Vec<PathBuf> {
+            vec![
+                self.path("src/routes/index.tsx"),
+                self.path("src/routes/about.tsx"),
+            ]
+        }
+
+        /// Backdate input mtimes past the memo freshness window so persist
+        /// records them (freshly written files are deliberately left out).
+        fn settle(&self, rels: &[&str]) {
+            let old = SystemTime::now() - Duration::from_secs(3600);
+            for rel in rels {
+                set_mtime(&self.path(rel), old);
+            }
+        }
+
+        fn entry_dir(&self, kind: &str, key: &str) -> PathBuf {
+            self.root
+                .join(".oj-cache/start-codegen")
+                .join(kind)
+                .join(key)
+        }
+    }
+
+    fn set_mtime(path: &Path, t: SystemTime) {
+        let f = fs::OpenOptions::new().append(true).open(path).unwrap();
+        f.set_times(fs::FileTimes::new().set_modified(t)).unwrap();
+    }
+
+    fn tree_outputs(fx: &Fixture) -> (PathBuf, PathBuf) {
+        (
+            fx.path("src/routeTree.gen.ts"),
+            fx.path("src/routeTree.gen.ts"),
+        )
+    }
+
+    #[test]
+    fn restore_misses_before_first_persist() {
+        let fx = Fixture::new("first");
+        let (out, _) = tree_outputs(&fx);
+        let outputs = [("routeTree.gen.ts", out.as_path())];
+        assert!(matches!(
+            fx.store().restore(&fx.inputs(), &outputs),
+            Err(Miss::NoEntryForKey(_))
+        ));
+    }
+
+    #[test]
+    fn persist_then_restore_roundtrips_output() {
+        let fx = Fixture::new("roundtrip");
+        let (out, _) = tree_outputs(&fx);
+        let outputs = [("routeTree.gen.ts", out.as_path())];
+        let key = fx.store().persist(&fx.inputs(), &outputs).unwrap();
+        fs::remove_file(&out).unwrap();
+        let stats = fx.store().restore(&fx.inputs(), &outputs).unwrap();
+        assert_eq!(stats.key, key);
+        assert_eq!(stats.keyed_files, 2);
+        assert_eq!(fs::read_to_string(&out).unwrap(), "// tree-v1");
+    }
+
+    #[test]
+    fn input_edit_changes_key_and_misses_until_repersisted() {
+        let fx = Fixture::new("edit");
+        fx.settle(&["src/routes/index.tsx", "src/routes/about.tsx"]);
+        let (out, _) = tree_outputs(&fx);
+        let outputs = [("routeTree.gen.ts", out.as_path())];
+        let key = fx.store().persist(&fx.inputs(), &outputs).unwrap();
+        fx.write("src/routes/index.tsx", "export const Route = 99;");
+        match fx.store().restore(&fx.inputs(), &outputs) {
+            Err(Miss::NoEntryForKey(k)) => assert_ne!(k, key),
+            other => panic!("expected key miss, got {other:?}"),
+        }
+        fx.write("src/routeTree.gen.ts", "// tree-v2");
+        let key2 = fx.store().persist(&fx.inputs(), &outputs).unwrap();
+        assert_ne!(key2, key);
+        fs::remove_file(&out).unwrap();
+        let stats = fx.store().restore(&fx.inputs(), &outputs).unwrap();
+        assert_eq!(stats.key, key2);
+        assert_eq!(fs::read_to_string(&out).unwrap(), "// tree-v2");
+    }
+
+    #[test]
+    fn added_and_removed_inputs_change_the_key() {
+        let fx = Fixture::new("addrm");
+        let (out, _) = tree_outputs(&fx);
+        let outputs = [("routeTree.gen.ts", out.as_path())];
+        let key = fx.store().persist(&fx.inputs(), &outputs).unwrap();
+        fx.write("src/routes/new.tsx", "export const Route = 3;");
+        let mut more = fx.inputs();
+        more.push(fx.path("src/routes/new.tsx"));
+        match fx.store().restore(&more, &outputs) {
+            Err(Miss::NoEntryForKey(k)) => assert_ne!(k, key),
+            other => panic!("expected key miss, got {other:?}"),
+        }
+        let fewer = vec![fx.path("src/routes/index.tsx")];
+        match fx.store().restore(&fewer, &outputs) {
+            Err(Miss::NoEntryForKey(k)) => assert_ne!(k, key),
+            other => panic!("expected key miss, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn marker_filters_unmarked_files_out_of_the_key() {
+        let fx = Fixture::new("marker");
+        fx.write("src/a.ts", "export const a = createServerFn().handler(x);");
+        fx.write("src/b.ts", "export const b = 1;");
+        fx.write("out.mjs", "// resolver-v1");
+        let out = fx.path("out.mjs");
+        let outputs = [("server-fn-resolver.mjs", out.as_path())];
+        let inputs = vec![fx.path("src/a.ts"), fx.path("src/b.ts")];
+        let key = fx.marked_store().persist(&inputs, &outputs).unwrap();
+
+        fx.write("src/b.ts", "export const b = 2;");
+        let stats = fx.marked_store().restore(&inputs, &outputs).unwrap();
+        assert_eq!(stats.key, key, "unmarked edit must still hit");
+        assert_eq!(stats.keyed_files, 1);
+
+        fx.write("src/b.ts", "export const b = createServerFn().handler(y);");
+        match fx.marked_store().restore(&inputs, &outputs) {
+            Err(Miss::NoEntryForKey(k)) => assert_ne!(k, key),
+            other => panic!("marker gained: expected miss, got {other:?}"),
+        }
+
+        fx.write("src/a.ts", "export const a = createServerFn().handler(z);");
+        fx.write("src/b.ts", "export const b = 1;");
+        assert!(matches!(
+            fx.marked_store().restore(&inputs, &outputs),
+            Err(Miss::NoEntryForKey(_))
+        ));
+    }
+
+    #[test]
+    fn salt_inputs_change_the_key() {
+        let fx = Fixture::new("salt");
+        let (out, _) = tree_outputs(&fx);
+        let outputs = [("routeTree.gen.ts", out.as_path())];
+        let key = fx.store().persist(&fx.inputs(), &outputs).unwrap();
+        let other_script =
+            StartCodegenStore::new(&fx.root, "route-tree", "0.0.1-test", b"script-v2", None)
+                .persist(&fx.inputs(), &outputs)
+                .unwrap();
+        assert_ne!(other_script, key, "script content salts the key");
+        let other_version =
+            StartCodegenStore::new(&fx.root, "route-tree", "9.9.9", b"script-v1", None)
+                .persist(&fx.inputs(), &outputs)
+                .unwrap();
+        assert_ne!(other_version, key, "tool version salts the key");
+    }
+
+    #[test]
+    fn deleted_input_is_a_miss_not_a_panic() {
+        let fx = Fixture::new("deleted");
+        let (out, _) = tree_outputs(&fx);
+        let outputs = [("routeTree.gen.ts", out.as_path())];
+        fx.store().persist(&fx.inputs(), &outputs).unwrap();
+        fs::remove_file(fx.path("src/routes/about.tsx")).unwrap();
+        assert!(matches!(
+            fx.store().restore(&fx.inputs(), &outputs),
+            Err(Miss::InputUnreadable(_))
+        ));
+    }
+
+    #[test]
+    fn corrupt_entry_deletes_itself() {
+        let fx = Fixture::new("corrupt");
+        let (out, _) = tree_outputs(&fx);
+        let outputs = [("routeTree.gen.ts", out.as_path())];
+        let key = fx.store().persist(&fx.inputs(), &outputs).unwrap();
+        let entry = fx.entry_dir("route-tree", &key);
+        fs::remove_file(entry.join("routeTree.gen.ts")).unwrap();
+        assert_eq!(
+            fx.store().restore(&fx.inputs(), &outputs),
+            Err(Miss::EntryCorrupt(key))
+        );
+        assert!(!entry.exists(), "corrupt entry must be removed");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn memo_verifies_settled_files_without_reading_them() {
+        use std::os::unix::fs::PermissionsExt;
+        let fx = Fixture::new("memo-noread");
+        fx.settle(&["src/routes/index.tsx", "src/routes/about.tsx"]);
+        let (out, _) = tree_outputs(&fx);
+        let outputs = [("routeTree.gen.ts", out.as_path())];
+        let key = fx.store().persist(&fx.inputs(), &outputs).unwrap();
+        for p in fx.inputs() {
+            fs::set_permissions(&p, fs::Permissions::from_mode(0o000)).unwrap();
+        }
+        let stats = fx.store().restore(&fx.inputs(), &outputs).unwrap();
+        assert_eq!(stats.key, key);
+        assert_eq!(stats.rehashed, 0, "memo hit must not read file contents");
+        for p in fx.inputs() {
+            fs::set_permissions(&p, fs::Permissions::from_mode(0o644)).unwrap();
+        }
+    }
+
+    #[test]
+    fn touched_but_unchanged_file_rehashes_to_the_same_key() {
+        let fx = Fixture::new("memo-touch");
+        fx.settle(&["src/routes/index.tsx", "src/routes/about.tsx"]);
+        let (out, _) = tree_outputs(&fx);
+        let outputs = [("routeTree.gen.ts", out.as_path())];
+        let key = fx.store().persist(&fx.inputs(), &outputs).unwrap();
+        fx.write("src/routes/index.tsx", "export const Route = 1;");
+        let stats = fx.store().restore(&fx.inputs(), &outputs).unwrap();
+        assert_eq!(stats.key, key, "same content must reach the same key");
+        assert!(stats.rehashed >= 1, "stat mismatch must force a re-hash");
+    }
+
+    #[test]
+    fn racy_fresh_files_are_not_memoized() {
+        let fx = Fixture::new("memo-racy");
+        let (out, _) = tree_outputs(&fx);
+        let outputs = [("routeTree.gen.ts", out.as_path())];
+        fx.store().persist(&fx.inputs(), &outputs).unwrap();
+        let target = fx.path("src/routes/index.tsx");
+        let orig_mtime = fs::metadata(&target).unwrap().modified().unwrap();
+        // Same length, same mtime, different content: only a re-hash sees it.
+        fx.write("src/routes/index.tsx", "export const Route = 9;");
+        set_mtime(&target, orig_mtime);
+        assert!(
+            matches!(
+                fx.store().restore(&fx.inputs(), &outputs),
+                Err(Miss::NoEntryForKey(_))
+            ),
+            "stat-identical edit within the racy window must still miss"
+        );
+    }
+
+    #[test]
+    fn prune_keeps_newest_entries() {
+        let fx = Fixture::new("prune");
+        let (out, _) = tree_outputs(&fx);
+        let outputs = [("routeTree.gen.ts", out.as_path())];
+        let store = fx.store();
+        let mut keys = Vec::new();
+        for i in 0..3 {
+            fx.write(
+                "src/routes/index.tsx",
+                &format!("export const Route = {i};"),
+            );
+            keys.push(store.persist(&fx.inputs(), &outputs).unwrap());
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        store.prune(1);
+        assert!(fx.entry_dir("route-tree", &keys[2]).is_dir());
+        assert!(!fx.entry_dir("route-tree", &keys[0]).is_dir());
+        assert!(!fx.entry_dir("route-tree", &keys[1]).is_dir());
+    }
+}

--- a/crates/oj_server/src/assets/css-preprocess.mjs
+++ b/crates/oj_server/src/assets/css-preprocess.mjs
@@ -35,7 +35,8 @@ let inflight = 0;
 let stdinClosed = false;
 const maybeExit = () => { if (stdinClosed && inflight === 0) process.exit(0); };
 try {
-  if (fstatSync(0).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
+  // bigint keeps the FIFO mode out of the shared stat buffer fs.realpathSync reads mid-walk
+  if (fstatSync(0, { bigint: true }).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
 } catch {}
 rl.on("line", async (line) => {
   let msg;

--- a/crates/oj_server/src/assets/css-preprocess.mjs
+++ b/crates/oj_server/src/assets/css-preprocess.mjs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Raphael Amorim
 
 import { createRequire } from "node:module";
+import { fstatSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import path from "node:path";
 import readline from "node:readline";
@@ -28,6 +29,14 @@ async function stylus(base, css, from) {
 }
 
 const rl = readline.createInterface({ input: process.stdin });
+// stdin EOF means the parent is gone (SIGKILL skips its teardown) or the
+// one-shot build path closed it: exit once no reply is in flight.
+let inflight = 0;
+let stdinClosed = false;
+const maybeExit = () => { if (stdinClosed && inflight === 0) process.exit(0); };
+try {
+  if (fstatSync(0).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
+} catch {}
 rl.on("line", async (line) => {
   let msg;
   try {
@@ -37,6 +46,7 @@ rl.on("line", async (line) => {
   }
   const { id, base, css, from } = msg;
   const ext = String(from || "").split("?")[0].split(".").pop().toLowerCase();
+  inflight += 1;
   try {
     let out = css;
     if (ext === "less") out = await less(base, css, from);
@@ -44,5 +54,8 @@ rl.on("line", async (line) => {
     process.stdout.write(JSON.stringify({ id, css: out }) + "\n");
   } catch (e) {
     process.stdout.write(JSON.stringify({ id, error: String((e && e.message) || e) }) + "\n");
+  } finally {
+    inflight -= 1;
+    maybeExit();
   }
 });

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -600,7 +600,8 @@ async function run(hook, args) {
 // stdin EOF means oj died without tearing us down (SIGKILL skips
 // kill_on_drop): exit instead of idling as an orphan.
 try {
-  if (fstatSync(0).isFIFO()) {
+  // bigint keeps the FIFO mode out of the shared stat buffer fs.realpathSync reads mid-walk
+  if (fstatSync(0, { bigint: true }).isFIFO()) {
     process.stdin.once("end", () => process.exit(0));
     process.stdin.once("close", () => process.exit(0));
   }

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 Raphael Amorim
 
 import http from "node:http";
-import { writeFileSync } from "node:fs";
+import { fstatSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { pathToFileURL } from "node:url";
 import { dirname } from "node:path";
@@ -595,6 +595,15 @@ async function run(hook, args) {
   }
   return null;
 }
+
+// stdin EOF means oj died without tearing us down (SIGKILL skips
+// kill_on_drop): exit instead of idling as an orphan.
+try {
+  if (fstatSync(0).isFIFO()) {
+    process.stdin.once("end", () => process.exit(0));
+    process.stdin.once("close", () => process.exit(0));
+  }
+} catch {}
 
 const rl = readline.createInterface({ input: process.stdin });
 rl.on("line", async (line) => {

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -338,19 +338,20 @@ async function setupConfigureServer() {
   const srv = http.createServer((req, res) => {
     let i = 0;
     const next = (err) => {
-      if (err) {
-        res.statusCode = 500;
-        res.end(String((err && err.stack) || err));
-        return;
-      }
       while (i < stack.length) {
         const { path, fn } = stack[i++];
         if (path && !req.url.startsWith(path)) continue;
+        if ((fn.length >= 4) !== (err != null)) continue;
         try {
-          return fn(req, res, next);
+          return err != null ? fn(err, req, res, next) : fn(req, res, next);
         } catch (e) {
           return next(e);
         }
+      }
+      if (err != null) {
+        res.statusCode = 500;
+        res.end(String((err && err.stack) || err));
+        return;
       }
       res.setHeader("x-oj-fallthrough", "1");
       res.statusCode = 404;

--- a/crates/oj_server/src/assets/ssr-runner.mjs
+++ b/crates/oj_server/src/assets/ssr-runner.mjs
@@ -251,7 +251,8 @@ connectHmr();
 // stdin EOF means oj died without tearing us down (the HMR reconnect timer
 // would otherwise keep an orphaned runner alive forever): exit.
 try {
-  if (fstatSync(0).isFIFO()) {
+  // bigint keeps the FIFO mode out of the shared stat buffer fs.realpathSync reads mid-walk
+  if (fstatSync(0, { bigint: true }).isFIFO()) {
     process.stdin.once("end", () => process.exit(0));
     process.stdin.once("close", () => process.exit(0));
   }

--- a/crates/oj_server/src/assets/ssr-runner.mjs
+++ b/crates/oj_server/src/assets/ssr-runner.mjs
@@ -3,7 +3,7 @@
 
 import vm from "node:vm";
 import readline from "node:readline";
-import { statSync } from "node:fs";
+import { fstatSync, statSync } from "node:fs";
 
 const [BASE, ENTRY] = process.argv.slice(2);
 
@@ -247,6 +247,15 @@ function connectHmr() {
   ws.addEventListener("error", () => {});
 }
 connectHmr();
+
+// stdin EOF means oj died without tearing us down (the HMR reconnect timer
+// would otherwise keep an orphaned runner alive forever): exit.
+try {
+  if (fstatSync(0).isFIFO()) {
+    process.stdin.once("end", () => process.exit(0));
+    process.stdin.once("close", () => process.exit(0));
+  }
+} catch {}
 
 const rl = readline.createInterface({ input: process.stdin });
 rl.on("line", (line) => {

--- a/crates/oj_server/src/assets/start/ARCHITECTURE.md
+++ b/crates/oj_server/src/assets/start/ARCHITECTURE.md
@@ -56,13 +56,17 @@ Shared build helpers:
 
 Dev:
 
-- `loader.mjs` is a Node ESM loader hook. It resolves the framework aliases,
-  the app's `#`-imports and tsconfig `paths`, asset conventions, `virtual:`
-  ids, `.mdx` and `.svg`, and provides CJS-to-ESM interop; it compiles TS/JSX
-  with rolldown's `transformSync` on the fly.
-- `runner.mjs` is the persistent SSR process. It registers `loader.mjs`,
-  imports the server entry, and answers render requests over stdio. A reload
-  message re-imports the entry in place (warm reload).
+- `loader.mjs` is a Node ESM loader hook (in-thread, synchronous — installed
+  via `module.registerHooks`). It resolves the framework aliases, the app's
+  `#`-imports and tsconfig `paths`, asset conventions, `virtual:` ids, `.mdx`
+  and `.svg`, and provides CJS-to-ESM interop; it compiles TS/JSX with
+  rolldown's `transformSync` on the fly. The async Vite plugin container runs
+  in a worker (`container-host.mjs`) behind an Atomics-based sync bridge
+  (`container-bridge.mjs`), so the hooks stay synchronous and container
+  bootstrap overlaps module loading.
+- `runner.mjs` is the persistent SSR process. It imports `loader.mjs` and
+  registers its hooks, imports the server entry, and answers render requests
+  over stdio. A reload message re-imports the entry in place (warm reload).
 - `generate.mjs` runs `@tanstack/router-generator` to write `routeTree.gen.ts`.
 - `gen-resolver.mjs` scans `src` for `createServerFn` and emits the server-fn
   resolver (`getServerFnById`) with static imports.

--- a/crates/oj_server/src/assets/start/bundle-client.mjs
+++ b/crates/oj_server/src/assets/start/bundle-client.mjs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { dirname, join, resolve, relative } from "node:path";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { importPkg, viteEnvDefine } from "./resolve-pkg.mjs";
 import { assetsPlugin, makeVitePlugins, nodeBuiltinShims, workspaceRoot } from "./rolldown-assets.mjs";
@@ -51,6 +51,19 @@ const container = await loadPluginContainer(APP, { command: "serve", environment
 
 const cssUrls = [];
 
+// Records every module the build traverses. chunk.modules alone is not enough:
+// tree-shaking drops most of the graph from the rendered chunk, but traversal
+// still shapes the output (e.g. manifest cssUrls come from css imports found
+// anywhere in the graph), so the cache key must cover all visited files.
+const visitedIds = new Set();
+const closureRecorder = {
+  name: "oj-closure-recorder",
+  transform(code, id) {
+    visitedIds.add(id);
+    return null;
+  },
+};
+
 const serverFnClient = {
   name: "server-fn-client",
   transform: {
@@ -92,6 +105,7 @@ const result = await build({
     },
   },
   plugins: [
+    closureRecorder,
     makeVitePlugins({ container, appRoot: APP, mode: "dev" }),
     assetsPlugin({ mode: "dev", cssUrls }),
     serverFnClient,
@@ -132,6 +146,31 @@ writeFileSync(
 // Module count for the editor's update-progress narration ("(N modules)").
 writeFileSync(join(HERE, "client-entry.modules"), String(moduleCount));
 
+// Closure manifest for the Rust-side whole-bundle cache: every real file
+// whose content shaped this build.
+const closure = new Set([routerEntry(), ...visitedIds, ...(container?.configDependencies ?? []), ...(container?.watchFiles ?? [])]);
+for (const o of result.output) {
+  if (o.type !== "chunk") continue;
+  for (const id of Object.keys(o.modules ?? {})) closure.add(id);
+}
+const closureFiles = [...closure]
+  .map((id) => String(id).split("?")[0])
+  .filter((p) => !p.startsWith("\0"))
+  // config dependencies come back root-relative from loadConfigFromFile
+  .map((p) => (isAbsolute(p) ? p : resolve(APP, p)))
+  // Derived files poison the key. HERE holds oj-generated files: static
+  // assets are covered by the oj version in the cache salt, and manifest.ts
+  // is this build's own output. The route tree is regenerated on every boot
+  // and rewritten again mid-run by the runner's generator with different
+  // formatting; its real inputs (route file names and contents) are already
+  // in the key.
+  .filter((p) => !p.startsWith(HERE) && !/(^|\/)routeTree\.gen\.[jt]sx?$/.test(p))
+  .filter((p) => {
+    try { return statSync(p).isFile(); } catch { return false; }
+  })
+  .sort();
+writeFileSync(join(HERE, "closure.json"), JSON.stringify(closureFiles));
+
 const devManifest = {
   routes: {
     __root__: {
@@ -145,6 +184,10 @@ writeFileSync(
   join(HERE, "manifest.ts"),
   `export const tsrStartManifest = () => (${JSON.stringify(devManifest)});\n`,
 );
+// Raw stylesheet-URL list for the store's generation manifest; write-then-
+// rename so a concurrent read never sees a partial JSON.
+writeFileSync(join(HERE, "css-urls.json.tmp"), JSON.stringify(cssUrls));
+renameSync(join(HERE, "css-urls.json.tmp"), join(HERE, "css-urls.json"));
 const _ojTTY = process.stderr.isTTY && !process.env.NO_COLOR;
 const OJ = _ojTTY ? "\x1b[48;2;255;255;255m\x1b[1;38;2;42;51;212m oj \x1b[0m" : "oj";
 process.stderr.write(`${OJ}${_ojTTY ? "" : ":"} client bundled (${result.output.length} files)\n`);

--- a/crates/oj_server/src/assets/start/bundle-client.mjs
+++ b/crates/oj_server/src/assets/start/bundle-client.mjs
@@ -184,8 +184,8 @@ writeFileSync(
   join(HERE, "manifest.ts"),
   `export const tsrStartManifest = () => (${JSON.stringify(devManifest)});\n`,
 );
-// Raw stylesheet-URL list for the store's generation manifest; write-then-
-// rename so a concurrent read never sees a partial JSON.
+// The SSR runner (manifest-dev.ts) polls this file per render; write-then-rename
+// so a concurrent read never sees a partial JSON.
 writeFileSync(join(HERE, "css-urls.json.tmp"), JSON.stringify(cssUrls));
 renameSync(join(HERE, "css-urls.json.tmp"), join(HERE, "css-urls.json"));
 const _ojTTY = process.stderr.isTTY && !process.env.NO_COLOR;

--- a/crates/oj_server/src/assets/start/bundle-client.mjs
+++ b/crates/oj_server/src/assets/start/bundle-client.mjs
@@ -53,17 +53,20 @@ const cssUrls = [];
 
 const serverFnClient = {
   name: "server-fn-client",
-  async transform(code, id) {
-    if (id.includes("/node_modules/") || id.startsWith("\0") || !/\.(ts|tsx)$/.test(id)) return null;
-    let out = code;
-    if (container) {
-      const t = await container.transformUserCode(out, id);
-      if (t != null) out = t;
-    }
-    out = transformGlob(out, id);
-    const rpc = rewriteServerFns(out, id);
-    if (rpc != null) return rpc;
-    return out === code ? null : out;
+  transform: {
+    filter: { id: { include: /\.(ts|tsx)$/, exclude: [/\/node_modules\//, /^\0/] } },
+    async handler(code, id) {
+      if (id.includes("/node_modules/") || id.startsWith("\0") || !/\.(ts|tsx)$/.test(id)) return null;
+      let out = code;
+      if (container) {
+        const t = await container.transformUserCode(out, id);
+        if (t != null) out = t;
+      }
+      out = transformGlob(out, id);
+      const rpc = rewriteServerFns(out, id);
+      if (rpc != null) return rpc;
+      return out === code ? null : out;
+    },
   },
 };
 

--- a/crates/oj_server/src/assets/start/bundle-client.mjs
+++ b/crates/oj_server/src/assets/start/bundle-client.mjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { importPkg, viteEnvDefine } from "./resolve-pkg.mjs";
@@ -106,10 +106,31 @@ const result = await build({
   write: false,
 });
 
-const chunk = result.output.find((o) => o.type === "chunk" && o.isEntry) ?? result.output[0];
-writeFileSync(join(HERE, "client-entry.js"), chunk.code);
+// Persist every output file. The build code-splits on dynamic imports
+// (route components), so the entry is a small glue chunk whose static and
+// dynamic imports reference sibling chunks; discarding them leaves the
+// entry unable to load and the client never hydrates.
+const entryChunk = result.output.find((o) => o.type === "chunk" && o.isEntry) ?? result.output[0];
+const chunksDir = join(HERE, "client-chunks");
+// Retries: recursive removal of a few thousand fresh files can hit a
+// transient ENOTEMPTY on macOS while the indexer still holds entries.
+rmSync(chunksDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+mkdirSync(chunksDir, { recursive: true });
+const chunkIndex = [];
+let moduleCount = 0;
+for (const o of result.output) {
+  const dest = join(chunksDir, o.fileName);
+  mkdirSync(dirname(dest), { recursive: true });
+  writeFileSync(dest, o.type === "chunk" ? o.code : o.source);
+  chunkIndex.push({ name: o.fileName, size: statSync(dest).size });
+  if (o.type === "chunk") moduleCount += Object.keys(o.modules ?? {}).length;
+}
+writeFileSync(
+  join(HERE, "client-chunks.json"),
+  JSON.stringify({ entry: entryChunk.fileName, files: chunkIndex }),
+);
 // Module count for the editor's update-progress narration ("(N modules)").
-writeFileSync(join(HERE, "client-entry.modules"), String(chunk.modules ? Object.keys(chunk.modules).length : 0));
+writeFileSync(join(HERE, "client-entry.modules"), String(moduleCount));
 
 const devManifest = {
   routes: {
@@ -126,4 +147,4 @@ writeFileSync(
 );
 const _ojTTY = process.stderr.isTTY && !process.env.NO_COLOR;
 const OJ = _ojTTY ? "\x1b[48;2;255;255;255m\x1b[1;38;2;42;51;212m oj \x1b[0m" : "oj";
-process.stderr.write(`${OJ}${_ojTTY ? "" : ":"} client entry bundled\n`);
+process.stderr.write(`${OJ}${_ojTTY ? "" : ":"} client bundled (${result.output.length} files)\n`);

--- a/crates/oj_server/src/assets/start/container-bridge.mjs
+++ b/crates/oj_server/src/assets/start/container-bridge.mjs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+
+// Synchronous facade over the async Vite plugin container, for use inside
+// module.registerHooks() hooks (which must return values, not promises).
+// The container itself runs in a worker (container-host.mjs); each call here
+// posts a request and blocks on Atomics.wait until the worker replies. The
+// main thread never waits for worker bootstrap itself — only a call issued
+// before the container is ready blocks until bootstrap (incl. buildStart)
+// completes, so cache-hit boots pay nothing for config eval.
+
+import { Worker, MessageChannel, receiveMessageOnPort } from "node:worker_threads";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { findConfig } from "./vite-plugin-bridge.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+export function loadPluginContainerSync(app, opts) {
+  if (!findConfig(app)) return null;
+  const { port1, port2 } = new MessageChannel();
+  const sab = new SharedArrayBuffer(4);
+  const flag = new Int32Array(sab);
+  const worker = new Worker(join(HERE, "container-host.mjs"), {
+    workerData: { app, opts, port: port2, sab },
+    transferList: [port2],
+  });
+  // Neither the worker nor the port may keep the runner alive after stdin
+  // closes; requests are driven synchronously so no listener is needed.
+  worker.unref();
+  port1.unref();
+  let seq = 0;
+  function call(method, args) {
+    const id = ++seq;
+    port1.postMessage({ id, method, args });
+    // buildStart can legitimately block on the cross-process lock in
+    // vite-plugin-bridge.mjs (stolen after 300s), so match that horizon.
+    const deadline = Date.now() + 300_000;
+    for (;;) {
+      Atomics.wait(flag, 0, 0, 200);
+      Atomics.store(flag, 0, 0);
+      const m = receiveMessageOnPort(port1);
+      if (m) {
+        if (m.message.id !== id) continue;
+        if (m.message.error != null) throw new Error(m.message.error);
+        return m.message.value;
+      }
+      if (Date.now() > deadline) throw new Error(`oj: SSR plugin container timed out (${method})`);
+    }
+  }
+  return {
+    resolveId: (id, importer) => call("resolveId", [id, importer]),
+    load: (id) => call("load", [id]),
+    transform: (code, id) => call("transform", [code, id]),
+    transformUserCode: (code, id) => call("transformUserCode", [code, id]),
+  };
+}

--- a/crates/oj_server/src/assets/start/container-bridge.mjs
+++ b/crates/oj_server/src/assets/start/container-bridge.mjs
@@ -21,7 +21,7 @@ export function loadPluginContainerSync(app, opts) {
   const sab = new SharedArrayBuffer(4);
   const flag = new Int32Array(sab);
   const worker = new Worker(join(HERE, "container-host.mjs"), {
-    workerData: { app, opts, port: port2, sab },
+    workerData: { app, opts, port: port2, sab, envBase: { ...process.env } },
     transferList: [port2],
   });
   // Neither the worker nor the port may keep the runner alive after stdin
@@ -52,5 +52,6 @@ export function loadPluginContainerSync(app, opts) {
     load: (id) => call("load", [id]),
     transform: (code, id) => call("transform", [code, id]),
     transformUserCode: (code, id) => call("transformUserCode", [code, id]),
+    env: () => call("__env", []),
   };
 }

--- a/crates/oj_server/src/assets/start/container-bridge.mjs
+++ b/crates/oj_server/src/assets/start/container-bridge.mjs
@@ -53,5 +53,6 @@ export function loadPluginContainerSync(app, opts) {
     transform: (code, id) => call("transform", [code, id]),
     transformUserCode: (code, id) => call("transformUserCode", [code, id]),
     env: () => call("__env", []),
+    heap: () => call("__heap", []),
   };
 }

--- a/crates/oj_server/src/assets/start/container-host.mjs
+++ b/crates/oj_server/src/assets/start/container-host.mjs
@@ -39,6 +39,10 @@ for (const [k, v] of Object.entries(process.env)) {
 
 port.on("message", async ({ id, method, args }) => {
   if (method === "__env") return respond({ id, value: envDelta });
+  if (method === "__heap") {
+    const v8 = await import("node:v8");
+    return respond({ id, value: v8.default.getHeapStatistics() });
+  }
   if (!container) return respond({ id, value: null });
   try {
     respond({ id, value: await container[method](...args) });

--- a/crates/oj_server/src/assets/start/container-host.mjs
+++ b/crates/oj_server/src/assets/start/container-host.mjs
@@ -9,7 +9,7 @@
 import { workerData } from "node:worker_threads";
 import { loadPluginContainer } from "./vite-plugin-bridge.mjs";
 
-const { app, opts, port, sab } = workerData;
+const { app, opts, port, sab, envBase } = workerData;
 const flag = new Int32Array(sab);
 
 function respond(msg) {
@@ -29,7 +29,16 @@ if (container) {
   catch (e) { process.stderr.write(`oj: SSR buildStart failed: ${(e && (e.stack || e.message)) || e}\n`); }
 }
 
+// Evaluating the config (and buildStart) mutates this worker's process.env
+// copy — e.g. configs that derive VITE_* vars from git state. The loader
+// fetches this delta to feed the same values into its define/env inlining.
+const envDelta = {};
+for (const [k, v] of Object.entries(process.env)) {
+  if (envBase[k] !== v) envDelta[k] = v;
+}
+
 port.on("message", async ({ id, method, args }) => {
+  if (method === "__env") return respond({ id, value: envDelta });
   if (!container) return respond({ id, value: null });
   try {
     respond({ id, value: await container[method](...args) });

--- a/crates/oj_server/src/assets/start/container-host.mjs
+++ b/crates/oj_server/src/assets/start/container-host.mjs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+
+// Worker side of the sync plugin-container bridge (see container-bridge.mjs).
+// Owns the async Vite plugin container: config eval, buildStart, and every
+// plugin hook run here, off the main thread. Requests queue on the port until
+// bootstrap finishes, so callers observe the same "buildStart before any
+// load" ordering the in-worker loader had.
+
+import { workerData } from "node:worker_threads";
+import { loadPluginContainer } from "./vite-plugin-bridge.mjs";
+
+const { app, opts, port, sab } = workerData;
+const flag = new Int32Array(sab);
+
+function respond(msg) {
+  port.postMessage(msg);
+  Atomics.store(flag, 0, 1);
+  Atomics.notify(flag, 0);
+}
+
+let container = null;
+try {
+  container = await loadPluginContainer(app, opts);
+} catch (e) {
+  process.stderr.write(`oj: SSR plugin container failed: ${(e && (e.stack || e.message)) || e}\n`);
+}
+if (container) {
+  try { await container.buildStart(); }
+  catch (e) { process.stderr.write(`oj: SSR buildStart failed: ${(e && (e.stack || e.message)) || e}\n`); }
+}
+
+port.on("message", async ({ id, method, args }) => {
+  if (!container) return respond({ id, value: null });
+  try {
+    respond({ id, value: await container[method](...args) });
+  } catch (e) {
+    respond({ id, error: String((e && e.stack) || e) });
+  }
+});

--- a/crates/oj_server/src/assets/start/css-host.mjs
+++ b/crates/oj_server/src/assets/start/css-host.mjs
@@ -9,6 +9,7 @@ const send = process.stdout.write.bind(process.stdout);
 process.stdout.write = process.stderr.write.bind(process.stderr);
 
 const APP = process.env.OJ_APP_ROOT ?? process.cwd();
+if (process.env.OJ_V8_COMPILE_CACHE === "on") { try { module.enableCompileCache?.(APP + "/.oj-cache/v8"); } catch {} }
 const req = createRequire(APP + "/package.json");
 
 let postcssProcessor;
@@ -89,6 +90,7 @@ for await (const line of rl) {
   try { msg = JSON.parse(line); } catch { continue; }
   try {
     send(JSON.stringify({ id: msg.id, css: await compile(msg.path) }) + "\n");
+    try { module.flushCompileCache?.(); } catch {}
   } catch (e) {
     send(JSON.stringify({ id: msg.id, error: String((e && e.stack) || e) }) + "\n");
   }

--- a/crates/oj_server/src/assets/start/css-host.mjs
+++ b/crates/oj_server/src/assets/start/css-host.mjs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-import { createRequire } from "node:module";
-import { existsSync, readFileSync } from "node:fs";
+import module, { createRequire } from "node:module";
+import { existsSync, fstatSync, readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import readline from "node:readline";
 
@@ -69,6 +69,19 @@ async function compile(path) {
 const _ojTTY = process.stderr.isTTY && !process.env.NO_COLOR;
 const OJ = _ojTTY ? "\x1b[48;2;255;255;255m\x1b[1;38;2;42;51;212m oj \x1b[0m" : "oj";
 process.stderr.write(`${OJ} css host: ready\n`);
+// stdin EOF means oj died without tearing us down (SIGKILL skips
+// kill_on_drop): exit instead of idling as an orphan.
+const onParentGone = () => {
+  try { module.flushCompileCache?.(); } catch {}
+  process.exit(0);
+};
+try {
+  if (fstatSync(0).isFIFO()) {
+    process.stdin.once("end", onParentGone);
+    process.stdin.once("close", onParentGone);
+  }
+} catch {}
+
 const rl = readline.createInterface({ input: process.stdin });
 for await (const line of rl) {
   let msg;

--- a/crates/oj_server/src/assets/start/css-host.mjs
+++ b/crates/oj_server/src/assets/start/css-host.mjs
@@ -76,7 +76,8 @@ const onParentGone = () => {
   process.exit(0);
 };
 try {
-  if (fstatSync(0).isFIFO()) {
+  // bigint keeps the FIFO mode out of the shared stat buffer fs.realpathSync reads mid-walk
+  if (fstatSync(0, { bigint: true }).isFIFO()) {
     process.stdin.once("end", onParentGone);
     process.stdin.once("close", onParentGone);
   }

--- a/crates/oj_server/src/assets/start/loader.mjs
+++ b/crates/oj_server/src/assets/start/loader.mjs
@@ -67,14 +67,65 @@ function cacheKey(mode, path, source) {
   }
 }
 const cachePath = (key) => pathResolve(CACHE_DIR, key.slice(0, 2), `${key}.json`);
+
+// Load pack: an in-memory index over the per-entry load cache, persisted as
+// one JSONL file (header line carries the epoch) and read once at init. A
+// warm boot serves its ~6k load hits from this Map instead of ~6k per-file
+// open/read/parse round trips. The per-entry cache stays authoritative: a key
+// missing here falls back to the per-file path below, and such hits are
+// re-appended so the pack converges opportunistically.
+const LOAD_PACK_FILE = pathResolve(CACHE_DIR, "ssr-load-pack.jsonl");
+const loadPack = new Map();
+let loadPackFileReady = false;
+if (EPOCH) {
+  try {
+    const lines = readFileSync(LOAD_PACK_FILE, "utf8").split("\n");
+    if (JSON.parse(lines[0]).epoch === EPOCH) {
+      loadPackFileReady = true;
+      for (let i = 1; i < lines.length; i++) {
+        if (!lines[i]) continue;
+        try { const e = JSON.parse(lines[i]); loadPack.set(e.k, e.c); } catch {}
+      }
+    }
+  } catch {}
+}
+let packPending = [];
+let packFlushChain = Promise.resolve();
+function flushLoadPack() {
+  const batch = packPending;
+  packPending = [];
+  if (batch.length === 0) return;
+  const body = batch.map((e) => JSON.stringify(e)).join("\n") + "\n";
+  const first = !loadPackFileReady;
+  loadPackFileReady = true;
+  packFlushChain = packFlushChain.then(async () => {
+    try {
+      await mkdir(CACHE_DIR, { recursive: true });
+      if (first) await writeFile(LOAD_PACK_FILE, JSON.stringify({ epoch: EPOCH }) + "\n" + body);
+      else await appendFile(LOAD_PACK_FILE, body);
+    } catch {}
+  });
+}
+function rememberPack(key, code) {
+  if (!EPOCH || loadPack.has(key)) return;
+  loadPack.set(key, code);
+  packPending.push({ k: key, c: code });
+}
+
 function cacheGet(key) {
   if (!key) return null;
+  const packed = loadPack.get(key);
+  if (packed !== undefined) { cacheStats.hits += 1; return packed; }
   const file = cachePath(key);
   let bytes;
   try { bytes = readFileSync(file, "utf8"); } catch { return null; }
   try {
     const entry = JSON.parse(bytes);
-    if (typeof entry.code === "string") { cacheStats.hits += 1; return entry.code; }
+    if (typeof entry.code === "string") {
+      cacheStats.hits += 1;
+      rememberPack(key, entry.code);
+      return entry.code;
+    }
   } catch {}
   try { unlinkSync(file); } catch {}
   return null;
@@ -103,6 +154,7 @@ function cachePut(key, code) {
   if (!key) { cacheStats.uncached += 1; return; }
   cacheStats.misses += 1;
   try {
+    rememberPack(key, code);
     writeQueue.push({
       file: cachePath(key),
       body: JSON.stringify({ code, map_data_url: null, imports: [], is_boundary: false, kind: "ssr-loader" }),
@@ -165,6 +217,7 @@ function rememberResolve(key, entry) {
 // almost nothing. The runner calls this at ready and after each response.
 export function flushCaches() {
   if (writeQueue.length > 0) drainWrites();
+  if (packPending.length > 0) flushLoadPack();
   if (resolvePending.length > 0) flushResolveCache();
 }
 

--- a/crates/oj_server/src/assets/start/loader.mjs
+++ b/crates/oj_server/src/assets/start/loader.mjs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 
 import { pathToFileURL, fileURLToPath } from "node:url";
-import { readFileSync } from "node:fs";
+import { readFileSync, unlinkSync } from "node:fs";
+import { writeFile, appendFile, rename, mkdir } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import { resolve as pathResolve, dirname } from "node:path";
 import { importPkg, viteEnvDefine, emptyVirtualStub } from "./resolve-pkg.mjs";
 import { loadPluginContainer } from "./vite-plugin-bridge.mjs";
@@ -26,10 +28,151 @@ if (container) {
   catch (e) { process.stderr.write(`oj: SSR buildStart failed: ${(e && (e.stack || e.message)) || e}\n`); }
 }
 const VIRTUAL_SCHEME = "ojvirtual:///";
+const DEFINE = viteEnvDefine({ ssr: true });
+
+// Persistent per-module result cache. Same on-disk layout as oj_cache's
+// PersistentCache (.oj-cache/<2hex>/<key>.json, corrupt entries self-delete)
+// so one prune covers both. Keys are salted with an epoch hash of everything
+// non-content that can change a transform result: lockfile, vite/oj config,
+// the loader assets themselves (which change with the oj version), and the
+// define/env inputs fed to transformSync. Any error degrades to a miss.
+const CACHE_DIR = pathResolve(APP, ".oj-cache");
+const cacheStats = { hits: 0, misses: 0, uncached: 0, rhits: 0, rmisses: 0 };
+const EPOCH = (() => {
+  if (process.env.OJ_SSR_LOADER_CACHE === "off") return null;
+  try {
+    const h = createHash("sha256");
+    const add = (label, bytes) => { h.update(label); h.update("\0"); h.update(bytes); h.update("\0"); };
+    add("v", "oj-ssr-loader-cache-v1");
+    add("node", process.version);
+    for (const name of [
+      "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lockb", "package.json",
+      "vite.config.ts", "vite.config.js", "vite.config.mjs", "vite.config.mts",
+      "oj.config.ts", "oj.config.js", "oj.config.mjs",
+    ]) {
+      try { add(name, readFileSync(pathResolve(APP, name))); } catch {}
+    }
+    for (const name of ["loader.mjs", "loader-util.mjs", "glob-transform.mjs", "vite-plugin-bridge.mjs", "resolve-pkg.mjs"]) {
+      try { add(name, readFileSync(pathResolve(HERE, name))); } catch {}
+    }
+    add("define", JSON.stringify(DEFINE));
+    add("fnbase", process.env.TSS_SERVER_FN_BASE ?? "");
+    return h.digest("hex");
+  } catch {
+    return null;
+  }
+})();
+function cacheKey(mode, path, source) {
+  if (!EPOCH) return null;
+  try {
+    const h = createHash("sha256");
+    for (const part of [EPOCH, mode, path, source]) { h.update(part); h.update("\0"); }
+    return h.digest("hex");
+  } catch {
+    return null;
+  }
+}
+const cachePath = (key) => pathResolve(CACHE_DIR, key.slice(0, 2), `${key}.json`);
+function cacheGet(key) {
+  if (!key) return null;
+  const file = cachePath(key);
+  let bytes;
+  try { bytes = readFileSync(file, "utf8"); } catch { return null; }
+  try {
+    const entry = JSON.parse(bytes);
+    if (typeof entry.code === "string") { cacheStats.hits += 1; return entry.code; }
+  } catch {}
+  try { unlinkSync(file); } catch {}
+  return null;
+}
+// Writes are queued and drained off the load path: a sync write per miss
+// would serialize thousands of fs calls into first-boot module loading.
+const writeQueue = [];
+let draining = false;
+async function drainWrites() {
+  if (draining) return;
+  draining = true;
+  while (writeQueue.length > 0) {
+    const { file, body } = writeQueue.shift();
+    try {
+      await mkdir(dirname(file), { recursive: true });
+      const tmp = file.replace(/\.json$/, ".tmp");
+      await writeFile(tmp, body);
+      await rename(tmp, file);
+    } catch {}
+  }
+  draining = false;
+}
+function cachePut(key, code) {
+  if (!key) { cacheStats.uncached += 1; return; }
+  cacheStats.misses += 1;
+  try {
+    writeQueue.push({
+      file: cachePath(key),
+      body: JSON.stringify({ code, map_data_url: null, imports: [], is_boundary: false, kind: "ssr-loader" }),
+    });
+    setTimeout(drainWrites, 0);
+  } catch {}
+}
+// Persistent resolution cache: (parentURL, specifier) -> resolved URL. The
+// resolve hook's fs probing and Node's own fallback resolution dominate the
+// hooks-thread time, so hits replace them with one existence check. Stored as
+// one JSONL pack (header line carries the epoch) and loaded into a Map at
+// init; entries whose file: target disappeared degrade to a miss. Accepted
+// staleness edge: a hit only re-checks that the target still exists, so a
+// newly added file that should shadow an old resolution (e.g. a new
+// tsconfig-path match) lands on the next epoch change, not instantly.
+const RESOLVE_CACHE_FILE = pathResolve(CACHE_DIR, "ssr-resolve.jsonl");
+const resolveCache = new Map();
+let resolveFileReady = false;
+if (EPOCH) {
+  try {
+    const lines = readFileSync(RESOLVE_CACHE_FILE, "utf8").split("\n");
+    if (JSON.parse(lines[0]).epoch === EPOCH) {
+      resolveFileReady = true;
+      for (let i = 1; i < lines.length; i++) {
+        if (!lines[i]) continue;
+        try { const e = JSON.parse(lines[i]); resolveCache.set(e.k, e); } catch {}
+      }
+    }
+  } catch {}
+}
+let resolvePending = [];
+let resolveFlushTimer = null;
+async function flushResolveCache() {
+  resolveFlushTimer = null;
+  const batch = resolvePending;
+  resolvePending = [];
+  if (batch.length === 0) return;
+  const body = batch.map((e) => JSON.stringify(e)).join("\n") + "\n";
+  try {
+    await mkdir(CACHE_DIR, { recursive: true });
+    if (resolveFileReady) {
+      await appendFile(RESOLVE_CACHE_FILE, body);
+    } else {
+      await writeFile(RESOLVE_CACHE_FILE, JSON.stringify({ epoch: EPOCH }) + "\n" + body);
+      resolveFileReady = true;
+    }
+  } catch {}
+}
+function rememberResolve(key, entry) {
+  if (!EPOCH || resolveCache.has(key)) return;
+  entry.k = key;
+  resolveCache.set(key, entry);
+  resolvePending.push(entry);
+  if (!resolveFlushTimer) resolveFlushTimer = setTimeout(flushResolveCache, 250);
+}
+
+function reportCacheStats() {
+  if (!EPOCH) return;
+  process.stderr.write(
+    `oj: ssr loader cache: load ${cacheStats.hits}/${cacheStats.hits + cacheStats.misses} hits (${cacheStats.uncached} uncacheable), resolve ${cacheStats.rhits}/${cacheStats.rhits + cacheStats.rmisses} hits\n`,
+  );
+}
 
 let V = 0;
 export async function initialize(data) {
-  if (data && data.port) data.port.on("message", (v) => (V = v));
+  if (data && data.port) data.port.on("message", (v) => (v === "stats" ? reportCacheStats() : (V = v)));
 }
 const stripQ = (u) => u.split("?")[0];
 const withV = (u) => (V ? `${stripQ(u)}?ojv=${V}` : stripQ(u));
@@ -90,6 +233,31 @@ function resolveTsPaths(spec) {
 
 export async function resolve(spec, context, next) {
   if (context.parentURL) context = { ...context, parentURL: stripQ(context.parentURL) };
+  const key = (context.parentURL ?? "") + "\0" + spec;
+  const rc = EPOCH ? resolveCache.get(key) : undefined;
+  if (rc !== undefined) {
+    try {
+      const cleanUrl = stripQ(rc.u);
+      if (!cleanUrl.startsWith("file:") || isFile(fileURLToPath(cleanUrl))) {
+        cacheStats.rhits += 1;
+        const out = { url: rc.v ? withV(rc.u) : rc.u, shortCircuit: true };
+        if (rc.f) out.format = rc.f;
+        return out;
+      }
+    } catch {}
+    resolveCache.delete(key);
+  }
+  const r = await resolveUncached(spec, context, next);
+  if (EPOCH && r && r.url && !r.url.startsWith(VIRTUAL_SCHEME)) {
+    cacheStats.rmisses += 1;
+    const versioned = r._ojv === true;
+    rememberResolve(key, { u: versioned ? stripQ(r.url) : r.url, v: versioned ? 1 : 0, f: r.format ?? null });
+  }
+  if (r && r._ojv) delete r._ojv;
+  return r;
+}
+
+async function resolveUncached(spec, context, next) {
   if (container && (spec.startsWith("virtual:") || spec.startsWith("\0"))) {
     const importer = context.parentURL && context.parentURL.startsWith("file:")
       ? fileURLToPath(context.parentURL)
@@ -132,20 +300,20 @@ export async function resolve(spec, context, next) {
   }
   if (ALIASES[spec]) {
     const hit = probe(ALIASES[spec]);
-    if (hit) return { url: withV(pathToFileURL(hit).href), shortCircuit: true };
+    if (hit) return { url: withV(pathToFileURL(hit).href), shortCircuit: true, _ojv: true };
   }
   if (spec.startsWith("#")) {
     const hit = resolveImports(spec);
-    if (hit) return { url: withV(pathToFileURL(hit).href), shortCircuit: true };
+    if (hit) return { url: withV(pathToFileURL(hit).href), shortCircuit: true, _ojv: true };
   }
   if (!spec.startsWith(".") && !spec.startsWith("/")) {
     const hit = resolveTsPaths(spec);
-    if (hit) return { url: withV(pathToFileURL(hit).href), shortCircuit: true };
+    if (hit) return { url: withV(pathToFileURL(hit).href), shortCircuit: true, _ojv: true };
   }
   if (spec.startsWith(".") && context.parentURL) {
     const base = pathResolve(dirname(fileURLToPath(context.parentURL)), spec);
     const hit = probe(base);
-    if (hit) return { url: withV(pathToFileURL(hit).href), shortCircuit: true };
+    if (hit) return { url: withV(pathToFileURL(hit).href), shortCircuit: true, _ojv: true };
   }
   let r;
   try {
@@ -160,7 +328,7 @@ export async function resolve(spec, context, next) {
     }
     throw err;
   }
-  if (r && r.url && isTanstack(r.url)) return { ...r, url: withV(r.url), shortCircuit: true };
+  if (r && r.url && isTanstack(r.url)) return { ...r, url: withV(r.url), shortCircuit: true, _ojv: true };
   return r;
 }
 
@@ -192,9 +360,28 @@ export async function load(url, context, next) {
   if (clean.endsWith(".tsx") || clean.endsWith(".ts")) {
     const path = fileURLToPath(clean);
     const userFile = container && !path.includes("/node_modules/");
+    // Try the on-disk bytes first: files no plugin load() claims (the vast
+    // majority) are stored under their disk-content key, so a hit skips the
+    // container.load round trip entirely. Plugin-claimed files never land in
+    // that namespace (their raw differs from disk), so a stale plugin result
+    // can't be served from a disk key.
+    let diskRaw = null;
+    if (userFile) {
+      try { diskRaw = readFileSync(path, "utf8"); } catch {}
+      if (diskRaw != null) {
+        const diskHit = cacheGet(cacheKey("ssr-loader", path, diskRaw));
+        if (diskHit != null) return { format: "module", source: diskHit, shortCircuit: true };
+      }
+    }
     // A plugin load() overrides the on-disk file (Vite: load runs before fs read).
+    // Its result can differ from the disk bytes, so it is what the key hashes.
     let raw = userFile ? await container.load(path) : null;
-    if (raw == null) raw = readFileSync(path, "utf8");
+    if (raw == null) raw = diskRaw ?? readFileSync(path, "utf8");
+    const key = cacheKey("ssr-loader", path, raw);
+    if (raw !== diskRaw) {
+      const hit = cacheGet(key);
+      if (hit != null) return { format: "module", source: hit, shortCircuit: true };
+    }
     if (userFile) {
       const t = await container.transformUserCode(raw, path);
       if (t != null) raw = t;
@@ -203,8 +390,11 @@ export async function load(url, context, next) {
     const out = transformSync(path, src, {
       lang: clean.endsWith("tsx") ? "tsx" : "ts",
       jsx: { runtime: "automatic" },
-      define: viteEnvDefine({ ssr: true }),
+      define: DEFINE,
     });
+    // Glob expansion depends on directory contents, not source bytes: a file
+    // added to a globbed dir would not change the key, so never persist these.
+    cachePut(raw.includes("import.meta.glob") ? null : key, out.code);
     return { format: "module", source: out.code, shortCircuit: true };
   }
   if (url.includes("?ojv=") && isTanstack(url)) {
@@ -219,12 +409,17 @@ export async function load(url, context, next) {
   }
   if (container && clean.endsWith(".mdx")) {
     const path = fileURLToPath(clean);
-    const compiled = await container.transform(readFileSync(path, "utf8"), path);
+    const raw = readFileSync(path, "utf8");
+    const key = cacheKey("ssr-loader-mdx", path, raw);
+    const hit = cacheGet(key);
+    if (hit != null) return { format: "module", source: hit, shortCircuit: true };
+    const compiled = await container.transform(raw, path);
     if (compiled != null) {
       const out = transformSync(path, compiled, {
         lang: "jsx", jsx: { runtime: "automatic" },
-        define: viteEnvDefine({ ssr: true }),
+        define: DEFINE,
       });
+      cachePut(compiled.includes("import.meta.glob") ? null : key, out.code);
       return { format: "module", source: out.code, shortCircuit: true };
     }
   }
@@ -244,7 +439,17 @@ export async function load(url, context, next) {
   if (clean.startsWith("file:") && clean.includes("/node_modules/")) {
     const path = fileURLToPath(clean);
     if (isCjsFile(path)) {
-      try { return { format: "module", source: cjsFacade(path), shortCircuit: true }; } catch {}
+      // cjsFacade require()s the module on the loader thread just to
+      // enumerate export names; a hit skips that duplicate graph eval.
+      let key = null;
+      try { key = cacheKey("ssr-loader-cjs", path, readFileSync(path)); } catch {}
+      const hit = cacheGet(key);
+      if (hit != null) return { format: "module", source: hit, shortCircuit: true };
+      try {
+        const src = cjsFacade(path);
+        cachePut(key, src);
+        return { format: "module", source: src, shortCircuit: true };
+      } catch {}
     }
   }
   return next(url, context);

--- a/crates/oj_server/src/assets/start/loader.mjs
+++ b/crates/oj_server/src/assets/start/loader.mjs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 import { pathToFileURL, fileURLToPath } from "node:url";
-import { readFileSync, unlinkSync, statSync } from "node:fs";
+import { readFileSync, unlinkSync, statSync, openSync, readSync } from "node:fs";
 import { writeFile, appendFile, rename, mkdir } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { resolve as pathResolve, dirname } from "node:path";
@@ -152,26 +152,55 @@ function cacheKey(mode, path, source) {
 }
 const cachePath = (key) => pathResolve(CACHE_DIR, key.slice(0, 2), `${key}.json`);
 
-// Load pack: an in-memory index over the per-entry load cache, persisted as
-// one JSONL file (header line carries the epoch) and read once at init. A
-// warm boot serves its ~6k load hits from this Map instead of ~6k per-file
-// open/read/parse round trips. The per-entry cache stays authoritative: a key
-// missing here falls back to the per-file path below, and such hits are
-// re-appended so the pack converges opportunistically.
+// Load pack: an index over the per-entry load cache, persisted as one JSONL
+// file (header line carries the epoch). At init only byte offsets are indexed;
+// a hit reads its line back from the open fd, so a warm boot's ~6k load hits
+// cost one pread each instead of one open/read/parse round trip — and the
+// sources are not held in memory after they are served. The per-entry cache
+// stays authoritative: a key missing here falls back to the per-file path
+// below, and such hits are re-appended so the pack converges opportunistically.
 const LOAD_PACK_FILE = pathResolve(CACHE_DIR, "ssr-load-pack.jsonl");
 const loadPack = new Map();
+const packIndex = new Map();
+const PACK_KEY_RE = /^[0-9a-f]{64}$/;
+let packFd = -1;
+let packFileBytes = 0;
 let loadPackFileReady = false;
 if (EPOCH) {
   try {
-    const lines = readFileSync(LOAD_PACK_FILE, "utf8").split("\n");
-    if (JSON.parse(lines[0]).epoch === EPOCH) {
+    const buf = readFileSync(LOAD_PACK_FILE);
+    const nl0 = buf.indexOf(10);
+    if (nl0 > 0 && JSON.parse(buf.toString("utf8", 0, nl0)).epoch === EPOCH) {
       loadPackFileReady = true;
-      for (let i = 1; i < lines.length; i++) {
-        if (!lines[i]) continue;
-        try { const e = JSON.parse(lines[i]); loadPack.set(e.k, e.c); } catch {}
+      packFileBytes = buf.length;
+      let off = nl0 + 1;
+      while (off < buf.length) {
+        let end = buf.indexOf(10, off);
+        if (end === -1) end = buf.length;
+        // Lines are written as {"k":"<64 hex>","c":...}; anything else is skipped.
+        if (end - off > 70 && buf[off] === 0x7b) {
+          const key = buf.toString("utf8", off + 6, off + 70);
+          if (PACK_KEY_RE.test(key)) packIndex.set(key, [off, end - off]);
+        }
+        off = end + 1;
       }
+      if (packIndex.size > 0) packFd = openSync(LOAD_PACK_FILE, "r");
     }
   } catch {}
+}
+function packGet(key) {
+  const mem = loadPack.get(key);
+  if (mem !== undefined) return mem;
+  const loc = packIndex.get(key);
+  if (loc === undefined || packFd < 0) return undefined;
+  try {
+    const b = Buffer.allocUnsafe(loc[1]);
+    readSync(packFd, b, 0, loc[1], loc[0]);
+    const e = JSON.parse(b.toString("utf8"));
+    if (e.k === key && typeof e.c === "string") return e.c;
+  } catch {}
+  packIndex.delete(key);
+  return undefined;
 }
 let packPending = [];
 let packFlushChain = Promise.resolve();
@@ -179,26 +208,39 @@ function flushLoadPack() {
   const batch = packPending;
   packPending = [];
   if (batch.length === 0) return;
-  const body = batch.map((e) => JSON.stringify(e)).join("\n") + "\n";
+  const lines = batch.map((e) => JSON.stringify(e) + "\n");
   const first = !loadPackFileReady;
   loadPackFileReady = true;
   packFlushChain = packFlushChain.then(async () => {
     try {
       await mkdir(CACHE_DIR, { recursive: true });
-      if (first) await writeFile(LOAD_PACK_FILE, JSON.stringify({ epoch: EPOCH }) + "\n" + body);
-      else await appendFile(LOAD_PACK_FILE, body);
+      if (first) {
+        const header = JSON.stringify({ epoch: EPOCH }) + "\n";
+        await writeFile(LOAD_PACK_FILE, header + lines.join(""));
+        packFileBytes = Buffer.byteLength(header);
+      } else {
+        await appendFile(LOAD_PACK_FILE, lines.join(""));
+      }
+      // Persisted entries are index-servable; drop their in-memory sources.
+      for (let i = 0; i < batch.length; i++) {
+        const len = Buffer.byteLength(lines[i]);
+        packIndex.set(batch[i].k, [packFileBytes, len - 1]);
+        packFileBytes += len;
+        loadPack.delete(batch[i].k);
+      }
+      if (packFd < 0) packFd = openSync(LOAD_PACK_FILE, "r");
     } catch {}
   });
 }
 function rememberPack(key, code) {
-  if (!EPOCH || loadPack.has(key)) return;
+  if (!EPOCH || loadPack.has(key) || packIndex.has(key)) return;
   loadPack.set(key, code);
   packPending.push({ k: key, c: code });
 }
 
 function cacheGet(key) {
   if (!key) return null;
-  const packed = loadPack.get(key);
+  const packed = packGet(key);
   if (packed !== undefined) { cacheStats.hits += 1; return packed; }
   const file = cachePath(key);
   let bytes;
@@ -310,6 +352,26 @@ function reportCacheStats() {
   process.stderr.write(
     `oj: ssr loader cache: load ${cacheStats.hits}/${cacheStats.hits + cacheStats.misses} hits (${cacheStats.uncached} uncacheable), resolve ${cacheStats.rhits}/${cacheStats.rhits + cacheStats.rmisses} hits\n`,
   );
+}
+
+// Debug accounting for OJ_SSR_MEM_STATS: what the loader's own structures hold.
+export function memStats() {
+  let packMemChars = 0;
+  for (const c of loadPack.values()) packMemChars += c.length;
+  let resolveChars = 0;
+  for (const e of resolveCache.values()) {
+    resolveChars += e.k.length + e.u.length + (e.f ? e.f.length : 0);
+  }
+  let containerHeap = null;
+  try { containerHeap = container ? container.heap() : null; } catch {}
+  return {
+    packIndexEntries: packIndex.size,
+    packMemEntries: loadPack.size,
+    packMemChars,
+    resolveEntries: resolveCache.size,
+    resolveChars,
+    containerHeap,
+  };
 }
 
 let V = 0;

--- a/crates/oj_server/src/assets/start/loader.mjs
+++ b/crates/oj_server/src/assets/start/loader.mjs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 import { pathToFileURL, fileURLToPath } from "node:url";
-import { readFileSync, unlinkSync } from "node:fs";
+import { readFileSync, unlinkSync, statSync } from "node:fs";
 import { writeFile, appendFile, rename, mkdir } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { resolve as pathResolve, dirname } from "node:path";
@@ -22,7 +22,103 @@ const { transformSync } = await importPkg(APP, "rolldown/experimental", ["vite",
 // it off-thread keeps its bootstrap out of the module-loading critical path.
 const container = loadPluginContainerSync(APP, { command: "serve", environment: "ssr" });
 const VIRTUAL_SCHEME = "ojvirtual:///";
-const DEFINE = viteEnvDefine({ ssr: true });
+const CACHE_DIR = pathResolve(APP, ".oj-cache");
+
+const BASE_FILES = [
+  "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lockb", "package.json",
+  "vite.config.ts", "vite.config.js", "vite.config.mjs", "vite.config.mts",
+  "oj.config.ts", "oj.config.js", "oj.config.mjs",
+];
+const LOADER_FILES = ["loader.mjs", "loader-util.mjs", "glob-transform.mjs", "vite-plugin-bridge.mjs", "resolve-pkg.mjs"];
+const hashAdd = (h, label, bytes) => { h.update(label); h.update("\0"); h.update(bytes); h.update("\0"); };
+function hashBaseInputs(h) {
+  hashAdd(h, "node", process.version);
+  for (const name of BASE_FILES) {
+    try { hashAdd(h, name, readFileSync(pathResolve(APP, name))); } catch {}
+  }
+  for (const name of LOADER_FILES) {
+    try { hashAdd(h, name, readFileSync(pathResolve(HERE, name))); } catch {}
+  }
+}
+
+// Config evaluation mutates process.env (e.g. VITE_* vars derived from git
+// state or .env files) and those values feed the import.meta.env inlining
+// below — but the eval now happens in the container worker's env copy. The
+// worker reports the delta; to keep warm boots from blocking on config eval,
+// the delta is persisted keyed by everything that can change it (config,
+// lockfile, loader assets, .env files, git HEAD). A key change means a boot
+// that recompiles anyway, so blocking on the worker there costs little.
+// Compromise vs the in-worker design: env side effects that are
+// nondeterministic for identical inputs are replayed, not recomputed.
+function gitStateBytes() {
+  try {
+    let dir = APP;
+    for (let i = 0; i < 12; i++) {
+      const dotGit = pathResolve(dir, ".git");
+      let gitDir = null;
+      try {
+        if (statSync(dotGit).isDirectory()) gitDir = dotGit;
+        else {
+          const m = readFileSync(dotGit, "utf8").match(/^gitdir:\s*(.+)$/m);
+          if (m) gitDir = pathResolve(dir, m[1].trim());
+        }
+      } catch {}
+      if (gitDir) {
+        const head = readFileSync(pathResolve(gitDir, "HEAD"), "utf8");
+        const ref = head.match(/^ref:\s*(.+)$/m);
+        let tip = "";
+        if (ref) {
+          const refPath = ref[1].trim();
+          for (const base of [gitDir, (() => { try { return pathResolve(gitDir, readFileSync(pathResolve(gitDir, "commondir"), "utf8").trim()); } catch { return null; } })()]) {
+            if (!base) continue;
+            try { tip = readFileSync(pathResolve(base, refPath), "utf8"); break; } catch {}
+            try { tip = readFileSync(pathResolve(base, "packed-refs"), "utf8"); break; } catch {}
+          }
+        }
+        return head + "\0" + tip;
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {}
+  return "";
+}
+const ENV_DELTA_FILE = pathResolve(CACHE_DIR, "ssr-env.json");
+const envDelta = (() => {
+  if (!container) return {};
+  let deltaKey = null;
+  if (process.env.OJ_SSR_LOADER_CACHE !== "off") {
+    try {
+      const h = createHash("sha256");
+      hashAdd(h, "v", "oj-ssr-env-delta-v1");
+      hashBaseInputs(h);
+      for (const name of [".env", ".env.local", ".env.development", ".env.development.local"]) {
+        try { hashAdd(h, name, readFileSync(pathResolve(APP, name))); } catch {}
+      }
+      hashAdd(h, "git", gitStateBytes());
+      deltaKey = h.digest("hex");
+    } catch {}
+  }
+  if (deltaKey) {
+    try {
+      const j = JSON.parse(readFileSync(ENV_DELTA_FILE, "utf8"));
+      if (j.key === deltaKey && j.delta && typeof j.delta === "object") return j.delta;
+    } catch {}
+  }
+  let fresh = {};
+  try { fresh = container.env() ?? {}; } catch {}
+  if (deltaKey) {
+    (async () => {
+      try {
+        await mkdir(CACHE_DIR, { recursive: true });
+        await writeFile(ENV_DELTA_FILE, JSON.stringify({ key: deltaKey, delta: fresh }));
+      } catch {}
+    })();
+  }
+  return fresh;
+})();
+const DEFINE = viteEnvDefine({ ssr: true, env: { ...process.env, ...envDelta } });
 
 // Persistent per-module result cache. Same on-disk layout as oj_cache's
 // PersistentCache (.oj-cache/<2hex>/<key>.json, corrupt entries self-delete)
@@ -30,27 +126,15 @@ const DEFINE = viteEnvDefine({ ssr: true });
 // non-content that can change a transform result: lockfile, vite/oj config,
 // the loader assets themselves (which change with the oj version), and the
 // define/env inputs fed to transformSync. Any error degrades to a miss.
-const CACHE_DIR = pathResolve(APP, ".oj-cache");
 const cacheStats = { hits: 0, misses: 0, uncached: 0, rhits: 0, rmisses: 0 };
 const EPOCH = (() => {
   if (process.env.OJ_SSR_LOADER_CACHE === "off") return null;
   try {
     const h = createHash("sha256");
-    const add = (label, bytes) => { h.update(label); h.update("\0"); h.update(bytes); h.update("\0"); };
-    add("v", "oj-ssr-loader-cache-v1");
-    add("node", process.version);
-    for (const name of [
-      "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lockb", "package.json",
-      "vite.config.ts", "vite.config.js", "vite.config.mjs", "vite.config.mts",
-      "oj.config.ts", "oj.config.js", "oj.config.mjs",
-    ]) {
-      try { add(name, readFileSync(pathResolve(APP, name))); } catch {}
-    }
-    for (const name of ["loader.mjs", "loader-util.mjs", "glob-transform.mjs", "vite-plugin-bridge.mjs", "resolve-pkg.mjs"]) {
-      try { add(name, readFileSync(pathResolve(HERE, name))); } catch {}
-    }
-    add("define", JSON.stringify(DEFINE));
-    add("fnbase", process.env.TSS_SERVER_FN_BASE ?? "");
+    hashAdd(h, "v", "oj-ssr-loader-cache-v1");
+    hashBaseInputs(h);
+    hashAdd(h, "define", JSON.stringify(DEFINE));
+    hashAdd(h, "fnbase", process.env.TSS_SERVER_FN_BASE ?? "");
     return h.digest("hex");
   } catch {
     return null;

--- a/crates/oj_server/src/assets/start/loader.mjs
+++ b/crates/oj_server/src/assets/start/loader.mjs
@@ -6,7 +6,7 @@ import { writeFile, appendFile, rename, mkdir } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { resolve as pathResolve, dirname } from "node:path";
 import { importPkg, viteEnvDefine, emptyVirtualStub } from "./resolve-pkg.mjs";
-import { loadPluginContainer } from "./vite-plugin-bridge.mjs";
+import { loadPluginContainerSync } from "./container-bridge.mjs";
 import { transformGlob } from "./glob-transform.mjs";
 import {
   EXTS, isFile, JS_TO_TS, probe, RESERVED, nearestPkgType,
@@ -17,16 +17,10 @@ import {
 const HERE = dirname(fileURLToPath(import.meta.url));
 const APP = process.env.OJ_APP_ROOT ?? process.cwd();
 const { transformSync } = await importPkg(APP, "rolldown/experimental", ["vite", "@tanstack/react-start"]);
-const container = await loadPluginContainer(APP, { command: "serve", environment: "ssr" });
-// Vite runs buildStart before serving any module; plugins that compile sources
-// (e.g. i18n message compilers) populate the state their load() hook serves.
-if (container) {
-  // buildStart degrades per-plugin inside the container (a plugin oj can't
-  // fully support is logged and skipped); this guards against a container-level
-  // failure without taking the SSR runner down.
-  try { await container.buildStart(); }
-  catch (e) { process.stderr.write(`oj: SSR buildStart failed: ${(e && (e.stack || e.message)) || e}\n`); }
-}
+// The plugin container (config eval + buildStart + plugin hooks) lives in a
+// worker behind a sync bridge: registerHooks hooks cannot await, and hosting
+// it off-thread keeps its bootstrap out of the module-loading critical path.
+const container = loadPluginContainerSync(APP, { command: "serve", environment: "ssr" });
 const VIRTUAL_SCHEME = "ojvirtual:///";
 const DEFINE = viteEnvDefine({ ssr: true });
 
@@ -93,13 +87,15 @@ async function drainWrites() {
   if (draining) return;
   draining = true;
   while (writeQueue.length > 0) {
-    const { file, body } = writeQueue.shift();
-    try {
-      await mkdir(dirname(file), { recursive: true });
-      const tmp = file.replace(/\.json$/, ".tmp");
-      await writeFile(tmp, body);
-      await rename(tmp, file);
-    } catch {}
+    const batch = writeQueue.splice(0, 64);
+    await Promise.all(batch.map(async ({ file, body }) => {
+      try {
+        await mkdir(dirname(file), { recursive: true });
+        const tmp = file.replace(/\.json$/, ".tmp");
+        await writeFile(tmp, body);
+        await rename(tmp, file);
+      } catch {}
+    }));
   }
   draining = false;
 }
@@ -163,6 +159,15 @@ function rememberResolve(key, entry) {
   if (!resolveFlushTimer) resolveFlushTimer = setTimeout(flushResolveCache, 250);
 }
 
+// With synchronous in-thread hooks the event loop never turns during a boot
+// or an SSR render, so the setTimeout-driven drains above starve until the
+// process idles — and a dev server killed shortly after boot would persist
+// almost nothing. The runner calls this at ready and after each response.
+export function flushCaches() {
+  if (writeQueue.length > 0) drainWrites();
+  if (resolvePending.length > 0) flushResolveCache();
+}
+
 function reportCacheStats() {
   if (!EPOCH) return;
   process.stderr.write(
@@ -171,9 +176,8 @@ function reportCacheStats() {
 }
 
 let V = 0;
-export async function initialize(data) {
-  if (data && data.port) data.port.on("message", (v) => (v === "stats" ? reportCacheStats() : (V = v)));
-}
+export function setVersion(v) { V = v; }
+export { reportCacheStats };
 const stripQ = (u) => u.split("?")[0];
 const withV = (u) => (V ? `${stripQ(u)}?ojv=${V}` : stripQ(u));
 const isTanstack = (u) => /\/@tanstack\//.test(u) && /\.(js|mjs)$/.test(stripQ(u));
@@ -233,7 +237,15 @@ function resolveTsPaths(spec) {
   return null;
 }
 
-export async function resolve(spec, context, next) {
+// Hooks are registered with module.registerHooks(), so they run synchronously
+// in-thread — and, unlike module.register(), they also see require() traffic.
+// Bail out of require operations entirely: the async-hooks design never
+// customized them, and the cjsFacade sources require() the module they front
+// (customizing that would recurse).
+const isRequire = (context) => context.conditions && context.conditions.includes("require");
+
+export function resolve(spec, context, next) {
+  if (isRequire(context)) return next(spec, context);
   if (context.parentURL) context = { ...context, parentURL: stripQ(context.parentURL) };
   const key = (context.parentURL ?? "") + "\0" + spec;
   const rc = EPOCH ? resolveCache.get(key) : undefined;
@@ -249,7 +261,7 @@ export async function resolve(spec, context, next) {
     } catch {}
     resolveCache.delete(key);
   }
-  const r = await resolveUncached(spec, context, next);
+  const r = resolveUncached(spec, context, next);
   if (EPOCH && r && r.url && !r.url.startsWith(VIRTUAL_SCHEME)) {
     cacheStats.rmisses += 1;
     const versioned = r._ojv === true;
@@ -259,12 +271,12 @@ export async function resolve(spec, context, next) {
   return r;
 }
 
-async function resolveUncached(spec, context, next) {
+function resolveUncached(spec, context, next) {
   if (container && (spec.startsWith("virtual:") || spec.startsWith("\0"))) {
     const importer = context.parentURL && context.parentURL.startsWith("file:")
       ? fileURLToPath(context.parentURL)
       : undefined;
-    const rid = await container.resolveId(spec, importer);
+    const rid = container.resolveId(spec, importer);
     if (rid != null) return { url: VIRTUAL_SCHEME + encodeURIComponent(rid), shortCircuit: true };
   }
   const suffix = spec.match(ASSET_SUFFIX);
@@ -281,7 +293,7 @@ async function resolveUncached(spec, context, next) {
     }
     if (!abs && clean.startsWith("#")) abs = resolveImports(clean);
     if (!abs) {
-      try { abs = fileURLToPath(stripQ((await next(clean, context)).url)); } catch {}
+      try { abs = fileURLToPath(stripQ(next(clean, context).url)); } catch {}
     }
     if (abs) return { url: pathToFileURL(abs).href + `?ojasset=${kind}`, shortCircuit: true };
   }
@@ -296,7 +308,7 @@ async function resolveUncached(spec, context, next) {
       abs = resolveTsPaths(clean);
     }
     if (!abs) {
-      try { abs = fileURLToPath(stripQ((await next(clean, context)).url)); } catch {}
+      try { abs = fileURLToPath(stripQ(next(clean, context).url)); } catch {}
     }
     if (abs) return { url: pathToFileURL(abs).href + "?ojsvg=react", shortCircuit: true };
   }
@@ -319,7 +331,7 @@ async function resolveUncached(spec, context, next) {
   }
   let r;
   try {
-    r = await next(spec, context);
+    r = next(spec, context);
   } catch (err) {
     if (err && err.code === "ERR_MODULE_NOT_FOUND") {
       const tried = err.url && err.url.startsWith("file:")
@@ -339,10 +351,11 @@ function transformServerFns(code, path) {
   return rewriteServerFns(code, rel);
 }
 
-export async function load(url, context, next) {
+export function load(url, context, next) {
+  if (isRequire(context)) return next(url, context);
   if (url.startsWith(VIRTUAL_SCHEME)) {
     const rid = decodeURIComponent(url.slice(VIRTUAL_SCHEME.length));
-    const code = container ? await container.load(rid) : null;
+    const code = container ? container.load(rid) : null;
     return { format: "module", source: code ?? emptyVirtualStub(APP, rid), shortCircuit: true };
   }
   const clean = stripQ(url);
@@ -377,7 +390,7 @@ export async function load(url, context, next) {
     }
     // A plugin load() overrides the on-disk file (Vite: load runs before fs read).
     // Its result can differ from the disk bytes, so it is what the key hashes.
-    let raw = userFile ? await container.load(path) : null;
+    let raw = userFile ? container.load(path) : null;
     if (raw == null) raw = diskRaw ?? readFileSync(path, "utf8");
     const key = cacheKey("ssr-loader", path, raw);
     if (raw !== diskRaw) {
@@ -385,7 +398,7 @@ export async function load(url, context, next) {
       if (hit != null) return { format: "module", source: hit, shortCircuit: true };
     }
     if (userFile) {
-      const t = await container.transformUserCode(raw, path);
+      const t = container.transformUserCode(raw, path);
       if (t != null) raw = t;
     }
     const src = transformServerFns(transformGlob(raw, path), path);
@@ -405,7 +418,7 @@ export async function load(url, context, next) {
   if (clean.endsWith(".svg")) {
     const path = fileURLToPath(clean);
     const id = /[?&]ojsvg=react/.test(url) ? path + "?react" : path;
-    const loaded = container ? await container.load(id) : null;
+    const loaded = container ? container.load(id) : null;
     const src = loaded != null ? loaded : `export default ${JSON.stringify("/@oj-start/fs" + path)};`;
     return { format: "module", source: src, shortCircuit: true };
   }
@@ -415,7 +428,7 @@ export async function load(url, context, next) {
     const key = cacheKey("ssr-loader-mdx", path, raw);
     const hit = cacheGet(key);
     if (hit != null) return { format: "module", source: hit, shortCircuit: true };
-    const compiled = await container.transform(raw, path);
+    const compiled = container.transform(raw, path);
     if (compiled != null) {
       const out = transformSync(path, compiled, {
         lang: "jsx", jsx: { runtime: "automatic" },
@@ -432,7 +445,7 @@ export async function load(url, context, next) {
   if (container && (clean.endsWith(".js") || clean.endsWith(".mjs"))) {
     const path = fileURLToPath(clean);
     if (!path.includes("/node_modules/")) {
-      const loaded = await container.load(path);
+      const loaded = container.load(path);
       if (loaded != null) {
         return { format: "module", source: transformGlob(loaded, path), shortCircuit: true };
       }
@@ -441,8 +454,8 @@ export async function load(url, context, next) {
   if (clean.startsWith("file:") && clean.includes("/node_modules/")) {
     const path = fileURLToPath(clean);
     if (isCjsFile(path)) {
-      // cjsFacade require()s the module on the loader thread just to
-      // enumerate export names; a hit skips that duplicate graph eval.
+      // cjsFacade require()s the module just to enumerate export names;
+      // a hit skips that duplicate graph eval.
       let key = null;
       try { key = cacheKey("ssr-loader-cjs", path, readFileSync(path)); } catch {}
       const hit = cacheGet(key);

--- a/crates/oj_server/src/assets/start/loader.mjs
+++ b/crates/oj_server/src/assets/start/loader.mjs
@@ -185,7 +185,9 @@ const ALIASES = {
   "#tanstack-start-entry": pathResolve(HERE, "start-entry.ts"),
   "#tanstack-start-plugin-adapters": pathResolve(HERE, "plugin-adapters.ts"),
   "#tanstack-start-server-fn-resolver": pathResolve(HERE, "server-fn-resolver.mjs"),
-  "tanstack-start-manifest:v": pathResolve(HERE, "manifest.ts"),
+  // Lazy manifest: reads css-urls.json per call, so the SSR runner can boot
+  // before bundle-client.mjs has collected the CSS URLs.
+  "tanstack-start-manifest:v": pathResolve(HERE, "manifest-dev.ts"),
   "@cloudflare/vite-plugin/server": pathResolve(HERE, "cf-server.mjs"),
 };
 

--- a/crates/oj_server/src/assets/start/manifest-dev.ts
+++ b/crates/oj_server/src/assets/start/manifest-dev.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+// Lazy CSS: bundle-client.mjs writes css-urls.json when the client bundle
+// finishes; reading it per call lets the SSR runner boot before the bundle.
+function cssUrls(): string[] {
+  try {
+    return JSON.parse(readFileSync(join(HERE, "css-urls.json"), "utf8"));
+  } catch {
+    return [];
+  }
+}
+
+export const tsrStartManifest = () => ({
+  routes: {
+    __root__: {
+      preloads: ["/@oj-start/client-entry.js"],
+      css: cssUrls(),
+      scripts: [{ attrs: { type: "module", async: true, src: "/@oj-start/client-entry.js" } }],
+    },
+  },
+});

--- a/crates/oj_server/src/assets/start/resolve-pkg.mjs
+++ b/crates/oj_server/src/assets/start/resolve-pkg.mjs
@@ -32,9 +32,9 @@ export async function importPkg(root, spec, preferred = []) {
   return m.default ?? m;
 }
 
-export function viteEnvDefine({ ssr = false, mode = "development" } = {}) {
+export function viteEnvDefine({ ssr = false, mode = "development", env: envSource = process.env } = {}) {
   const env = { MODE: mode, DEV: mode !== "production", PROD: mode === "production", SSR: !!ssr, BASE_URL: "/" };
-  for (const [k, v] of Object.entries(process.env)) if (k.startsWith("VITE_")) env[k] = v;
+  for (const [k, v] of Object.entries(envSource)) if (k.startsWith("VITE_")) env[k] = v;
   return { "import.meta.env": JSON.stringify(env) };
 }
 

--- a/crates/oj_server/src/assets/start/rolldown-assets.mjs
+++ b/crates/oj_server/src/assets/start/rolldown-assets.mjs
@@ -33,35 +33,41 @@ export function assetsPlugin({ mode = "dev", server = false, fsBase = "/@oj-star
   const urlFor = makeUrlFor({ mode, fsBase, emit });
   return {
     name: "oj-assets",
-    async resolveId(source, importer, options) {
-      if (options?.custom?.ojAsset) return null;
-      let tag = null;
-      if (/\?raw$/.test(source)) tag = "raw";
-      else if (/\?url$/.test(source)) tag = "url";
-      else if (/\?inline$/.test(source)) tag = "inline";
-      else if (ASSET_EXT.test(source)) tag = "url";
-      else if (/\.css(\?|$)/.test(source)) tag = "css";
-      if (!tag) return null;
-      const clean = source.replace(SUFFIX, "").replace(/\?.*$/, "");
-      const r = await this.resolve(clean, importer, { skipSelf: true, custom: { ojAsset: true } });
-      if (!r) return null;
-      return V(tag, r.id);
+    resolveId: {
+      filter: { id: { include: [SUFFIX, ASSET_EXT, /\.css(\?|$)/] } },
+      async handler(source, importer, options) {
+        if (options?.custom?.ojAsset) return null;
+        let tag = null;
+        if (/\?raw$/.test(source)) tag = "raw";
+        else if (/\?url$/.test(source)) tag = "url";
+        else if (/\?inline$/.test(source)) tag = "inline";
+        else if (ASSET_EXT.test(source)) tag = "url";
+        else if (/\.css(\?|$)/.test(source)) tag = "css";
+        if (!tag) return null;
+        const clean = source.replace(SUFFIX, "").replace(/\?.*$/, "");
+        const r = await this.resolve(clean, importer, { skipSelf: true, custom: { ojAsset: true } });
+        if (!r) return null;
+        return V(tag, r.id);
+      },
     },
-    async load(id) {
-      const v = parseV(id);
-      if (!v) return null;
-      const js = (code) => ({ code, moduleType: "js" });
-      if (v.tag === "raw") return js(`export default ${JSON.stringify(readFileSync(v.path, "utf8"))};`);
-      if (v.tag === "url") return js(`export default ${JSON.stringify(await urlFor(v.path))};`);
-      if (v.tag === "inline") return js(`export default ${JSON.stringify(dataUri(v.path))};`);
-      if (v.tag === "css") {
-        if (!server) {
-          const href = await urlFor(v.path);
-          if (cssUrls && !cssUrls.includes(href)) cssUrls.push(href);
+    load: {
+      filter: { id: /^\0oj-(raw|url|inline|css):/ },
+      async handler(id) {
+        const v = parseV(id);
+        if (!v) return null;
+        const js = (code) => ({ code, moduleType: "js" });
+        if (v.tag === "raw") return js(`export default ${JSON.stringify(readFileSync(v.path, "utf8"))};`);
+        if (v.tag === "url") return js(`export default ${JSON.stringify(await urlFor(v.path))};`);
+        if (v.tag === "inline") return js(`export default ${JSON.stringify(dataUri(v.path))};`);
+        if (v.tag === "css") {
+          if (!server) {
+            const href = await urlFor(v.path);
+            if (cssUrls && !cssUrls.includes(href)) cssUrls.push(href);
+          }
+          return js("export default {};");
         }
-        return js("export default {};");
-      }
-      return null;
+        return null;
+      },
     },
   };
 }
@@ -84,71 +90,82 @@ export function makeVitePlugins({ container, fallback, appRoot, mode = "dev", fs
       if (container?.buildStart) await container.buildStart();
       if (fallback?.buildStart && fallback !== container) await fallback.buildStart();
     },
-    async resolveId(source, importer, options) {
-      if (options?.custom?.ojSvg) return null;
-      if (/\.svg\?react$/.test(source)) {
-        const r = await this.resolve(source.slice(0, -"?react".length), importer, {
-          skipSelf: true,
-          custom: { ojSvg: true },
-        });
-        return r ? V("svg-react", r.id) : null;
-      }
-      if (!container) return null;
-      if (/^virtual:/.test(source) || source.startsWith("\0")) {
-        if (parseV(source)) return null;
-        const rid = await container.resolveId(source, importer);
-        return rid ? V("vite-virtual", rid) : null;
-      }
-      return null;
-    },
-    async load(id) {
-      const v = parseV(id);
-      if (v && v.tag === "svg-react") return svgModule(v.path, v.path + "?react");
-      if (v && v.tag === "vite-virtual") {
-        let code = await container.load(v.path);
-        if (code == null && fallback) code = await fallback.load(v.path);
-        if (code == null) {
-          if (!warnedVirtual.has(v.path)) {
-            warnedVirtual.add(v.path);
-            process.stderr.write(
-              `oj: plugin virtual "${v.path}" produced no content in the dev client bundle; ` +
-                `emitting an empty module. This virtual likely needs the full build graph oj does not run in dev.\n`,
-            );
-          }
-          return { code: emptyVirtualStub(appRoot, v.path), moduleType: "js" };
+    resolveId: {
+      filter: { id: { include: [/\.svg\?react$/, /^virtual:/, /^\0/] } },
+      async handler(source, importer, options) {
+        if (options?.custom?.ojSvg) return null;
+        if (/\.svg\?react$/.test(source)) {
+          const r = await this.resolve(source.slice(0, -"?react".length), importer, {
+            skipSelf: true,
+            custom: { ojSvg: true },
+          });
+          return r ? V("svg-react", r.id) : null;
         }
-        return { code, moduleType: "jsx" };
-      }
-      if (/\.svg$/.test(id) && !id.startsWith("\0")) return svgModule(id, id);
-      // A user plugin's load() may override a real on-disk source file (Vite:
-      // load runs before the fs read). Consult it for user files in the build
-      // too, so compile-on-startup plugins produce the same output as dev.
-      if (container && !id.startsWith("\0") && !id.includes("/node_modules/")) {
-        const cleanId = id.replace(/\?.*$/, "");
-        if (/\.(jsx?|mjs|tsx?)$/.test(cleanId)) {
-          let code = await container.load(cleanId);
-          if (code == null && fallback) code = await fallback.load(cleanId);
-          if (code != null) {
-            const moduleType = cleanId.endsWith(".tsx")
-              ? "tsx"
-              : cleanId.endsWith(".ts")
-                ? "ts"
-                : cleanId.endsWith(".jsx")
-                  ? "jsx"
-                  : "js";
-            return { code, moduleType };
+        if (!container) return null;
+        if (/^virtual:/.test(source) || source.startsWith("\0")) {
+          if (parseV(source)) return null;
+          const rid = await container.resolveId(source, importer);
+          return rid ? V("vite-virtual", rid) : null;
+        }
+        return null;
+      },
+    },
+    load: {
+      // The lookahead mirrors the in-handler node_modules bail for the
+      // user-file branch; \0 and .svg ids stay unrestricted.
+      filter: { id: { include: [/^\0oj-/, /\.svg$/, /^(?!.*\/node_modules\/).*\.(jsx?|mjs|tsx?)(\?|$)/] } },
+      async handler(id) {
+        const v = parseV(id);
+        if (v && v.tag === "svg-react") return svgModule(v.path, v.path + "?react");
+        if (v && v.tag === "vite-virtual") {
+          let code = await container.load(v.path);
+          if (code == null && fallback) code = await fallback.load(v.path);
+          if (code == null) {
+            if (!warnedVirtual.has(v.path)) {
+              warnedVirtual.add(v.path);
+              process.stderr.write(
+                `oj: plugin virtual "${v.path}" produced no content in the dev client bundle; ` +
+                  `emitting an empty module. This virtual likely needs the full build graph oj does not run in dev.\n`,
+              );
+            }
+            return { code: emptyVirtualStub(appRoot, v.path), moduleType: "js" };
+          }
+          return { code, moduleType: "jsx" };
+        }
+        if (/\.svg$/.test(id) && !id.startsWith("\0")) return svgModule(id, id);
+        // A user plugin's load() may override a real on-disk source file (Vite:
+        // load runs before the fs read). Consult it for user files in the build
+        // too, so compile-on-startup plugins produce the same output as dev.
+        if (container && !id.startsWith("\0") && !id.includes("/node_modules/")) {
+          const cleanId = id.replace(/\?.*$/, "");
+          if (/\.(jsx?|mjs|tsx?)$/.test(cleanId)) {
+            let code = await container.load(cleanId);
+            if (code == null && fallback) code = await fallback.load(cleanId);
+            if (code != null) {
+              const moduleType = cleanId.endsWith(".tsx")
+                ? "tsx"
+                : cleanId.endsWith(".ts")
+                  ? "ts"
+                  : cleanId.endsWith(".jsx")
+                    ? "jsx"
+                    : "js";
+              return { code, moduleType };
+            }
           }
         }
-      }
-      return null;
+        return null;
+      },
     },
-    async transform(code, id) {
-      if (!container) return null;
-      if (/\.mdx?$/.test(id)) {
-        const out = await container.transform(code, id);
-        return out == null ? null : out;
-      }
-      return null;
+    transform: {
+      filter: { id: /\.mdx?$/ },
+      async handler(code, id) {
+        if (!container) return null;
+        if (/\.mdx?$/.test(id)) {
+          const out = await container.transform(code, id);
+          return out == null ? null : out;
+        }
+        return null;
+      },
     },
   };
 }
@@ -184,13 +201,19 @@ function shimSource(spec) {
 }
 export const nodeBuiltinShims = {
   name: "node-builtin-shims",
-  resolveId(source) {
-    if (/^node:/.test(source) || BARE_BUILTINS.test(source)) return V("node-shim", source);
-    return null;
+  resolveId: {
+    filter: { id: { include: [/^node:/, BARE_BUILTINS] } },
+    handler(source) {
+      if (/^node:/.test(source) || BARE_BUILTINS.test(source)) return V("node-shim", source);
+      return null;
+    },
   },
-  load(id) {
-    const v = parseV(id);
-    return v && v.tag === "node-shim" ? { code: shimSource(v.path), moduleType: "js" } : null;
+  load: {
+    filter: { id: /^\0oj-node-shim:/ },
+    handler(id) {
+      const v = parseV(id);
+      return v && v.tag === "node-shim" ? { code: shimSource(v.path), moduleType: "js" } : null;
+    },
   },
 };
 

--- a/crates/oj_server/src/assets/start/runner.mjs
+++ b/crates/oj_server/src/assets/start/runner.mjs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-import { register } from "node:module";
+import module, { register } from "node:module";
+import { fstatSync } from "node:fs";
 import { pathToFileURL, fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { MessageChannel } from "node:worker_threads";
@@ -26,6 +27,19 @@ let handler = (await import(ENTRY)).default;
 const _ojTTY = process.stderr.isTTY && !process.env.NO_COLOR;
 const OJ = _ojTTY ? "\x1b[48;2;255;255;255m\x1b[1;38;2;42;51;212m oj \x1b[0m" : "oj";
 process.stderr.write(`${OJ} start runner: ready\n`);
+
+// stdin EOF means oj died without tearing us down (SIGKILL skips
+// kill_on_drop): exit instead of idling as an orphan.
+const onParentGone = () => {
+  try { module.flushCompileCache?.(); } catch {}
+  process.exit(0);
+};
+try {
+  if (fstatSync(0).isFIFO()) {
+    process.stdin.once("end", onParentGone);
+    process.stdin.once("close", onParentGone);
+  }
+} catch {}
 
 const rl = readline.createInterface({ input: process.stdin });
 for await (const line of rl) {

--- a/crates/oj_server/src/assets/start/runner.mjs
+++ b/crates/oj_server/src/assets/start/runner.mjs
@@ -35,7 +35,8 @@ const onParentGone = () => {
   process.exit(0);
 };
 try {
-  if (fstatSync(0).isFIFO()) {
+  // bigint keeps the FIFO mode out of the shared stat buffer fs.realpathSync reads mid-walk
+  if (fstatSync(0, { bigint: true }).isFIFO()) {
     process.stdin.once("end", onParentGone);
     process.stdin.once("close", onParentGone);
   }

--- a/crates/oj_server/src/assets/start/runner.mjs
+++ b/crates/oj_server/src/assets/start/runner.mjs
@@ -10,6 +10,17 @@ import readline from "node:readline";
 process.env.TSS_SERVER_FN_BASE ??= "/_serverFn/";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
+const APP = process.env.OJ_APP_ROOT ?? process.cwd();
+// Opt-in: measured on a large app, the bytecode cache costs more per boot
+// (read + deserialize + produce for ~6k modules) than the ~0.7s compile it
+// saves. Env var too: the loader runs on a worker thread reading it at spawn.
+if (process.env.OJ_V8_COMPILE_CACHE === "on") {
+  try {
+    const v8Dir = join(APP, ".oj-cache", "v8");
+    process.env.NODE_COMPILE_CACHE ??= v8Dir;
+    module.enableCompileCache?.(v8Dir);
+  } catch {}
+}
 const ENTRY = pathToFileURL(process.env.OJ_RUNNER_ENTRY || join(HERE, "server-entry.tsx")).href;
 const LOADER = pathToFileURL(process.env.OJ_RUNNER_LOADER || join(HERE, "loader.mjs")).href;
 const { port1, port2 } = new MessageChannel();
@@ -22,8 +33,11 @@ register(LOADER, {
 const send = process.stdout.write.bind(process.stdout);
 process.stdout.write = process.stderr.write.bind(process.stderr);
 
+const flushV8 = () => { try { module.flushCompileCache?.(); } catch {} };
 let version = 0;
+let statsSent = false;
 let handler = (await import(ENTRY)).default;
+flushV8();
 const _ojTTY = process.stderr.isTTY && !process.env.NO_COLOR;
 const OJ = _ojTTY ? "\x1b[48;2;255;255;255m\x1b[1;38;2;42;51;212m oj \x1b[0m" : "oj";
 process.stderr.write(`${OJ} start runner: ready\n`);
@@ -51,6 +65,7 @@ for await (const line of rl) {
       version += 1;
       port1.postMessage(version);
       handler = (await import(`${ENTRY}?ojv=${version}`)).default;
+      flushV8();
       send(JSON.stringify({ reloaded: true }) + "\n");
     } catch (e) {
       send(JSON.stringify({ reloaded: false, error: String((e && e.stack) || e) }) + "\n");
@@ -66,6 +81,7 @@ for await (const line of rl) {
     const headers = {};
     res.headers.forEach((v, k) => { headers[k] = v; });
     send(JSON.stringify({ id: msg.id, status: res.status, headers, body }) + "\n");
+    if (!statsSent) { statsSent = true; port1.postMessage("stats"); flushV8(); }
   } catch (e) {
     send(JSON.stringify({ id: msg.id, status: 500, headers: {}, body: String((e && e.stack) || e) }) + "\n");
   }

--- a/crates/oj_server/src/assets/start/runner.mjs
+++ b/crates/oj_server/src/assets/start/runner.mjs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MIT
 
-import module, { register } from "node:module";
+import module from "node:module";
 import { fstatSync } from "node:fs";
 import { pathToFileURL, fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { MessageChannel } from "node:worker_threads";
 import readline from "node:readline";
 
 process.env.TSS_SERVER_FN_BASE ??= "/_serverFn/";
@@ -18,7 +17,7 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const APP = process.env.OJ_APP_ROOT ?? process.cwd();
 // Opt-in: measured on a large app, the bytecode cache costs more per boot
 // (read + deserialize + produce for ~6k modules) than the ~0.7s compile it
-// saves. Env var too: the loader runs on a worker thread reading it at spawn.
+// saves.
 if (process.env.OJ_V8_COMPILE_CACHE === "on") {
   try {
     const v8Dir = join(APP, ".oj-cache", "v8");
@@ -28,12 +27,11 @@ if (process.env.OJ_V8_COMPILE_CACHE === "on") {
 }
 const ENTRY = pathToFileURL(process.env.OJ_RUNNER_ENTRY || join(HERE, "server-entry.tsx")).href;
 const LOADER = pathToFileURL(process.env.OJ_RUNNER_LOADER || join(HERE, "loader.mjs")).href;
-const { port1, port2 } = new MessageChannel();
-register(LOADER, {
-  parentURL: pathToFileURL(HERE + "/").href,
-  data: { port: port2 },
-  transferList: [port2],
-});
+// In-thread synchronous hooks (registerHooks, Node 22.15+/23.5+): no hooks
+// worker, no sync-IPC round-trip per resolve/load. The loader itself is
+// imported before registration, so its own dependency graph loads unhooked.
+const loaderApi = await import(LOADER);
+module.registerHooks({ resolve: loaderApi.resolve, load: loaderApi.load });
 
 const send = process.stdout.write.bind(process.stdout);
 process.stdout.write = process.stderr.write.bind(process.stderr);
@@ -43,6 +41,7 @@ let version = 0;
 let statsSent = false;
 let handler = (await import(ENTRY)).default;
 flushV8();
+loaderApi.flushCaches();
 const _ojTTY = process.stderr.isTTY && !process.env.NO_COLOR;
 const OJ = _ojTTY ? "\x1b[48;2;255;255;255m\x1b[1;38;2;42;51;212m oj \x1b[0m" : "oj";
 process.stderr.write(`${OJ} start runner: ready\n`);
@@ -68,9 +67,10 @@ for await (const line of rl) {
   if (msg.cmd === "reload") {
     try {
       version += 1;
-      port1.postMessage(version);
+      loaderApi.setVersion(version);
       handler = (await import(`${ENTRY}?ojv=${version}`)).default;
       flushV8();
+      loaderApi.flushCaches();
       send(JSON.stringify({ reloaded: true }) + "\n");
     } catch (e) {
       send(JSON.stringify({ reloaded: false, error: String((e && e.stack) || e) }) + "\n");
@@ -86,7 +86,8 @@ for await (const line of rl) {
     const headers = {};
     res.headers.forEach((v, k) => { headers[k] = v; });
     send(JSON.stringify({ id: msg.id, status: res.status, headers, body }) + "\n");
-    if (!statsSent) { statsSent = true; port1.postMessage("stats"); flushV8(); }
+    loaderApi.flushCaches();
+    if (!statsSent) { statsSent = true; loaderApi.reportCacheStats(); flushV8(); }
   } catch (e) {
     send(JSON.stringify({ id: msg.id, status: 500, headers: {}, body: String((e && e.stack) || e) }) + "\n");
   }

--- a/crates/oj_server/src/assets/start/runner.mjs
+++ b/crates/oj_server/src/assets/start/runner.mjs
@@ -8,6 +8,11 @@ import { MessageChannel } from "node:worker_threads";
 import readline from "node:readline";
 
 process.env.TSS_SERVER_FN_BASE ??= "/_serverFn/";
+// Vite dev sets this too: start-server-core then resolves the manifest per
+// request instead of caching the first render's (possibly CSS-less) result.
+process.env.TSS_DEV_SERVER ??= "true";
+// oj serves no dev-styles endpoint, so keep that <link> injection off.
+process.env.TSS_DEV_SSR_STYLES_ENABLED ??= "false";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const APP = process.env.OJ_APP_ROOT ?? process.cwd();

--- a/crates/oj_server/src/assets/start/runner.mjs
+++ b/crates/oj_server/src/assets/start/runner.mjs
@@ -31,7 +31,7 @@ const LOADER = pathToFileURL(process.env.OJ_RUNNER_LOADER || join(HERE, "loader.
 // worker, no sync-IPC round-trip per resolve/load. The loader itself is
 // imported before registration, so its own dependency graph loads unhooked.
 const loaderApi = await import(LOADER);
-module.registerHooks({ resolve: loaderApi.resolve, load: loaderApi.load });
+if (loaderApi.resolve || loaderApi.load) module.registerHooks({ resolve: loaderApi.resolve, load: loaderApi.load });
 
 const send = process.stdout.write.bind(process.stdout);
 process.stdout.write = process.stderr.write.bind(process.stderr);
@@ -41,7 +41,7 @@ let version = 0;
 let statsSent = false;
 let handler = (await import(ENTRY)).default;
 flushV8();
-loaderApi.flushCaches();
+loaderApi.flushCaches?.();
 const _ojTTY = process.stderr.isTTY && !process.env.NO_COLOR;
 const OJ = _ojTTY ? "\x1b[48;2;255;255;255m\x1b[1;38;2;42;51;212m oj \x1b[0m" : "oj";
 process.stderr.write(`${OJ} start runner: ready\n`);
@@ -67,10 +67,10 @@ for await (const line of rl) {
   if (msg.cmd === "reload") {
     try {
       version += 1;
-      loaderApi.setVersion(version);
+      loaderApi.setVersion?.(version);
       handler = (await import(`${ENTRY}?ojv=${version}`)).default;
       flushV8();
-      loaderApi.flushCaches();
+      loaderApi.flushCaches?.();
       send(JSON.stringify({ reloaded: true }) + "\n");
     } catch (e) {
       send(JSON.stringify({ reloaded: false, error: String((e && e.stack) || e) }) + "\n");
@@ -86,8 +86,21 @@ for await (const line of rl) {
     const headers = {};
     res.headers.forEach((v, k) => { headers[k] = v; });
     send(JSON.stringify({ id: msg.id, status: res.status, headers, body }) + "\n");
-    loaderApi.flushCaches();
-    if (!statsSent) { statsSent = true; loaderApi.reportCacheStats(); flushV8(); }
+    loaderApi.flushCaches?.();
+    if (!statsSent) {
+      statsSent = true;
+      loaderApi.reportCacheStats?.();
+      flushV8();
+      if (process.env.OJ_SSR_MEM_STATS === "1") {
+        const v8 = await import("node:v8");
+        const stats = {
+          rss: process.memoryUsage.rss(),
+          heap: v8.default.getHeapStatistics(),
+          loader: loaderApi.memStats?.() ?? null,
+        };
+        process.stderr.write(`oj ssr memstats: ${JSON.stringify(stats)}\n`);
+      }
+    }
   } catch (e) {
     send(JSON.stringify({ id: msg.id, status: 500, headers: {}, body: String((e && e.stack) || e) }) + "\n");
   }

--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -87,7 +87,7 @@ async function withBuildStartLock(fn) {
   finally { try { rmSync(lock, { recursive: true, force: true }); } catch {} }
 }
 
-function findConfig(app) {
+export function findConfig(app) {
   for (const f of CONFIG_FILES) {
     const p = join(app, f);
     if (existsSync(p)) return p;

--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -97,6 +97,7 @@ export async function loadPluginContainer(app, { command = "serve", mode = "deve
   // and oj serves an export-less stub — surfacing downstream as an undefined
   // import. Mirror Vite's shape so those plugins take their intended branch.
   const consumer = environment === "client" ? "client" : "server";
+  const watchFiles = new Set();
   const ctx = {
     environment: {
       name: environment,
@@ -108,7 +109,7 @@ export async function loadPluginContainer(app, { command = "serve", mode = "deve
     error(m) { throw new Error(typeof m === "string" ? m : m?.message ?? String(m)); },
     emitFile() { return "oj-emit-ref"; },
     setAssetSource() {}, getFileName() { return ""; },
-    addWatchFile() {}, getWatchFiles() { return []; },
+    addWatchFile(id) { watchFiles.add(String(id)); }, getWatchFiles() { return [...watchFiles]; },
     getModuleInfo() { return null; }, getModuleIds() { return [][Symbol.iterator](); },
     async resolve() { return null; }, async load() { return null; },
     parse,
@@ -210,7 +211,8 @@ export async function loadPluginContainer(app, { command = "serve", mode = "deve
   }
 
   const publicDir = typeof loaded?.config?.publicDir === "string" ? loaded.config.publicDir : null;
-  return { resolveId, load, transform, transformUserCode, buildStart, generateBundle, publicDir, pluginCount: plugins.length };
+  const configDependencies = [configFile, ...(loaded?.dependencies ?? [])];
+  return { resolveId, load, transform, transformUserCode, buildStart, generateBundle, publicDir, pluginCount: plugins.length, watchFiles, configDependencies };
 }
 
 export const __test = { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows };

--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 
 import { importPkg } from "./resolve-pkg.mjs";
-import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 process.env.VITE_CONFIG_NATIVE_IGNORE_WARNING ??= "true";
 
@@ -57,6 +58,33 @@ function ordered(plugins) {
     else normal.push(p);
   }
   return [...pre, ...normal, ...post];
+}
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+// The SSR loader and the client bundler are separate processes whose user-
+// plugin buildStart runs now overlap (the runner spawns concurrently with the
+// bundle); plugins that compile to shared on-disk state must not interleave.
+// Cross-process single-flight: mkdir is the atomic acquire, a dead holder's
+// lock is stolen so a crashed process can't wedge the other one.
+async function withBuildStartLock(fn) {
+  const lock = join(HERE, "buildstart.lock");
+  for (;;) {
+    try { mkdirSync(lock); break; }
+    catch {
+      let pid = 0;
+      try { pid = Number(readFileSync(join(lock, "holder"), "utf8")); } catch {}
+      let alive = false;
+      if (pid) { try { process.kill(pid, 0); alive = true; } catch {} }
+      let expired = false;
+      try { expired = Date.now() - statSync(lock).mtimeMs > 300_000; } catch {}
+      if ((pid && !alive) || expired) { try { rmSync(lock, { recursive: true, force: true }); } catch {} }
+      else await new Promise((r) => setTimeout(r, 50));
+    }
+  }
+  try { writeFileSync(join(lock, "holder"), String(process.pid)); } catch {}
+  try { return await fn(); }
+  finally { try { rmSync(lock, { recursive: true, force: true }); } catch {} }
 }
 
 function findConfig(app) {
@@ -193,21 +221,23 @@ export async function loadPluginContainer(app, { command = "serve", mode = "deve
   async function buildStart() {
     if (buildStarted) return;
     buildStarted = true;
-    for (const p of plugins) {
-      if (ojReimplemented(p.name) || !envAllows(p, environment)) continue;
-      const h = hookHandler(p.buildStart);
-      if (!h) continue;
-      // Degrade gracefully: oj's plugin context is minimal (e.g. a stubbed
-      // this.resolve), so some plugins' buildStart throw here though they'd
-      // succeed under full Vite. Log and continue rather than abort the whole
-      // dev server — a plugin that genuinely needed buildStart will surface as
-      // its own load() output being wrong, which is strictly better than one
-      // unsupported plugin taking down every other plugin's startup.
-      try { await h.call(ctx, {}); }
-      catch (e) {
-        process.stderr.write(`oj: plugin "${p.name || "?"}" buildStart failed (skipped): ${(e && e.message) || e}\n`);
+    await withBuildStartLock(async () => {
+      for (const p of plugins) {
+        if (ojReimplemented(p.name) || !envAllows(p, environment)) continue;
+        const h = hookHandler(p.buildStart);
+        if (!h) continue;
+        // Degrade gracefully: oj's plugin context is minimal (e.g. a stubbed
+        // this.resolve), so some plugins' buildStart throw here though they'd
+        // succeed under full Vite. Log and continue rather than abort the whole
+        // dev server — a plugin that genuinely needed buildStart will surface as
+        // its own load() output being wrong, which is strictly better than one
+        // unsupported plugin taking down every other plugin's startup.
+        try { await h.call(ctx, {}); }
+        catch (e) {
+          process.stderr.write(`oj: plugin "${p.name || "?"}" buildStart failed (skipped): ${(e && e.message) || e}\n`);
+        }
       }
-    }
+    });
   }
 
   const publicDir = typeof loaded?.config?.publicDir === "string" ? loaded.config.publicDir : null;

--- a/crates/oj_server/src/assets/svelte-compile.mjs
+++ b/crates/oj_server/src/assets/svelte-compile.mjs
@@ -31,7 +31,8 @@ let inflight = 0;
 let stdinClosed = false;
 const maybeExit = () => { if (stdinClosed && inflight === 0) process.exit(0); };
 try {
-  if (fstatSync(0).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
+  // bigint keeps the FIFO mode out of the shared stat buffer fs.realpathSync reads mid-walk
+  if (fstatSync(0, { bigint: true }).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
 } catch {}
 rl.on("line", async (line) => {
   let msg;

--- a/crates/oj_server/src/assets/svelte-compile.mjs
+++ b/crates/oj_server/src/assets/svelte-compile.mjs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Raphael Amorim
 
 import { createRequire } from "node:module";
+import { fstatSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import path from "node:path";
 import readline from "node:readline";
@@ -24,6 +25,14 @@ async function toolchain(base) {
 }
 
 const rl = readline.createInterface({ input: process.stdin });
+// stdin EOF means the parent is gone (SIGKILL skips its teardown) or the
+// one-shot build path closed it: exit once no reply is in flight.
+let inflight = 0;
+let stdinClosed = false;
+const maybeExit = () => { if (stdinClosed && inflight === 0) process.exit(0); };
+try {
+  if (fstatSync(0).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
+} catch {}
 rl.on("line", async (line) => {
   let msg;
   try {
@@ -33,6 +42,7 @@ rl.on("line", async (line) => {
   }
   const { id, base, css: source, from } = msg;
   const dev = msg.dev !== false;
+  inflight += 1;
   try {
     const { compile, preprocess, preprocessors } = await toolchain(base);
     let code = source;
@@ -50,5 +60,8 @@ rl.on("line", async (line) => {
     process.stdout.write(JSON.stringify({ id, css: out.js.code }) + "\n");
   } catch (e) {
     process.stdout.write(JSON.stringify({ id, error: String((e && e.message) || e) }) + "\n");
+  } finally {
+    inflight -= 1;
+    maybeExit();
   }
 });

--- a/crates/oj_server/src/assets/tailwind-sidecar.mjs
+++ b/crates/oj_server/src/assets/tailwind-sidecar.mjs
@@ -75,7 +75,8 @@ if (process.argv[2] === "--once") {
   let stdinClosed = false;
   const maybeExit = () => { if (stdinClosed && inflight === 0) process.exit(0); };
   try {
-    if (fstatSync(0).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
+    // bigint keeps the FIFO mode out of the shared stat buffer fs.realpathSync reads mid-walk
+    if (fstatSync(0, { bigint: true }).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
   } catch {}
   rl.on("line", async (line) => {
     let msg;

--- a/crates/oj_server/src/assets/tailwind-sidecar.mjs
+++ b/crates/oj_server/src/assets/tailwind-sidecar.mjs
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 Raphael Amorim
 
 import { createRequire } from "node:module";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, fstatSync, readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import readline from "node:readline";
 
@@ -69,14 +69,26 @@ if (process.argv[2] === "--once") {
     .catch((err) => { console.error(String(err)); process.exit(1); });
 } else {
   const rl = readline.createInterface({ input: process.stdin });
+  // stdin EOF means the parent is gone (SIGKILL skips its teardown): exit
+  // once no reply is in flight instead of idling as an orphan.
+  let inflight = 0;
+  let stdinClosed = false;
+  const maybeExit = () => { if (stdinClosed && inflight === 0) process.exit(0); };
+  try {
+    if (fstatSync(0).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
+  } catch {}
   rl.on("line", async (line) => {
     let msg;
     try { msg = JSON.parse(line); } catch { return; }
+    inflight += 1;
     try {
       const css = await compileCss(msg.base, msg.css, msg.from);
       process.stdout.write(JSON.stringify({ id: msg.id, css }) + "\n");
     } catch (err) {
       process.stdout.write(JSON.stringify({ id: msg.id, error: String(err) }) + "\n");
+    } finally {
+      inflight -= 1;
+      maybeExit();
     }
   });
 }

--- a/crates/oj_server/src/assets/vite-extract.mjs
+++ b/crates/oj_server/src/assets/vite-extract.mjs
@@ -3,7 +3,7 @@
 
 import { createRequire } from "node:module";
 import { pathToFileURL } from "node:url";
-import { dirname } from "node:path";
+import { dirname, resolve } from "node:path";
 import { writeFileSync, readFileSync } from "node:fs";
 
 const configPath = process.argv[2];
@@ -37,6 +37,9 @@ function resolvePkg(spec) {
   return null;
 }
 
+const absDeps = (deps) =>
+  (deps ?? []).filter((d) => typeof d === "string").map((d) => resolve(appRoot, d));
+
 async function loadConfig() {
   let viteErr = null;
   const vitePath = resolvePkg("vite");
@@ -45,7 +48,9 @@ async function loadConfig() {
       const vite = await import(pathToFileURL(vitePath).href);
       if (typeof vite.loadConfigFromFile === "function") {
         const loaded = await vite.loadConfigFromFile({ command, mode }, configPath, appRoot);
-        if (loaded && loaded.config) return loaded.config;
+        if (loaded && loaded.config) {
+          return { config: loaded.config, deps: absDeps(loaded.dependencies) };
+        }
       }
     } catch (e) {
       viteErr = e;
@@ -60,6 +65,7 @@ async function loadConfig() {
     const r = await esbuild.build({
       entryPoints: [configPath], bundle: true, platform: "node", format: "esm",
       packages: "external", write: false, logLevel: "silent", absWorkingDir: appRoot,
+      metafile: true,
       define: {
         __dirname: JSON.stringify(dirname(configPath)),
         __filename: JSON.stringify(configPath),
@@ -68,10 +74,16 @@ async function loadConfig() {
     const out = `${appRoot}/.oj-cache/oj-vite-config.mjs`;
     writeFileSync(out, r.outputFiles[0].text);
     const m = await import(pathToFileURL(out).href);
-    return typeof m.default === "function" ? await m.default({ command, mode }) : m.default;
+    return {
+      config: typeof m.default === "function" ? await m.default({ command, mode }) : m.default,
+      deps: absDeps(Object.keys(r.metafile?.inputs ?? {})),
+    };
   }
   const m = await import(pathToFileURL(configPath).href);
-  return typeof m.default === "function" ? await m.default({ command, mode }) : m.default;
+  return {
+    config: typeof m.default === "function" ? await m.default({ command, mode }) : m.default,
+    deps: [],
+  };
 }
 
 function extractAlias(alias) {
@@ -142,10 +154,13 @@ function warnUnsupported(c) {
 }
 
 try {
-  const c = (await loadConfig()) ?? {};
+  const { config, deps } = (await loadConfig()) ?? {};
+  const c = config ?? {};
   warnUnsupported(c);
   process.stdout.write(
     JSON.stringify({
+      __ok: true,
+      __deps: deps ?? [],
       base: typeof c.base === "string" ? c.base : null,
       publicDir: typeof c.publicDir === "string" ? c.publicDir : null,
       port: typeof c.server?.port === "number" ? c.server.port : null,

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -148,6 +148,7 @@ const START_ASSETS: &[(&str, &str)] = &[
         include_str!("assets/start/plugin-adapters.ts"),
     ),
     ("manifest.ts", include_str!("assets/start/manifest.ts")),
+    ("manifest-dev.ts", include_str!("assets/start/manifest-dev.ts")),
 ];
 
 // V8 bytecode cache for every node child oj spawns; a user-set value wins.

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -159,6 +159,18 @@ const START_ASSETS: &[(&str, &str)] = &[
     ("manifest-dev.ts", include_str!("assets/start/manifest-dev.ts")),
 ];
 
+// Boot-phase timestamps (epoch ms) for profiling, enabled by OJ_BOOT_PHASES=1.
+pub fn boot_phase(label: &str) {
+    if std::env::var_os("OJ_BOOT_PHASES").is_none() {
+        return;
+    }
+    let ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    eprintln!("[oj-phase] {ms} {label}");
+}
+
 // V8 bytecode cache for every node child oj spawns; a user-set value wins.
 pub fn node_compile_cache(root: &Path) -> std::ffi::OsString {
     std::env::var_os("NODE_COMPILE_CACHE")
@@ -290,8 +302,10 @@ impl DevServer {
             plugins::set_vite_config_override(cfg);
         }
 
+        boot_phase("build_app begin");
         let mut config = oj_config::load(&root).map_err(|e| anyhow::anyhow!("{e}"))?;
         plugins::adopt_vite_config_values(&mut config, &root);
+        boot_phase("vite config values adopted");
 
         let env_prefix = config.env_prefix.as_deref().unwrap_or("VITE_");
         let env_dir = config
@@ -375,6 +389,7 @@ impl DevServer {
         let plugin_config = plugin_cfg.to_string();
         plugin_cfg["environment"]["name"] = serde_json::json!("ssr");
         let ssr_plugin_config = plugin_cfg.to_string();
+        boot_phase("plugin host spawning");
         let plugin_host = match plugins_path {
             Some(file) => match PluginHost::spawn(&root, &file, &plugin_config).await {
                 Ok(host) => {
@@ -404,6 +419,7 @@ impl DevServer {
             },
             None => None,
         };
+        boot_phase("plugin host ready");
         let plugin_mw_port = match &plugin_host {
             Some(host) => host.middleware_port().await,
             None => None,

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -150,6 +150,22 @@ const START_ASSETS: &[(&str, &str)] = &[
     ("manifest.ts", include_str!("assets/start/manifest.ts")),
 ];
 
+// V8 bytecode cache for every node child oj spawns; a user-set value wins.
+pub fn node_compile_cache(root: &Path) -> std::ffi::OsString {
+    std::env::var_os("NODE_COMPILE_CACHE")
+        .unwrap_or_else(|| root.join(".oj-cache").join("v8").into_os_string())
+}
+
+// The SSR runner and css-host pay more in V8 cache maintenance than they save
+// (measured net 1-3s cost), so for those services the cache is opt-in.
+pub fn node_compile_cache_opt_in(root: &Path) -> Option<std::ffi::OsString> {
+    let v = std::env::var_os("OJ_V8_COMPILE_CACHE")?;
+    if v.is_empty() || v == "0" {
+        return None;
+    }
+    Some(node_compile_cache(root))
+}
+
 pub fn write_start_assets(dir: &Path) -> std::io::Result<()> {
     std::fs::create_dir_all(dir)?;
     for (name, content) in START_ASSETS {

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -105,6 +105,14 @@ const START_ASSETS: &[(&str, &str)] = &[
         include_str!("assets/start/vite-plugin-bridge.mjs"),
     ),
     (
+        "container-bridge.mjs",
+        include_str!("assets/start/container-bridge.mjs"),
+    ),
+    (
+        "container-host.mjs",
+        include_str!("assets/start/container-host.mjs"),
+    ),
+    (
         "glob-transform.mjs",
         include_str!("assets/start/glob-transform.mjs"),
     ),

--- a/crates/oj_server/src/optimize.rs
+++ b/crates/oj_server/src/optimize.rs
@@ -186,6 +186,7 @@ async fn run_optimizer(
     let out = tokio::process::Command::new("node")
         .arg(&script)
         .arg(&cfg)
+        .env("NODE_COMPILE_CACHE", crate::node_compile_cache(root))
         .current_dir(root)
         .output()
         .await

--- a/crates/oj_server/src/plugins.rs
+++ b/crates/oj_server/src/plugins.rs
@@ -88,6 +88,23 @@ pub fn extract_vite_values(root: &Path) -> Option<ViteValues> {
         return None;
     }
     let vite = vite_config_file(root)?;
+    let store = oj_cache::config_extract::ConfigExtractStore::new(
+        root,
+        &format!(
+            "{}:{}",
+            env!("CARGO_PKG_VERSION"),
+            blake3::hash(VITE_EXTRACT_JS.as_bytes()).to_hex()
+        ),
+    );
+    if let Some(hit) = store.lookup(&vite, "serve", "development") {
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&hit.output) {
+            if !hit.stderr.is_empty() {
+                eprint!("{}", hit.stderr);
+            }
+            crate::boot_phase("vite-extract cache hit");
+            return Some(parse_vite_values(&json));
+        }
+    }
     let cache = root.join(".oj-cache");
     let _ = std::fs::create_dir_all(&cache);
     let script = cache.join("oj-vite-extract.mjs");
@@ -102,10 +119,31 @@ pub fn extract_vite_values(root: &Path) -> Option<ViteValues> {
         .current_dir(root)
         .output()
         .ok()?;
-    if !out.stderr.is_empty() {
-        eprint!("{}", String::from_utf8_lossy(&out.stderr));
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    if !stderr.is_empty() {
+        eprint!("{stderr}");
     }
     let json: serde_json::Value = serde_json::from_slice(&out.stdout).ok()?;
+    if json.get("__ok").and_then(|v| v.as_bool()) == Some(true) {
+        let deps: Vec<PathBuf> = json
+            .get("__deps")
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|d| d.as_str().map(PathBuf::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        store.store(
+            &vite,
+            "serve",
+            "development",
+            &deps,
+            &String::from_utf8_lossy(&out.stdout),
+            &stderr,
+        );
+    }
+    crate::boot_phase("vite-extract cache miss (subprocess ran)");
     Some(parse_vite_values(&json))
 }
 

--- a/crates/oj_server/src/plugins.rs
+++ b/crates/oj_server/src/plugins.rs
@@ -98,6 +98,7 @@ pub fn extract_vite_values(root: &Path) -> Option<ViteValues> {
         .arg(root)
         .arg("serve")
         .arg("development")
+        .env("NODE_COMPILE_CACHE", crate::node_compile_cache(root))
         .current_dir(root)
         .output()
         .ok()?;
@@ -342,6 +343,7 @@ impl PluginHost {
             .arg(&script)
             .arg(plugins_file)
             .arg(config_json)
+            .env("NODE_COMPILE_CACHE", crate::node_compile_cache(root))
             .current_dir(root)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())

--- a/crates/oj_server/src/sidecar.rs
+++ b/crates/oj_server/src/sidecar.rs
@@ -72,6 +72,7 @@ impl Sidecar {
 
         let mut child = tokio::process::Command::new("node")
             .arg(&script)
+            .env("NODE_COMPILE_CACHE", crate::node_compile_cache(root))
             .current_dir(root)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())

--- a/e2e/start.mjs
+++ b/e2e/start.mjs
@@ -25,7 +25,18 @@ if (!installed) {
 }
 
 execSync("cargo build -p oj", { cwd: repo, stdio: "inherit" });
-const rm = (p) => fs.rmSync(p, { recursive: true, force: true });
+// Retried: SIGKILLed servers orphan node children for a beat, and their
+// NODE_COMPILE_CACHE flush into .oj-cache/v8 races the removal (ENOTEMPTY).
+const rm = (p) => {
+  for (let i = 0; ; i++) {
+    try {
+      return fs.rmSync(p, { recursive: true, force: true });
+    } catch (e) {
+      if (i >= 20) throw e;
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
+    }
+  }
+};
 
 const get = async (port, route = "/") => {
   const res = await fetch(`http://localhost:${port}${route}`);


### PR DESCRIPTION
Part 12 of 16 in a series. Depends on #20 — this PR's diff includes the commits of the PRs below it in the series; to see only this part: https://github.com/aeriksson-lovable/oj/compare/pr/09-config-extract-cache...pr/10-memory-pass. Series overview in #12.

---

Depends on #19 ("run SSR loader hooks in-thread via
module.registerHooks"): that PR introduces the JSONL load pack this PR
changes.

## Problem

Definitions first. The runner is the Node.js process that executes the
app's server code in start mode. oj spawns it from
`crates/oj/src/start_dev.rs`. The loader
(`crates/oj_server/src/assets/start/loader.mjs`) runs inside the runner and
serves every module resolve and load. The load pack is the loader's warm
cache for compiled module sources: one JSONL file at
`.oj-cache/ssr-load-pack.jsonl`. Its header line carries the epoch, a hash
of the config and lockfiles. Each following line is one pack entry:
`{"k":"<64-hex key>","c":"<compiled source>"}`. The per-entry cache (one
JSON file per key under `.oj-cache/`) stays authoritative; the pack only
batches it. (A later pack-integrity PR frames each line with a
length + payload-hash prefix and a format-version header; the offset index
and pread path are unchanged.)

Before this change, the loader read the pack file once at init and stored
every entry's compiled source in a `Map` for the process lifetime. On our
test app this `Map` held about 20 million characters. The `Map` also grew
without bound during a dev session: `rememberPack` added an entry for every
newly compiled module, and no entry was ever removed. Entries that a boot
never serves — modules superseded by edits within one epoch, and routes
that a session never evaluates — stayed in memory forever.

We measured before changing anything. Steady-state RSS per process (warm
boot, 18,600-module app, macOS arm64; conditions in Performance below):

| Process | RSS after first 200 | RSS settled |
| --- | --- | --- |
| runner | 1,096 MB | 746 MB |
| plugin host | 620 MB | 472 MB |
| css host | 41 MB | 41 MB |
| oj (Rust) | 31 MB | 31 MB |
| total | 1,788 MB | — |

Heap snapshots of the runner attributed the pack's 20 million characters.
The result was negative for the obvious suspect: entries that a boot serves
alias the module sources V8 already retains for loaded scripts. Deleting
those entries after they were served freed only about 0.2 MB. The real cost
is the entries that are never served, plus the unbounded growth. So the fix
targets retention and growth, not the served entries.

## Change

The loader now indexes the pack file instead of materializing it.

1. At init, the loader reads the pack file once. For each valid line it
   records only the byte offset and length in a new `packIndex` `Map`. A
   valid line starts with `{`, is longer than 70 bytes, and carries a
   64-hex key at the fixed position bytes 6–70. Invalid lines are skipped.
2. The loader opens the pack file read-only and keeps the file descriptor
   for the process lifetime.
3. A cache hit calls `packGet(key)`. It checks the in-memory `Map` first,
   then the index. An index hit is one positioned `readSync` (a single
   `pread`) from the open descriptor, then one `JSON.parse`. The parsed
   entry must repeat the key and hold a string source; otherwise the loader
   deletes the index entry and reports a miss.
4. A miss falls through to the per-entry cache, unchanged. Such hits are
   re-appended to the pack, so the pack still converges.
5. New entries keep their source in memory only until the next flush.
   `flushLoadPack` appends the batch to the file, records each entry's byte
   offset in `packIndex`, and deletes the in-memory source. Steady state
   therefore holds offsets, not sources.
6. `OJ_SSR_MEM_STATS=1` adds a one-shot diagnostic. After the first
   rendered response, the runner prints one stderr line with its RSS, its
   V8 heap statistics, the loader's own accounting (`packIndexEntries`,
   `packMemEntries`, `packMemChars`, `resolveEntries`, `resolveChars`), and
   the plugin-container worker's heap via a new `__heap` bridge call.
7. A small fix rides along: a stub loader set via `OJ_RUNNER_LOADER` (the
   test `e2e/unit/runner-protocol.test.mjs` uses one) exports none of
   `resolve` / `load` / `flushCaches` / `setVersion` / `reportCacheStats`.
   The runner crashed on the `flushCaches` call before it printed ready.
   All loader API calls are now optional.

Files changed:

| Path | Change |
| --- | --- |
| `crates/oj_server/src/assets/start/loader.mjs` | Pack init indexes byte offsets; `packGet` serves hits with one `pread`; flush moves entries to the index and drops sources; new `memStats()` export. |
| `crates/oj_server/src/assets/start/runner.mjs` | All loader API calls optional (stub-loader fix); `OJ_SSR_MEM_STATS=1` one-shot diagnostic after the first response. |
| `crates/oj_server/src/assets/start/container-bridge.mjs` | New `heap()` bridge method. |
| `crates/oj_server/src/assets/start/container-host.mjs` | `__heap` handler returns `v8.getHeapStatistics()` for the container worker. |

## Correctness

The per-entry cache stays authoritative. Every failure path in `packGet`
degrades to a miss: a failed read, a failed parse, a key mismatch, or a
non-string source deletes the index entry and falls through to the
per-entry cache. A miss that hits the per-entry cache re-appends the entry,
so the pack heals itself.

Edge cases:

- Corrupt or truncated line: skipped at init by the shape check, or
  rejected in `packGet` by the key/type check. Result is a per-entry-cache
  hit, not a failure.
- Epoch mismatch: the whole pack is ignored, as before this change.
- Read-during-append: appends run on a serialized promise chain
  (`packFlushChain`). An entry enters `packIndex` only after its append
  completes, so a recorded offset always points at fully written bytes.
- Fresh epoch: the first flush rewrites the file with a new header. The
  descriptor opens after that write, so it never points at a replaced file.
- Stub loaders: `module.registerHooks` is called only when the loader
  exports `resolve` or `load`; all other loader calls use optional
  chaining. `e2e/unit/runner-protocol.test.mjs` covers this path.

Intentionally not covered: `packIndex` itself still grows during a session
(one key string plus two integers per entry). We accept that; it is the
index, not the sources. The pack file also grows on disk within an epoch;
an epoch change resets it.

We also measured two other caches and deliberately left them alone:

- The loader's resolve cache (`.oj-cache/ssr-resolve.jsonl`, held in a
  `Map`) weighs 15 MB in memory, but every retained entry served a hit
  during the measured session (100% live hit rate). Evicting it would trade
  15 MB for repeated resolution work. Kept as is.
- The Rust `MemoryCache` in `crates/oj_server/src/lib.rs` is empty in start
  mode. No change.

## Performance

We measured on a large real-world app: a TanStack Start application with
approximately 18,600 client modules, approximately 2,500 SSR modules, and a
788-line Vite config that registers 53 plugins. Hardware: macOS arm64
(M-series), release build of oj. TTFC means the wall-clock time from
`oj dev` start until `GET /` returns HTTP 200 with HTML. Warm means the
`.oj-cache` directory is populated from a previous run. Cold means the
cache directory is empty. All measurements ran serially, never
concurrently.

Method: warm boots, RSS sampled per process at the first 200 response and
again after the processes settle; heap snapshots of the runner for
attribution.

- Before: total RSS across the four oj processes at the first 200 response
  was 1,788 MB (runner 1,096 MB, settling to 746 MB; plugin host 620 MB,
  settling to 472 MB; css host 41 MB; Rust oj 31 MB).
- After: total RSS settles at 1,265 MB, and the loader's pack no longer
  grows with session length — steady state holds byte offsets only.
- Negative result, reported on purpose: deleting pack entries after they
  were served freed only about 0.2 MB, because those strings alias module
  sources V8 retains anyway. That measurement redirected the fix from
  eviction of served entries to never materializing unserved ones.
- Left alone with numbers: the resolve cache (15 MB, 100% live hit rate)
  and the Rust `MemoryCache` (empty in start mode).
- The per-hit `pread` is TTFC-neutral within run-to-run noise. Control at
  the same base: cold 7 s (1 run), warm 5 s, 3 s, 3 s, 3 s (4 runs). With
  this change, two series: cold 7 s, warm 4 s, 3 s, 3 s; and cold 7 s,
  warm 5 s, 3 s, 3 s (1 cold and 3 warm runs each).

## How to test

1. Build oj and run `oj dev` twice on an app so `.oj-cache` is warm.
2. Run `OJ_SSR_MEM_STATS=1 oj dev`, request `/` once, and read the stderr
   line `oj ssr memstats: {...}`. On a warm boot, expect `packIndexEntries`
   near the module count and `packMemEntries` / `packMemChars` near zero.
3. Delete `.oj-cache/ssr-load-pack.jsonl` and boot again. The boot must
   succeed from the per-entry cache, and the pack file must regenerate.
4. Truncate the last line of `ssr-load-pack.jsonl` mid-entry and boot. The
   damaged entry must degrade to a per-entry-cache hit, not an error.
5. Run `node --test e2e/unit/runner-protocol.test.mjs`. It exercises the
   stub-loader path that previously crashed the runner.



