### PR TITLE
fix(plugins): prevent stalled buildStart hooks from blocking SSR

### DIFF
--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -105,7 +105,7 @@ export function findConfig(app) {
   return null;
 }
 
-export function createPluginContainer(vite, allPlugins, { command = "serve", mode = "development", environment = "client" } = {}) {
+export function createPluginContainer(vite, allPlugins, { command = "serve", mode = "development", environment = "client", buildStartTimeoutMs = 5_000 } = {}) {
   const plugins = ordered(
     allPlugins.filter(
       (p) => (p.resolveId || p.load || p.transform || p.generateBundle) && applyMatches(p, command, mode),
@@ -230,10 +230,19 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
         // dev server — a plugin that genuinely needed buildStart will surface as
         // its own load() output being wrong, which is strictly better than one
         // unsupported plugin taking down every other plugin's startup.
-        try { await h.call(ctx, {}); }
+        let timer;
+        try {
+          await Promise.race([
+            h.call(ctx, {}),
+            new Promise((_, reject) => {
+              timer = setTimeout(() => reject(new Error(`timed out after ${buildStartTimeoutMs}ms`)), buildStartTimeoutMs);
+            }),
+          ]);
+        }
         catch (e) {
           process.stderr.write(`oj: plugin "${p.name || "?"}" buildStart failed (skipped): ${(e && e.message) || e}\n`);
         }
+        finally { clearTimeout(timer); }
       }
     });
   }

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { __test, createPluginContainer } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -108,4 +108,64 @@ test("hookHandler / hookFilter: function form and object form", () => {
 
   assert.equal(hookHandler(undefined), null);
   assert.equal(hookHandler({ handler: "not-a-fn" }), null);
+});
+
+test("buildStart: a stalled plugin cannot block later plugins or SSR startup", async () => {
+  const events = [];
+  let release;
+  const stalled = new Promise((resolve) => { release = resolve; });
+  const container = createPluginContainer({}, [
+    {
+      name: "stalled-start",
+      enforce: "pre",
+      resolveId() {},
+      async buildStart() {
+        events.push("stalled");
+        await stalled;
+      },
+    },
+    {
+      name: "healthy-start",
+      resolveId() {},
+      async buildStart() {
+        events.push("healthy");
+      },
+    },
+  ], { environment: "ssr", buildStartTimeoutMs: 25 });
+
+  const pending = container.buildStart();
+  let deadline;
+  try {
+    const completed = await Promise.race([
+      pending.then(() => true),
+      new Promise((resolve) => { deadline = setTimeout(() => resolve(false), 250); }),
+    ]);
+    assert.equal(completed, true, "a non-settling buildStart must not block SSR readiness");
+    assert.deepEqual(events, ["stalled", "healthy"]);
+  } finally {
+    clearTimeout(deadline);
+    release();
+    await pending;
+  }
+});
+
+test("buildStart: successful asynchronous hooks retain plugin order", async () => {
+  const events = [];
+  const plugin = (name, enforce) => ({
+    name,
+    enforce,
+    resolveId() {},
+    async buildStart() {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      events.push(name);
+    },
+  });
+  const container = createPluginContainer({}, [
+    plugin("normal"),
+    plugin("post", "post"),
+    plugin("pre", "pre"),
+  ], { environment: "ssr", buildStartTimeoutMs: 50 });
+
+  await container.buildStart();
+  assert.deepEqual(events, ["pre", "normal", "post"]);
 });


### PR DESCRIPTION
## Summary
- Give each plugin buildStart hook a bounded startup window so a non-settling hook cannot prevent the SSR bridge becoming ready.
- Preserve normal plugin ordering and continue initializing healthy plugins after a timed-out hook.
- Add independent synthetic regressions for a non-settling initialization hook and ordered successful asynchronous hooks.

## Verification
- Confirmed the synthetic stalled-hook regression fails against the unchanged upstream implementation.
- Confirmed it passes with the timeout fix.
- Ran the JavaScript unit suite successfully.