### PR TITLE
Honor resolve.extensions, mainFields and preserveSymlinks

### DIFF
--- a/crates/oj_config/src/lib.rs
+++ b/crates/oj_config/src/lib.rs
@@ -95,6 +95,22 @@ pub fn resolve_dedupe(config: &OjConfig) -> Vec<String> {
         .unwrap_or_default()
 }
 
+pub fn resolve_extensions(config: &OjConfig) -> Option<Vec<String>> {
+    config.resolve.as_ref().and_then(|r| r.extensions.clone())
+}
+
+pub fn resolve_main_fields(config: &OjConfig) -> Option<Vec<String>> {
+    config.resolve.as_ref().and_then(|r| r.main_fields.clone())
+}
+
+pub fn resolve_preserve_symlinks(config: &OjConfig) -> bool {
+    config
+        .resolve
+        .as_ref()
+        .and_then(|r| r.preserve_symlinks)
+        .unwrap_or(false)
+}
+
 pub fn optimize_deps_lists(config: &OjConfig) -> (Vec<String>, Vec<String>, Vec<String>) {
     let od = config.optimize_deps.as_ref();
     let take = |f: Option<&Vec<String>>| f.cloned().unwrap_or_default();
@@ -411,6 +427,33 @@ mod tests {
         assert_eq!(inc, vec!["cjs-dep".to_string()]);
         assert_eq!(exc, vec!["big-esm".to_string()]);
         assert_eq!(ent, vec!["src/main.tsx".to_string()]);
+    }
+
+    #[test]
+    fn resolve_extensions_main_fields_and_preserve_symlinks_accessors() {
+        let json = r#"{"resolve":{
+            "extensions":[".vue",".ts",".js"],
+            "mainFields":["main","module"],
+            "preserveSymlinks":true}}"#;
+        let cfg: OjConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            resolve_extensions(&cfg),
+            Some(vec![
+                ".vue".to_string(),
+                ".ts".to_string(),
+                ".js".to_string()
+            ])
+        );
+        assert_eq!(
+            resolve_main_fields(&cfg),
+            Some(vec!["main".to_string(), "module".to_string()])
+        );
+        assert!(resolve_preserve_symlinks(&cfg));
+        // Absent resolve.* leaves extensions/mainFields unset, symlinks followed.
+        let empty: OjConfig = serde_json::from_str("{}").unwrap();
+        assert!(resolve_extensions(&empty).is_none());
+        assert!(resolve_main_fields(&empty).is_none());
+        assert!(!resolve_preserve_symlinks(&empty));
     }
 
     #[test]

--- a/crates/oj_config/src/schema.rs
+++ b/crates/oj_config/src/schema.rs
@@ -130,7 +130,9 @@ pub struct ResolveConfig {
     pub alias: Option<BTreeMap<String, String>>,
     pub dedupe: Option<Vec<String>>,
     pub extensions: Option<Vec<String>>,
+    pub main_fields: Option<Vec<String>>,
     pub conditions: Option<Vec<String>>,
+    pub preserve_symlinks: Option<bool>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/crates/oj_resolver/fixtures/extensions/Widget.vue
+++ b/crates/oj_resolver/fixtures/extensions/Widget.vue
@@ -1,0 +1,1 @@
+export default { name: "Widget" };

--- a/crates/oj_resolver/src/lib.rs
+++ b/crates/oj_resolver/src/lib.rs
@@ -41,6 +41,16 @@ pub struct ResolveFailure {
     pub ignored: bool,
 }
 
+#[derive(Clone, Default)]
+pub struct ResolveSettings {
+    pub conditions: Vec<String>,
+    pub alias: Vec<(String, String)>,
+    pub dedupe: Vec<String>,
+    pub extensions: Option<Vec<String>>,
+    pub main_fields: Option<Vec<String>>,
+    pub preserve_symlinks: bool,
+}
+
 impl OjResolver {
     pub fn new(root: &Path) -> Self {
         Self::with_conditions(
@@ -59,8 +69,21 @@ impl OjResolver {
         alias: &[(String, String)],
         dedupe: &[String],
     ) -> Self {
+        Self::with_settings(
+            root,
+            ResolveSettings {
+                conditions: conditions.to_vec(),
+                alias: alias.to_vec(),
+                dedupe: dedupe.to_vec(),
+                ..ResolveSettings::default()
+            },
+        )
+    }
+
+    pub fn with_settings(root: &Path, settings: ResolveSettings) -> Self {
         let tsconfig = root.join("tsconfig.json");
-        let alias = alias
+        let alias = settings
+            .alias
             .iter()
             .map(|(find, replacement)| {
                 let target = if replacement.starts_with('.') {
@@ -71,23 +94,26 @@ impl OjResolver {
                 (find.clone(), vec![AliasValue::Path(target)])
             })
             .collect();
+        let default_extensions = [".tsx", ".ts", ".jsx", ".js", ".mjs", ".cjs", ".json"]
+            .map(String::from)
+            .to_vec();
+        // Package entry resolution for legacy deps without an `exports` map
+        // (with one, condition_names decides and this is unused). `module`
+        // leads so a dep shipping both an ESM build and a `browser` STRING
+        // that points at a UMD/CJS bundle (e.g. transliteration) serves its
+        // ESM — real named exports, no CJS-interop guessing. The `browser`
+        // OBJECT remap (node-shim swaps) is unaffected: it runs through
+        // alias_fields below, not here.
+        let default_main_fields = ["module", "browser", "jsnext:main", "jsnext", "main"]
+            .map(String::from)
+            .to_vec();
         let options = ResolveOptions {
-            extensions: [".tsx", ".ts", ".jsx", ".js", ".mjs", ".cjs", ".json"]
-                .map(String::from)
-                .to_vec(),
-            // Package entry resolution for legacy deps without an `exports` map
-            // (with one, condition_names decides and this is unused). `module`
-            // leads so a dep shipping both an ESM build and a `browser` STRING
-            // that points at a UMD/CJS bundle (e.g. transliteration) serves its
-            // ESM — real named exports, no CJS-interop guessing. The `browser`
-            // OBJECT remap (node-shim swaps) is unaffected: it runs through
-            // alias_fields below, not here.
-            main_fields: ["module", "browser", "jsnext:main", "jsnext", "main"]
-                .map(String::from)
-                .to_vec(),
+            extensions: settings.extensions.unwrap_or(default_extensions),
+            main_fields: settings.main_fields.unwrap_or(default_main_fields),
             alias_fields: vec![vec!["browser".to_string()]],
-            condition_names: conditions.to_vec(),
+            condition_names: settings.conditions,
             alias,
+            symlinks: !settings.preserve_symlinks,
             tsconfig: tsconfig.is_file().then(|| {
                 TsconfigDiscovery::Manual(TsconfigOptions {
                     config_file: tsconfig,
@@ -99,7 +125,7 @@ impl OjResolver {
         Self {
             inner: Resolver::new(options),
             root: root.to_path_buf(),
-            dedupe: dedupe.to_vec(),
+            dedupe: settings.dedupe,
         }
     }
 
@@ -291,6 +317,105 @@ mod tests {
                 .unwrap()
                 .ends_with("Counter.module.css"),
             "exact-path .css should resolve",
+        );
+    }
+
+    #[test]
+    fn honors_custom_resolve_extensions() {
+        // resolve.extensions replaces the default probe list (Vite semantics):
+        // a `.vue` file is only reachable once the caller supplies the extension.
+        let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures/extensions");
+        let default = OjResolver::new(&dir);
+        assert!(
+            default.resolve(&dir, "./Widget").is_err(),
+            "default extensions must not resolve a .vue file",
+        );
+        let custom = OjResolver::with_settings(
+            &dir,
+            ResolveSettings {
+                conditions: ["import", "default"].map(String::from).to_vec(),
+                extensions: Some(vec![".vue".to_string()]),
+                ..ResolveSettings::default()
+            },
+        );
+        assert!(
+            custom
+                .resolve(&dir, "./Widget")
+                .unwrap()
+                .ends_with("Widget.vue"),
+            "custom .vue extension should resolve",
+        );
+    }
+
+    #[test]
+    fn honors_main_fields_override() {
+        // mf-pkg ships both `module` (esm.js) and `main` (cjs.js). The default
+        // ordering prefers module; forcing mainFields:["main"] must pick main.
+        let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures/mainfields");
+        let default = OjResolver::new(&dir);
+        assert!(
+            default.resolve(&dir, "mf-pkg").unwrap().ends_with("esm.js"),
+            "default mainFields prefers module",
+        );
+        let main_first = OjResolver::with_settings(
+            &dir,
+            ResolveSettings {
+                conditions: ["import", "default"].map(String::from).to_vec(),
+                main_fields: Some(vec!["main".to_string()]),
+                ..ResolveSettings::default()
+            },
+        );
+        assert!(
+            main_first
+                .resolve(&dir, "mf-pkg")
+                .unwrap()
+                .ends_with("cjs.js"),
+            "mainFields:[main] must pick the main entry",
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn preserve_symlinks_controls_realpath() {
+        use std::os::unix::fs::symlink;
+        // A linked package dir: real files at `real/`, imported through `link/`.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let real = root.join("real");
+        std::fs::create_dir_all(&real).unwrap();
+        std::fs::write(real.join("index.js"), "export default 1;\n").unwrap();
+        symlink(&real, root.join("link")).unwrap();
+        let conds = ["import", "default"].map(String::from).to_vec();
+
+        // Default follows symlinks: the resolved path lands in the real dir.
+        let resolved = OjResolver::with_settings(
+            root,
+            ResolveSettings {
+                conditions: conds.clone(),
+                ..ResolveSettings::default()
+            },
+        )
+        .resolve(root, "./link/index.js")
+        .unwrap();
+        assert!(
+            resolved.starts_with(std::fs::canonicalize(&real).unwrap()),
+            "default realpaths through the symlink: {resolved:?}",
+        );
+
+        // preserveSymlinks keeps the symlink location instead of realpathing.
+        let preserved = OjResolver::with_settings(
+            root,
+            ResolveSettings {
+                conditions: conds,
+                preserve_symlinks: true,
+                ..ResolveSettings::default()
+            },
+        )
+        .resolve(root, "./link/index.js")
+        .unwrap();
+        assert!(
+            preserved.to_string_lossy().contains("link"),
+            "preserveSymlinks keeps the symlink path: {preserved:?}",
         );
     }
 }

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -543,17 +543,27 @@ impl DevServer {
             bundle,
             reload_tx: reload_tx.clone(),
             graph: Mutex::new(ModuleGraph::new()),
-            resolver: Arc::new(OjResolver::with_options(
+            resolver: Arc::new(OjResolver::with_settings(
                 &root,
-                &oj_config::resolve_conditions(&config, "client"),
-                &oj_config::resolve_alias(&config, "client"),
-                &oj_config::resolve_dedupe(&config),
+                oj_resolver::ResolveSettings {
+                    conditions: oj_config::resolve_conditions(&config, "client"),
+                    alias: oj_config::resolve_alias(&config, "client"),
+                    dedupe: oj_config::resolve_dedupe(&config),
+                    extensions: oj_config::resolve_extensions(&config),
+                    main_fields: oj_config::resolve_main_fields(&config),
+                    preserve_symlinks: oj_config::resolve_preserve_symlinks(&config),
+                },
             )),
-            ssr_resolver: Arc::new(OjResolver::with_options(
+            ssr_resolver: Arc::new(OjResolver::with_settings(
                 &root,
-                &oj_config::resolve_conditions(&config, "ssr"),
-                &oj_config::resolve_alias(&config, "ssr"),
-                &oj_config::resolve_dedupe(&config),
+                oj_resolver::ResolveSettings {
+                    conditions: oj_config::resolve_conditions(&config, "ssr"),
+                    alias: oj_config::resolve_alias(&config, "ssr"),
+                    dedupe: oj_config::resolve_dedupe(&config),
+                    extensions: oj_config::resolve_extensions(&config),
+                    main_fields: oj_config::resolve_main_fields(&config),
+                    preserve_symlinks: oj_config::resolve_preserve_symlinks(&config),
+                },
             )),
             cache: PersistentCache::new(oj_cache::cache_root(&root), env!("CARGO_PKG_VERSION")),
             memory: Mutex::new(MemoryCache::new(memory_cache_budget())),


### PR DESCRIPTION
oj's resolver (a policy layer over `oxc_resolver`) hardcoded these three options, so the matching `resolve.*` config keys were silently ignored — a real gap for monorepos and packages with hand-picked entry fields.

## What changed
- `resolve.extensions` — now replaces the default probe list (Vite semantics) instead of being dropped. It was already in the schema but never passed to the resolver.
- `resolve.mainFields` — new; overrides the default `["module","browser","jsnext:main","jsnext","main"]` ordering. Lets an app force a package's `main` (CJS) build when its `module` entry is broken.
- `resolve.preserveSymlinks` — new; maps to oxc's `symlinks` flag so linked/monorepo packages can resolve from the symlink location instead of the realpath.

All three flow `oj_config -> OjResolver::with_settings` for both the client and SSR resolvers. `with_options` stays as a thin wrapper, so existing callers are unchanged.

## Tests
- `oj_resolver`: custom `.vue` extension resolves only when supplied; `mainFields:["main"]` picks `cjs.js` over `esm.js` (reusing the `mainfields` fixture); `preserveSymlinks` keeps vs. realpaths a symlinked dir (new tempdir-based test).
- `oj_config`: accessor test for the three keys plus the absent-config defaults.