### PR TITLE
fix(plugins): apply Vite config hooks before initialization

### DIFF
--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -241,6 +241,18 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
   return { resolveId, load, transform, transformUserCode, buildStart, generateBundle, pluginCount: plugins.length, watchFiles };
 }
 
+function mergeConfigValues(current, update) {
+  if (Array.isArray(current) && Array.isArray(update)) return [...current, ...update];
+  if (current && update && typeof current === "object" && typeof update === "object") {
+    const merged = { ...current };
+    for (const key of Object.keys(update)) {
+      merged[key] = key in current ? mergeConfigValues(current[key], update[key]) : update[key];
+    }
+    return merged;
+  }
+  return update === undefined ? current : update;
+}
+
 export async function loadPluginContainer(app, opts = {}) {
   const { command = "serve", mode = "development" } = opts;
   const configFile = findConfig(app);
@@ -254,9 +266,19 @@ export async function loadPluginContainer(app, opts = {}) {
   } catch {
     return null;
   }
-  const all = (loaded?.config?.plugins ?? []).flat(Infinity).filter(Boolean);
+  let config = loaded?.config ?? {};
+  const all = (config.plugins ?? []).flat(Infinity).filter(Boolean);
+  for (const plugin of all) {
+    const handler = hookHandler(plugin.config);
+    if (!handler || !applyMatches(plugin, command, mode)) continue;
+    const partial = await handler.call(plugin, config, { command, mode });
+    if (partial) config = typeof vite.mergeConfig === "function"
+      ? vite.mergeConfig(config, partial)
+      : mergeConfigValues(config, partial);
+  }
+  if (loaded) loaded.config = config;
   const container = createPluginContainer(vite, all, opts);
-  const publicDir = typeof loaded?.config?.publicDir === "string" ? loaded.config.publicDir : null;
+  const publicDir = typeof config.publicDir === "string" ? config.publicDir : null;
   const configDependencies = [configFile, ...(loaded?.dependencies ?? [])];
   return { ...container, publicDir, configDependencies };
 }

--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -271,10 +271,12 @@ export async function loadPluginContainer(app, opts = {}) {
   for (const plugin of all) {
     const handler = hookHandler(plugin.config);
     if (!handler || !applyMatches(plugin, command, mode)) continue;
-    const partial = await handler.call(plugin, config, { command, mode });
-    if (partial) config = typeof vite.mergeConfig === "function"
-      ? vite.mergeConfig(config, partial)
-      : mergeConfigValues(config, partial);
+    try {
+      const partial = await handler.call(plugin, config, { command, mode });
+      if (partial) config = typeof vite.mergeConfig === "function"
+        ? vite.mergeConfig(config, partial)
+        : mergeConfigValues(config, partial);
+    } catch {}
   }
   if (loaded) loaded.config = config;
   const container = createPluginContainer(vite, all, opts);

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -130,6 +130,12 @@ test("plugin config hooks initialize state and merge nested configuration", asyn
             resolve: { alias: ["initial"] },
             plugins: [
               {
+                name: "synthetic-unsupported-config",
+                config(config) {
+                  return config.build.rollupOptions;
+                },
+              },
+              {
                 name: "synthetic-config-producer",
                 async config(_config, environment) {
                   return {

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,10 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { __test, loadPluginContainer } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -108,4 +111,57 @@ test("hookHandler / hookFilter: function form and object form", () => {
 
   assert.equal(hookHandler(undefined), null);
   assert.equal(hookHandler({ handler: "not-a-fn" }), null);
+});
+
+test("plugin config hooks initialize state and merge nested configuration", async () => {
+  const root = mkdtempSync(join(tmpdir(), "oj-plugin-config-hooks-"));
+  try {
+    const vite = join(root, "node_modules", "vite");
+    mkdirSync(vite, { recursive: true });
+    writeFileSync(join(root, "package.json"), '{"name":"synthetic-app"}');
+    writeFileSync(join(root, "vite.config.mjs"), "export default {};\n");
+    writeFileSync(join(vite, "package.json"), '{"name":"vite","type":"module","main":"./index.mjs"}');
+    writeFileSync(join(vite, "index.mjs"), `
+      export async function loadConfigFromFile() {
+        let observed;
+        return {
+          config: {
+            define: { EXISTING: "preserved" },
+            resolve: { alias: ["initial"] },
+            plugins: [
+              {
+                name: "synthetic-config-producer",
+                async config(_config, environment) {
+                  return {
+                    define: { TOKEN: environment.command + ":" + environment.mode },
+                    resolve: { alias: ["configured"] },
+                    publicDir: "configured-public",
+                  };
+                },
+              },
+              {
+                name: "synthetic-config-consumer",
+                config(config) {
+                  observed = [config.define.TOKEN, config.define.EXISTING, config.resolve.alias.join(",")].join("|");
+                },
+                transform() {
+                  return observed ? "export default " + JSON.stringify(observed) + ";" : null;
+                },
+              },
+            ],
+          },
+        };
+      }
+    `);
+
+    const container = await loadPluginContainer(root, { command: "serve", mode: "staging" });
+
+    assert.equal(
+      await container.transform("", "/app.ts"),
+      'export default "serve:staging|preserved|initial,configured";',
+    );
+    assert.equal(container.publicDir, "configured-public");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Execute Vite plugin config hooks sequentially before initializing the TanStack Start plugin bridge. Honor command/mode plugin gating and async hooks, preserve nested existing settings, merge partial objects and arrays using vite.mergeConfig when available, and expose updated configuration to later hooks and bridge settings. The public playground config plugin already requires this lifecycle to populate its define values. This fix is independent of configResolved notification: its synthetic regression initializes state exclusively from config hooks and verifies sequential nested/array merging plus configured publicDir. Regression is committed before the minimal implementation. Verification: node --test e2e/unit/plugin-gating.test.mjs (12 passing; regression fails on its test-only commit); node --test e2e/unit/asset-routing.test.mjs e2e/unit/rolldown-assets.test.mjs e2e/unit/resolve-pkg.test.mjs (19 passing, 7 optional fixture-dependent skips).