### PR TITLE
fix(ssr): serialize import.meta.glob query objects

### DIFF
--- a/crates/oj_server/src/assets/start/glob-transform.mjs
+++ b/crates/oj_server/src/assets/start/glob-transform.mjs
@@ -85,7 +85,11 @@ export function transformGlob(code, filePath) {
     const files = [...new Set(includes.flatMap((p) => matchPattern(fileDir, p)))]
       .filter((f) => !exclude.has(f))
       .sort();
-    const query = typeof opts.query === "string" ? opts.query : "";
+    const query = typeof opts.query === "string"
+      ? opts.query
+      : opts.query && typeof opts.query === "object"
+        ? `?${new URLSearchParams(opts.query)}`
+        : "";
     const wantDefault = opts.import === "default";
     const entries = files.map((f, idx) => {
       const rel = toRel(fileDir, f);

--- a/e2e/unit/glob-transform.test.mjs
+++ b/e2e/unit/glob-transform.test.mjs
@@ -78,6 +78,21 @@ test("non-eager import:default awaits the default export", () => {
   }
 });
 
+test("glob query objects are serialized into generated import specifiers", () => {
+  const dir = fixture();
+  try {
+    const out = transformGlob(
+      'const modules = import.meta.glob("./content/*.md", { query: { raw: "", locale: "en US" } });',
+      join(dir, "index.ts"),
+    );
+
+    assert.match(out, /import\("\.\/content\/a\.md\?raw=&locale=en\+US"\)/);
+    assert.match(out, /"\.\/content\/a\.md":/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("negated patterns exclude matches", () => {
   const dir = fixture();
   try {


### PR DESCRIPTION
Summary: Serialize object-form import.meta.glob query options into generated import specifiers while preserving original map keys. Adds a synthetic regression covering multiple encoded query parameters. Verification: node --test e2e/unit/glob-transform.test.mjs (8 passing; new case fails against upstream main).