### PR TITLE
fix(plugins): honor transform hook source-code filters

### DIFF
--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -170,7 +170,8 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
     for (const p of plugins) {
       if (!envAllows(p, environment)) continue;
       const h = hookHandler(p.transform);
-      if (!h || !idAllowed(hookFilter(p.transform), id)) continue;
+      const filter = hookFilter(p.transform);
+      if (!h || !idAllowed(filter, id) || !idAllowed(filter?.code, current)) continue;
       let r;
       try { r = await h.call(ctx, current, id); } catch { continue; }
       const next = r == null ? null : typeof r === "string" ? r : r.code;
@@ -185,7 +186,8 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
     for (const p of plugins) {
       if (ojReimplemented(p.name) || !envAllows(p, environment)) continue;
       const h = hookHandler(p.transform);
-      if (!h || !idAllowed(hookFilter(p.transform), id)) continue;
+      const filter = hookFilter(p.transform);
+      if (!h || !idAllowed(filter, id) || !idAllowed(filter?.code, current)) continue;
       let r;
       try { r = await h.call(ctx, current, id, { ssr }); } catch { continue; }
       const next = r == null ? null : typeof r === "string" ? r : r.code;

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { __test, createPluginContainer } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -108,4 +108,21 @@ test("hookHandler / hookFilter: function form and object form", () => {
 
   assert.equal(hookHandler(undefined), null);
   assert.equal(hookHandler({ handler: "not-a-fn" }), null);
+});
+
+test("transform hook code filters gate both transform entry points", async () => {
+  const plugin = {
+    name: "synthetic-selective-transform",
+    transform: {
+      filter: { id: /\.tsx$/, code: { include: /@enabled/, exclude: /@disabled/ } },
+      handler(code) { return `${code}\ntransformed();`; },
+    },
+  };
+  const container = createPluginContainer({}, [plugin]);
+
+  assert.equal(await container.transform("plain();", "/app.tsx"), null);
+  assert.equal(await container.transform("/* @enabled @disabled */", "/app.tsx"), null);
+  assert.equal(await container.transform("/* @enabled */", "/app.tsx"), "/* @enabled */\ntransformed();");
+  assert.equal(await container.transformUserCode("plain();", "/app.tsx"), null);
+  assert.equal(await container.transformUserCode("/* @enabled */", "/app.tsx"), "/* @enabled */\ntransformed();");
 });


### PR DESCRIPTION
Summary: Apply include and exclude code-content filters to both plugin transform entry points instead of transforming modules that plugins explicitly exclude. Adds a synthetic regression for inclusion, exclusion, and both transform paths. Verification: node --test e2e/unit/plugin-gating.test.mjs (12 passing; new case fails against upstream main).