### PR TITLE
fix(plugins): invoke moduleParsed lifecycle callbacks

### DIFF
--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -108,7 +108,8 @@ export function findConfig(app) {
 export function createPluginContainer(vite, allPlugins, { command = "serve", mode = "development", environment = "client" } = {}) {
   const plugins = ordered(
     allPlugins.filter(
-      (p) => (p.resolveId || p.load || p.transform || p.generateBundle) && applyMatches(p, command, mode),
+      (p) => (p.resolveId || p.load || p.transform || p.moduleParsed || p.generateBundle)
+        && applyMatches(p, command, mode),
     ),
   );
 
@@ -165,6 +166,14 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
     return null;
   }
 
+  async function moduleParsed(id, code) {
+    const info = { id, code, importedIds: [] };
+    for (const plugin of plugins) {
+      const handler = hookHandler(plugin.moduleParsed);
+      if (handler && envAllows(plugin, environment)) await handler.call(ctx, info);
+    }
+  }
+
   async function transform(code, id) {
     let current = code, changed = false;
     for (const p of plugins) {
@@ -176,6 +185,7 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
       const next = r == null ? null : typeof r === "string" ? r : r.code;
       if (next != null) { current = next; changed = true; }
     }
+    await moduleParsed(id, current);
     return changed ? current : null;
   }
 
@@ -191,6 +201,7 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
       const next = r == null ? null : typeof r === "string" ? r : r.code;
       if (next != null) { current = next; changed = true; }
     }
+    await moduleParsed(id, current);
     return changed ? current : null;
   }
 

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { __test, createPluginContainer } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -108,4 +108,30 @@ test("hookHandler / hookFilter: function form and object form", () => {
 
   assert.equal(hookHandler(undefined), null);
   assert.equal(hookHandler({ handler: "not-a-fn" }), null);
+});
+
+test("moduleParsed plugins observe transformed framework and user modules", async () => {
+  const parsed = [];
+  const container = createPluginContainer({}, [
+    {
+      name: "synthetic-module-graph-observer",
+      moduleParsed(info) {
+        parsed.push({ id: info.id, code: info.code, importedIds: info.importedIds });
+      },
+    },
+    {
+      name: "synthetic-module-transform",
+      transform(code) {
+        return `${code}\ntransformed();`;
+      },
+    },
+  ]);
+
+  await container.transform("entry();", "/entry.ts");
+  await container.transformUserCode("page();", "/page.ts");
+
+  assert.deepEqual(parsed, [
+    { id: "/entry.ts", code: "entry();\ntransformed();", importedIds: [] },
+    { id: "/page.ts", code: "page();\ntransformed();", importedIds: [] },
+  ]);
 });


### PR DESCRIPTION
Implement the Vite/Rollup moduleParsed plugin lifecycle in the TanStack Start bridge. Preserve plugins whose only supported hook observes parsed modules and invoke enabled observers with module id, transformed source, and importedIds after both framework and user-code transforms. The public playground graph plugin and its existing browser assertion already require this lifecycle, while the regular plugin host already implements it. This is independent from plugin-context module metadata inspection in PR #66. A wholly synthetic regression is committed before the minimal fix. Verification: node --test e2e/unit/plugin-gating.test.mjs (12 passing; new regression fails against the test-only commit); node --test e2e/unit/asset-routing.test.mjs e2e/unit/rolldown-assets.test.mjs e2e/unit/resolve-pkg.test.mjs (19 passing, 7 optional fixture-dependent skips).