### PR TITLE
fix(plugins): pass SSR context to resolve and load hooks

### DIFF
--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -147,7 +147,7 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
       const h = hookHandler(p.resolveId);
       if (!h || !idAllowed(hookFilter(p.resolveId), id)) continue;
       let r;
-      try { r = await h.call(ctx, id, importer, { isEntry: false }); } catch { continue; }
+      try { r = await h.call(ctx, id, importer, { isEntry: false, ssr: environment === "ssr" }); } catch { continue; }
       if (r != null) return typeof r === "string" ? r : r.id;
     }
     return null;
@@ -159,7 +159,7 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
       const h = hookHandler(p.load);
       if (!h || !idAllowed(hookFilter(p.load), id)) continue;
       let r;
-      try { r = await h.call(ctx, id); } catch { continue; }
+      try { r = await h.call(ctx, id, { ssr: environment === "ssr" }); } catch { continue; }
       if (r != null) return typeof r === "string" ? r : r.code;
     }
     return null;

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { __test, createPluginContainer } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -108,4 +108,24 @@ test("hookHandler / hookFilter: function form and object form", () => {
 
   assert.equal(hookHandler(undefined), null);
   assert.equal(hookHandler({ handler: "not-a-fn" }), null);
+});
+
+test("resolveId and load receive Vite SSR hook options", async () => {
+  const plugin = {
+    name: "synthetic-environment-module",
+    resolveId(source, _importer, options) {
+      return `\0${options?.ssr ? "server" : "client"}:${source}`;
+    },
+    load(_id, options) {
+      return `export default ${JSON.stringify(options?.ssr ? "server" : "client")};`;
+    },
+  };
+
+  const server = createPluginContainer({}, [plugin], { environment: "ssr" });
+  const client = createPluginContainer({}, [plugin], { environment: "client" });
+
+  assert.equal(await server.resolveId("virtual:entry", "/app.ts"), "\0server:virtual:entry");
+  assert.equal(await server.load("\0server:virtual:entry"), 'export default "server";');
+  assert.equal(await client.resolveId("virtual:entry", "/app.ts"), "\0client:virtual:entry");
+  assert.equal(await client.load("\0client:virtual:entry"), 'export default "client";');
 });


### PR DESCRIPTION
The plugin bridge passes SSR options to transformation hooks but omits them from resolveId and load. Plugins that provide environment-specific virtual modules therefore return client implementations while preparing the server bundle, breaking SSR compatibility. Pass the Vite-compatible ssr option consistently to both hooks without changing client behavior. The first commit introduces a wholly synthetic regression demonstrating server resolution incorrectly returning a client module; the second commit applies the minimal two-line fix. All 104 public unit tests pass (93 passing, 11 fixture-dependent skips). No customer content is included.