### PR TITLE
Support css.preprocessorOptions additionalData (Sass)

### DIFF
--- a/crates/oj_config/src/lib.rs
+++ b/crates/oj_config/src/lib.rs
@@ -50,6 +50,15 @@ pub fn env_prefixes(config: &OjConfig) -> Vec<String> {
         .unwrap_or_else(|| vec!["VITE_".to_string()])
 }
 
+pub fn css_additional_data(config: &OjConfig, lang: &str) -> Option<String> {
+    config
+        .css
+        .as_ref()
+        .and_then(|c| c.preprocessor_options.as_ref())
+        .and_then(|m| m.get(lang))
+        .and_then(|e| e.additional_data.clone())
+}
+
 pub fn config_defines(config: &OjConfig) -> Vec<(String, String)> {
     config
         .define
@@ -482,6 +491,23 @@ mod tests {
         assert_eq!(env_prefixes(&none), vec!["VITE_".to_string()]);
         let empty: OjConfig = serde_json::from_str(r#"{"envPrefix":[]}"#).unwrap();
         assert_eq!(env_prefixes(&empty), vec!["VITE_".to_string()]);
+    }
+
+    #[test]
+    fn css_additional_data_accessor_reads_per_language() {
+        let json = r#"{"css":{"preprocessorOptions":{
+            "scss":{"additionalData":"@use 'src/vars' as *;"},
+            "sass":{"additionalData":"$x: 1"}}}}"#;
+        let cfg: OjConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            css_additional_data(&cfg, "scss").as_deref(),
+            Some("@use 'src/vars' as *;")
+        );
+        assert_eq!(css_additional_data(&cfg, "sass").as_deref(), Some("$x: 1"));
+        // A language without an entry, and an absent css config, are both None.
+        assert!(css_additional_data(&cfg, "less").is_none());
+        let empty: OjConfig = serde_json::from_str("{}").unwrap();
+        assert!(css_additional_data(&empty, "scss").is_none());
     }
 
     #[test]

--- a/crates/oj_config/src/schema.rs
+++ b/crates/oj_config/src/schema.rs
@@ -13,6 +13,7 @@ pub struct OjConfig {
     pub public_dir: Option<String>,
     pub server: Option<ServerConfig>,
     pub resolve: Option<ResolveConfig>,
+    pub css: Option<CssConfig>,
     pub define: Option<BTreeMap<String, serde_json::Value>>,
     pub env_prefix: Option<StringOrList>,
     pub env_dir: Option<String>,
@@ -38,6 +39,18 @@ impl StringOrList {
             StringOrList::Many(v) => v.clone(),
         }
     }
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct CssConfig {
+    pub preprocessor_options: Option<BTreeMap<String, PreprocessorEntry>>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct PreprocessorEntry {
+    pub additional_data: Option<String>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/crates/oj_css/src/lib.rs
+++ b/crates/oj_css/src/lib.rs
@@ -115,12 +115,24 @@ fn strip_sass_import_ext(source: &str) -> String {
 }
 
 pub fn compile_sass(source: &str, load_dir: Option<&Path>) -> Result<String, String> {
+    compile_sass_with(source, load_dir, None)
+}
+
+pub fn compile_sass_with(
+    source: &str,
+    load_dir: Option<&Path>,
+    additional_data: Option<&str>,
+) -> Result<String, String> {
     let fs = DottedFs;
     let mut options = grass::Options::default().fs(&fs);
     if let Some(dir) = load_dir {
         options = options.load_path(dir);
     }
-    let source = strip_sass_import_ext(source);
+    let stripped = strip_sass_import_ext(source);
+    let source = match additional_data {
+        Some(data) if !data.is_empty() => format!("{data}\n{stripped}"),
+        _ => stripped,
+    };
     grass::from_string(source, &options).map_err(|e| format!("sass error: {e}"))
 }
 
@@ -238,6 +250,22 @@ mod tests {
         let css = compile_sass(".a { .b { color: red } }", None).unwrap();
         let out = compile_css("/x.scss", &css, true).unwrap();
         assert!(out.css.contains(".a .b{color:red}"), "{}", out.css);
+    }
+
+    #[test]
+    fn additional_data_is_prepended_before_compiling() {
+        // css.preprocessorOptions.scss.additionalData: a global variable the
+        // stylesheet never declares must resolve because it is injected first.
+        let scss = ".btn { color: $brand; }";
+        let css = compile_sass_with(scss, None, Some("$brand: #f00;")).unwrap();
+        assert!(css.contains("color: #f00"), "injected var resolved: {css}");
+        // Without the injection the same source fails (undefined variable).
+        assert!(
+            compile_sass(scss, None).is_err(),
+            "undeclared variable must fail without additionalData",
+        );
+        // Empty / absent additionalData leaves compilation unchanged.
+        assert!(compile_sass_with(".a { color: red; }", None, Some("")).is_ok());
     }
 
     // grass 0.13 mis-reads a dotted basename (`variables.module`) as an

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -248,6 +248,8 @@ struct ServerState {
     svelte: tokio::sync::OnceCell<std::sync::Arc<Sidecar>>,
     tailwind_urls: Mutex<std::collections::HashSet<String>>,
     has_postcss: bool,
+    scss_additional_data: Option<String>,
+    sass_additional_data: Option<String>,
     preload_snapshot: Vec<String>,
     proxy: Vec<(String, oj_config::ProxyEntry)>,
     http: reqwest::Client,
@@ -576,6 +578,8 @@ impl DevServer {
             svelte: tokio::sync::OnceCell::new(),
             tailwind_urls: Mutex::new(std::collections::HashSet::new()),
             has_postcss: has_postcss_config(&root),
+            scss_additional_data: oj_config::css_additional_data(&config, "scss"),
+            sass_additional_data: oj_config::css_additional_data(&config, "sass"),
             fs_allow: Arc::new(Mutex::new(
                 server_cfg
                     .fs
@@ -883,6 +887,18 @@ async fn ssr_plugin_host(state: &Arc<ServerState>) -> Option<std::sync::Arc<Plug
         })
         .await
         .clone()
+}
+
+fn sass_additional_data_for(state: &ServerState, url: &str) -> Option<String> {
+    if !oj_css::is_sass(url) {
+        return None;
+    }
+    let indented = url.split('?').next().unwrap_or(url).ends_with(".sass");
+    if indented {
+        state.sass_additional_data.clone()
+    } else {
+        state.scss_additional_data.clone()
+    }
 }
 
 fn ssr_css_module(root: &Path, path: &Path, source: &str) -> Result<String, String> {
@@ -1927,6 +1943,7 @@ async fn ensure_module(
         file.to_path_buf()
     };
     let url_owned = url.to_string();
+    let sass_data = sass_additional_data_for(state, &url_owned);
     let bundle = state.bundle;
     let plugin_fallback = state.plugins.is_some() && !bundle;
     let importer_abs = file.to_string_lossy().into_owned();
@@ -1960,7 +1977,7 @@ async fn ensure_module(
         }
         if is_css {
             let css_src = if oj_css::is_sass(&url_owned) {
-                oj_css::compile_sass(&source, Some(&dir))?
+                oj_css::compile_sass_with(&source, Some(&dir), sass_data.as_deref())?
             } else {
                 source.clone()
             };


### PR DESCRIPTION
oj had no `css` config surface at all, so `css.preprocessorOptions.scss.additionalData` — the common way to inject global Sass variables/mixins into every stylesheet — was silently ignored. Apps that rely on it hit `Undefined variable` errors on every `.scss` file.

## What changed
- New `css.preprocessorOptions` config (`{ scss: { additionalData }, sass: { additionalData }, ... }`), keyed by preprocessor language.
- New `oj_config::css_additional_data(config, lang)` accessor.
- `oj_css::compile_sass_with(source, load_dir, additionalData)` prepends the injected content before compiling (Vite semantics); `compile_sass` stays as a `None` wrapper so existing callers are unchanged.
- The dev-server Sass path picks the entry by file extension (`.scss` vs `.sass`) and passes the configured `additionalData`.

Scope: the primary dev-serving Sass path. The TanStack-Start SSR CSS path (`ssr_css_module`) and the Less/Stylus sidecar are left on the default for now (follow-up).

## Tests
- `oj_css`: injected `$brand` resolves via `additionalData`; the same source fails without it; empty data is a no-op.
- `oj_config`: `css_additional_data` per language, plus absent-entry and absent-config defaults.