### PR TITLE
fix(config): preserve first-match Vite alias precedence

### DIFF
--- a/crates/oj_server/src/assets/vite-extract.mjs
+++ b/crates/oj_server/src/assets/vite-extract.mjs
@@ -109,7 +109,7 @@ function extractAlias(alias) {
   for (const [find, replacement] of entries) {
     if (typeof replacement !== "string") continue;
     if (typeof find === "string") {
-      out[find] = replacement;
+      if (out[find] == null) out[find] = replacement;
     } else if (find instanceof RegExp) {
       const key = aliasKeyFromRegex(find.source);
       if (!key || /[.*+?()[\]{}|^$]/.test(key)) {

--- a/e2e/unit/vite-extract.test.mjs
+++ b/e2e/unit/vite-extract.test.mjs
@@ -14,6 +14,15 @@ test("array-form string aliases are read from find/replacement", () => {
   assert.deepEqual(out, { "@app": "/src" });
 });
 
+test("duplicate array-form aliases preserve Vite first-match precedence", () => {
+  const out = extractAlias([
+    { find: "@app", replacement: "/first/src" },
+    { find: "@app", replacement: "/second/src" },
+  ]);
+
+  assert.equal(out["@app"], "/first/src");
+});
+
 test("a monorepo regex alias pair collapses to one directory alias", () => {
   // The standard TanStack/monorepo shape: an exact match to the package entry
   // plus a subpath match. Both must collapse to `@x/pkg -> .../src`.


### PR DESCRIPTION
Summary: Preserve first-match precedence for duplicate array-form Vite resolve aliases instead of silently overwriting earlier entries. Adds a synthetic conflicting-alias regression. Verification: node --test e2e/unit/vite-extract.test.mjs (8 passing; new case fails against upstream main).