### PR TITLE
fix(ssr): omit invalid reserved CommonJS export bindings

### DIFF
--- a/crates/oj_server/src/assets/start/loader-util.mjs
+++ b/crates/oj_server/src/assets/start/loader-util.mjs
@@ -32,7 +32,7 @@ export function probe(base) {
 export const RESERVED = new Set(
   ("break case catch class const continue debugger default delete do else enum export extends false finally " +
     "for function if import in instanceof new null return super switch this throw true try typeof var void " +
-    "while with yield let static await").split(" "),
+    "while with yield let static await implements interface package private protected public arguments eval").split(" "),
 );
 
 const pkgTypeCache = new Map();

--- a/e2e/unit/loader-util.test.mjs
+++ b/e2e/unit/loader-util.test.mjs
@@ -111,6 +111,20 @@ test("cjsFacade unwraps default for __esModule (transpiled ESM) modules", () => 
   }
 });
 
+test("cjsFacade omits strict-mode reserved identifiers from named exports", () => {
+  const dir = mk("facade-reserved");
+  try {
+    const file = join(dir, "legacy.cjs");
+    writeFileSync(file, "module.exports = { interface: 1, implements: 2, private: 3, valid: 4 };");
+
+    const facade = cjsFacade(file);
+    assert.match(facade, /export const valid =/);
+    assert.doesNotMatch(facade, /export const (?:interface|implements|private) =/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("parseImportsField flattens string and conditional-object targets", () => {
   const rules = parseImportsField({
     "#lib/*": "./src/lib/*",


### PR DESCRIPTION
Summary: Exclude strict-mode reserved binding names from generated CommonJS facade named exports so legacy packages cannot produce syntactically invalid ES modules. Adds a synthetic CommonJS fixture with valid and reserved property names. Verification: node --test e2e/unit/loader-util.test.mjs (19 passing; new case fails against upstream main).