### PR TITLE
fix(ssr): resolve fallback package import targets

### DIFF
--- a/crates/oj_server/src/assets/start/loader-util.mjs
+++ b/crates/oj_server/src/assets/start/loader-util.mjs
@@ -111,11 +111,20 @@ export function readJsonc(file) {
 }
 
 export function parseImportsField(imports = {}) {
+  const targetOf = (target) => {
+    if (typeof target === "string") return target;
+    if (Array.isArray(target)) {
+      for (const entry of target) {
+        const resolved = targetOf(entry);
+        if (resolved) return resolved;
+      }
+      return null;
+    }
+    if (!target || typeof target !== "object") return null;
+    return targetOf(target.import) ?? targetOf(target.default) ?? targetOf(target.node);
+  };
   return Object.entries(imports)
-    .map(([pattern, target]) => [
-      pattern,
-      typeof target === "string" ? target : target?.import ?? target?.default ?? target?.node,
-    ])
+    .map(([pattern, target]) => [pattern, targetOf(target)])
     .filter(([, t]) => typeof t === "string");
 }
 

--- a/e2e/unit/loader-util.test.mjs
+++ b/e2e/unit/loader-util.test.mjs
@@ -132,6 +132,18 @@ test("parseImportsField tolerates an empty/absent map", () => {
   assert.deepEqual(parseImportsField({}), []);
 });
 
+test("parseImportsField resolves fallback arrays and nested import conditions", () => {
+  const rules = Object.fromEntries(parseImportsField({
+    "#fallback": [null, "./src/fallback.ts"],
+    "#nested": { import: { default: "./src/nested.ts" } },
+    "#array-condition": [{ require: "./ignored.cjs" }, { import: "./src/module.ts" }],
+  }));
+
+  assert.equal(rules["#fallback"], "./src/fallback.ts");
+  assert.equal(rules["#nested"], "./src/nested.ts");
+  assert.equal(rules["#array-condition"], "./src/module.ts");
+});
+
 test("mergeTsConfig merges paths across an extends chain, later wins", () => {
   const base = "/app";
   const chain = [


### PR DESCRIPTION
Summary: Resolve package import targets expressed as fallback arrays or nested conditional objects, preserving existing import, default, and node condition precedence. Adds synthetic coverage for three valid package import target shapes. Verification: node --test e2e/unit/loader-util.test.mjs (19 passing; new case fails against upstream main).