### PR TITLE
fix(ssr): match Vite hidden-file glob behavior

### DIFF
--- a/crates/oj_server/src/assets/start/glob-transform.mjs
+++ b/crates/oj_server/src/assets/start/glob-transform.mjs
@@ -48,9 +48,17 @@ function matchPattern(fileDir, pattern) {
   const starIdx = absGlob.search(/[*?{]/);
   const base = starIdx === -1 ? dirname(absGlob) : absGlob.slice(0, absGlob.lastIndexOf("/", starIdx));
   const re = globToRegExp(absGlob);
+  const explicitHidden = absGlob.slice(base.length + 1).split("/")
+    .filter((part) => part.startsWith("."))
+    .map(globToRegExp);
   const all = [];
   walk(base.split("/").join(sep), all);
-  return all.filter((f) => re.test(f.split(sep).join("/")));
+  return all.filter((f) => {
+    const normalized = f.split(sep).join("/");
+    if (!re.test(normalized)) return false;
+    return normalized.slice(base.length + 1).split("/")
+      .every((part) => !part.startsWith(".") || explicitHidden.some((pattern) => pattern.test(part)));
+  });
 }
 
 const toRel = (fileDir, abs) => {

--- a/e2e/unit/glob-transform.test.mjs
+++ b/e2e/unit/glob-transform.test.mjs
@@ -38,6 +38,24 @@ test("expands a lazy glob to a map of dynamic imports", () => {
   }
 });
 
+test("glob wildcards omit hidden paths unless explicitly requested", () => {
+  const dir = fixture();
+  try {
+    writeFileSync(join(dir, "content", ".hidden.md"), "hidden");
+    mkdirSync(join(dir, "content", ".draft"), { recursive: true });
+    writeFileSync(join(dir, "content", ".draft", "nested.md"), "draft");
+
+    const normal = transformGlob('const modules = import.meta.glob("./content/**/*.md");', join(dir, "index.ts"));
+    const explicit = transformGlob('const modules = import.meta.glob("./content/.*.md");', join(dir, "index.ts"));
+
+    assert.match(normal, /\.\/content\/a\.md/);
+    assert.doesNotMatch(normal, /\.hidden\.md|\.draft/);
+    assert.match(explicit, /\.\/content\/\.hidden\.md/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("handles the <T> type argument and a single-star segment", () => {
   const dir = fixture();
   try {


### PR DESCRIPTION
Summary: Exclude hidden files and directories from ordinary import.meta.glob wildcard matches while retaining explicitly requested dot-prefixed patterns. Adds a synthetic regression covering regular files, hidden files, hidden directories, and explicit dot-file matching. Verification: node --test e2e/unit/glob-transform.test.mjs (8 passing; new case fails against upstream main).