### PR TITLE
fix(config): preserve comma sequences inside JSONC strings

### DIFF
--- a/crates/oj_server/src/assets/start/loader-util.mjs
+++ b/crates/oj_server/src/assets/start/loader-util.mjs
@@ -97,6 +97,9 @@ export function stripJsonc(s) {
     if (c === '"' || c === "'") { inStr = true; q = c; out += c; i++; continue; }
     if (c === "/" && n === "/") { while (i < s.length && s[i] !== "\n") i++; continue; }
     if (c === "/" && n === "*") { i += 2; while (i < s.length && !(s[i] === "*" && s[i + 1] === "/")) i++; i += 2; continue; }
+    if (c === "," && /^(?:\s|\/\/[^\n]*(?:\n|$)|\/\*[\s\S]*?\*\/)*[}\]]/.test(s.slice(i + 1))) {
+      i++; continue;
+    }
     out += c; i++;
   }
   return out;
@@ -104,7 +107,7 @@ export function stripJsonc(s) {
 
 export function readJsonc(file) {
   try {
-    return JSON.parse(stripJsonc(readFileSync(file, "utf8")).replace(/,(\s*[}\]])/g, "$1"));
+    return JSON.parse(stripJsonc(readFileSync(file, "utf8")));
   } catch {
     return null;
   }

--- a/e2e/unit/loader-util.test.mjs
+++ b/e2e/unit/loader-util.test.mjs
@@ -224,3 +224,17 @@ test("stripJsonc + readJsonc tolerate comments and trailing commas", () => {
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test("readJsonc preserves comma-and-bracket sequences inside string values", () => {
+  const dir = mk("jsonc-string");
+  try {
+    const file = join(dir, "tsconfig.json");
+    writeFileSync(file, '{"compilerOptions":{"custom":"literal,} and ,]",},}');
+
+    assert.deepEqual(readJsonc(file), {
+      compilerOptions: { custom: "literal,} and ,]" },
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Summary: Strip JSONC trailing commas only outside quoted strings and correctly tolerate intervening comments. Prevents tsconfig string values from being silently corrupted by comma-plus-bracket sequences. Verification: node --test e2e/unit/loader-util.test.mjs (19 passing; new case fails against upstream main).