### PR TITLE
fix(build): pass command and mode to Vite configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - run: npx --prefix e2e playwright install --with-deps chromium
       - name: run e2e suite
         run: node e2e/run.mjs ${{ matrix.mode == 'bundle' && '--bundle' || '' }}
+      - name: Vite build command and mode
+        if: matrix.mode == 'unbundled'
+        run: node e2e/vite-config-command.mjs
       - name: warm-cache plugin side effects
         if: matrix.mode == 'unbundled'
         run: node e2e/warm-cache.mjs

--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -1070,7 +1070,7 @@ pub async fn build(
 
     let mut config =
         oj_config::load_with(&root, "build", mode).map_err(|e| anyhow::anyhow!("{e}"))?;
-    oj_server::plugins::adopt_vite_config_values(&mut config, &root);
+    oj_server::plugins::adopt_vite_config_values_with(&mut config, &root, "build", mode);
     let build_cfg = config.build.clone().unwrap_or_default();
     let ro_opts = oj_config::rolldown_options(&config);
     let out = out
@@ -1527,7 +1527,7 @@ pub(crate) async fn build_ssr(
 
     let mut config =
         oj_config::load_with(root, "build", "production").map_err(|e| anyhow::anyhow!("{e}"))?;
-    oj_server::plugins::adopt_vite_config_values(&mut config, root);
+    oj_server::plugins::adopt_vite_config_values_with(&mut config, root, "build", "production");
     let ssr_base = config.base.clone().unwrap_or_else(|| "/".into());
     let plugin_host = user_plugin_host(
         root,
@@ -2033,7 +2033,7 @@ async fn build_client_entry(
 
     let mut config =
         oj_config::load_with(root, "build", "production").map_err(|e| anyhow::anyhow!("{e}"))?;
-    oj_server::plugins::adopt_vite_config_values(&mut config, root);
+    oj_server::plugins::adopt_vite_config_values_with(&mut config, root, "build", "production");
     let client_base = config.base.clone().unwrap_or_else(|| "/".into());
     let plugin_host = user_plugin_host(
         root,

--- a/crates/oj_server/src/plugins.rs
+++ b/crates/oj_server/src/plugins.rs
@@ -172,6 +172,10 @@ pub struct ViteValues {
 }
 
 pub fn extract_vite_values(root: &Path) -> Option<ViteValues> {
+    extract_vite_values_with(root, "serve", "development")
+}
+
+pub fn extract_vite_values_with(root: &Path, command: &str, mode: &str) -> Option<ViteValues> {
     if plugins_file(root).is_some() {
         return None;
     }
@@ -184,7 +188,7 @@ pub fn extract_vite_values(root: &Path) -> Option<ViteValues> {
             blake3::hash(VITE_EXTRACT_JS.as_bytes()).to_hex()
         ),
     );
-    if let Some(hit) = store.lookup(&vite, "serve", "development") {
+    if let Some(hit) = store.lookup(&vite, command, mode) {
         if let Ok(json) = serde_json::from_str::<serde_json::Value>(&hit.output) {
             if !hit.stderr.is_empty() {
                 eprint!("{}", hit.stderr);
@@ -201,8 +205,8 @@ pub fn extract_vite_values(root: &Path) -> Option<ViteValues> {
         .arg(&script)
         .arg(&vite)
         .arg(root)
-        .arg("serve")
-        .arg("development")
+        .arg(command)
+        .arg(mode)
         .env("OJ_CACHE_ROOT", oj_cache::cache_root(root))
         .env("NODE_COMPILE_CACHE", crate::node_compile_cache(root))
         .current_dir(root)
@@ -225,8 +229,8 @@ pub fn extract_vite_values(root: &Path) -> Option<ViteValues> {
             .unwrap_or_default();
         store.store(
             &vite,
-            "serve",
-            "development",
+            command,
+            mode,
             &deps,
             &String::from_utf8_lossy(&out.stdout),
             &stderr,
@@ -274,7 +278,16 @@ fn parse_vite_values(json: &serde_json::Value) -> ViteValues {
 
 #[inline]
 pub fn adopt_vite_config_values(config: &mut oj_config::OjConfig, root: &Path) {
-    let Some(v) = extract_vite_values(root) else {
+    adopt_vite_config_values_with(config, root, "serve", "development");
+}
+
+pub fn adopt_vite_config_values_with(
+    config: &mut oj_config::OjConfig,
+    root: &Path,
+    command: &str,
+    mode: &str,
+) {
+    let Some(v) = extract_vite_values_with(root, command, mode) else {
         return;
     };
     merge_vite_values(config, v);

--- a/e2e/vite-config-command.mjs
+++ b/e2e/vite-config-command.mjs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const binary = path.join(root, "target", "debug", "oj");
+const project = fs.mkdtempSync(path.join(os.tmpdir(), "oj-config-command-"));
+
+try {
+  fs.writeFileSync(path.join(project, "package.json"), JSON.stringify({ type: "module" }));
+  fs.writeFileSync(path.join(project, "index.html"), '<html><body><script type="module" src="/main.js"></script></body></html>');
+  fs.writeFileSync(path.join(project, "main.js"), 'document.body.textContent = __BUILD_MODE__;');
+  fs.writeFileSync(path.join(project, "vite.config.mjs"), `
+    export default ({ command, mode }) => ({
+      base: command === "build" ? "/release/" : "/development/",
+      define: { __BUILD_MODE__: JSON.stringify(mode) },
+    });
+  `);
+
+  const build = spawnSync(binary, ["build", project, "--mode", "staging"], { cwd: root, encoding: "utf8" });
+  assert.equal(build.status, 0, `build failed:\n${build.stdout}\n${build.stderr}`);
+
+  const html = fs.readFileSync(path.join(project, "dist", "index.html"), "utf8");
+  assert.match(html, /\/release\/assets\//, `Vite config must receive command=build:\n${html}`);
+
+  const assets = fs.readdirSync(path.join(project, "dist", "assets"));
+  const javascript = assets.filter((file) => file.endsWith(".js"))
+    .map((file) => fs.readFileSync(path.join(project, "dist", "assets", file), "utf8"))
+    .join("\n");
+  assert.match(javascript, /staging/, `Vite config must receive the selected build mode:\n${javascript}`);
+
+  console.log("VITE-CONFIG-COMMAND E2E PASSED");
+} finally {
+  fs.rmSync(project, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- Evaluate Vite configuration with command=build and the selected build mode instead of serve/development.
- Separate cached configuration extraction by command and mode.
- Preserve the existing development-server configuration behavior.
- Add a synthetic regression to the existing CI job without adding runners.

## Verification
- Confirmed the regression fails against main because production builds receive the development base.
- Confirmed the identical regression passes after the fix.
- cargo test --offline --workspace
- node e2e/vite-config-command.mjs