### PR TITLE
fix(plugins): resolve modules from Vite hook contexts

### DIFF
--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -141,13 +141,23 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
     parse,
   };
 
-  async function resolveId(id, importer) {
+  function pluginContext(plugin, base = ctx) {
+    return Object.assign(Object.create(base), {
+      async resolve(source, importer, options = {}) {
+        const resolved = await resolveId(source, importer, options.skipSelf === false ? undefined : plugin);
+        return resolved == null ? null : { id: resolved };
+      },
+    });
+  }
+
+  async function resolveId(id, importer, skippedPlugin) {
     for (const p of plugins) {
+      if (p === skippedPlugin) continue;
       if (!envAllows(p, environment)) continue;
       const h = hookHandler(p.resolveId);
       if (!h || !idAllowed(hookFilter(p.resolveId), id)) continue;
       let r;
-      try { r = await h.call(ctx, id, importer, { isEntry: false }); } catch { continue; }
+      try { r = await h.call(pluginContext(p), id, importer, { isEntry: false }); } catch { continue; }
       if (r != null) return typeof r === "string" ? r : r.id;
     }
     return null;
@@ -159,7 +169,7 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
       const h = hookHandler(p.load);
       if (!h || !idAllowed(hookFilter(p.load), id)) continue;
       let r;
-      try { r = await h.call(ctx, id); } catch { continue; }
+      try { r = await h.call(pluginContext(p), id); } catch { continue; }
       if (r != null) return typeof r === "string" ? r : r.code;
     }
     return null;
@@ -172,7 +182,7 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
       const h = hookHandler(p.transform);
       if (!h || !idAllowed(hookFilter(p.transform), id)) continue;
       let r;
-      try { r = await h.call(ctx, current, id); } catch { continue; }
+      try { r = await h.call(pluginContext(p), current, id); } catch { continue; }
       const next = r == null ? null : typeof r === "string" ? r : r.code;
       if (next != null) { current = next; changed = true; }
     }
@@ -187,7 +197,7 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
       const h = hookHandler(p.transform);
       if (!h || !idAllowed(hookFilter(p.transform), id)) continue;
       let r;
-      try { r = await h.call(ctx, current, id, { ssr }); } catch { continue; }
+      try { r = await h.call(pluginContext(p), current, id, { ssr }); } catch { continue; }
       const next = r == null ? null : typeof r === "string" ? r : r.code;
       if (next != null) { current = next; changed = true; }
     }
@@ -205,7 +215,7 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
         try { ok = ae({ name: environment }); } catch { ok = true; }
         if (ok === false) continue;
       }
-      try { await h.call(genCtx, { format: "es" }, {}, false); } catch {}
+      try { await h.call(pluginContext(p, genCtx), { format: "es" }, {}, false); } catch {}
     }
   }
 
@@ -230,7 +240,7 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
         // dev server — a plugin that genuinely needed buildStart will surface as
         // its own load() output being wrong, which is strictly better than one
         // unsupported plugin taking down every other plugin's startup.
-        try { await h.call(ctx, {}); }
+        try { await h.call(pluginContext(p), {}); }
         catch (e) {
           process.stderr.write(`oj: plugin "${p.name || "?"}" buildStart failed (skipped): ${(e && e.message) || e}\n`);
         }

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { __test, createPluginContainer } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -108,4 +108,37 @@ test("hookHandler / hookFilter: function form and object form", () => {
 
   assert.equal(hookHandler(undefined), null);
   assert.equal(hookHandler({ handler: "not-a-fn" }), null);
+});
+
+test("plugin hook contexts resolve virtual dependencies without reentering themselves", async () => {
+  let resolverCalls = 0;
+  const container = createPluginContainer({}, [
+    {
+      name: "synthetic-delegating-resolver",
+      async resolveId(source, importer) {
+        if (source !== "virtual:entry") return null;
+        resolverCalls++;
+        const resolved = await this.resolve(source, importer, { skipSelf: true });
+        return `${resolved.id}?wrapped`;
+      },
+    },
+    {
+      name: "synthetic-fallback-resolver",
+      resolveId(source) {
+        return source.startsWith("virtual:") ? `\0resolved:${source.slice(8)}` : null;
+      },
+    },
+    {
+      name: "synthetic-dependency-loader",
+      async load(id) {
+        if (id !== "\0resolved:entry?wrapped") return null;
+        const dependency = await this.resolve("virtual:dependency", id);
+        return `export default ${JSON.stringify(dependency.id)};`;
+      },
+    },
+  ]);
+
+  assert.equal(await container.resolveId("virtual:entry", "/app.ts"), "\0resolved:entry?wrapped");
+  assert.equal(resolverCalls, 1);
+  assert.equal(await container.load("\0resolved:entry?wrapped"), 'export default "\\u0000resolved:dependency";');
 });


### PR DESCRIPTION
Summary: Implement Vite plugin-context module resolution across resolveId, load, transform, buildStart, and generateBundle hooks. Preserve default skipSelf semantics so delegating resolvers cannot recursively reenter themselves. Adds a wholly synthetic virtual-module regression committed before the independent fix. Verification: node --test e2e/unit/plugin-gating.test.mjs (12 passing; new regression fails against upstream main); node --test e2e/unit/asset-routing.test.mjs e2e/unit/rolldown-assets.test.mjs e2e/unit/resolve-pkg.test.mjs (19 passing, 7 optional fixture-dependent skips).