### PR TITLE
stat stdin with bigint to avoid corrupting the realpath cache

### DIFF
--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -25,7 +25,10 @@ struct StartState {
     proxy_prefixes: Vec<String>,
     plugin_mw_port: Option<u16>,
     runner: Arc<tokio::sync::Mutex<Runner>>,
-    client_bundle: PathBuf,
+    // The chunk set of the client build this server serves: swapped whole on
+    // watch rebuilds, so every /@oj-start/<chunk> resolves against exactly
+    // one build and a name outside it is a deliberate 404.
+    bundle: std::sync::RwLock<Arc<PinnedBundle>>,
     live_reload: PathBuf,
     workspace_root: PathBuf,
     reload_tx: broadcast::Sender<()>,
@@ -60,7 +63,12 @@ pub async fn start_dev(
     route_tree.await??;
     let bundle = {
         let (root, cache) = (root.clone(), cache.clone());
-        tokio::task::spawn_blocking(move || bundle_client_entry(&root, &cache))
+        tokio::task::spawn_blocking(move || -> anyhow::Result<PinnedBundle> {
+            bundle_client_entry(&root, &cache)?;
+            PinnedBundle::from_build_dir(&cache).ok_or_else(|| {
+                anyhow::anyhow!("client chunk index missing after successful bundle")
+            })
+        })
     };
     let built_fut = oj_server::DevServer {
         root: root.clone(),
@@ -71,7 +79,7 @@ pub async fn start_dev(
     }
     .build_app();
     let (bundle_res, built_res) = tokio::join!(bundle, built_fut);
-    bundle_res??;
+    let pinned = bundle_res??;
     resolver.await??;
     let built = built_res?;
     let runner = spawn_start_runner(&root, &cache).await?;
@@ -88,7 +96,7 @@ pub async fn start_dev(
         proxy_prefixes: built.proxy_prefixes.clone(),
         plugin_mw_port: built.plugin_mw_port,
         runner: Arc::new(tokio::sync::Mutex::new(runner)),
-        client_bundle: cache.join("client-entry.js"),
+        bundle: std::sync::RwLock::new(Arc::new(pinned)),
         live_reload: cache.join("live-reload.js"),
         workspace_root: workspace_root(&root),
         reload_tx: reload_tx.clone(),
@@ -253,9 +261,15 @@ fn spawn_start_watcher(root: PathBuf, cache: PathBuf, state: Arc<StartState>) {
             rt.block_on(async {
                 let (r, c) = (root.clone(), cache.clone());
                 let client = tokio::task::spawn_blocking(move || {
-                    let _ = bundle_client_entry(&r, &c);
+                    if bundle_client_entry(&r, &c).is_err() {
+                        return None;
+                    }
+                    PinnedBundle::from_build_dir(&c)
                 });
-                let (_, _) = tokio::join!(client, reload_runner(&state));
+                let (pinned, _) = tokio::join!(client, reload_runner(&state));
+                if let Ok(Some(pinned)) = pinned {
+                    *state.bundle.write().unwrap() = Arc::new(pinned);
+                }
             });
             let _ = state.reload_tx.send(());
             let modules = client_module_count(&cache);
@@ -316,6 +330,44 @@ fn bundle_client_entry(root: &Path, cache: &Path) -> anyhow::Result<()> {
         &cache.join("bundle-client.mjs"),
         "client entry bundling",
     )
+}
+
+/// The chunk set of one client build: chunk name -> on-disk file. Names
+/// absent from the map do not exist for the serve path.
+#[derive(Debug, Clone, PartialEq)]
+struct PinnedBundle {
+    entry: String,
+    chunks: std::collections::HashMap<String, PinnedChunk>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct PinnedChunk {
+    path: PathBuf,
+}
+
+impl PinnedBundle {
+    fn chunk(&self, name: &str) -> Option<&PinnedChunk> {
+        self.chunks
+            .get(name)
+            .or_else(|| (name == "client-entry.js").then(|| self.chunks.get(&self.entry))?)
+    }
+
+    /// Pin the chunk set a fresh build left in `start_dir/client-chunks`,
+    /// reading the index (`client-chunks.json`) bundle-client.mjs wrote.
+    fn from_build_dir(start_dir: &Path) -> Option<Self> {
+        let raw = std::fs::read_to_string(start_dir.join("client-chunks.json")).ok()?;
+        let index: serde_json::Value = serde_json::from_str(&raw).ok()?;
+        let entry = index.get("entry")?.as_str()?.to_string();
+        let chunk_dir = start_dir.join("client-chunks");
+        let files = index.get("files")?.as_array()?;
+        let mut chunks = std::collections::HashMap::with_capacity(files.len());
+        for f in files {
+            let name = f.get("name")?.as_str()?.to_string();
+            let path = chunk_dir.join(&name);
+            chunks.insert(name, PinnedChunk { path });
+        }
+        Some(Self { entry, chunks })
+    }
 }
 
 // Client module count written by bundle-client.mjs, for update/boot narration.
@@ -451,14 +503,16 @@ async fn start_route(State(state): State<Arc<StartState>>, req: Request, next: N
             Err(e) => e.into_response(),
         };
     }
-    if req.uri().path() == "/@oj-start/client-entry.js" {
-        return serve_js(&state.client_bundle, "client entry").await;
-    }
     if req.uri().path() == "/@oj-start/live-reload.js" {
         return serve_js(&state.live_reload, "live-reload client").await;
     }
-    if let Some(abs) = req.uri().path().strip_prefix("/@oj-start/fs") {
-        return serve_fs_asset(&state, abs).await;
+    // "/fs/" with the trailing slash: a bare "fs" prefix would shadow any
+    // client chunk whose name starts with "fs".
+    if let Some(rest) = req.uri().path().strip_prefix("/@oj-start/fs/") {
+        return serve_fs_asset(&state, &format!("/{rest}")).await;
+    }
+    if let Some(name) = req.uri().path().strip_prefix("/@oj-start/") {
+        return serve_client_chunk(&state, name).await;
     }
     if req.uri().path().starts_with("/_serverFn/") {
         let method = req.method().to_string();
@@ -497,6 +551,43 @@ async fn start_route(State(state): State<Arc<StartState>>, req: Request, next: N
             forward(&state, "GET".into(), document_url(&raw), vec![], None).await
         }
         Route::Pass => next.run(req).await,
+    }
+}
+
+/// Serve one file of the pinned client build. Resolution goes only through
+/// the pinned index: an unknown name is a deliberate 404, so the serve set
+/// can never mix two builds.
+async fn serve_client_chunk(state: &StartState, name: &str) -> Response {
+    let name = percent_decode(name);
+    let bundle = state
+        .bundle
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    let Some(chunk) = bundle.chunk(&name) else {
+        return (
+            StatusCode::NOT_FOUND,
+            format!("oj start: {name} is not in the client bundle manifest"),
+        )
+            .into_response();
+    };
+    match tokio::fs::read(&chunk.path).await {
+        Ok(bytes) => {
+            let ext = name.rsplit('.').next().unwrap_or("");
+            (
+                [
+                    (header::CONTENT_TYPE, asset_mime(ext)),
+                    (header::CACHE_CONTROL, "no-cache"),
+                ],
+                bytes,
+            )
+                .into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("oj start: chunk {name}: {e}"),
+        )
+            .into_response(),
     }
 }
 

--- a/crates/oj_server/src/assets/css-preprocess.mjs
+++ b/crates/oj_server/src/assets/css-preprocess.mjs
@@ -35,7 +35,8 @@ let inflight = 0;
 let stdinClosed = false;
 const maybeExit = () => { if (stdinClosed && inflight === 0) process.exit(0); };
 try {
-  if (fstatSync(0).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
+  // bigint keeps the FIFO mode out of the shared stat buffer fs.realpathSync reads mid-walk
+  if (fstatSync(0, { bigint: true }).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
 } catch {}
 rl.on("line", async (line) => {
   let msg;

--- a/crates/oj_server/src/assets/css-preprocess.mjs
+++ b/crates/oj_server/src/assets/css-preprocess.mjs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Raphael Amorim
 
 import { createRequire } from "node:module";
+import { fstatSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import path from "node:path";
 import readline from "node:readline";
@@ -28,6 +29,14 @@ async function stylus(base, css, from) {
 }
 
 const rl = readline.createInterface({ input: process.stdin });
+// stdin EOF means the parent is gone (SIGKILL skips its teardown) or the
+// one-shot build path closed it: exit once no reply is in flight.
+let inflight = 0;
+let stdinClosed = false;
+const maybeExit = () => { if (stdinClosed && inflight === 0) process.exit(0); };
+try {
+  if (fstatSync(0).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
+} catch {}
 rl.on("line", async (line) => {
   let msg;
   try {
@@ -37,6 +46,7 @@ rl.on("line", async (line) => {
   }
   const { id, base, css, from } = msg;
   const ext = String(from || "").split("?")[0].split(".").pop().toLowerCase();
+  inflight += 1;
   try {
     let out = css;
     if (ext === "less") out = await less(base, css, from);
@@ -44,5 +54,8 @@ rl.on("line", async (line) => {
     process.stdout.write(JSON.stringify({ id, css: out }) + "\n");
   } catch (e) {
     process.stdout.write(JSON.stringify({ id, error: String((e && e.message) || e) }) + "\n");
+  } finally {
+    inflight -= 1;
+    maybeExit();
   }
 });

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -600,7 +600,8 @@ async function run(hook, args) {
 // stdin EOF means oj died without tearing us down (SIGKILL skips
 // kill_on_drop): exit instead of idling as an orphan.
 try {
-  if (fstatSync(0).isFIFO()) {
+  // bigint keeps the FIFO mode out of the shared stat buffer fs.realpathSync reads mid-walk
+  if (fstatSync(0, { bigint: true }).isFIFO()) {
     process.stdin.once("end", () => process.exit(0));
     process.stdin.once("close", () => process.exit(0));
   }

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 Raphael Amorim
 
 import http from "node:http";
-import { writeFileSync } from "node:fs";
+import { fstatSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { pathToFileURL } from "node:url";
 import { dirname } from "node:path";
@@ -595,6 +595,15 @@ async function run(hook, args) {
   }
   return null;
 }
+
+// stdin EOF means oj died without tearing us down (SIGKILL skips
+// kill_on_drop): exit instead of idling as an orphan.
+try {
+  if (fstatSync(0).isFIFO()) {
+    process.stdin.once("end", () => process.exit(0));
+    process.stdin.once("close", () => process.exit(0));
+  }
+} catch {}
 
 const rl = readline.createInterface({ input: process.stdin });
 rl.on("line", async (line) => {

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -338,19 +338,20 @@ async function setupConfigureServer() {
   const srv = http.createServer((req, res) => {
     let i = 0;
     const next = (err) => {
-      if (err) {
-        res.statusCode = 500;
-        res.end(String((err && err.stack) || err));
-        return;
-      }
       while (i < stack.length) {
         const { path, fn } = stack[i++];
         if (path && !req.url.startsWith(path)) continue;
+        if ((fn.length >= 4) !== (err != null)) continue;
         try {
-          return fn(req, res, next);
+          return err != null ? fn(err, req, res, next) : fn(req, res, next);
         } catch (e) {
           return next(e);
         }
+      }
+      if (err != null) {
+        res.statusCode = 500;
+        res.end(String((err && err.stack) || err));
+        return;
       }
       res.setHeader("x-oj-fallthrough", "1");
       res.statusCode = 404;

--- a/crates/oj_server/src/assets/ssr-runner.mjs
+++ b/crates/oj_server/src/assets/ssr-runner.mjs
@@ -251,7 +251,8 @@ connectHmr();
 // stdin EOF means oj died without tearing us down (the HMR reconnect timer
 // would otherwise keep an orphaned runner alive forever): exit.
 try {
-  if (fstatSync(0).isFIFO()) {
+  // bigint keeps the FIFO mode out of the shared stat buffer fs.realpathSync reads mid-walk
+  if (fstatSync(0, { bigint: true }).isFIFO()) {
     process.stdin.once("end", () => process.exit(0));
     process.stdin.once("close", () => process.exit(0));
   }

--- a/crates/oj_server/src/assets/ssr-runner.mjs
+++ b/crates/oj_server/src/assets/ssr-runner.mjs
@@ -3,7 +3,7 @@
 
 import vm from "node:vm";
 import readline from "node:readline";
-import { statSync } from "node:fs";
+import { fstatSync, statSync } from "node:fs";
 
 const [BASE, ENTRY] = process.argv.slice(2);
 
@@ -247,6 +247,15 @@ function connectHmr() {
   ws.addEventListener("error", () => {});
 }
 connectHmr();
+
+// stdin EOF means oj died without tearing us down (the HMR reconnect timer
+// would otherwise keep an orphaned runner alive forever): exit.
+try {
+  if (fstatSync(0).isFIFO()) {
+    process.stdin.once("end", () => process.exit(0));
+    process.stdin.once("close", () => process.exit(0));
+  }
+} catch {}
 
 const rl = readline.createInterface({ input: process.stdin });
 rl.on("line", (line) => {

--- a/crates/oj_server/src/assets/start/bundle-client.mjs
+++ b/crates/oj_server/src/assets/start/bundle-client.mjs
@@ -53,17 +53,20 @@ const cssUrls = [];
 
 const serverFnClient = {
   name: "server-fn-client",
-  async transform(code, id) {
-    if (id.includes("/node_modules/") || id.startsWith("\0") || !/\.(ts|tsx)$/.test(id)) return null;
-    let out = code;
-    if (container) {
-      const t = await container.transformUserCode(out, id);
-      if (t != null) out = t;
-    }
-    out = transformGlob(out, id);
-    const rpc = rewriteServerFns(out, id);
-    if (rpc != null) return rpc;
-    return out === code ? null : out;
+  transform: {
+    filter: { id: { include: /\.(ts|tsx)$/, exclude: [/\/node_modules\//, /^\0/] } },
+    async handler(code, id) {
+      if (id.includes("/node_modules/") || id.startsWith("\0") || !/\.(ts|tsx)$/.test(id)) return null;
+      let out = code;
+      if (container) {
+        const t = await container.transformUserCode(out, id);
+        if (t != null) out = t;
+      }
+      out = transformGlob(out, id);
+      const rpc = rewriteServerFns(out, id);
+      if (rpc != null) return rpc;
+      return out === code ? null : out;
+    },
   },
 };
 

--- a/crates/oj_server/src/assets/start/bundle-client.mjs
+++ b/crates/oj_server/src/assets/start/bundle-client.mjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { importPkg, viteEnvDefine } from "./resolve-pkg.mjs";
@@ -106,10 +106,31 @@ const result = await build({
   write: false,
 });
 
-const chunk = result.output.find((o) => o.type === "chunk" && o.isEntry) ?? result.output[0];
-writeFileSync(join(HERE, "client-entry.js"), chunk.code);
+// Persist every output file. The build code-splits on dynamic imports
+// (route components), so the entry is a small glue chunk whose static and
+// dynamic imports reference sibling chunks; discarding them leaves the
+// entry unable to load and the client never hydrates.
+const entryChunk = result.output.find((o) => o.type === "chunk" && o.isEntry) ?? result.output[0];
+const chunksDir = join(HERE, "client-chunks");
+// Retries: recursive removal of a few thousand fresh files can hit a
+// transient ENOTEMPTY on macOS while the indexer still holds entries.
+rmSync(chunksDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+mkdirSync(chunksDir, { recursive: true });
+const chunkIndex = [];
+let moduleCount = 0;
+for (const o of result.output) {
+  const dest = join(chunksDir, o.fileName);
+  mkdirSync(dirname(dest), { recursive: true });
+  writeFileSync(dest, o.type === "chunk" ? o.code : o.source);
+  chunkIndex.push({ name: o.fileName, size: statSync(dest).size });
+  if (o.type === "chunk") moduleCount += Object.keys(o.modules ?? {}).length;
+}
+writeFileSync(
+  join(HERE, "client-chunks.json"),
+  JSON.stringify({ entry: entryChunk.fileName, files: chunkIndex }),
+);
 // Module count for the editor's update-progress narration ("(N modules)").
-writeFileSync(join(HERE, "client-entry.modules"), String(chunk.modules ? Object.keys(chunk.modules).length : 0));
+writeFileSync(join(HERE, "client-entry.modules"), String(moduleCount));
 
 const devManifest = {
   routes: {
@@ -126,4 +147,4 @@ writeFileSync(
 );
 const _ojTTY = process.stderr.isTTY && !process.env.NO_COLOR;
 const OJ = _ojTTY ? "\x1b[48;2;255;255;255m\x1b[1;38;2;42;51;212m oj \x1b[0m" : "oj";
-process.stderr.write(`${OJ}${_ojTTY ? "" : ":"} client entry bundled\n`);
+process.stderr.write(`${OJ}${_ojTTY ? "" : ":"} client bundled (${result.output.length} files)\n`);

--- a/crates/oj_server/src/assets/start/css-host.mjs
+++ b/crates/oj_server/src/assets/start/css-host.mjs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-import { createRequire } from "node:module";
-import { existsSync, readFileSync } from "node:fs";
+import module, { createRequire } from "node:module";
+import { existsSync, fstatSync, readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import readline from "node:readline";
 
@@ -69,6 +69,19 @@ async function compile(path) {
 const _ojTTY = process.stderr.isTTY && !process.env.NO_COLOR;
 const OJ = _ojTTY ? "\x1b[48;2;255;255;255m\x1b[1;38;2;42;51;212m oj \x1b[0m" : "oj";
 process.stderr.write(`${OJ} css host: ready\n`);
+// stdin EOF means oj died without tearing us down (SIGKILL skips
+// kill_on_drop): exit instead of idling as an orphan.
+const onParentGone = () => {
+  try { module.flushCompileCache?.(); } catch {}
+  process.exit(0);
+};
+try {
+  if (fstatSync(0).isFIFO()) {
+    process.stdin.once("end", onParentGone);
+    process.stdin.once("close", onParentGone);
+  }
+} catch {}
+
 const rl = readline.createInterface({ input: process.stdin });
 for await (const line of rl) {
   let msg;

--- a/crates/oj_server/src/assets/start/css-host.mjs
+++ b/crates/oj_server/src/assets/start/css-host.mjs
@@ -76,7 +76,8 @@ const onParentGone = () => {
   process.exit(0);
 };
 try {
-  if (fstatSync(0).isFIFO()) {
+  // bigint keeps the FIFO mode out of the shared stat buffer fs.realpathSync reads mid-walk
+  if (fstatSync(0, { bigint: true }).isFIFO()) {
     process.stdin.once("end", onParentGone);
     process.stdin.once("close", onParentGone);
   }

--- a/crates/oj_server/src/assets/start/rolldown-assets.mjs
+++ b/crates/oj_server/src/assets/start/rolldown-assets.mjs
@@ -33,35 +33,41 @@ export function assetsPlugin({ mode = "dev", server = false, fsBase = "/@oj-star
   const urlFor = makeUrlFor({ mode, fsBase, emit });
   return {
     name: "oj-assets",
-    async resolveId(source, importer, options) {
-      if (options?.custom?.ojAsset) return null;
-      let tag = null;
-      if (/\?raw$/.test(source)) tag = "raw";
-      else if (/\?url$/.test(source)) tag = "url";
-      else if (/\?inline$/.test(source)) tag = "inline";
-      else if (ASSET_EXT.test(source)) tag = "url";
-      else if (/\.css(\?|$)/.test(source)) tag = "css";
-      if (!tag) return null;
-      const clean = source.replace(SUFFIX, "").replace(/\?.*$/, "");
-      const r = await this.resolve(clean, importer, { skipSelf: true, custom: { ojAsset: true } });
-      if (!r) return null;
-      return V(tag, r.id);
+    resolveId: {
+      filter: { id: { include: [SUFFIX, ASSET_EXT, /\.css(\?|$)/] } },
+      async handler(source, importer, options) {
+        if (options?.custom?.ojAsset) return null;
+        let tag = null;
+        if (/\?raw$/.test(source)) tag = "raw";
+        else if (/\?url$/.test(source)) tag = "url";
+        else if (/\?inline$/.test(source)) tag = "inline";
+        else if (ASSET_EXT.test(source)) tag = "url";
+        else if (/\.css(\?|$)/.test(source)) tag = "css";
+        if (!tag) return null;
+        const clean = source.replace(SUFFIX, "").replace(/\?.*$/, "");
+        const r = await this.resolve(clean, importer, { skipSelf: true, custom: { ojAsset: true } });
+        if (!r) return null;
+        return V(tag, r.id);
+      },
     },
-    async load(id) {
-      const v = parseV(id);
-      if (!v) return null;
-      const js = (code) => ({ code, moduleType: "js" });
-      if (v.tag === "raw") return js(`export default ${JSON.stringify(readFileSync(v.path, "utf8"))};`);
-      if (v.tag === "url") return js(`export default ${JSON.stringify(await urlFor(v.path))};`);
-      if (v.tag === "inline") return js(`export default ${JSON.stringify(dataUri(v.path))};`);
-      if (v.tag === "css") {
-        if (!server) {
-          const href = await urlFor(v.path);
-          if (cssUrls && !cssUrls.includes(href)) cssUrls.push(href);
+    load: {
+      filter: { id: /^\0oj-(raw|url|inline|css):/ },
+      async handler(id) {
+        const v = parseV(id);
+        if (!v) return null;
+        const js = (code) => ({ code, moduleType: "js" });
+        if (v.tag === "raw") return js(`export default ${JSON.stringify(readFileSync(v.path, "utf8"))};`);
+        if (v.tag === "url") return js(`export default ${JSON.stringify(await urlFor(v.path))};`);
+        if (v.tag === "inline") return js(`export default ${JSON.stringify(dataUri(v.path))};`);
+        if (v.tag === "css") {
+          if (!server) {
+            const href = await urlFor(v.path);
+            if (cssUrls && !cssUrls.includes(href)) cssUrls.push(href);
+          }
+          return js("export default {};");
         }
-        return js("export default {};");
-      }
-      return null;
+        return null;
+      },
     },
   };
 }
@@ -84,71 +90,82 @@ export function makeVitePlugins({ container, fallback, appRoot, mode = "dev", fs
       if (container?.buildStart) await container.buildStart();
       if (fallback?.buildStart && fallback !== container) await fallback.buildStart();
     },
-    async resolveId(source, importer, options) {
-      if (options?.custom?.ojSvg) return null;
-      if (/\.svg\?react$/.test(source)) {
-        const r = await this.resolve(source.slice(0, -"?react".length), importer, {
-          skipSelf: true,
-          custom: { ojSvg: true },
-        });
-        return r ? V("svg-react", r.id) : null;
-      }
-      if (!container) return null;
-      if (/^virtual:/.test(source) || source.startsWith("\0")) {
-        if (parseV(source)) return null;
-        const rid = await container.resolveId(source, importer);
-        return rid ? V("vite-virtual", rid) : null;
-      }
-      return null;
-    },
-    async load(id) {
-      const v = parseV(id);
-      if (v && v.tag === "svg-react") return svgModule(v.path, v.path + "?react");
-      if (v && v.tag === "vite-virtual") {
-        let code = await container.load(v.path);
-        if (code == null && fallback) code = await fallback.load(v.path);
-        if (code == null) {
-          if (!warnedVirtual.has(v.path)) {
-            warnedVirtual.add(v.path);
-            process.stderr.write(
-              `oj: plugin virtual "${v.path}" produced no content in the dev client bundle; ` +
-                `emitting an empty module. This virtual likely needs the full build graph oj does not run in dev.\n`,
-            );
-          }
-          return { code: emptyVirtualStub(appRoot, v.path), moduleType: "js" };
+    resolveId: {
+      filter: { id: { include: [/\.svg\?react$/, /^virtual:/, /^\0/] } },
+      async handler(source, importer, options) {
+        if (options?.custom?.ojSvg) return null;
+        if (/\.svg\?react$/.test(source)) {
+          const r = await this.resolve(source.slice(0, -"?react".length), importer, {
+            skipSelf: true,
+            custom: { ojSvg: true },
+          });
+          return r ? V("svg-react", r.id) : null;
         }
-        return { code, moduleType: "jsx" };
-      }
-      if (/\.svg$/.test(id) && !id.startsWith("\0")) return svgModule(id, id);
-      // A user plugin's load() may override a real on-disk source file (Vite:
-      // load runs before the fs read). Consult it for user files in the build
-      // too, so compile-on-startup plugins produce the same output as dev.
-      if (container && !id.startsWith("\0") && !id.includes("/node_modules/")) {
-        const cleanId = id.replace(/\?.*$/, "");
-        if (/\.(jsx?|mjs|tsx?)$/.test(cleanId)) {
-          let code = await container.load(cleanId);
-          if (code == null && fallback) code = await fallback.load(cleanId);
-          if (code != null) {
-            const moduleType = cleanId.endsWith(".tsx")
-              ? "tsx"
-              : cleanId.endsWith(".ts")
-                ? "ts"
-                : cleanId.endsWith(".jsx")
-                  ? "jsx"
-                  : "js";
-            return { code, moduleType };
+        if (!container) return null;
+        if (/^virtual:/.test(source) || source.startsWith("\0")) {
+          if (parseV(source)) return null;
+          const rid = await container.resolveId(source, importer);
+          return rid ? V("vite-virtual", rid) : null;
+        }
+        return null;
+      },
+    },
+    load: {
+      // The lookahead mirrors the in-handler node_modules bail for the
+      // user-file branch; \0 and .svg ids stay unrestricted.
+      filter: { id: { include: [/^\0oj-/, /\.svg$/, /^(?!.*\/node_modules\/).*\.(jsx?|mjs|tsx?)(\?|$)/] } },
+      async handler(id) {
+        const v = parseV(id);
+        if (v && v.tag === "svg-react") return svgModule(v.path, v.path + "?react");
+        if (v && v.tag === "vite-virtual") {
+          let code = await container.load(v.path);
+          if (code == null && fallback) code = await fallback.load(v.path);
+          if (code == null) {
+            if (!warnedVirtual.has(v.path)) {
+              warnedVirtual.add(v.path);
+              process.stderr.write(
+                `oj: plugin virtual "${v.path}" produced no content in the dev client bundle; ` +
+                  `emitting an empty module. This virtual likely needs the full build graph oj does not run in dev.\n`,
+              );
+            }
+            return { code: emptyVirtualStub(appRoot, v.path), moduleType: "js" };
+          }
+          return { code, moduleType: "jsx" };
+        }
+        if (/\.svg$/.test(id) && !id.startsWith("\0")) return svgModule(id, id);
+        // A user plugin's load() may override a real on-disk source file (Vite:
+        // load runs before the fs read). Consult it for user files in the build
+        // too, so compile-on-startup plugins produce the same output as dev.
+        if (container && !id.startsWith("\0") && !id.includes("/node_modules/")) {
+          const cleanId = id.replace(/\?.*$/, "");
+          if (/\.(jsx?|mjs|tsx?)$/.test(cleanId)) {
+            let code = await container.load(cleanId);
+            if (code == null && fallback) code = await fallback.load(cleanId);
+            if (code != null) {
+              const moduleType = cleanId.endsWith(".tsx")
+                ? "tsx"
+                : cleanId.endsWith(".ts")
+                  ? "ts"
+                  : cleanId.endsWith(".jsx")
+                    ? "jsx"
+                    : "js";
+              return { code, moduleType };
+            }
           }
         }
-      }
-      return null;
+        return null;
+      },
     },
-    async transform(code, id) {
-      if (!container) return null;
-      if (/\.mdx?$/.test(id)) {
-        const out = await container.transform(code, id);
-        return out == null ? null : out;
-      }
-      return null;
+    transform: {
+      filter: { id: /\.mdx?$/ },
+      async handler(code, id) {
+        if (!container) return null;
+        if (/\.mdx?$/.test(id)) {
+          const out = await container.transform(code, id);
+          return out == null ? null : out;
+        }
+        return null;
+      },
     },
   };
 }
@@ -184,13 +201,19 @@ function shimSource(spec) {
 }
 export const nodeBuiltinShims = {
   name: "node-builtin-shims",
-  resolveId(source) {
-    if (/^node:/.test(source) || BARE_BUILTINS.test(source)) return V("node-shim", source);
-    return null;
+  resolveId: {
+    filter: { id: { include: [/^node:/, BARE_BUILTINS] } },
+    handler(source) {
+      if (/^node:/.test(source) || BARE_BUILTINS.test(source)) return V("node-shim", source);
+      return null;
+    },
   },
-  load(id) {
-    const v = parseV(id);
-    return v && v.tag === "node-shim" ? { code: shimSource(v.path), moduleType: "js" } : null;
+  load: {
+    filter: { id: /^\0oj-node-shim:/ },
+    handler(id) {
+      const v = parseV(id);
+      return v && v.tag === "node-shim" ? { code: shimSource(v.path), moduleType: "js" } : null;
+    },
   },
 };
 

--- a/crates/oj_server/src/assets/start/runner.mjs
+++ b/crates/oj_server/src/assets/start/runner.mjs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-import { register } from "node:module";
+import module, { register } from "node:module";
+import { fstatSync } from "node:fs";
 import { pathToFileURL, fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { MessageChannel } from "node:worker_threads";
@@ -26,6 +27,19 @@ let handler = (await import(ENTRY)).default;
 const _ojTTY = process.stderr.isTTY && !process.env.NO_COLOR;
 const OJ = _ojTTY ? "\x1b[48;2;255;255;255m\x1b[1;38;2;42;51;212m oj \x1b[0m" : "oj";
 process.stderr.write(`${OJ} start runner: ready\n`);
+
+// stdin EOF means oj died without tearing us down (SIGKILL skips
+// kill_on_drop): exit instead of idling as an orphan.
+const onParentGone = () => {
+  try { module.flushCompileCache?.(); } catch {}
+  process.exit(0);
+};
+try {
+  if (fstatSync(0).isFIFO()) {
+    process.stdin.once("end", onParentGone);
+    process.stdin.once("close", onParentGone);
+  }
+} catch {}
 
 const rl = readline.createInterface({ input: process.stdin });
 for await (const line of rl) {

--- a/crates/oj_server/src/assets/start/runner.mjs
+++ b/crates/oj_server/src/assets/start/runner.mjs
@@ -35,7 +35,8 @@ const onParentGone = () => {
   process.exit(0);
 };
 try {
-  if (fstatSync(0).isFIFO()) {
+  // bigint keeps the FIFO mode out of the shared stat buffer fs.realpathSync reads mid-walk
+  if (fstatSync(0, { bigint: true }).isFIFO()) {
     process.stdin.once("end", onParentGone);
     process.stdin.once("close", onParentGone);
   }

--- a/crates/oj_server/src/assets/svelte-compile.mjs
+++ b/crates/oj_server/src/assets/svelte-compile.mjs
@@ -31,7 +31,8 @@ let inflight = 0;
 let stdinClosed = false;
 const maybeExit = () => { if (stdinClosed && inflight === 0) process.exit(0); };
 try {
-  if (fstatSync(0).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
+  // bigint keeps the FIFO mode out of the shared stat buffer fs.realpathSync reads mid-walk
+  if (fstatSync(0, { bigint: true }).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
 } catch {}
 rl.on("line", async (line) => {
   let msg;

--- a/crates/oj_server/src/assets/svelte-compile.mjs
+++ b/crates/oj_server/src/assets/svelte-compile.mjs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Raphael Amorim
 
 import { createRequire } from "node:module";
+import { fstatSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import path from "node:path";
 import readline from "node:readline";
@@ -24,6 +25,14 @@ async function toolchain(base) {
 }
 
 const rl = readline.createInterface({ input: process.stdin });
+// stdin EOF means the parent is gone (SIGKILL skips its teardown) or the
+// one-shot build path closed it: exit once no reply is in flight.
+let inflight = 0;
+let stdinClosed = false;
+const maybeExit = () => { if (stdinClosed && inflight === 0) process.exit(0); };
+try {
+  if (fstatSync(0).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
+} catch {}
 rl.on("line", async (line) => {
   let msg;
   try {
@@ -33,6 +42,7 @@ rl.on("line", async (line) => {
   }
   const { id, base, css: source, from } = msg;
   const dev = msg.dev !== false;
+  inflight += 1;
   try {
     const { compile, preprocess, preprocessors } = await toolchain(base);
     let code = source;
@@ -50,5 +60,8 @@ rl.on("line", async (line) => {
     process.stdout.write(JSON.stringify({ id, css: out.js.code }) + "\n");
   } catch (e) {
     process.stdout.write(JSON.stringify({ id, error: String((e && e.message) || e) }) + "\n");
+  } finally {
+    inflight -= 1;
+    maybeExit();
   }
 });

--- a/crates/oj_server/src/assets/tailwind-sidecar.mjs
+++ b/crates/oj_server/src/assets/tailwind-sidecar.mjs
@@ -75,7 +75,8 @@ if (process.argv[2] === "--once") {
   let stdinClosed = false;
   const maybeExit = () => { if (stdinClosed && inflight === 0) process.exit(0); };
   try {
-    if (fstatSync(0).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
+    // bigint keeps the FIFO mode out of the shared stat buffer fs.realpathSync reads mid-walk
+    if (fstatSync(0, { bigint: true }).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
   } catch {}
   rl.on("line", async (line) => {
     let msg;

--- a/crates/oj_server/src/assets/tailwind-sidecar.mjs
+++ b/crates/oj_server/src/assets/tailwind-sidecar.mjs
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 Raphael Amorim
 
 import { createRequire } from "node:module";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, fstatSync, readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import readline from "node:readline";
 
@@ -69,14 +69,26 @@ if (process.argv[2] === "--once") {
     .catch((err) => { console.error(String(err)); process.exit(1); });
 } else {
   const rl = readline.createInterface({ input: process.stdin });
+  // stdin EOF means the parent is gone (SIGKILL skips its teardown): exit
+  // once no reply is in flight instead of idling as an orphan.
+  let inflight = 0;
+  let stdinClosed = false;
+  const maybeExit = () => { if (stdinClosed && inflight === 0) process.exit(0); };
+  try {
+    if (fstatSync(0).isFIFO()) rl.once("close", () => { stdinClosed = true; maybeExit(); });
+  } catch {}
   rl.on("line", async (line) => {
     let msg;
     try { msg = JSON.parse(line); } catch { return; }
+    inflight += 1;
     try {
       const css = await compileCss(msg.base, msg.css, msg.from);
       process.stdout.write(JSON.stringify({ id: msg.id, css }) + "\n");
     } catch (err) {
       process.stdout.write(JSON.stringify({ id: msg.id, error: String(err) }) + "\n");
+    } finally {
+      inflight -= 1;
+      maybeExit();
     }
   });
 }


### PR DESCRIPTION
Part 5 of 16 in a series. Depends on #26 — this PR's diff includes the commits of the PRs below it in the series; to see only this part: https://github.com/aeriksson-lovable/oj/compare/pr/03b-connect-error-middleware...pr/03c-nested-require-resolution. Series overview in #12.

---

## Problem

Node resolves a bare specifier (`require("immer")`, `import "immer"`)
against the `node_modules` directories above the importer's file, after
resolving symlinks in the importer's own path. pnpm depends on this: every
package lives once under `node_modules/.pnpm/<pkg>@<version>/node_modules/
<pkg>`, and its dependencies are sibling symlinks in that same directory.
When an app pins one major version of a package and a dependency of a
dependency needs a different major version, both copies exist, and the
symlink resolution step is what routes each importer to its own copy.

Part 1 of this series (#12) breaks that step. It gave every long-lived
Node service oj spawns — the SSR runner, the plugin host, the CSS host,
the CSS/Tailwind/Svelte sidecars — one check at startup:
`fstatSync(0).isFIFO()`, to arm the orphan-exit handler only when stdin
is a pipe. `fstatSync` without options writes its result into a
process-wide stat buffer (`statValues` in `node:fs`) that
`fs.realpathSync` also reads. `realpathSync` walks a path one directory at
a time; for a directory it already has in its cache it skips the `lstat`
and instead consults that shared buffer to decide whether the walk hit a
pipe or a socket — and if the buffer says so, it stops and returns the
rest of the path unresolved (`node:fs`, `realpathSync`, the
`isFileType(statValues, S_IFIFO)` check inside the
`knownHard.has(base) || cache?.get(base) === base` branch). The buffer is
stale at that point: it still holds the FIFO entry from the startup check,
because the CJS loader stats files through `internalModuleStat`, which
never touches it. The first `require()` after boot that needs a realpath
therefore returns its input path unresolved — and `realpathSync` caches
that identity mapping, so every later resolution of the same path stays
wrong for the lifetime of the process.

The failure this produces: an app whose dependencies need a different
major version of a package than the app itself pins. Measured case: the
app pins `immer@10`; its chart library depends on `@reduxjs/toolkit`,
which needs `immer@11`. The chart library's CJS code calls
`require("@reduxjs/toolkit")`. The resolver finds the package through the
library's sibling symlink
(`node_modules/.pnpm/recharts@…/node_modules/@reduxjs/toolkit`), and —
with the realpath step disabled by the stale buffer — keeps the symlink
path instead of the real one. The package's entry is an ES module, so
`require()` loads it as an ESM graph rooted at the symlink URL. Its
`import { setUseStrictIteration } from "immer"` then walks `node_modules`
up from the symlink location, where pnpm placed the app's `immer@10`, not
the toolkit's own `immer@11`. Every SSR render fails with:

```
SyntaxError: The requested module 'immer' does not provide an export
named 'setUseStrictIteration'
```

The window opens exactly at the startup check. The SSR runner imports the
app's server entry before it stats stdin, so boot-time resolution is
correct; routes load lazily per request, after the stat, so the first
request poisons the cache and every request after it answers 500.

## Change

Request BigInt stats for the stdin check: `fstatSync(0, { bigint: true })`.
BigInt stat calls fill a separate buffer (`bigintStats`) and leave the
shared one untouched, so `realpathSync` never sees the FIFO entry.
`BigIntStats` has the same `isFIFO()` method; the orphan-exit behavior is
unchanged. One-token change at each of the seven startup checks:

| Path | What changed |
| --- | --- |
| `crates/oj_server/src/assets/start/runner.mjs` | stdin FIFO check → bigint |
| `crates/oj_server/src/assets/start/css-host.mjs` | same |
| `crates/oj_server/src/assets/plugin-host.mjs` | same |
| `crates/oj_server/src/assets/ssr-runner.mjs` | same |
| `crates/oj_server/src/assets/css-preprocess.mjs` | same |
| `crates/oj_server/src/assets/tailwind-sidecar.mjs` | same |
| `crates/oj_server/src/assets/svelte-compile.mjs` | same |

The underlying stale-buffer read is a Node bug (`realpathSync` trusts
`statValues` in a branch that performed no stat call); it is worth an
upstream report. This change removes the poisoning source that #12's
startup checks introduced in oj's own processes.

## Correctness

- `fs.fstatSync(fd, { bigint: true })` returns a `BigIntStats` object;
  `isFIFO()` reads the mode bits the same way. The check's result is
  identical for every fd kind.
- The change is in the startup path only. No per-request code changes.
- The fix removes the poisoning source inside oj's own services. App code
  that itself stats a pipe or a socket on the main thread can still
  trigger the Node bug; that is out of scope here and needs the upstream
  fix.
- All seven services get the same change, so no oj-spawned process leaves
  a FIFO entry in the shared buffer.

Standalone demonstration of the mechanism, no oj involved (macOS arm64,
Node 24.14.1):

```
mkdir -p /tmp/rp/real && cd /tmp/rp
echo "module.exports = 1;" > real/target.js
ln -s real/target.js link.js
echo | node -e '
  const fs = require("fs");
  require.resolve("./real/target.js");  // seeds the realpath cache
  fs.fstatSync(0);                      // stdin is a pipe: FIFO enters the shared buffer
  console.log(require.resolve("./link.js"));'
```

This prints `/tmp/rp/link.js` — the symlink, unresolved. Drop the
`fstatSync` line, or change it to `fstatSync(0, { bigint: true })`, and it
prints `/tmp/rp/real/target.js`.

## Performance

None expected: the change swaps which stat buffer one startup call fills.
Measured on a large real-world app: a TanStack Start application with
approximately 18,600 client modules, approximately 2,500 SSR modules, and
a 788-line Vite config that registers 53 plugins (75 in its
remote-development profile, the one that loads the chart library on the
SSR path). Hardware: macOS arm64 (M-series), release build of oj. TTFC
means the wall-clock time from `oj dev` start until `GET /` returns HTTP
200 with HTML. Warm means the `.oj-cache` directory is populated from a
previous run. All measurements ran serially, never concurrently.

- Before this change, with the remote-development profile: every request
  answers 500 with the immer SyntaxError above — at this commit and at
  every later optimization commit before the in-thread-hooks change
  (#19), which masks the bug by accident (in-thread loading keeps
  refreshing the shared buffer between stats).
- After this change, same profile, this commit only (no persistent caches
  exist yet at this commit): every request answers 200. TTFC 13.96 s
  cold, 14.33 s and 14.41 s on two repeat runs; full 3,950-file / 83.2 MB
  transitive asset closure fetched with 200s in 15.5 s; steady RSS
  ~2.3 GB across the process group.
- After this change, with the later optimization commits (#15, #16, #17,
  #18) rebased on top: TTFC 10.81 s cold, 5.32 s and 5.71 s warm; closure
  6.8–7.2 s warm; steady RSS ~2.4 GB. Identical closure size — same
  rendered app.
- The in-thread-hooks build (#19) re-booted with no code change: 200s,
  same closure, warm TTFC 4.89 s — unchanged behavior class. Its commits
  also apply cleanly on top of this change.

## How to test

1. Run the standalone snippet above on Node with `require(esm)` support:
   it must print the real path with this change's `bigint` form and the
   symlink path with the plain form.
2. pnpm app check: create a pnpm app that pins `immer@10` and depends on
   `recharts@3` (which depends on `@reduxjs/toolkit`, which needs
   `immer@11`). Add a page that renders any chart during SSR. `oj dev .`
   and request the page twice. Before this change the second request (and
   every one after) answers 500 with the `setUseStrictIteration`
   SyntaxError; after it, every request answers 200.
3. Orphan-exit check still works: `oj dev .`, `kill -9` the oj process,
   and confirm the runner/css-host/plugin-host processes exit instead of
   idling.
