### PR TITLE
fix(plugins): load modules from Vite hook contexts

### DIFF
--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -137,7 +137,12 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
     setAssetSource() {}, getFileName() { return ""; },
     addWatchFile(id) { watchFiles.add(String(id)); }, getWatchFiles() { return [...watchFiles]; },
     getModuleInfo() { return null; }, getModuleIds() { return [][Symbol.iterator](); },
-    async resolve() { return null; }, async load() { return null; },
+    async resolve() { return null; },
+    async load(options) {
+      const id = typeof options === "string" ? options : options.id;
+      const code = await load(id);
+      return code == null ? null : { id, code };
+    },
     parse,
   };
 

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { __test, createPluginContainer } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -108,4 +108,28 @@ test("hookHandler / hookFilter: function form and object form", () => {
 
   assert.equal(hookHandler(undefined), null);
   assert.equal(hookHandler({ handler: "not-a-fn" }), null);
+});
+
+test("plugin hook contexts load virtual dependency modules", async () => {
+  const container = createPluginContainer({}, [
+    {
+      name: "synthetic-virtual-module-loader",
+      load(id) {
+        return id === "\0synthetic:dependency" ? "export const value = 42;" : null;
+      },
+    },
+    {
+      name: "synthetic-dependency-transform",
+      async transform(_code, id) {
+        if (id !== "/app.ts") return null;
+        const dependency = await this.load({ id: "\0synthetic:dependency" });
+        return `export default ${JSON.stringify(dependency.code)};`;
+      },
+    },
+  ]);
+
+  assert.equal(
+    await container.transform("", "/app.ts"),
+    'export default "export const value = 42;";',
+  );
 });


### PR DESCRIPTION
Implement Vite plugin-context module loading in the TanStack Start plugin bridge. Plugins that call this.load with a virtual dependency now receive its module id and source code instead of null, matching the ordinary plugin-host contract and preventing silently swallowed transform failures. This is independent from plugin-context module resolution in PR #63. The wholly synthetic regression is committed separately before the minimal fix. Verification: node --test e2e/unit/plugin-gating.test.mjs (12 passing; regression fails on test-only commit); node --test e2e/unit/asset-routing.test.mjs e2e/unit/rolldown-assets.test.mjs e2e/unit/resolve-pkg.test.mjs (19 passing, 7 optional fixture-dependent skips).