### PR TITLE
fix(plugins): preserve buildStart-only initialization hooks

### DIFF
--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -108,7 +108,7 @@ export function findConfig(app) {
 export function createPluginContainer(vite, allPlugins, { command = "serve", mode = "development", environment = "client" } = {}) {
   const plugins = ordered(
     allPlugins.filter(
-      (p) => (p.resolveId || p.load || p.transform || p.generateBundle) && applyMatches(p, command, mode),
+      (p) => (p.buildStart || p.resolveId || p.load || p.transform || p.generateBundle) && applyMatches(p, command, mode),
     ),
   );
 

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { __test, createPluginContainer } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -108,4 +108,17 @@ test("hookHandler / hookFilter: function form and object form", () => {
 
   assert.equal(hookHandler(undefined), null);
   assert.equal(hookHandler({ handler: "not-a-fn" }), null);
+});
+
+test("buildStart runs plugins whose only hook initializes generated sources", async () => {
+  let initialized = 0;
+  const container = createPluginContainer({}, [{
+    name: "synthetic-source-generator",
+    buildStart() { initialized++; },
+  }]);
+
+  await container.buildStart();
+  await container.buildStart();
+
+  assert.equal(initialized, 1);
 });


### PR DESCRIPTION
Plugins that only implement buildStart are currently discarded while constructing the Vite plugin container. Consequently source generators and initialization plugins never run, even though the bridge explicitly supports buildStart. Preserve these plugins so their initialization runs exactly once. The first commit adds a synthetic regression that fails on upstream main (0 !== 1); the second commit applies the one-line fix. All 104 public unit tests pass (93 passing, 11 fixture-dependent skips). No customer content is included.