### PR TITLE
fix(config): accept byte-order marks in TypeScript configs

### DIFF
--- a/crates/oj_server/src/assets/start/loader-util.mjs
+++ b/crates/oj_server/src/assets/start/loader-util.mjs
@@ -104,7 +104,7 @@ export function stripJsonc(s) {
 
 export function readJsonc(file) {
   try {
-    return JSON.parse(stripJsonc(readFileSync(file, "utf8")).replace(/,(\s*[}\]])/g, "$1"));
+    return JSON.parse(stripJsonc(readFileSync(file, "utf8")).replace(/^\ufeff/, "").replace(/,(\s*[}\]])/g, "$1"));
   } catch {
     return null;
   }

--- a/e2e/unit/loader-util.test.mjs
+++ b/e2e/unit/loader-util.test.mjs
@@ -224,3 +224,15 @@ test("stripJsonc + readJsonc tolerate comments and trailing commas", () => {
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test("readJsonc accepts TypeScript configuration with a UTF-8 byte-order mark", () => {
+  const dir = mk("jsonc-bom");
+  try {
+    const file = join(dir, "tsconfig.json");
+    writeFileSync(file, '\ufeff{"compilerOptions":{"baseUrl":"./src"}}');
+
+    assert.deepEqual(readJsonc(file), { compilerOptions: { baseUrl: "./src" } });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Summary: Strip an initial UTF-8 byte-order mark before parsing TypeScript JSONC configuration so valid tsconfig files retain their aliases and compiler settings. Adds a synthetic BOM-prefixed configuration regression. Verification: node --test e2e/unit/loader-util.test.mjs (19 passing; new case fails against upstream main).