### PR TITLE
Make persistent cache opt-in (--enable-cache), bump 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1808,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "oj"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -1833,7 +1833,7 @@ dependencies = [
 
 [[package]]
 name = "oj_cache"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "blake3",
  "proptest",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "oj_compiler"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "glob",
  "memchr",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "oj_config"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "oxc_allocator",
  "oxc_codegen",
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "oj_css"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "grass",
  "lightningcss",
@@ -1896,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "oj_env"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "proptest",
  "serde_json",
@@ -1905,14 +1905,14 @@ dependencies = [
 
 [[package]]
 name = "oj_graph"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "oj_resolver"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "oxc_resolver",
  "tempfile",
@@ -1921,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "oj_server"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,19 +13,19 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT"
 
 [workspace.dependencies]
-oj_compiler = { version = "0.1.2", path = "crates/oj_compiler" }
-oj_resolver = { version = "0.1.2", path = "crates/oj_resolver" }
-oj_graph = { version = "0.1.2", path = "crates/oj_graph" }
-oj_cache = { version = "0.1.2", path = "crates/oj_cache" }
-oj_css = { version = "0.1.2", path = "crates/oj_css" }
-oj_env = { version = "0.1.2", path = "crates/oj_env" }
-oj_config = { version = "0.1.2", path = "crates/oj_config" }
-oj_server = { version = "0.1.2", path = "crates/oj_server" }
+oj_compiler = { version = "0.1.3", path = "crates/oj_compiler" }
+oj_resolver = { version = "0.1.3", path = "crates/oj_resolver" }
+oj_graph = { version = "0.1.3", path = "crates/oj_graph" }
+oj_cache = { version = "0.1.3", path = "crates/oj_cache" }
+oj_css = { version = "0.1.3", path = "crates/oj_css" }
+oj_env = { version = "0.1.3", path = "crates/oj_env" }
+oj_config = { version = "0.1.3", path = "crates/oj_config" }
+oj_server = { version = "0.1.3", path = "crates/oj_server" }
 
 oxc_allocator = "0.146.0"
 oxc_parser = "0.146.0"

--- a/crates/oj/src/main.rs
+++ b/crates/oj/src/main.rs
@@ -35,7 +35,11 @@ enum Command {
         host: Option<String>,
         #[arg(long)]
         config: Option<PathBuf>,
-        /// Disable the on-disk module cache (always recompile; also OJ_NO_CACHE=1).
+        /// Enable the experimental on-disk module cache (also OJ_ENABLE_CACHE=1).
+        /// Off by default; warm restarts then re-serve compiled modules from disk.
+        #[arg(long)]
+        enable_cache: bool,
+        /// Force the on-disk module cache off even if enabled (also OJ_NO_CACHE=1).
         #[arg(long)]
         no_cache: bool,
         /// Compile modules on demand instead of eagerly crawling the whole graph
@@ -87,6 +91,7 @@ async fn run() -> anyhow::Result<()> {
             ssr,
             host,
             config,
+            enable_cache,
             no_cache,
             lazy,
         } => {
@@ -109,6 +114,7 @@ async fn run() -> anyhow::Result<()> {
                     bundle,
                     host,
                     config,
+                    enable_cache,
                     no_cache,
                     lazy,
                 }

--- a/crates/oj/src/ssr_dev.rs
+++ b/crates/oj/src/ssr_dev.rs
@@ -42,6 +42,7 @@ pub async fn ssr_dev(
         bundle: false,
         host,
         config: None,
+        enable_cache: false,
         no_cache: false,
         lazy: false,
     }

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -58,6 +58,7 @@ pub async fn start_dev(
             bundle: false,
             host,
             config: None,
+            enable_cache: false,
             no_cache: false,
             lazy: false,
         }

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -216,7 +216,9 @@ pub struct DevServer {
     pub bundle: bool,
     pub host: Option<String>,
     pub config: Option<PathBuf>,
-    /// Disable the on-disk module cache (always recompile).
+    /// Enable the experimental on-disk module cache (off by default).
+    pub enable_cache: bool,
+    /// Force the on-disk module cache off even if enabled.
     pub no_cache: bool,
     /// Skip the eager graph crawl; compile modules on demand (Vite's default).
     pub lazy: bool,
@@ -372,10 +374,13 @@ impl DevServer {
         let server_cfg = config.server.clone().unwrap_or_default();
         let port = self.port.or(server_cfg.port).unwrap_or(5199);
         let bundle = self.bundle || config.bundle.unwrap_or(false);
-        // The on-disk module cache is on by default; `oj dev --no-cache` (or
-        // OJ_NO_CACHE=1) turns it off so every module recompiles each start.
-        let persistent_cache = !self.no_cache
-            && !std::env::var("OJ_NO_CACHE").is_ok_and(|v| !v.is_empty() && v != "0");
+        // The on-disk module cache is experimental and off by default. Opt in
+        // with `oj dev --enable-cache` (or OJ_ENABLE_CACHE=1); `--no-cache`
+        // (or OJ_NO_CACHE=1) forces it off even when otherwise enabled.
+        let env_flag = |k: &str| std::env::var(k).is_ok_and(|v| !v.is_empty() && v != "0");
+        let cache_enabled = self.enable_cache || env_flag("OJ_ENABLE_CACHE");
+        let cache_forced_off = self.no_cache || env_flag("OJ_NO_CACHE");
+        let persistent_cache = cache_enabled && !cache_forced_off;
         let host = resolve_host(self.host.as_deref().or(server_cfg.host.as_deref()));
         let proxy: Vec<(String, oj_config::ProxyEntry)> = server_cfg
             .proxy


### PR DESCRIPTION
## What

Makes the on-disk persistent module cache **experimental and off by default**. Opt in with:

- `oj dev --enable-cache`
- or `OJ_ENABLE_CACHE=1`

`--no-cache` / `OJ_NO_CACHE=1` stay as an explicit force-off that overrides the opt-in.

## Why

The persistent cache is the biggest warm-start win, but it has a sharp edge: plugins that stash in-memory state (e.g. `wyw-in-js`'s virtual CSS map) can leave a warm restart serving cached code that imports state the plugin no longer holds. The surgical re-transform handles the known case, but until that path is hardened across plugins, defaulting the cache off is the safe choice. This makes it opt-in without removing it.

## Change

- `persistent_cache = (--enable-cache || OJ_ENABLE_CACHE) && !(--no-cache || OJ_NO_CACHE)` (previously on-by-default, gated only by `--no-cache`).
- New `--enable-cache` CLI flag + `enable_cache` field on `DevServer`; SSR and Start dev paths pass it through and still honor the env var.
- Version bump to 0.1.3.

## Verified

`--help` lists both flags; `oj_server` tests pass; functionally the module-cache store (`.oj-cache/v1/<xx>/*.json`) is written only with the flag set, and default runs produce none.
