### PR TITLE
fix(ssr): preserve inherited TypeScript baseUrl mappings

### DIFF
--- a/crates/oj_server/src/assets/start/loader-util.mjs
+++ b/crates/oj_server/src/assets/start/loader-util.mjs
@@ -124,7 +124,7 @@ export function mergeTsConfig(chain, fallbackBaseDir) {
   for (const { cfg, dir } of chain) {
     const co = cfg.compilerOptions || {};
     if (co.paths) paths = { ...paths, ...co.paths };
-    baseDir = co.baseUrl != null ? pathResolve(dir, co.baseUrl) : dir;
+    if (co.baseUrl != null) baseDir = pathResolve(dir, co.baseUrl);
   }
   return { rules: Object.entries(paths).map(([k, v]) => [k, Array.isArray(v) ? v : [v]]), baseDir };
 }

--- a/e2e/unit/loader-util.test.mjs
+++ b/e2e/unit/loader-util.test.mjs
@@ -154,6 +154,25 @@ test("mergeTsConfig resolves baseUrl against its config dir and arrays targets",
   assert.deepEqual(Object.fromEntries(rules)["@x"], ["./x.ts"]);
 });
 
+test("mergeTsConfig preserves an inherited baseUrl when the child omits it", () => {
+  const chain = [
+    {
+      cfg: { compilerOptions: { baseUrl: "./shared", paths: { "@shared/*": ["./*"] } } },
+      dir: "/workspace/config",
+    },
+    {
+      cfg: { compilerOptions: { paths: { "@app/*": ["./app/*"] } } },
+      dir: "/workspace/apps/web",
+    },
+  ];
+
+  const { rules, baseDir } = mergeTsConfig(chain, "/workspace/apps/web");
+
+  assert.equal(baseDir, ["/workspace", "config", "shared"].join(sep));
+  assert.deepEqual(Object.fromEntries(rules)["@shared/*"], ["./*"]);
+  assert.deepEqual(Object.fromEntries(rules)["@app/*"], ["./app/*"]);
+});
+
 test("substituteAlias fills a trailing-star pattern (tsconfig + imports style)", () => {
   assert.equal(substituteAlias("@app/*", "./src/*", "@app/lib/format"), "./src/lib/format");
   assert.equal(substituteAlias("#lib/*", "./src/lib/*", "#lib/format"), "./src/lib/format");


### PR DESCRIPTION
When a child TypeScript configuration extends another configuration but omits baseUrl, the SSR loader replaces the inherited baseUrl with the child directory. This resolves shared path aliases against the wrong directory and breaks valid monorepo imports. Preserve the previously resolved baseUrl unless the current configuration explicitly overrides it. The first commit adds a synthetic extended-configuration regression that fails on upstream main; the second commit applies the one-line fix. All 104 public unit tests pass (93 passing, 11 fixture-dependent skips). No customer content is included.