### PR TITLE
fix(ssr): resolve extensionless JSON module imports

### DIFF
--- a/crates/oj_server/src/assets/start/loader-util.mjs
+++ b/crates/oj_server/src/assets/start/loader-util.mjs
@@ -7,8 +7,8 @@ import { createRequire } from "node:module";
 import { createHash } from "node:crypto";
 
 export const EXTS = [
-  ".ts", ".tsx", ".js", ".jsx", ".mjs",
-  "/index.ts", "/index.tsx", "/index.js", "/index.jsx", "/index.mjs",
+  ".ts", ".tsx", ".js", ".jsx", ".mjs", ".json",
+  "/index.ts", "/index.tsx", "/index.js", "/index.jsx", "/index.mjs", "/index.json",
 ];
 
 export const isFile = (p) => {

--- a/e2e/unit/loader-util.test.mjs
+++ b/e2e/unit/loader-util.test.mjs
@@ -30,6 +30,20 @@ test("probe finds an exact file, else a .ts for a .js import, else an index", ()
   }
 });
 
+test("probe resolves extensionless JSON modules and directory indexes", () => {
+  const dir = mk("json-probe");
+  try {
+    mkdirSync(join(dir, "config"), { recursive: true });
+    writeFileSync(join(dir, "settings.json"), "{}");
+    writeFileSync(join(dir, "config", "index.json"), "{}");
+
+    assert.equal(probe(join(dir, "settings")), join(dir, "settings.json"));
+    assert.equal(probe(join(dir, "config")), join(dir, "config", "index.json"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("hasEsmSyntax detects import/export at statement position", () => {
   assert.ok(hasEsmSyntax(fileWith("export const x = 1;")));
   assert.ok(hasEsmSyntax(fileWith("import x from 'y';")));


### PR DESCRIPTION
Summary: Include JSON modules and JSON directory indexes in extensionless SSR resolution, matching Vite module resolution. Adds a synthetic regression for both direct modules and index modules. Verification: node --test e2e/unit/loader-util.test.mjs (19 passing; new case fails against upstream main).