### PR TITLE
fix(build): respect disabled Vite public directories

### DIFF
--- a/crates/oj_server/src/assets/start/build.mjs
+++ b/crates/oj_server/src/assets/start/build.mjs
@@ -252,8 +252,10 @@ writeFileSync(
     '}\n',
 );
 
-const publicDir = resolve(APP, clientContainer?.publicDir ?? "public");
-if (existsSync(publicDir)) cpSync(publicDir, CLIENT, { recursive: true });
+if (clientContainer?.publicDir !== false) {
+  const publicDir = resolve(APP, clientContainer?.publicDir ?? "public");
+  if (existsSync(publicDir)) cpSync(publicDir, CLIENT, { recursive: true });
+}
 
 const prerender = (process.env.OJ_PRERENDER || "").split(",").map((s) => s.trim()).filter(Boolean);
 if (prerender.length) {

--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -256,7 +256,9 @@ export async function loadPluginContainer(app, opts = {}) {
   }
   const all = (loaded?.config?.plugins ?? []).flat(Infinity).filter(Boolean);
   const container = createPluginContainer(vite, all, opts);
-  const publicDir = typeof loaded?.config?.publicDir === "string" ? loaded.config.publicDir : null;
+  const publicDir = loaded?.config?.publicDir === false
+    ? false
+    : typeof loaded?.config?.publicDir === "string" ? loaded.config.publicDir : null;
   const configDependencies = [configFile, ...(loaded?.dependencies ?? [])];
   return { ...container, publicDir, configDependencies };
 }

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,10 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { __test, loadPluginContainer } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -108,4 +111,21 @@ test("hookHandler / hookFilter: function form and object form", () => {
 
   assert.equal(hookHandler(undefined), null);
   assert.equal(hookHandler({ handler: "not-a-fn" }), null);
+});
+
+test("plugin container preserves an explicitly disabled Vite public directory", async () => {
+  const root = mkdtempSync(join(tmpdir(), "oj-no-public-"));
+  try {
+    const vite = join(root, "node_modules", "vite");
+    mkdirSync(vite, { recursive: true });
+    writeFileSync(join(root, "package.json"), '{"name":"synthetic-app"}');
+    writeFileSync(join(root, "vite.config.mjs"), "export default {};\n");
+    writeFileSync(join(vite, "package.json"), '{"name":"vite","type":"module","main":"./index.mjs"}');
+    writeFileSync(join(vite, "index.mjs"),
+      "export async function loadConfigFromFile() { return { config: { plugins: [], publicDir: false } }; }\n");
+
+    assert.equal((await loadPluginContainer(root)).publicDir, false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Summary: Preserve publicDir false when loading Vite configuration and skip the public-directory copy during production builds. Adds a synthetic plugin-container regression using a minimal Vite fixture. Verification: node --test e2e/unit/plugin-gating.test.mjs (12 passing; new case fails against upstream main).