### PR TITLE
fix(plugins): honor environment consumers during bundle generation

### DIFF
--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -198,13 +198,7 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
     const genCtx = { ...ctx, emitFile: (f) => (emit(f), "oj-emit-ref") };
     for (const p of plugins) {
       const h = hookHandler(p.generateBundle);
-      if (!h) continue;
-      const ae = p.applyToEnvironment;
-      if (typeof ae === "function") {
-        let ok;
-        try { ok = ae({ name: environment }); } catch { ok = true; }
-        if (ok === false) continue;
-      }
+      if (!h || !envAllows(p, environment)) continue;
       try { await h.call(genCtx, { format: "es" }, {}, false); } catch {}
     }
   }

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { __test, createPluginContainer } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -108,4 +108,24 @@ test("hookHandler / hookFilter: function form and object form", () => {
 
   assert.equal(hookHandler(undefined), null);
   assert.equal(hookHandler({ handler: "not-a-fn" }), null);
+});
+
+test("generateBundle honors environment consumer gates", async () => {
+  const emitted = [];
+  const plugin = {
+    name: "synthetic-server-manifest",
+    applyToEnvironment: (environment) => environment.config.consumer === "server",
+    generateBundle() {
+      this.emitFile({ type: "asset", fileName: "server-manifest.json", source: "{}" });
+    },
+  };
+
+  await createPluginContainer({}, [plugin], { environment: "client" })
+    .generateBundle((asset) => emitted.push(asset));
+  assert.deepEqual(emitted, []);
+
+  await createPluginContainer({}, [plugin], { environment: "ssr" })
+    .generateBundle((asset) => emitted.push(asset));
+  assert.equal(emitted.length, 1);
+  assert.equal(emitted[0].fileName, "server-manifest.json");
 });


### PR DESCRIPTION
The generateBundle bridge invokes applyToEnvironment with only an environment name, unlike every other plugin hook. Plugins checking environment.config.consumer throw; their errors are swallowed and server-only assets leak into client bundles. Reuse the existing environment gate so generation receives the same Vite-compatible environment shape. The first commit adds a synthetic regression demonstrating the leaked asset; the second commit replaces the inconsistent gate. All 104 public unit tests pass (93 passing, 11 fixture-dependent skips). No customer content is included.