### PR TITLE
fix(config): discover CommonJS Vite configuration formats

### DIFF
--- a/crates/oj_cache/src/start_bundle.rs
+++ b/crates/oj_cache/src/start_bundle.rs
@@ -497,6 +497,8 @@ fn epoch(root: &Path) -> String {
         "vite.config.js",
         "vite.config.mjs",
         "vite.config.mts",
+        "vite.config.cjs",
+        "vite.config.cts",
         "oj.config.ts",
         "oj.config.js",
         "oj.config.mjs",

--- a/crates/oj_server/src/assets/start/loader.mjs
+++ b/crates/oj_server/src/assets/start/loader.mjs
@@ -24,7 +24,7 @@ const CACHE_DIR = process.env.OJ_CACHE_ROOT ?? pathResolve(HERE, "..");
 
 const BASE_FILES = [
   "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lockb", "package.json",
-  "vite.config.ts", "vite.config.js", "vite.config.mjs", "vite.config.mts",
+  "vite.config.ts", "vite.config.js", "vite.config.mjs", "vite.config.mts", "vite.config.cjs", "vite.config.cts",
   "oj.config.ts", "oj.config.js", "oj.config.mjs",
 ];
 const LOADER_FILES = ["loader.mjs", "loader-util.mjs", "glob-transform.mjs", "vite-plugin-bridge.mjs", "resolve-pkg.mjs"];

--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 process.env.VITE_CONFIG_NATIVE_IGNORE_WARNING ??= "true";
 
 const CONFIG_FILES = [
-  "vite.config.ts", "vite.config.js", "vite.config.mjs", "vite.config.mts",
+  "vite.config.ts", "vite.config.js", "vite.config.mjs", "vite.config.mts", "vite.config.cjs", "vite.config.cts",
   "oj.config.ts", "oj.config.js", "oj.config.mjs",
 ];
 

--- a/crates/oj_server/src/plugins.rs
+++ b/crates/oj_server/src/plugins.rs
@@ -137,6 +137,8 @@ pub fn vite_config_file(root: &Path) -> Option<std::path::PathBuf> {
         "vite.config.mts",
         "vite.config.mjs",
         "vite.config.js",
+        "vite.config.cjs",
+        "vite.config.cts",
     ]
     .into_iter()
     .map(|f| root.join(f))
@@ -846,6 +848,21 @@ mod ssr_bridge_tests {
 #[cfg(test)]
 mod vite_values_tests {
     use super::*;
+
+    #[test]
+    fn finds_commonjs_vite_config_formats() {
+        for extension in ["cjs", "cts"] {
+            let root = std::env::temp_dir().join(format!(
+                "oj-config-format-{}-{extension}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&root).unwrap();
+            let path = root.join(format!("vite.config.{extension}"));
+            std::fs::write(&path, "module.exports = {};").unwrap();
+            assert_eq!(vite_config_file(&root), Some(path));
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+    }
 
     #[test]
     fn parse_reads_all_fields() {

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,10 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { __test, findConfig } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -11,6 +14,19 @@ test("matchOne: RegExp tests, string is a substring match", () => {
   assert.ok(!matchOne(/\.mdx$/, "/a/b.tsx"));
   assert.ok(matchOne("virtual:", "virtual:foo"));
   assert.ok(!matchOne("virtual:", "./real"));
+});
+
+test("findConfig discovers CommonJS Vite configuration formats", () => {
+  for (const name of ["vite.config.cjs", "vite.config.cts"]) {
+    const root = mkdtempSync(join(tmpdir(), "oj-config-format-"));
+    try {
+      const config = join(root, name);
+      writeFileSync(config, "module.exports = {};\n");
+      assert.equal(findConfig(root), config);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
 });
 
 test("idAllowed: no filter allows everything", () => {


### PR DESCRIPTION
Summary: Recognize vite.config.cjs and vite.config.cts consistently in Rust config discovery, the plugin bridge, and bundle cache invalidation. Adds independent Rust and Node synthetic regressions for both supported config formats. Verification: node --test e2e/unit/plugin-gating.test.mjs (12 passing); cargo test -p oj_server finds_commonjs_vite_config_formats --offline (passing).