### PR TITLE
route connect error middlewares per their arity

### DIFF
--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -25,7 +25,10 @@ struct StartState {
     proxy_prefixes: Vec<String>,
     plugin_mw_port: Option<u16>,
     runner: Arc<tokio::sync::Mutex<Runner>>,
-    client_bundle: PathBuf,
+    // The chunk set of the client build this server serves: swapped whole on
+    // watch rebuilds, so every /@oj-start/<chunk> resolves against exactly
+    // one build and a name outside it is a deliberate 404.
+    bundle: std::sync::RwLock<Arc<PinnedBundle>>,
     live_reload: PathBuf,
     workspace_root: PathBuf,
     reload_tx: broadcast::Sender<()>,
@@ -60,7 +63,12 @@ pub async fn start_dev(
     route_tree.await??;
     let bundle = {
         let (root, cache) = (root.clone(), cache.clone());
-        tokio::task::spawn_blocking(move || bundle_client_entry(&root, &cache))
+        tokio::task::spawn_blocking(move || -> anyhow::Result<PinnedBundle> {
+            bundle_client_entry(&root, &cache)?;
+            PinnedBundle::from_build_dir(&cache).ok_or_else(|| {
+                anyhow::anyhow!("client chunk index missing after successful bundle")
+            })
+        })
     };
     let built_fut = oj_server::DevServer {
         root: root.clone(),
@@ -71,7 +79,7 @@ pub async fn start_dev(
     }
     .build_app();
     let (bundle_res, built_res) = tokio::join!(bundle, built_fut);
-    bundle_res??;
+    let pinned = bundle_res??;
     resolver.await??;
     let built = built_res?;
     let runner = spawn_start_runner(&root, &cache).await?;
@@ -88,7 +96,7 @@ pub async fn start_dev(
         proxy_prefixes: built.proxy_prefixes.clone(),
         plugin_mw_port: built.plugin_mw_port,
         runner: Arc::new(tokio::sync::Mutex::new(runner)),
-        client_bundle: cache.join("client-entry.js"),
+        bundle: std::sync::RwLock::new(Arc::new(pinned)),
         live_reload: cache.join("live-reload.js"),
         workspace_root: workspace_root(&root),
         reload_tx: reload_tx.clone(),
@@ -253,9 +261,15 @@ fn spawn_start_watcher(root: PathBuf, cache: PathBuf, state: Arc<StartState>) {
             rt.block_on(async {
                 let (r, c) = (root.clone(), cache.clone());
                 let client = tokio::task::spawn_blocking(move || {
-                    let _ = bundle_client_entry(&r, &c);
+                    if bundle_client_entry(&r, &c).is_err() {
+                        return None;
+                    }
+                    PinnedBundle::from_build_dir(&c)
                 });
-                let (_, _) = tokio::join!(client, reload_runner(&state));
+                let (pinned, _) = tokio::join!(client, reload_runner(&state));
+                if let Ok(Some(pinned)) = pinned {
+                    *state.bundle.write().unwrap() = Arc::new(pinned);
+                }
             });
             let _ = state.reload_tx.send(());
             let modules = client_module_count(&cache);
@@ -316,6 +330,44 @@ fn bundle_client_entry(root: &Path, cache: &Path) -> anyhow::Result<()> {
         &cache.join("bundle-client.mjs"),
         "client entry bundling",
     )
+}
+
+/// The chunk set of one client build: chunk name -> on-disk file. Names
+/// absent from the map do not exist for the serve path.
+#[derive(Debug, Clone, PartialEq)]
+struct PinnedBundle {
+    entry: String,
+    chunks: std::collections::HashMap<String, PinnedChunk>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct PinnedChunk {
+    path: PathBuf,
+}
+
+impl PinnedBundle {
+    fn chunk(&self, name: &str) -> Option<&PinnedChunk> {
+        self.chunks
+            .get(name)
+            .or_else(|| (name == "client-entry.js").then(|| self.chunks.get(&self.entry))?)
+    }
+
+    /// Pin the chunk set a fresh build left in `start_dir/client-chunks`,
+    /// reading the index (`client-chunks.json`) bundle-client.mjs wrote.
+    fn from_build_dir(start_dir: &Path) -> Option<Self> {
+        let raw = std::fs::read_to_string(start_dir.join("client-chunks.json")).ok()?;
+        let index: serde_json::Value = serde_json::from_str(&raw).ok()?;
+        let entry = index.get("entry")?.as_str()?.to_string();
+        let chunk_dir = start_dir.join("client-chunks");
+        let files = index.get("files")?.as_array()?;
+        let mut chunks = std::collections::HashMap::with_capacity(files.len());
+        for f in files {
+            let name = f.get("name")?.as_str()?.to_string();
+            let path = chunk_dir.join(&name);
+            chunks.insert(name, PinnedChunk { path });
+        }
+        Some(Self { entry, chunks })
+    }
 }
 
 // Client module count written by bundle-client.mjs, for update/boot narration.
@@ -451,14 +503,16 @@ async fn start_route(State(state): State<Arc<StartState>>, req: Request, next: N
             Err(e) => e.into_response(),
         };
     }
-    if req.uri().path() == "/@oj-start/client-entry.js" {
-        return serve_js(&state.client_bundle, "client entry").await;
-    }
     if req.uri().path() == "/@oj-start/live-reload.js" {
         return serve_js(&state.live_reload, "live-reload client").await;
     }
-    if let Some(abs) = req.uri().path().strip_prefix("/@oj-start/fs") {
-        return serve_fs_asset(&state, abs).await;
+    // "/fs/" with the trailing slash: a bare "fs" prefix would shadow any
+    // client chunk whose name starts with "fs".
+    if let Some(rest) = req.uri().path().strip_prefix("/@oj-start/fs/") {
+        return serve_fs_asset(&state, &format!("/{rest}")).await;
+    }
+    if let Some(name) = req.uri().path().strip_prefix("/@oj-start/") {
+        return serve_client_chunk(&state, name).await;
     }
     if req.uri().path().starts_with("/_serverFn/") {
         let method = req.method().to_string();
@@ -497,6 +551,43 @@ async fn start_route(State(state): State<Arc<StartState>>, req: Request, next: N
             forward(&state, "GET".into(), document_url(&raw), vec![], None).await
         }
         Route::Pass => next.run(req).await,
+    }
+}
+
+/// Serve one file of the pinned client build. Resolution goes only through
+/// the pinned index: an unknown name is a deliberate 404, so the serve set
+/// can never mix two builds.
+async fn serve_client_chunk(state: &StartState, name: &str) -> Response {
+    let name = percent_decode(name);
+    let bundle = state
+        .bundle
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    let Some(chunk) = bundle.chunk(&name) else {
+        return (
+            StatusCode::NOT_FOUND,
+            format!("oj start: {name} is not in the client bundle manifest"),
+        )
+            .into_response();
+    };
+    match tokio::fs::read(&chunk.path).await {
+        Ok(bytes) => {
+            let ext = name.rsplit('.').next().unwrap_or("");
+            (
+                [
+                    (header::CONTENT_TYPE, asset_mime(ext)),
+                    (header::CACHE_CONTROL, "no-cache"),
+                ],
+                bytes,
+            )
+                .into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("oj start: chunk {name}: {e}"),
+        )
+            .into_response(),
     }
 }
 

--- a/crates/oj_server/src/assets/css-preprocess.mjs
+++ b/crates/oj_server/src/assets/css-preprocess.mjs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Raphael Amorim
 
 import { createRequire } from "node:module";
+import { fstatSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import path from "node:path";
 import readline from "node:readline";
@@ -28,6 +29,14 @@ async function stylus(base, css, from) {
 }
 
 const rl = readline.createInterface({ input: process.stdin });
+// stdin EOF means the parent is gone (SIGKILL skips its teardown) or the
+// one-shot build path closed it: exit once no reply is in flight.
+let inflight = 0;
+let stdinClosed = false;
+const maybeExit = () => { if (stdinClosed && inflight === 0) process.exit(0); };
+try {
+  if (fstatSync(0).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
+} catch {}
 rl.on("line", async (line) => {
   let msg;
   try {
@@ -37,6 +46,7 @@ rl.on("line", async (line) => {
   }
   const { id, base, css, from } = msg;
   const ext = String(from || "").split("?")[0].split(".").pop().toLowerCase();
+  inflight += 1;
   try {
     let out = css;
     if (ext === "less") out = await less(base, css, from);
@@ -44,5 +54,8 @@ rl.on("line", async (line) => {
     process.stdout.write(JSON.stringify({ id, css: out }) + "\n");
   } catch (e) {
     process.stdout.write(JSON.stringify({ id, error: String((e && e.message) || e) }) + "\n");
+  } finally {
+    inflight -= 1;
+    maybeExit();
   }
 });

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 Raphael Amorim
 
 import http from "node:http";
-import { writeFileSync } from "node:fs";
+import { fstatSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { pathToFileURL } from "node:url";
 import { dirname } from "node:path";
@@ -595,6 +595,15 @@ async function run(hook, args) {
   }
   return null;
 }
+
+// stdin EOF means oj died without tearing us down (SIGKILL skips
+// kill_on_drop): exit instead of idling as an orphan.
+try {
+  if (fstatSync(0).isFIFO()) {
+    process.stdin.once("end", () => process.exit(0));
+    process.stdin.once("close", () => process.exit(0));
+  }
+} catch {}
 
 const rl = readline.createInterface({ input: process.stdin });
 rl.on("line", async (line) => {

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -338,19 +338,20 @@ async function setupConfigureServer() {
   const srv = http.createServer((req, res) => {
     let i = 0;
     const next = (err) => {
-      if (err) {
-        res.statusCode = 500;
-        res.end(String((err && err.stack) || err));
-        return;
-      }
       while (i < stack.length) {
         const { path, fn } = stack[i++];
         if (path && !req.url.startsWith(path)) continue;
+        if ((fn.length >= 4) !== (err != null)) continue;
         try {
-          return fn(req, res, next);
+          return err != null ? fn(err, req, res, next) : fn(req, res, next);
         } catch (e) {
           return next(e);
         }
+      }
+      if (err != null) {
+        res.statusCode = 500;
+        res.end(String((err && err.stack) || err));
+        return;
       }
       res.setHeader("x-oj-fallthrough", "1");
       res.statusCode = 404;

--- a/crates/oj_server/src/assets/ssr-runner.mjs
+++ b/crates/oj_server/src/assets/ssr-runner.mjs
@@ -3,7 +3,7 @@
 
 import vm from "node:vm";
 import readline from "node:readline";
-import { statSync } from "node:fs";
+import { fstatSync, statSync } from "node:fs";
 
 const [BASE, ENTRY] = process.argv.slice(2);
 
@@ -247,6 +247,15 @@ function connectHmr() {
   ws.addEventListener("error", () => {});
 }
 connectHmr();
+
+// stdin EOF means oj died without tearing us down (the HMR reconnect timer
+// would otherwise keep an orphaned runner alive forever): exit.
+try {
+  if (fstatSync(0).isFIFO()) {
+    process.stdin.once("end", () => process.exit(0));
+    process.stdin.once("close", () => process.exit(0));
+  }
+} catch {}
 
 const rl = readline.createInterface({ input: process.stdin });
 rl.on("line", (line) => {

--- a/crates/oj_server/src/assets/start/bundle-client.mjs
+++ b/crates/oj_server/src/assets/start/bundle-client.mjs
@@ -53,17 +53,20 @@ const cssUrls = [];
 
 const serverFnClient = {
   name: "server-fn-client",
-  async transform(code, id) {
-    if (id.includes("/node_modules/") || id.startsWith("\0") || !/\.(ts|tsx)$/.test(id)) return null;
-    let out = code;
-    if (container) {
-      const t = await container.transformUserCode(out, id);
-      if (t != null) out = t;
-    }
-    out = transformGlob(out, id);
-    const rpc = rewriteServerFns(out, id);
-    if (rpc != null) return rpc;
-    return out === code ? null : out;
+  transform: {
+    filter: { id: { include: /\.(ts|tsx)$/, exclude: [/\/node_modules\//, /^\0/] } },
+    async handler(code, id) {
+      if (id.includes("/node_modules/") || id.startsWith("\0") || !/\.(ts|tsx)$/.test(id)) return null;
+      let out = code;
+      if (container) {
+        const t = await container.transformUserCode(out, id);
+        if (t != null) out = t;
+      }
+      out = transformGlob(out, id);
+      const rpc = rewriteServerFns(out, id);
+      if (rpc != null) return rpc;
+      return out === code ? null : out;
+    },
   },
 };
 

--- a/crates/oj_server/src/assets/start/bundle-client.mjs
+++ b/crates/oj_server/src/assets/start/bundle-client.mjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { importPkg, viteEnvDefine } from "./resolve-pkg.mjs";
@@ -106,10 +106,31 @@ const result = await build({
   write: false,
 });
 
-const chunk = result.output.find((o) => o.type === "chunk" && o.isEntry) ?? result.output[0];
-writeFileSync(join(HERE, "client-entry.js"), chunk.code);
+// Persist every output file. The build code-splits on dynamic imports
+// (route components), so the entry is a small glue chunk whose static and
+// dynamic imports reference sibling chunks; discarding them leaves the
+// entry unable to load and the client never hydrates.
+const entryChunk = result.output.find((o) => o.type === "chunk" && o.isEntry) ?? result.output[0];
+const chunksDir = join(HERE, "client-chunks");
+// Retries: recursive removal of a few thousand fresh files can hit a
+// transient ENOTEMPTY on macOS while the indexer still holds entries.
+rmSync(chunksDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+mkdirSync(chunksDir, { recursive: true });
+const chunkIndex = [];
+let moduleCount = 0;
+for (const o of result.output) {
+  const dest = join(chunksDir, o.fileName);
+  mkdirSync(dirname(dest), { recursive: true });
+  writeFileSync(dest, o.type === "chunk" ? o.code : o.source);
+  chunkIndex.push({ name: o.fileName, size: statSync(dest).size });
+  if (o.type === "chunk") moduleCount += Object.keys(o.modules ?? {}).length;
+}
+writeFileSync(
+  join(HERE, "client-chunks.json"),
+  JSON.stringify({ entry: entryChunk.fileName, files: chunkIndex }),
+);
 // Module count for the editor's update-progress narration ("(N modules)").
-writeFileSync(join(HERE, "client-entry.modules"), String(chunk.modules ? Object.keys(chunk.modules).length : 0));
+writeFileSync(join(HERE, "client-entry.modules"), String(moduleCount));
 
 const devManifest = {
   routes: {
@@ -126,4 +147,4 @@ writeFileSync(
 );
 const _ojTTY = process.stderr.isTTY && !process.env.NO_COLOR;
 const OJ = _ojTTY ? "\x1b[48;2;255;255;255m\x1b[1;38;2;42;51;212m oj \x1b[0m" : "oj";
-process.stderr.write(`${OJ}${_ojTTY ? "" : ":"} client entry bundled\n`);
+process.stderr.write(`${OJ}${_ojTTY ? "" : ":"} client bundled (${result.output.length} files)\n`);

--- a/crates/oj_server/src/assets/start/css-host.mjs
+++ b/crates/oj_server/src/assets/start/css-host.mjs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-import { createRequire } from "node:module";
-import { existsSync, readFileSync } from "node:fs";
+import module, { createRequire } from "node:module";
+import { existsSync, fstatSync, readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import readline from "node:readline";
 
@@ -69,6 +69,19 @@ async function compile(path) {
 const _ojTTY = process.stderr.isTTY && !process.env.NO_COLOR;
 const OJ = _ojTTY ? "\x1b[48;2;255;255;255m\x1b[1;38;2;42;51;212m oj \x1b[0m" : "oj";
 process.stderr.write(`${OJ} css host: ready\n`);
+// stdin EOF means oj died without tearing us down (SIGKILL skips
+// kill_on_drop): exit instead of idling as an orphan.
+const onParentGone = () => {
+  try { module.flushCompileCache?.(); } catch {}
+  process.exit(0);
+};
+try {
+  if (fstatSync(0).isFIFO()) {
+    process.stdin.once("end", onParentGone);
+    process.stdin.once("close", onParentGone);
+  }
+} catch {}
+
 const rl = readline.createInterface({ input: process.stdin });
 for await (const line of rl) {
   let msg;

--- a/crates/oj_server/src/assets/start/rolldown-assets.mjs
+++ b/crates/oj_server/src/assets/start/rolldown-assets.mjs
@@ -33,35 +33,41 @@ export function assetsPlugin({ mode = "dev", server = false, fsBase = "/@oj-star
   const urlFor = makeUrlFor({ mode, fsBase, emit });
   return {
     name: "oj-assets",
-    async resolveId(source, importer, options) {
-      if (options?.custom?.ojAsset) return null;
-      let tag = null;
-      if (/\?raw$/.test(source)) tag = "raw";
-      else if (/\?url$/.test(source)) tag = "url";
-      else if (/\?inline$/.test(source)) tag = "inline";
-      else if (ASSET_EXT.test(source)) tag = "url";
-      else if (/\.css(\?|$)/.test(source)) tag = "css";
-      if (!tag) return null;
-      const clean = source.replace(SUFFIX, "").replace(/\?.*$/, "");
-      const r = await this.resolve(clean, importer, { skipSelf: true, custom: { ojAsset: true } });
-      if (!r) return null;
-      return V(tag, r.id);
+    resolveId: {
+      filter: { id: { include: [SUFFIX, ASSET_EXT, /\.css(\?|$)/] } },
+      async handler(source, importer, options) {
+        if (options?.custom?.ojAsset) return null;
+        let tag = null;
+        if (/\?raw$/.test(source)) tag = "raw";
+        else if (/\?url$/.test(source)) tag = "url";
+        else if (/\?inline$/.test(source)) tag = "inline";
+        else if (ASSET_EXT.test(source)) tag = "url";
+        else if (/\.css(\?|$)/.test(source)) tag = "css";
+        if (!tag) return null;
+        const clean = source.replace(SUFFIX, "").replace(/\?.*$/, "");
+        const r = await this.resolve(clean, importer, { skipSelf: true, custom: { ojAsset: true } });
+        if (!r) return null;
+        return V(tag, r.id);
+      },
     },
-    async load(id) {
-      const v = parseV(id);
-      if (!v) return null;
-      const js = (code) => ({ code, moduleType: "js" });
-      if (v.tag === "raw") return js(`export default ${JSON.stringify(readFileSync(v.path, "utf8"))};`);
-      if (v.tag === "url") return js(`export default ${JSON.stringify(await urlFor(v.path))};`);
-      if (v.tag === "inline") return js(`export default ${JSON.stringify(dataUri(v.path))};`);
-      if (v.tag === "css") {
-        if (!server) {
-          const href = await urlFor(v.path);
-          if (cssUrls && !cssUrls.includes(href)) cssUrls.push(href);
+    load: {
+      filter: { id: /^\0oj-(raw|url|inline|css):/ },
+      async handler(id) {
+        const v = parseV(id);
+        if (!v) return null;
+        const js = (code) => ({ code, moduleType: "js" });
+        if (v.tag === "raw") return js(`export default ${JSON.stringify(readFileSync(v.path, "utf8"))};`);
+        if (v.tag === "url") return js(`export default ${JSON.stringify(await urlFor(v.path))};`);
+        if (v.tag === "inline") return js(`export default ${JSON.stringify(dataUri(v.path))};`);
+        if (v.tag === "css") {
+          if (!server) {
+            const href = await urlFor(v.path);
+            if (cssUrls && !cssUrls.includes(href)) cssUrls.push(href);
+          }
+          return js("export default {};");
         }
-        return js("export default {};");
-      }
-      return null;
+        return null;
+      },
     },
   };
 }
@@ -84,71 +90,82 @@ export function makeVitePlugins({ container, fallback, appRoot, mode = "dev", fs
       if (container?.buildStart) await container.buildStart();
       if (fallback?.buildStart && fallback !== container) await fallback.buildStart();
     },
-    async resolveId(source, importer, options) {
-      if (options?.custom?.ojSvg) return null;
-      if (/\.svg\?react$/.test(source)) {
-        const r = await this.resolve(source.slice(0, -"?react".length), importer, {
-          skipSelf: true,
-          custom: { ojSvg: true },
-        });
-        return r ? V("svg-react", r.id) : null;
-      }
-      if (!container) return null;
-      if (/^virtual:/.test(source) || source.startsWith("\0")) {
-        if (parseV(source)) return null;
-        const rid = await container.resolveId(source, importer);
-        return rid ? V("vite-virtual", rid) : null;
-      }
-      return null;
-    },
-    async load(id) {
-      const v = parseV(id);
-      if (v && v.tag === "svg-react") return svgModule(v.path, v.path + "?react");
-      if (v && v.tag === "vite-virtual") {
-        let code = await container.load(v.path);
-        if (code == null && fallback) code = await fallback.load(v.path);
-        if (code == null) {
-          if (!warnedVirtual.has(v.path)) {
-            warnedVirtual.add(v.path);
-            process.stderr.write(
-              `oj: plugin virtual "${v.path}" produced no content in the dev client bundle; ` +
-                `emitting an empty module. This virtual likely needs the full build graph oj does not run in dev.\n`,
-            );
-          }
-          return { code: emptyVirtualStub(appRoot, v.path), moduleType: "js" };
+    resolveId: {
+      filter: { id: { include: [/\.svg\?react$/, /^virtual:/, /^\0/] } },
+      async handler(source, importer, options) {
+        if (options?.custom?.ojSvg) return null;
+        if (/\.svg\?react$/.test(source)) {
+          const r = await this.resolve(source.slice(0, -"?react".length), importer, {
+            skipSelf: true,
+            custom: { ojSvg: true },
+          });
+          return r ? V("svg-react", r.id) : null;
         }
-        return { code, moduleType: "jsx" };
-      }
-      if (/\.svg$/.test(id) && !id.startsWith("\0")) return svgModule(id, id);
-      // A user plugin's load() may override a real on-disk source file (Vite:
-      // load runs before the fs read). Consult it for user files in the build
-      // too, so compile-on-startup plugins produce the same output as dev.
-      if (container && !id.startsWith("\0") && !id.includes("/node_modules/")) {
-        const cleanId = id.replace(/\?.*$/, "");
-        if (/\.(jsx?|mjs|tsx?)$/.test(cleanId)) {
-          let code = await container.load(cleanId);
-          if (code == null && fallback) code = await fallback.load(cleanId);
-          if (code != null) {
-            const moduleType = cleanId.endsWith(".tsx")
-              ? "tsx"
-              : cleanId.endsWith(".ts")
-                ? "ts"
-                : cleanId.endsWith(".jsx")
-                  ? "jsx"
-                  : "js";
-            return { code, moduleType };
+        if (!container) return null;
+        if (/^virtual:/.test(source) || source.startsWith("\0")) {
+          if (parseV(source)) return null;
+          const rid = await container.resolveId(source, importer);
+          return rid ? V("vite-virtual", rid) : null;
+        }
+        return null;
+      },
+    },
+    load: {
+      // The lookahead mirrors the in-handler node_modules bail for the
+      // user-file branch; \0 and .svg ids stay unrestricted.
+      filter: { id: { include: [/^\0oj-/, /\.svg$/, /^(?!.*\/node_modules\/).*\.(jsx?|mjs|tsx?)(\?|$)/] } },
+      async handler(id) {
+        const v = parseV(id);
+        if (v && v.tag === "svg-react") return svgModule(v.path, v.path + "?react");
+        if (v && v.tag === "vite-virtual") {
+          let code = await container.load(v.path);
+          if (code == null && fallback) code = await fallback.load(v.path);
+          if (code == null) {
+            if (!warnedVirtual.has(v.path)) {
+              warnedVirtual.add(v.path);
+              process.stderr.write(
+                `oj: plugin virtual "${v.path}" produced no content in the dev client bundle; ` +
+                  `emitting an empty module. This virtual likely needs the full build graph oj does not run in dev.\n`,
+              );
+            }
+            return { code: emptyVirtualStub(appRoot, v.path), moduleType: "js" };
+          }
+          return { code, moduleType: "jsx" };
+        }
+        if (/\.svg$/.test(id) && !id.startsWith("\0")) return svgModule(id, id);
+        // A user plugin's load() may override a real on-disk source file (Vite:
+        // load runs before the fs read). Consult it for user files in the build
+        // too, so compile-on-startup plugins produce the same output as dev.
+        if (container && !id.startsWith("\0") && !id.includes("/node_modules/")) {
+          const cleanId = id.replace(/\?.*$/, "");
+          if (/\.(jsx?|mjs|tsx?)$/.test(cleanId)) {
+            let code = await container.load(cleanId);
+            if (code == null && fallback) code = await fallback.load(cleanId);
+            if (code != null) {
+              const moduleType = cleanId.endsWith(".tsx")
+                ? "tsx"
+                : cleanId.endsWith(".ts")
+                  ? "ts"
+                  : cleanId.endsWith(".jsx")
+                    ? "jsx"
+                    : "js";
+              return { code, moduleType };
+            }
           }
         }
-      }
-      return null;
+        return null;
+      },
     },
-    async transform(code, id) {
-      if (!container) return null;
-      if (/\.mdx?$/.test(id)) {
-        const out = await container.transform(code, id);
-        return out == null ? null : out;
-      }
-      return null;
+    transform: {
+      filter: { id: /\.mdx?$/ },
+      async handler(code, id) {
+        if (!container) return null;
+        if (/\.mdx?$/.test(id)) {
+          const out = await container.transform(code, id);
+          return out == null ? null : out;
+        }
+        return null;
+      },
     },
   };
 }
@@ -184,13 +201,19 @@ function shimSource(spec) {
 }
 export const nodeBuiltinShims = {
   name: "node-builtin-shims",
-  resolveId(source) {
-    if (/^node:/.test(source) || BARE_BUILTINS.test(source)) return V("node-shim", source);
-    return null;
+  resolveId: {
+    filter: { id: { include: [/^node:/, BARE_BUILTINS] } },
+    handler(source) {
+      if (/^node:/.test(source) || BARE_BUILTINS.test(source)) return V("node-shim", source);
+      return null;
+    },
   },
-  load(id) {
-    const v = parseV(id);
-    return v && v.tag === "node-shim" ? { code: shimSource(v.path), moduleType: "js" } : null;
+  load: {
+    filter: { id: /^\0oj-node-shim:/ },
+    handler(id) {
+      const v = parseV(id);
+      return v && v.tag === "node-shim" ? { code: shimSource(v.path), moduleType: "js" } : null;
+    },
   },
 };
 

--- a/crates/oj_server/src/assets/start/runner.mjs
+++ b/crates/oj_server/src/assets/start/runner.mjs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-import { register } from "node:module";
+import module, { register } from "node:module";
+import { fstatSync } from "node:fs";
 import { pathToFileURL, fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { MessageChannel } from "node:worker_threads";
@@ -26,6 +27,19 @@ let handler = (await import(ENTRY)).default;
 const _ojTTY = process.stderr.isTTY && !process.env.NO_COLOR;
 const OJ = _ojTTY ? "\x1b[48;2;255;255;255m\x1b[1;38;2;42;51;212m oj \x1b[0m" : "oj";
 process.stderr.write(`${OJ} start runner: ready\n`);
+
+// stdin EOF means oj died without tearing us down (SIGKILL skips
+// kill_on_drop): exit instead of idling as an orphan.
+const onParentGone = () => {
+  try { module.flushCompileCache?.(); } catch {}
+  process.exit(0);
+};
+try {
+  if (fstatSync(0).isFIFO()) {
+    process.stdin.once("end", onParentGone);
+    process.stdin.once("close", onParentGone);
+  }
+} catch {}
 
 const rl = readline.createInterface({ input: process.stdin });
 for await (const line of rl) {

--- a/crates/oj_server/src/assets/svelte-compile.mjs
+++ b/crates/oj_server/src/assets/svelte-compile.mjs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Raphael Amorim
 
 import { createRequire } from "node:module";
+import { fstatSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import path from "node:path";
 import readline from "node:readline";
@@ -24,6 +25,14 @@ async function toolchain(base) {
 }
 
 const rl = readline.createInterface({ input: process.stdin });
+// stdin EOF means the parent is gone (SIGKILL skips its teardown) or the
+// one-shot build path closed it: exit once no reply is in flight.
+let inflight = 0;
+let stdinClosed = false;
+const maybeExit = () => { if (stdinClosed && inflight === 0) process.exit(0); };
+try {
+  if (fstatSync(0).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
+} catch {}
 rl.on("line", async (line) => {
   let msg;
   try {
@@ -33,6 +42,7 @@ rl.on("line", async (line) => {
   }
   const { id, base, css: source, from } = msg;
   const dev = msg.dev !== false;
+  inflight += 1;
   try {
     const { compile, preprocess, preprocessors } = await toolchain(base);
     let code = source;
@@ -50,5 +60,8 @@ rl.on("line", async (line) => {
     process.stdout.write(JSON.stringify({ id, css: out.js.code }) + "\n");
   } catch (e) {
     process.stdout.write(JSON.stringify({ id, error: String((e && e.message) || e) }) + "\n");
+  } finally {
+    inflight -= 1;
+    maybeExit();
   }
 });

--- a/crates/oj_server/src/assets/tailwind-sidecar.mjs
+++ b/crates/oj_server/src/assets/tailwind-sidecar.mjs
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 Raphael Amorim
 
 import { createRequire } from "node:module";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, fstatSync, readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import readline from "node:readline";
 
@@ -69,14 +69,26 @@ if (process.argv[2] === "--once") {
     .catch((err) => { console.error(String(err)); process.exit(1); });
 } else {
   const rl = readline.createInterface({ input: process.stdin });
+  // stdin EOF means the parent is gone (SIGKILL skips its teardown): exit
+  // once no reply is in flight instead of idling as an orphan.
+  let inflight = 0;
+  let stdinClosed = false;
+  const maybeExit = () => { if (stdinClosed && inflight === 0) process.exit(0); };
+  try {
+    if (fstatSync(0).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
+  } catch {}
   rl.on("line", async (line) => {
     let msg;
     try { msg = JSON.parse(line); } catch { return; }
+    inflight += 1;
     try {
       const css = await compileCss(msg.base, msg.css, msg.from);
       process.stdout.write(JSON.stringify({ id: msg.id, css }) + "\n");
     } catch (err) {
       process.stdout.write(JSON.stringify({ id: msg.id, error: String(err) }) + "\n");
+    } finally {
+      inflight -= 1;
+      maybeExit();
     }
   });
 }


### PR DESCRIPTION
Part 4 of 16 in a series. Depends on #14 — this PR's diff includes the commits of the PRs below it in the series; to see only this part: https://github.com/aeriksson-lovable/oj/compare/pr/03-serve-all-client-chunks...pr/03b-connect-error-middleware. Series overview in #12.

---

## Problem

`configureServer` plugins register middleware through
`server.middlewares.use(fn)`. In Vite, `server.middlewares` is a connect
instance. Connect defines two middleware kinds by function arity:

- A normal middleware takes three parameters: `(req, res, next)`.
- An error middleware takes four: `(err, req, res, next)`. Connect detects
  it with `fn.length >= 4`.

Connect dispatches the two kinds on separate paths. Normal dispatch calls
only normal middlewares. When a middleware passes an error to `next(err)`,
or throws synchronously, dispatch switches to the error path: it skips
normal middlewares and calls only error middlewares, as
`(err, req, res, next)`.

The middleware chain in `crates/oj_server/src/assets/plugin-host.mjs`
(`setupConfigureServer`) ignored arity. It called every registered
middleware as `(req, res, next)`. An error middleware then received
shifted arguments: `err` = the request, `req` = the response, `res` = the
`next` function, `next` = `undefined`. The first time it called
`next(err)` — the standard pass-through for an error it does not handle —
it threw `TypeError: next is not a function`. The chain caught the throw
and answered 500.

This breaks real configurations. We hit it with a dev-server plugin that
registers an error-handling middleware to convert a specific upstream
failure into a retry page. With that plugin active, every HTML request
through oj returned 500. The same config serves normally under Vite,
because connect never calls the error middleware on the normal path.

## Change

The dispatch loop in `setupConfigureServer` now follows the connect
contract:

1. `next(err)` carries the in-flight error. `next()` with no argument
   means no error is in flight.
2. The loop walks the stack from the current index. For each entry it
   first applies the existing path filter, unchanged.
3. It then compares the entry's kind against the error state:
   `fn.length >= 4` marks an error middleware. While no error is in
   flight, error middlewares are skipped. While an error is in flight,
   normal middlewares are skipped.
4. A matching normal middleware is called as `(req, res, next)`. A
   matching error middleware is called as `(err, req, res, next)`.
5. An error middleware that calls `next()` with no argument clears the
   error; dispatch resumes with normal middlewares at the next stack
   index. Calling `next(err2)` keeps the error path with the new error.
6. A synchronous throw in either kind becomes the in-flight error, as
   before.
7. End-of-stack behavior is unchanged. With an error in flight the
   response is 500 with the error stack, exactly what the old code
   answered on any `next(err)`. Without an error it stays the 404 with
   the `x-oj-fallthrough` header.

Files changed:

| Path | What changed |
| --- | --- |
| `crates/oj_server/src/assets/plugin-host.mjs` | The `next` closure in `setupConfigureServer` checks `fn.length` per stack entry and routes normal and error middlewares per the connect contract. |

## Correctness

- The skip rules are exactly connect's (`connect@3`, `proto.handle`): it
  selects on `fn.length >= 4` versus `error` being set, and calls
  `fn(err, req, res, next)` or `fn(req, res, next)` accordingly.
- Chains without error middlewares behave as before. A `next(err)` walks
  the rest of the stack, matches nothing (no entry has arity >= 4), and
  answers the same 500 with the error stack that the old code produced
  immediately.
- Chains with error middlewares gain the connect behavior: the error
  middleware only runs when an earlier middleware failed, and it receives
  the error as its first argument.
- `fn.length` counts declared parameters before the first default or rest
  parameter. A handler written as `(...args)` or with fewer named
  parameters reports a length below 4 and is treated as a normal
  middleware. This matches connect itself, which has the same limitation;
  middleware authors already must declare four named parameters for
  connect to treat a function as an error handler.
- Path-filtered entries (`use(path, fn)`) keep their prefix check on both
  dispatch paths.

## Performance

None expected: the change adds one arity comparison per stack entry per
request. Measured on a large real-world app: a TanStack Start application
with approximately 18,600 client modules, approximately 2,500 SSR modules,
and a 788-line Vite config. Hardware: macOS arm64 (M-series), release
build of oj. TTFC means the wall-clock time from `oj dev` start until
`GET /` returns HTTP 200 with HTML. All measurements ran serially.

- Plain config (53 plugins, no error middleware registered): warm TTFC
  3 s then 2 s, SSR loader caches at full hits (load 5,980/5,980, resolve
  44,157/44,157) — parity with the same binary before this change.
- Remote-development config of the same app (75 plugins, one error
  middleware): before this change every HTML request answered 500; after
  it, `GET /` answers 200 text/html. Cold TTFC 10.0 s; warm 3.7 s and
  2.6 s. Full 3,950-file / 83.2 MB transitive asset closure fetched with
  200s in 4.7 s (warm, fetched at concurrency 8). Steady RSS
  ~1.5 GB across the process group.

## How to test

1. Create a Vite app whose config registers both middleware kinds:

   ```js
   // vite.config.mjs (plugin)
   configureServer(server) {
     server.middlewares.use((req, res, next) => {
       if (req.url === "/boom") return next(new Error("boom"));
       next();
     });
     server.middlewares.use((err, req, res, next) => {
       res.statusCode = 503;
       res.end("handled: " + err.message);
     });
   }
   ```

2. `oj dev .` and request any normal page: it must answer 200. Before
   this change it answers 500 `TypeError: next is not a function` as soon
   as the request reaches the middleware chain.
3. Request `/boom`: the error middleware must answer it (503
   `handled: boom`).
4. Request a path whose error no middleware handles (the error middleware
   calls `next(err)`): the response must be 500 with the error stack (the
   unchanged end-of-chain behavior).

We ran these steps against this branch: `GET /` answers 200, `/boom`
answers 503 `handled: boom`, and an unhandled error answers the stack.

