### PR TITLE
fix(plugins): reset stateful hook filter expressions

### DIFF
--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -40,7 +40,10 @@ function envAllows(plugin, environment) {
 }
 
 function matchOne(pat, id) {
-  if (pat instanceof RegExp) return pat.test(id);
+  if (pat instanceof RegExp) {
+    pat.lastIndex = 0;
+    return pat.test(id);
+  }
   if (typeof pat === "string") return id.includes(pat);
   return false;
 }

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -13,6 +13,16 @@ test("matchOne: RegExp tests, string is a substring match", () => {
   assert.ok(!matchOne("virtual:", "./real"));
 });
 
+test("global and sticky expression filters match consistently across modules", () => {
+  const global = /\.tsx$/g;
+  const sticky = /component/y;
+
+  assert.ok(matchOne(global, "/src/first.tsx"));
+  assert.ok(matchOne(global, "/src/second.tsx"));
+  assert.ok(matchOne(sticky, "component-one"));
+  assert.ok(matchOne(sticky, "component-two"));
+});
+
 test("idAllowed: no filter allows everything", () => {
   assert.ok(idAllowed(undefined, "anything"));
   assert.ok(idAllowed(null, "anything"));


### PR DESCRIPTION
Summary: Reset lastIndex before matching global or sticky plugin-hook filter expressions so repeated modules are consistently transformed. Adds a synthetic regression covering both RegExp modes. Verification: node --test e2e/unit/plugin-gating.test.mjs (12 passing; new case fails against upstream main).