### PR TITLE
fix(plugins): respect per-hook transform ordering

### DIFF
--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -111,6 +111,10 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
       (p) => (p.resolveId || p.load || p.transform || p.generateBundle) && applyMatches(p, command, mode),
     ),
   );
+  const transformPlugins = [...plugins].sort((a, b) => {
+    const rank = (hook) => hook?.order === "pre" ? -1 : hook?.order === "post" ? 1 : 0;
+    return rank(a.transform) - rank(b.transform);
+  });
 
   const parse = typeof vite?.parseAst === "function"
     ? (code, opts) => vite.parseAst(code, opts)
@@ -167,7 +171,7 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
 
   async function transform(code, id) {
     let current = code, changed = false;
-    for (const p of plugins) {
+    for (const p of transformPlugins) {
       if (!envAllows(p, environment)) continue;
       const h = hookHandler(p.transform);
       if (!h || !idAllowed(hookFilter(p.transform), id)) continue;
@@ -182,7 +186,7 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
   async function transformUserCode(code, id) {
     const ssr = environment === "ssr";
     let current = code, changed = false;
-    for (const p of plugins) {
+    for (const p of transformPlugins) {
       if (ojReimplemented(p.name) || !envAllows(p, environment)) continue;
       const h = hookHandler(p.transform);
       if (!h || !idAllowed(hookFilter(p.transform), id)) continue;

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { __test, createPluginContainer } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -108,4 +108,22 @@ test("hookHandler / hookFilter: function form and object form", () => {
 
   assert.equal(hookHandler(undefined), null);
   assert.equal(hookHandler({ handler: "not-a-fn" }), null);
+});
+
+test("transform hooks honor per-hook pre and post ordering", async () => {
+  const plugin = (name, order) => ({
+    name,
+    transform: {
+      ...(order ? { order } : {}),
+      handler(code) { return `${code}${name};`; },
+    },
+  });
+  const container = createPluginContainer({}, [
+    plugin("post", "post"),
+    plugin("normal"),
+    plugin("pre", "pre"),
+  ]);
+
+  assert.equal(await container.transform("", "/app.ts"), "pre;normal;post;");
+  assert.equal(await container.transformUserCode("", "/app.ts"), "pre;normal;post;");
 });


### PR DESCRIPTION
Summary: Respect object-form transform hook pre and post ordering in both standard and user-code transform pipelines. Adds a synthetic regression where registration order differs from declared execution order. Verification: node --test e2e/unit/plugin-gating.test.mjs (12 passing; new case fails against upstream main).