### PR TITLE
fix(ssr): honor named import.meta.glob exports

### DIFF
--- a/crates/oj_server/src/assets/start/glob-transform.mjs
+++ b/crates/oj_server/src/assets/start/glob-transform.mjs
@@ -86,7 +86,8 @@ export function transformGlob(code, filePath) {
       .filter((f) => !exclude.has(f))
       .sort();
     const query = typeof opts.query === "string" ? opts.query : "";
-    const wantDefault = opts.import === "default";
+    const importName = typeof opts.import === "string" ? opts.import : null;
+    const wantDefault = importName === "default";
     const entries = files.map((f, idx) => {
       const rel = toRel(fileDir, f);
       const spec = rel + query;
@@ -95,12 +96,16 @@ export function transformGlob(code, filePath) {
         const id = `__oj_glob${g}_${idx}`;
         prelude.push(wantDefault
           ? `import ${id} from ${JSON.stringify(spec)};`
-          : `import * as ${id} from ${JSON.stringify(spec)};`);
+          : importName
+            ? `import { ${importName} as ${id} } from ${JSON.stringify(spec)};`
+            : `import * as ${id} from ${JSON.stringify(spec)};`);
         return `${key}: ${id}`;
       }
       const imp = wantDefault
         ? `() => import(${JSON.stringify(spec)}).then((m) => m.default)`
-        : `() => import(${JSON.stringify(spec)})`;
+        : importName
+          ? `() => import(${JSON.stringify(spec)}).then((m) => m[${JSON.stringify(importName)}])`
+          : `() => import(${JSON.stringify(spec)})`;
       return `${key}: ${imp}`;
     });
     out += code.slice(last, m.index) + `{${entries.join(", ")}}`;

--- a/e2e/unit/glob-transform.test.mjs
+++ b/e2e/unit/glob-transform.test.mjs
@@ -78,6 +78,25 @@ test("non-eager import:default awaits the default export", () => {
   }
 });
 
+test("named glob imports select the requested export in eager and lazy modes", () => {
+  const dir = fixture();
+  try {
+    const lazy = transformGlob(
+      'const modules = import.meta.glob("./content/*.md", { import: "metadata" });',
+      join(dir, "index.ts"),
+    );
+    const eager = transformGlob(
+      'const modules = import.meta.glob("./content/*.md", { eager: true, import: "metadata" });',
+      join(dir, "index.ts"),
+    );
+
+    assert.match(lazy, /import\("\.\/content\/a\.md"\)\.then\(\(m\) => m\["metadata"\]\)/);
+    assert.match(eager, /^import \{ metadata as __oj_glob0_0 \} from "\.\/content\/a\.md";/m);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("negated patterns exclude matches", () => {
   const dir = fixture();
   try {


### PR DESCRIPTION
Summary: Preserve Vite named-export selection for eager and lazy import.meta.glob calls instead of returning full module namespaces. Adds a synthetic regression covering both loading modes. Verification: node --test e2e/unit/glob-transform.test.mjs (8 passing; new case fails against upstream main).