### PR TITLE
fix(plugins): expose SSR options to transform hooks

### DIFF
--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -172,7 +172,7 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
       const h = hookHandler(p.transform);
       if (!h || !idAllowed(hookFilter(p.transform), id)) continue;
       let r;
-      try { r = await h.call(ctx, current, id); } catch { continue; }
+      try { r = await h.call(ctx, current, id, { ssr: environment === "ssr" }); } catch { continue; }
       const next = r == null ? null : typeof r === "string" ? r : r.code;
       if (next != null) { current = next; changed = true; }
     }

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { __test, createPluginContainer } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -108,4 +108,19 @@ test("hookHandler / hookFilter: function form and object form", () => {
 
   assert.equal(hookHandler(undefined), null);
   assert.equal(hookHandler({ handler: "not-a-fn" }), null);
+});
+
+test("transform hooks receive the active SSR environment option", async () => {
+  const plugin = {
+    name: "synthetic-environment-transform",
+    transform(_code, _id, options) {
+      return `export default ${JSON.stringify(options?.ssr ? "server" : "client")};`;
+    },
+  };
+
+  const server = createPluginContainer({}, [plugin], { environment: "ssr" });
+  const client = createPluginContainer({}, [plugin], { environment: "client" });
+
+  assert.equal(await server.transform("", "/page.mdx"), 'export default "server";');
+  assert.equal(await client.transform("", "/page.mdx"), 'export default "client";');
 });


### PR DESCRIPTION
Summary: Pass the Vite SSR boolean to transform hooks so environment-aware Markdown and other transforms choose the correct server or client output. Adds a synthetic regression for both environments. Verification: node --test e2e/unit/plugin-gating.test.mjs (12 passing; new case fails against upstream main).