### PR TITLE
fix(plugins): expose module graph metadata to hook contexts

### DIFF
--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -124,6 +124,7 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
   // import. Mirror Vite's shape so those plugins take their intended branch.
   const consumer = environment === "client" ? "client" : "server";
   const watchFiles = new Set();
+  const moduleInfo = new Map();
   const ctx = {
     environment: {
       name: environment,
@@ -136,7 +137,8 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
     emitFile() { return "oj-emit-ref"; },
     setAssetSource() {}, getFileName() { return ""; },
     addWatchFile(id) { watchFiles.add(String(id)); }, getWatchFiles() { return [...watchFiles]; },
-    getModuleInfo() { return null; }, getModuleIds() { return [][Symbol.iterator](); },
+    getModuleInfo(id) { return moduleInfo.get(id) ?? null; },
+    getModuleIds() { return moduleInfo.keys(); },
     async resolve() { return null; }, async load() { return null; },
     parse,
   };
@@ -160,12 +162,17 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
       if (!h || !idAllowed(hookFilter(p.load), id)) continue;
       let r;
       try { r = await h.call(ctx, id); } catch { continue; }
-      if (r != null) return typeof r === "string" ? r : r.code;
+      if (r != null) {
+        const code = typeof r === "string" ? r : r.code;
+        moduleInfo.set(id, { id, code, importedIds: [] });
+        return code;
+      }
     }
     return null;
   }
 
   async function transform(code, id) {
+    moduleInfo.set(id, { id, code, importedIds: [] });
     let current = code, changed = false;
     for (const p of plugins) {
       if (!envAllows(p, environment)) continue;
@@ -180,6 +187,7 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
   }
 
   async function transformUserCode(code, id) {
+    moduleInfo.set(id, { id, code, importedIds: [] });
     const ssr = environment === "ssr";
     let current = code, changed = false;
     for (const p of plugins) {

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { __test, createPluginContainer } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -108,4 +108,38 @@ test("hookHandler / hookFilter: function form and object form", () => {
 
   assert.equal(hookHandler(undefined), null);
   assert.equal(hookHandler({ handler: "not-a-fn" }), null);
+});
+
+test("plugin hooks can inspect loaded and transformed module metadata", async () => {
+  const dependencyId = "\0synthetic:dependency";
+  const dependencyCode = "export const value = 42;";
+  const container = createPluginContainer({}, [
+    {
+      name: "synthetic-virtual-module",
+      load(id) {
+        return id === dependencyId ? dependencyCode : null;
+      },
+    },
+    {
+      name: "synthetic-module-graph-inspector",
+      transform(code, id) {
+        const dependency = this.getModuleInfo(dependencyId);
+        const current = this.getModuleInfo(id);
+        const moduleIds = [...this.getModuleIds()];
+        return [
+          dependency.code,
+          dependency.importedIds.length,
+          current.code === code,
+          moduleIds.includes(dependencyId),
+          moduleIds.includes(id),
+        ].join(":");
+      },
+    },
+  ]);
+
+  assert.equal(await container.load(dependencyId), dependencyCode);
+  assert.equal(
+    await container.transform("export default 1;", "/app.ts"),
+    "export const value = 42;:0:true:true:true",
+  );
 });


### PR DESCRIPTION
Implement Vite plugin-context module graph inspection in the TanStack Start plugin bridge. Track loaded and transformed modules so plugins can inspect module source and importedIds through getModuleInfo and enumerate observed module identifiers through getModuleIds. The existing public playground already exercises both APIs, but the TanStack bridge previously returned null and an empty iterator unconditionally. This is independent from plugin-context resolution in PR #63 and module loading in PR #65. A wholly synthetic regression is committed separately before the minimal fix. Verification: node --test e2e/unit/plugin-gating.test.mjs (12 passing; new regression fails on its test-only commit); node --test e2e/unit/asset-routing.test.mjs e2e/unit/rolldown-assets.test.mjs e2e/unit/resolve-pkg.test.mjs (19 passing, 7 optional fixture-dependent skips).