### PR TITLE
fix(plugins): initialize configResolved before module hooks

### DIFF
--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -105,7 +105,9 @@ export function findConfig(app) {
   return null;
 }
 
-export function createPluginContainer(vite, allPlugins, { command = "serve", mode = "development", environment = "client" } = {}) {
+export function createPluginContainer(vite, allPlugins, {
+  command = "serve", mode = command === "build" ? "production" : "development", environment = "client", config = {},
+} = {}) {
   const plugins = ordered(
     allPlugins.filter(
       (p) => (p.resolveId || p.load || p.transform || p.generateBundle) && applyMatches(p, command, mode),
@@ -124,11 +126,29 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
   // import. Mirror Vite's shape so those plugins take their intended branch.
   const consumer = environment === "client" ? "client" : "server";
   const watchFiles = new Set();
+  const resolvedConfig = {
+    root: process.cwd(),
+    base: "/",
+    build: {},
+    server: {},
+    resolve: {},
+    define: {},
+    optimizeDeps: {},
+    ssr: {},
+    env: {},
+    experimental: {},
+    environments: { client: {}, ssr: {} },
+    ...config,
+    command,
+    mode,
+    plugins: allPlugins,
+    isProduction: mode === "production",
+  };
   const ctx = {
     environment: {
       name: environment,
       mode: command === "build" ? "build" : "dev",
-      config: { command, consumer, mode: command === "build" ? "production" : "development" },
+      config: { ...resolvedConfig, consumer },
     },
     meta: { rollupVersion: "4.0.0", watchMode: command !== "build", framework: "oj" },
     warn() {}, info() {}, debug() {},
@@ -141,7 +161,23 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
     parse,
   };
 
+  let initialization;
+  function initializePlugins() {
+    initialization ??= (async () => {
+      for (const plugin of plugins) {
+        const hook = hookHandler(plugin.configResolved);
+        if (!hook) continue;
+        try { await hook.call(ctx, resolvedConfig); }
+        catch (error) {
+          process.stderr.write(`oj: plugin "${plugin.name || "?"}" configResolved failed (skipped): ${error?.message ?? error}\n`);
+        }
+      }
+    })();
+    return initialization;
+  }
+
   async function resolveId(id, importer) {
+    await initializePlugins();
     for (const p of plugins) {
       if (!envAllows(p, environment)) continue;
       const h = hookHandler(p.resolveId);
@@ -154,6 +190,7 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
   }
 
   async function load(id) {
+    await initializePlugins();
     for (const p of plugins) {
       if (!envAllows(p, environment)) continue;
       const h = hookHandler(p.load);
@@ -166,6 +203,7 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
   }
 
   async function transform(code, id) {
+    await initializePlugins();
     let current = code, changed = false;
     for (const p of plugins) {
       if (!envAllows(p, environment)) continue;
@@ -180,6 +218,7 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
   }
 
   async function transformUserCode(code, id) {
+    await initializePlugins();
     const ssr = environment === "ssr";
     let current = code, changed = false;
     for (const p of plugins) {
@@ -195,6 +234,7 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
   }
 
   async function generateBundle(emit) {
+    await initializePlugins();
     const genCtx = { ...ctx, emitFile: (f) => (emit(f), "oj-emit-ref") };
     for (const p of plugins) {
       const h = hookHandler(p.generateBundle);
@@ -217,6 +257,8 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
   // handles don't newly execute a hook they never ran under oj before.
   let buildStarted = false;
   async function buildStart() {
+    if (buildStarted) return;
+    await initializePlugins();
     if (buildStarted) return;
     buildStarted = true;
     await withBuildStartLock(async () => {
@@ -255,7 +297,10 @@ export async function loadPluginContainer(app, opts = {}) {
     return null;
   }
   const all = (loaded?.config?.plugins ?? []).flat(Infinity).filter(Boolean);
-  const container = createPluginContainer(vite, all, opts);
+  const container = createPluginContainer(vite, all, {
+    ...opts,
+    config: { ...loaded?.config, root: loaded?.config?.root ?? app },
+  });
   const publicDir = typeof loaded?.config?.publicDir === "string" ? loaded.config.publicDir : null;
   const configDependencies = [configFile, ...(loaded?.dependencies ?? [])];
   return { ...container, publicDir, configDependencies };

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { __test, createPluginContainer } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -108,4 +108,43 @@ test("hookHandler / hookFilter: function form and object form", () => {
 
   assert.equal(hookHandler(undefined), null);
   assert.equal(hookHandler({ handler: "not-a-fn" }), null);
+});
+
+test("configResolved initializes plugin state once before concurrent module hooks", async () => {
+  let resolved;
+  let initializations = 0;
+  const plugin = {
+    name: "synthetic-config-initialized-loader",
+    async configResolved(config) {
+      initializations++;
+      await Promise.resolve();
+      resolved = config;
+    },
+    resolveId(source) {
+      return `${resolved.root}/${source}`;
+    },
+    load() {
+      return `export default ${JSON.stringify(`${resolved.command}:${resolved.mode}:${resolved.base}`)};`;
+    },
+    transform(code) {
+      return `${code}:${resolved.plugins.length}`;
+    },
+  };
+  const container = createPluginContainer({}, [plugin], {
+    command: "serve",
+    mode: "staging",
+    environment: "ssr",
+    config: { root: "/synthetic-app", base: "/preview/" },
+  });
+
+  const [loaded, transformed, id] = await Promise.all([
+    container.load("virtual:entry"),
+    container.transform("module", "/entry.ts"),
+    container.resolveId("virtual:entry", "/entry.ts"),
+  ]);
+
+  assert.equal(loaded, 'export default "serve:staging:/preview/";');
+  assert.equal(transformed, "module:1");
+  assert.equal(id, "/synthetic-app/virtual:entry");
+  assert.equal(initializations, 1);
 });


### PR DESCRIPTION
Initialize Vite plugin configResolved hooks before TanStack Start plugin bridge module resolution, loading, transformation, build startup, and bundle generation. Share one asynchronous initialization across concurrent module hooks and provide ordinary resolved configuration fields including root, base, command, mode, plugin list, and standard option groups. Existing public playground plugins already initialize closure state in configResolved before consuming it in module hooks. The first commit adds a wholly synthetic regression that fails independently against upstream main; the second commit implements the minimal lifecycle fix. The regression verifies concurrent resolve/load/transform calls observe initialized state and invoke configResolved exactly once. Verification: node --test e2e/unit/plugin-gating.test.mjs e2e/unit/asset-routing.test.mjs e2e/unit/rolldown-assets.test.mjs e2e/unit/resolve-pkg.test.mjs (31 passing, 7 optional fixture-dependent skips). This is independent from plugin config partial merging, moduleParsed callbacks, and module graph metadata.