### PR TITLE
fix(build): accept valid HTML attribute quoting forms

### DIFF
--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -1469,34 +1469,92 @@ fn human_bytes(bytes: usize) -> String {
 }
 
 fn module_script_srcs(html: &str) -> Vec<String> {
-    scan_attrs(html, "<script", "src=\"")
+    scan_attrs(html, "<script", "src")
         .into_iter()
         .filter(|src| oj_server::html_entry_src(src).is_some())
         .collect()
 }
 
 fn link_hrefs(html: &str) -> Vec<String> {
-    scan_attrs(html, "<link", "href=\"")
+    scan_attrs(html, "<link", "href")
         .into_iter()
         .filter(|href| href.starts_with('/'))
         .collect()
 }
 
-fn scan_attrs(html: &str, tag_prefix: &str, attr_prefix: &str) -> Vec<String> {
+fn html_attr<'a>(tag: &'a str, name: &str) -> Option<&'a str> {
+    let bytes = tag.as_bytes();
+    let mut cursor = bytes.iter().position(u8::is_ascii_whitespace)?;
+
+    while cursor < bytes.len() {
+        while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+        let start = cursor;
+        while cursor < bytes.len()
+            && !bytes[cursor].is_ascii_whitespace()
+            && bytes[cursor] != b'='
+            && bytes[cursor] != b'/'
+        {
+            cursor += 1;
+        }
+        if cursor == start {
+            cursor += 1;
+            continue;
+        }
+        let attribute = &tag[start..cursor];
+        while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+        if cursor >= bytes.len() || bytes[cursor] != b'=' {
+            continue;
+        }
+        cursor += 1;
+        while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+        if cursor >= bytes.len() {
+            return None;
+        }
+        let (value_start, value_end) = if matches!(bytes[cursor], b'\'' | b'"') {
+            let quote = bytes[cursor];
+            let start = cursor + 1;
+            cursor = start;
+            while cursor < bytes.len() && bytes[cursor] != quote {
+                cursor += 1;
+            }
+            let end = cursor;
+            cursor += usize::from(cursor < bytes.len());
+            (start, end)
+        } else {
+            let start = cursor;
+            while cursor < bytes.len() && !bytes[cursor].is_ascii_whitespace() {
+                cursor += 1;
+            }
+            (start, cursor)
+        };
+        if attribute.eq_ignore_ascii_case(name) {
+            return Some(&tag[value_start..value_end]);
+        }
+    }
+
+    None
+}
+
+fn scan_attrs(html: &str, tag_prefix: &str, attr_name: &str) -> Vec<String> {
     let mut values = Vec::new();
     for (start, _) in html.match_indices(tag_prefix) {
         let Some(end) = html[start..].find('>') else {
             continue;
         };
         let tag = &html[start..start + end];
-        if tag_prefix == "<script" && !tag.contains("type=\"module\"") {
+        if tag_prefix == "<script"
+            && !html_attr(tag, "type").is_some_and(|value| value.eq_ignore_ascii_case("module"))
+        {
             continue;
         }
-        if let Some(at) = tag.find(attr_prefix) {
-            let rest = &tag[at + attr_prefix.len()..];
-            if let Some(close) = rest.find('"') {
-                values.push(rest[..close].to_string());
-            }
+        if let Some(value) = html_attr(tag, attr_name) {
+            values.push(value.to_string());
         }
     }
     values

--- a/e2e/html-attribute-quotes.test.js
+++ b/e2e/html-attribute-quotes.test.js
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "..");
+const binary = process.env.OJ_BIN ?? path.join(root, "target", "debug", "oj");
+
+const fixtures = [
+  {
+    name: "single-quoted attributes",
+    stylesheet: "<link rel='stylesheet' href='/site.css'>",
+    entry: "<script type='module' src='/main.js'></script>",
+  },
+  {
+    name: "whitespace around attribute values",
+    stylesheet: '<link rel = "stylesheet" href = "/site.css">',
+    entry: '<script type = "module" src = "/main.js"></script>',
+  },
+  {
+    name: "unquoted attributes",
+    stylesheet: "<link rel=stylesheet href=/site.css>",
+    entry: "<script type=module src=/main.js></script>",
+  },
+  {
+    name: "attribute-name boundaries",
+    stylesheet: "<link data-href='/ignored.css' href='/site.css'>",
+    entry: "<script data-type='module' data-src='/ignored.js' type='module' src='/main.js'></script>",
+  },
+];
+
+for (const fixture of fixtures) {
+  const project = fs.mkdtempSync(path.join(os.tmpdir(), "oj-html-attributes-"));
+  try {
+    fs.writeFileSync(path.join(project, "package.json"), JSON.stringify({ type: "module" }));
+    fs.writeFileSync(path.join(project, "index.html"), `<html><head>${fixture.stylesheet}</head><body>${fixture.entry}</body></html>`);
+    fs.writeFileSync(path.join(project, "main.js"), 'document.body.textContent = "ready";');
+    fs.writeFileSync(path.join(project, "site.css"), "body { color: red; }");
+
+    const build = spawnSync(binary, ["build", project], { cwd: root, encoding: "utf8" });
+    assert.equal(build.status, 0, `${fixture.name} must build successfully:\n${build.stdout}\n${build.stderr}`);
+
+    const html = fs.readFileSync(path.join(project, "dist", "index.html"), "utf8");
+    assert.match(html, /\/assets\/main-[^"'\s>]+\.js/, `${fixture.name} must rewrite the module entry:\n${html}`);
+    assert.equal(fs.readFileSync(path.join(project, "dist", "site.css"), "utf8"), "body { color: red; }");
+  } finally {
+    fs.rmSync(project, { recursive: true, force: true });
+  }
+}
+
+console.log("HTML-ATTRIBUTE-QUOTES E2E PASSED");


### PR DESCRIPTION
## Summary
- parse single-quoted, double-quoted, and unquoted HTML attribute values, including whitespace around equals signs
- discover module entries and copy stylesheet assets without mistaking data-src or data-href for real attributes
- add an independently failing synthetic end-to-end regression covering all four cases; the regression runs automatically in both existing e2e CI jobs

## Validation
- synthetic regression fails before the fix with the missing module-entry error and passes unchanged after the fix
- cargo test --workspace passes
- node --test e2e/unit/*.test.mjs passes (92 passing, 11 existing fixture skips)

Regression commit: ecf6b4a
Fix commit: f8d39e3