### PR TITLE
fix(config): reject Vite configurations that fail to load

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - run: npx --prefix e2e playwright install --with-deps chromium
       - name: run e2e suite
         run: node e2e/run.mjs ${{ matrix.mode == 'bundle' && '--bundle' || '' }}
+      - name: Vite config load failures
+        if: matrix.mode == 'unbundled'
+        run: node e2e/config-load-failure.mjs
       - name: warm-cache plugin side effects
         if: matrix.mode == 'unbundled'
         run: node e2e/warm-cache.mjs

--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -1070,7 +1070,8 @@ pub async fn build(
 
     let mut config =
         oj_config::load_with(&root, "build", mode).map_err(|e| anyhow::anyhow!("{e}"))?;
-    oj_server::plugins::adopt_vite_config_values(&mut config, &root);
+    oj_server::plugins::adopt_vite_config_values(&mut config, &root)
+        .map_err(|error| anyhow::anyhow!(error))?;
     let build_cfg = config.build.clone().unwrap_or_default();
     let ro_opts = oj_config::rolldown_options(&config);
     let out = out
@@ -1527,7 +1528,8 @@ pub(crate) async fn build_ssr(
 
     let mut config =
         oj_config::load_with(root, "build", "production").map_err(|e| anyhow::anyhow!("{e}"))?;
-    oj_server::plugins::adopt_vite_config_values(&mut config, root);
+    oj_server::plugins::adopt_vite_config_values(&mut config, root)
+        .map_err(|error| anyhow::anyhow!(error))?;
     let ssr_base = config.base.clone().unwrap_or_else(|| "/".into());
     let plugin_host = user_plugin_host(
         root,
@@ -2033,7 +2035,8 @@ async fn build_client_entry(
 
     let mut config =
         oj_config::load_with(root, "build", "production").map_err(|e| anyhow::anyhow!("{e}"))?;
-    oj_server::plugins::adopt_vite_config_values(&mut config, root);
+    oj_server::plugins::adopt_vite_config_values(&mut config, root)
+        .map_err(|error| anyhow::anyhow!(error))?;
     let client_base = config.base.clone().unwrap_or_else(|| "/".into());
     let plugin_host = user_plugin_host(
         root,

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -320,7 +320,8 @@ impl DevServer {
         boot_phase("build_app begin");
         prepare_cache_root(&root);
         let mut config = oj_config::load(&root).map_err(|e| anyhow::anyhow!("{e}"))?;
-        plugins::adopt_vite_config_values(&mut config, &root);
+        plugins::adopt_vite_config_values(&mut config, &root)
+            .map_err(|error| anyhow::anyhow!(error))?;
         boot_phase("vite config values adopted");
 
         // Feed optimizeDeps.include/exclude/needsInterop into partial bundling so

--- a/crates/oj_server/src/plugins.rs
+++ b/crates/oj_server/src/plugins.rs
@@ -213,25 +213,27 @@ pub fn extract_vite_values(root: &Path) -> Option<ViteValues> {
         eprint!("{stderr}");
     }
     let json: serde_json::Value = serde_json::from_slice(&out.stdout).ok()?;
-    if json.get("__ok").and_then(|v| v.as_bool()) == Some(true) {
-        let deps: Vec<PathBuf> = json
-            .get("__deps")
-            .and_then(|v| v.as_array())
-            .map(|a| {
-                a.iter()
-                    .filter_map(|d| d.as_str().map(PathBuf::from))
-                    .collect()
-            })
-            .unwrap_or_default();
-        store.store(
-            &vite,
-            "serve",
-            "development",
-            &deps,
-            &String::from_utf8_lossy(&out.stdout),
-            &stderr,
-        );
+    if json.get("__ok").and_then(|value| value.as_bool()) != Some(true) {
+        return None;
     }
+    let deps: Vec<PathBuf> = json
+        .get("__deps")
+        .and_then(|values| values.as_array())
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|dependency| dependency.as_str().map(PathBuf::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    store.store(
+        &vite,
+        "serve",
+        "development",
+        &deps,
+        &String::from_utf8_lossy(&out.stdout),
+        &stderr,
+    );
     crate::boot_phase("vite-extract cache miss (subprocess ran)");
     Some(parse_vite_values(&json))
 }
@@ -273,11 +275,20 @@ fn parse_vite_values(json: &serde_json::Value) -> ViteValues {
 }
 
 #[inline]
-pub fn adopt_vite_config_values(config: &mut oj_config::OjConfig, root: &Path) {
+pub fn adopt_vite_config_values(
+    config: &mut oj_config::OjConfig,
+    root: &Path,
+) -> Result<(), String> {
     let Some(v) = extract_vite_values(root) else {
-        return;
+        if plugins_file(root).is_none() {
+            if let Some(path) = vite_config_file(root) {
+                return Err(format!("failed to load Vite config: {}", path.display()));
+            }
+        }
+        return Ok(());
     };
     merge_vite_values(config, v);
+    Ok(())
 }
 
 fn merge_vite_values(config: &mut oj_config::OjConfig, v: ViteValues) {

--- a/e2e/config-load-failure.mjs
+++ b/e2e/config-load-failure.mjs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const binary = path.join(root, "target", "debug", "oj");
+const project = fs.mkdtempSync(path.join(os.tmpdir(), "oj-config-failure-"));
+
+try {
+  fs.writeFileSync(path.join(project, "package.json"), JSON.stringify({ type: "module" }));
+  fs.writeFileSync(path.join(project, "index.html"), '<html><body><script type="module" src="/main.js"></script></body></html>');
+  fs.writeFileSync(path.join(project, "main.js"), 'document.body.textContent = "ready";');
+  fs.writeFileSync(path.join(project, "vite.config.mjs"), 'import "missing-config-plugin"; export default {};\n');
+
+  const build = spawnSync(binary, ["build", project], { cwd: root, encoding: "utf8" });
+  assert.notEqual(build.status, 0, `a broken Vite config must fail instead of being ignored:\n${build.stdout}\n${build.stderr}`);
+  assert.match(`${build.stdout}\n${build.stderr}`, /missing-config-plugin/);
+
+  console.log("CONFIG-LOAD-FAILURE E2E PASSED");
+} finally {
+  fs.rmSync(project, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- Fail builds and development-server startup when an existing Vite configuration cannot be loaded.
- Stop treating unsuccessful configuration extraction as a valid empty configuration.
- Preserve projects without a Vite configuration and explicit plugin files.
- Add a synthetic missing-plugin regression to the existing CI job without adding runners.

## Verification
- Confirmed the regression fails against main because an invalid Vite configuration is silently ignored.
- Confirmed the identical regression passes after the fix.
- cargo test --offline --workspace
- node e2e/config-load-failure.mjs