### PR TITLE
fix(build): fail on unresolved imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
           node-version: 22
       - run: npm ci --prefix playground
       - run: cargo run -p oj -- build playground
+      - name: reject unresolved build imports
+        run: node e2e/build-unresolved.mjs
       - name: check outputs
         run: |
           test -f playground/dist/index.html

--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -1214,6 +1214,19 @@ pub async fn build(
         .await
         .map_err(|errs| anyhow::anyhow!("close failed:\n{errs:?}"))?;
 
+    let unresolved: Vec<String> = output
+        .warnings
+        .iter()
+        .filter(|warning| warning.kind().to_string() == "UNRESOLVED_IMPORT")
+        .map(|warning| warning.to_string())
+        .collect();
+    if !unresolved.is_empty() {
+        bail!(
+            "build failed: unresolved imports:\n{}",
+            unresolved.join("\n")
+        );
+    }
+
     if let Some(host) = &plugin_host {
         if let Err(e) = host.build_end().await {
             eprintln!("oj build: plugin buildEnd failed: {e}");

--- a/e2e/build-unresolved.mjs
+++ b/e2e/build-unresolved.mjs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const binary = path.join(root, "target", "debug", "oj");
+const project = fs.mkdtempSync(path.join(os.tmpdir(), "oj-unresolved-"));
+
+try {
+  fs.writeFileSync(path.join(project, "package.json"), JSON.stringify({ type: "module" }));
+  fs.writeFileSync(path.join(project, "index.html"), '<html><body><script type="module" src="/main.js"></script></body></html>');
+  fs.writeFileSync(path.join(project, "main.js"), 'import "missing-example-dependency"; document.body.textContent = "ready";');
+
+  const missing = spawnSync(binary, ["build", project], { cwd: root, encoding: "utf8" });
+  assert.notEqual(missing.status, 0, `an unresolved dependency must fail the build:\n${missing.stdout}\n${missing.stderr}`);
+  assert.match(`${missing.stdout}\n${missing.stderr}`, /missing-example-dependency/);
+
+  fs.writeFileSync(path.join(project, "oj.config.json"), JSON.stringify({
+    build: { rollupOptions: { external: ["missing-example-dependency"] } },
+  }));
+  const external = spawnSync(binary, ["build", project], { cwd: root, encoding: "utf8" });
+  assert.equal(external.status, 0, `an explicitly external dependency must remain allowed:\n${external.stdout}\n${external.stderr}`);
+
+  console.log("BUILD-UNRESOLVED E2E PASSED");
+} finally {
+  fs.rmSync(project, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

- Treat unresolved Rollup imports as build failures instead of publishing a broken JavaScript bundle.
- Continue allowing dependencies explicitly declared external.
- Add a synthetic regression and execute it in the existing build job without adding a runner.

## Verification

- Confirmed the regression fails against main before the fix.
- cargo build --offline -p oj
- node e2e/build-unresolved.mjs
- cargo test --offline --workspace