### PR TITLE
fix(css): resolve transitive Tailwind v4 dependencies

### DIFF
--- a/crates/oj_server/src/assets/start/build.mjs
+++ b/crates/oj_server/src/assets/start/build.mjs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, cpSync, rmSync } from "node:fs";
-import { createRequire } from "node:module";
 import { dirname, join, resolve, relative } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { importPkg, viteEnvDefine } from "./resolve-pkg.mjs";
@@ -129,7 +128,6 @@ rmSync(DIST, { recursive: true, force: true });
 mkdirSync(CLIENT, { recursive: true });
 
 const compileCss = await (async () => {
-  const req = createRequire(APP + "/package.json");
   try {
     const postcss = (await importPkg(APP, "postcss", [])).default ?? (await importPkg(APP, "postcss", []));
     const twMod = await importPkg(APP, "@tailwindcss/postcss", ["tailwindcss"]);
@@ -137,8 +135,9 @@ const compileCss = await (async () => {
     return async (from, src) => (await postcss([tailwind()]).process(src, { from })).css;
   } catch {}
   try {
-    const tw = await import(req.resolve("@tailwindcss/node"));
-    const oxide = await import(req.resolve("@tailwindcss/oxide"));
+    const anchors = ["@tailwindcss/vite", "@tailwindcss/postcss", "tailwindcss"];
+    const tw = await importPkg(APP, "@tailwindcss/node", anchors);
+    const oxide = await importPkg(APP, "@tailwindcss/oxide", anchors);
     return async (from, src) => {
       const compiler = await tw.compile(src, { base: APP, from, onDependency: () => {} });
       const scanner = new oxide.Scanner({ sources: [{ base: APP, pattern: "**/*", negated: false }] });

--- a/crates/oj_server/src/assets/start/css-host.mjs
+++ b/crates/oj_server/src/assets/start/css-host.mjs
@@ -4,6 +4,7 @@ import module, { createRequire } from "node:module";
 import { existsSync, fstatSync, readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import readline from "node:readline";
+import { importPkg } from "./resolve-pkg.mjs";
 
 const send = process.stdout.write.bind(process.stdout);
 process.stdout.write = process.stderr.write.bind(process.stderr);
@@ -50,8 +51,9 @@ async function loadPostcss() {
 // Tailwind v4 via @tailwindcss/vite: no PostCSS plugin, compile through
 // @tailwindcss/node + scan class candidates with @tailwindcss/oxide.
 async function v4Compile(css, from) {
-  const tw = await import(req.resolve("@tailwindcss/node"));
-  const oxide = await import(req.resolve("@tailwindcss/oxide"));
+  const anchors = ["@tailwindcss/vite", "@tailwindcss/postcss", "tailwindcss"];
+  const tw = await importPkg(APP, "@tailwindcss/node", anchors);
+  const oxide = await importPkg(APP, "@tailwindcss/oxide", anchors);
   const compiler = await tw.compile(css, { base: APP, from, onDependency: () => {} });
   const scanner = new oxide.Scanner({ sources: [{ base: APP, pattern: "**/*", negated: false }] });
   return compiler.build(scanner.scan());

--- a/e2e/unit/resolve-pkg.test.mjs
+++ b/e2e/unit/resolve-pkg.test.mjs
@@ -2,9 +2,12 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { viteEnvDefine, makeResolver, importPkg } from "../../crates/oj_server/src/assets/start/resolve-pkg.mjs";
 
 test("viteEnvDefine builds import.meta.env with the standard flags", () => {
@@ -171,6 +174,56 @@ test("importPkg reaches a transitive dep through a preferred anchor", async () =
     });
     const mod = await importPkg(root, "dep", ["anchor"]);
     assert.equal(mod.ok, true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("CSS host resolves Tailwind v4 dependencies beneath the Vite plugin", () => {
+  const root = mkdtempSync(join(tmpdir(), "oj-tailwind-strict-layout-"));
+  try {
+    writeFileSync(join(root, "package.json"), JSON.stringify({
+      name: "synthetic-app",
+      dependencies: { "@tailwindcss/vite": "1.0.0" },
+    }));
+    writePkg(root, "@tailwindcss/vite", {
+      "package.json": JSON.stringify({
+        name: "@tailwindcss/vite",
+        main: "index.js",
+        dependencies: { "@tailwindcss/node": "1.0.0", "@tailwindcss/oxide": "1.0.0" },
+      }),
+      "index.js": "module.exports = {};",
+    });
+    const anchor = join(root, "node_modules", "@tailwindcss", "vite");
+    writePkg(anchor, "@tailwindcss/node", {
+      "package.json": '{"name":"@tailwindcss/node","type":"module","main":"index.mjs"}',
+      "index.mjs": "export async function compile(source) { return { build(tokens) { return source + tokens.join(','); } }; }",
+    });
+    writePkg(anchor, "@tailwindcss/oxide", {
+      "package.json": '{"name":"@tailwindcss/oxide","type":"module","main":"index.mjs"}',
+      "index.mjs": "export class Scanner { scan() { return ['synthetic-tailwind-token']; } }",
+    });
+
+    const requireFromApp = createRequire(join(root, "package.json"));
+    assert.throws(() => requireFromApp.resolve("@tailwindcss/node"), { code: "MODULE_NOT_FOUND" });
+    assert.throws(() => requireFromApp.resolve("@tailwindcss/oxide"), { code: "MODULE_NOT_FOUND" });
+
+    const stylesheet = join(root, "styles.css");
+    writeFileSync(stylesheet, '@import "tailwindcss";');
+    const cssHost = fileURLToPath(new URL("../../crates/oj_server/src/assets/start/css-host.mjs", import.meta.url));
+    const result = spawnSync(process.execPath, [cssHost], {
+      cwd: root,
+      env: { ...process.env, OJ_APP_ROOT: root },
+      input: `${JSON.stringify({ id: 1, path: stylesheet })}\n`,
+      encoding: "utf8",
+      timeout: 10_000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout.trim()), {
+      id: 1,
+      css: '@import "tailwindcss";synthetic-tailwind-token',
+    });
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Resolve Tailwind v4 compiler and scanner dependencies through the existing breadth-first package resolver instead of requiring them to be installed directly at the application root. Strict pnpm-style layouts commonly place @tailwindcss/node and @tailwindcss/oxide beneath the direct @tailwindcss/vite or @tailwindcss/postcss package. Both the development CSS host and production CSS fallback now resolve through those package anchors. A wholly synthetic subprocess regression constructs a strict nested layout, explicitly proves root resolution fails, and verifies CSS compilation still succeeds. The regression is committed before the minimal fix. Verification: node --test e2e/unit/resolve-pkg.test.mjs (12 passing; new strict-layout CSS-host regression fails before fix); node --test e2e/unit/plugin-gating.test.mjs e2e/unit/asset-routing.test.mjs e2e/unit/rolldown-assets.test.mjs (19 passing, 7 optional fixture-dependent skips).