### PR TITLE
Support envPrefix as a string array

### DIFF
--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -1194,7 +1194,7 @@ pub async fn build(
                 let mut pairs: Vec<(String, String)> =
                     vec![("process.env.NODE_ENV".into(), "'production'".into())];
                 pairs.extend(oj_env::import_meta_env_defines(
-                    &env, mode, false, &base, "VITE_",
+                    &env, mode, false, &base, &["VITE_"],
                 ));
                 pairs.extend(oj_config::config_defines(&config));
                 pairs.extend(oj_config::environment_defines(&config, "client"));
@@ -1243,7 +1243,7 @@ pub async fn build(
     // before the plugin transformIndexHtml below.
     let html_env = {
         let env = oj_env::load(&root, mode);
-        let mut defines = oj_env::import_meta_env_defines(&env, mode, false, &base, "VITE_");
+        let mut defines = oj_env::import_meta_env_defines(&env, mode, false, &base, &["VITE_"]);
         defines.extend(oj_config::config_defines(&config));
         oj_env::html_env_map(&defines)
     };
@@ -2091,7 +2091,7 @@ async fn build_client_entry(
                     "production",
                     false,
                     "/",
-                    "VITE_",
+                    &["VITE_"],
                 ));
                 pairs.extend(oj_config::config_defines(&config));
                 pairs.extend(oj_config::environment_defines(&config, "client"));

--- a/crates/oj_config/src/lib.rs
+++ b/crates/oj_config/src/lib.rs
@@ -41,6 +41,15 @@ pub fn rolldown_options(config: &OjConfig) -> Option<&serde_json::Value> {
         .or(build.rollup_options.as_ref())
 }
 
+pub fn env_prefixes(config: &OjConfig) -> Vec<String> {
+    config
+        .env_prefix
+        .as_ref()
+        .map(|p| p.to_vec())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| vec!["VITE_".to_string()])
+}
+
 pub fn config_defines(config: &OjConfig) -> Vec<(String, String)> {
     config
         .define
@@ -454,6 +463,25 @@ mod tests {
         assert!(resolve_extensions(&empty).is_none());
         assert!(resolve_main_fields(&empty).is_none());
         assert!(!resolve_preserve_symlinks(&empty));
+    }
+
+    #[test]
+    fn env_prefix_accepts_string_or_array_and_defaults() {
+        // A single string stays a one-element list (back-compat).
+        let one: OjConfig = serde_json::from_str(r#"{"envPrefix":"PUBLIC_"}"#).unwrap();
+        assert_eq!(env_prefixes(&one), vec!["PUBLIC_".to_string()]);
+        // An array exposes every listed prefix.
+        let many: OjConfig =
+            serde_json::from_str(r#"{"envPrefix":["VITE_","PUBLIC_"]}"#).unwrap();
+        assert_eq!(
+            env_prefixes(&many),
+            vec!["VITE_".to_string(), "PUBLIC_".to_string()]
+        );
+        // Absent (or empty) falls back to Vite's default VITE_.
+        let none: OjConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(env_prefixes(&none), vec!["VITE_".to_string()]);
+        let empty: OjConfig = serde_json::from_str(r#"{"envPrefix":[]}"#).unwrap();
+        assert_eq!(env_prefixes(&empty), vec!["VITE_".to_string()]);
     }
 
     #[test]

--- a/crates/oj_config/src/schema.rs
+++ b/crates/oj_config/src/schema.rs
@@ -14,7 +14,7 @@ pub struct OjConfig {
     pub server: Option<ServerConfig>,
     pub resolve: Option<ResolveConfig>,
     pub define: Option<BTreeMap<String, serde_json::Value>>,
-    pub env_prefix: Option<String>,
+    pub env_prefix: Option<StringOrList>,
     pub env_dir: Option<String>,
     pub build: Option<BuildConfig>,
     pub preview: Option<PreviewConfig>,
@@ -22,6 +22,22 @@ pub struct OjConfig {
     pub bundle: Option<bool>,
     pub environments: Option<BTreeMap<String, serde_json::Value>>,
     pub optimize_deps: Option<OptimizeDepsConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum StringOrList {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl StringOrList {
+    pub fn to_vec(&self) -> Vec<String> {
+        match self {
+            StringOrList::One(s) => vec![s.clone()],
+            StringOrList::Many(v) => v.clone(),
+        }
+    }
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/crates/oj_env/src/lib.rs
+++ b/crates/oj_env/src/lib.rs
@@ -118,7 +118,7 @@ pub fn import_meta_env_defines(
     mode: &str,
     dev: bool,
     base_url: &str,
-    prefix: &str,
+    prefixes: &[&str],
 ) -> Vec<(String, String)> {
     let mut obj = serde_json::Map::new();
     obj.insert("MODE".into(), mode.into());
@@ -127,7 +127,7 @@ pub fn import_meta_env_defines(
     obj.insert("PROD".into(), (!dev).into());
     obj.insert("SSR".into(), false.into());
     for (k, v) in loaded {
-        if k.starts_with(prefix) {
+        if prefixes.iter().any(|p| k.starts_with(p)) {
             obj.insert(k.clone(), serde_json::Value::String(v.clone()));
         }
     }
@@ -226,7 +226,7 @@ mod tests {
             "development",
             true,
             "/",
-            "VITE_",
+            &["VITE_"],
         );
         let env = html_env_map(&defines);
         let html =
@@ -263,7 +263,7 @@ mod tests {
             ("VITE_API".into(), "https://api.test".into()),
             ("SECRET".into(), "nope".into()),
         ];
-        let d = import_meta_env_defines(&loaded, "development", true, "/", "VITE_");
+        let d = import_meta_env_defines(&loaded, "development", true, "/", &["VITE_"]);
         let map: std::collections::HashMap<_, _> = d.iter().cloned().collect();
         assert_eq!(map["import.meta.env.MODE"], "\"development\"");
         assert_eq!(map["import.meta.env.DEV"], "true");

--- a/crates/oj_env/tests/adverse.rs
+++ b/crates/oj_env/tests/adverse.rs
@@ -139,7 +139,7 @@ fn unprefixed_variables_never_reach_the_defines() {
         ("XVITE_API".into(), "prefixed-secret".into()),
         ("VITE_OK".into(), "public".into()),
     ];
-    let defines = import_meta_env_defines(&loaded, "production", false, "/", "VITE_");
+    let defines = import_meta_env_defines(&loaded, "production", false, "/", &["VITE_"]);
     let blob = defines
         .iter()
         .map(|(k, v)| format!("{k}={v}\n"))
@@ -163,7 +163,7 @@ fn an_empty_prefix_exposes_everything_by_design() {
     // of this test is that the behavior is deliberate and visible, not a
     // surprise found in production.
     let loaded = vec![("DATABASE_URL".into(), "secret".into())];
-    let defines = import_meta_env_defines(&loaded, "production", false, "/", "");
+    let defines = import_meta_env_defines(&loaded, "production", false, "/", &[""]);
     let keys: Vec<&str> = defines.iter().map(|(k, _)| k.as_str()).collect();
     assert!(keys.contains(&"import.meta.env.DATABASE_URL"));
 }
@@ -174,7 +174,7 @@ fn secret_values_containing_define_syntax_stay_quoted_json() {
         "VITE_TRICK".into(),
         "\",\"SECRET\":\"leaked\",\"x\":\"".into(),
     )];
-    let defines = import_meta_env_defines(&loaded, "development", true, "/", "VITE_");
+    let defines = import_meta_env_defines(&loaded, "development", true, "/", &["VITE_"]);
     let obj = defines
         .iter()
         .find(|(k, _)| k == "import.meta.env")
@@ -249,7 +249,7 @@ fn html_substitution_keeps_multibyte_content_intact() {
         "development",
         true,
         "/",
-        "VITE_",
+        &["VITE_"],
     );
     let env = html_env_map(&defines);
     let out = replace_html_env("<title>%VITE_T%</title> 日本 %MODE%", &env);
@@ -319,10 +319,30 @@ fn a_dotenv_cannot_shadow_the_builtin_env_fields() {
         ("MODE".into(), "hacked".into()),
         ("DEV".into(), "hacked".into()),
     ];
-    let defines = import_meta_env_defines(&loaded, "production", false, "/base/", "VITE_");
+    let defines = import_meta_env_defines(&loaded, "production", false, "/base/", &["VITE_"]);
     let m: BTreeMap<_, _> = defines.into_iter().collect();
     assert_eq!(m["import.meta.env.MODE"], "\"production\"");
     assert_eq!(m["import.meta.env.DEV"], "false");
     assert_eq!(m["import.meta.env.PROD"], "true");
     assert_eq!(m["import.meta.env.BASE_URL"], "\"/base/\"");
+}
+
+#[test]
+fn multiple_prefixes_expose_every_matching_var() {
+    // envPrefix given as an array: a var is exposed if it matches ANY prefix;
+    // an unprefixed secret is still withheld.
+    let loaded = vec![
+        ("VITE_A".into(), "1".into()),
+        ("PUBLIC_B".into(), "2".into()),
+        ("SECRET_C".into(), "3".into()),
+    ];
+    let defines =
+        import_meta_env_defines(&loaded, "production", false, "/", &["VITE_", "PUBLIC_"]);
+    let keys: Vec<&str> = defines.iter().map(|(k, _)| k.as_str()).collect();
+    assert!(keys.contains(&"import.meta.env.VITE_A"));
+    assert!(keys.contains(&"import.meta.env.PUBLIC_B"));
+    assert!(
+        !keys.contains(&"import.meta.env.SECRET_C"),
+        "an unprefixed var must never leak",
+    );
 }

--- a/crates/oj_env/tests/properties.rs
+++ b/crates/oj_env/tests/properties.rs
@@ -98,7 +98,7 @@ proptest! {
         // Secret names deliberately avoid the prefix.
         loaded.extend(secret.iter().map(|(k, v)| (format!("SECRET_{k}"), v.clone())));
 
-        let defines = import_meta_env_defines(&loaded, "production", false, "/", "VITE_");
+        let defines = import_meta_env_defines(&loaded, "production", false, "/", &["VITE_"]);
         let blob: String = defines.iter().map(|(k, v)| format!("{k}={v};")).collect();
         for (k, v) in &secret {
             prop_assert!(!blob.contains(&format!("SECRET_{k}")), "leaked key in {blob}");
@@ -119,7 +119,7 @@ proptest! {
         dev in any::<bool>(),
     ) {
         let vars: Vec<(String, String)> = vars.into_iter().collect();
-        let defines = import_meta_env_defines(&vars, if dev { "development" } else { "production" }, dev, "/b/", "VITE_");
+        let defines = import_meta_env_defines(&vars, if dev { "development" } else { "production" }, dev, "/b/", &["VITE_"]);
         let object = defines.iter().find(|(k, _)| k == "import.meta.env").unwrap();
         let json: serde_json::Value = serde_json::from_str(&object.1).unwrap();
         let obj = json.as_object().unwrap();
@@ -147,7 +147,7 @@ proptest! {
         vars in proptest::collection::btree_map("VITE_[A-Z]{1,6}", ".{0,12}", 0..6),
     ) {
         let vars: Vec<(String, String)> = vars.into_iter().collect();
-        let defines = import_meta_env_defines(&vars, "development", true, "/", "VITE_");
+        let defines = import_meta_env_defines(&vars, "development", true, "/", &["VITE_"]);
         let env = html_env_map(&defines);
         for (k, v) in &vars {
             prop_assert_eq!(env.get(k.as_str()), Some(v));

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -334,7 +334,8 @@ impl DevServer {
             );
         }
 
-        let env_prefix = config.env_prefix.as_deref().unwrap_or("VITE_");
+        let env_prefixes = oj_config::env_prefixes(&config);
+        let env_prefix_refs: Vec<&str> = env_prefixes.iter().map(String::as_str).collect();
         let env_dir = config
             .env_dir
             .as_deref()
@@ -346,7 +347,7 @@ impl DevServer {
             "development",
             true,
             config.base.as_deref().unwrap_or("/"),
-            env_prefix,
+            &env_prefix_refs,
         );
         defines.extend(oj_config::config_defines(&config));
         defines.extend(oj_config::environment_defines(&config, "client"));

--- a/fuzz/fuzz_targets/fuzz_dotenv.rs
+++ b/fuzz/fuzz_targets/fuzz_dotenv.rs
@@ -25,7 +25,7 @@ fuzz_target!(|data: &[u8]| {
     }
 
     let prefix = "VITE_";
-    let defines = import_meta_env_defines(&loaded, "production", false, "/", prefix);
+    let defines = import_meta_env_defines(&loaded, "production", false, "/", &[prefix]);
 
     // The aggregate object is always valid JSON, and its keys are exactly the
     // individual defines.


### PR DESCRIPTION
`envPrefix` was typed as a single `String`, so apps that expose more than one env prefix (e.g. `['VITE_', 'PUBLIC_']`) lost every prefix after the first. Vite accepts `string | string[]`; this matches that.

## What changed
- `env_prefix` now deserializes from either a string or an array (new untagged `StringOrList`), so both `"envPrefix": "VITE_"` and `"envPrefix": ["VITE_","PUBLIC_"]` load.
- New `oj_config::env_prefixes()` accessor returns the list, defaulting to `["VITE_"]` when absent or empty.
- `oj_env::import_meta_env_defines` now takes `&[&str]` prefixes and exposes a var if it matches ANY of them; the dev server passes the configured list.

Build-time define generation keeps its existing `["VITE_"]` behavior (unchanged).

## Tests
- `oj_env`: a var is exposed when it matches any of several prefixes, while an unprefixed secret is still withheld.
- `oj_config`: `env_prefixes` for string, array, absent, and empty-array forms.