### PR TITLE
fix(plugins): expose emitted chunks to generateBundle

### DIFF
--- a/crates/oj_server/src/assets/start/build.mjs
+++ b/crates/oj_server/src/assets/start/build.mjs
@@ -190,12 +190,21 @@ const entryChunk = client.output.find((o) => o.type === "chunk" && o.isEntry);
 const clientUrl = "/" + entryChunk.fileName;
 
 if (clientContainer) {
+  const bundle = Object.fromEntries(client.output.map((output) => [output.fileName, output]));
+  const originalCode = new Map(client.output
+    .filter((output) => output.type === "chunk")
+    .map((output) => [output.fileName, output.code]));
   await clientContainer.generateBundle(({ type, fileName, source }) => {
     if (type !== "asset" || !fileName || source == null) return;
     const outFile = join(CLIENT, fileName);
     mkdirSync(dirname(outFile), { recursive: true });
     writeFileSync(outFile, source);
-  });
+  }, bundle);
+  for (const output of Object.values(bundle)) {
+    if (output.type === "chunk" && output.code !== originalCode.get(output.fileName)) {
+      writeFileSync(join(CLIENT, output.fileName), output.code);
+    }
+  }
 }
 
 const rootManifest = {

--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -194,7 +194,7 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
     return changed ? current : null;
   }
 
-  async function generateBundle(emit) {
+  async function generateBundle(emit, bundle = {}) {
     const genCtx = { ...ctx, emitFile: (f) => (emit(f), "oj-emit-ref") };
     for (const p of plugins) {
       const h = hookHandler(p.generateBundle);
@@ -205,7 +205,7 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
         try { ok = ae({ name: environment }); } catch { ok = true; }
         if (ok === false) continue;
       }
-      try { await h.call(genCtx, { format: "es" }, {}, false); } catch {}
+      try { await h.call(genCtx, { format: "es" }, bundle, false); } catch {}
     }
   }
 

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { __test, createPluginContainer } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -108,4 +108,28 @@ test("hookHandler / hookFilter: function form and object form", () => {
 
   assert.equal(hookHandler(undefined), null);
   assert.equal(hookHandler({ handler: "not-a-fn" }), null);
+});
+
+test("generateBundle receives and can mutate actual emitted chunks", async () => {
+  const emitted = [];
+  const bundle = {
+    "assets/entry.js": { type: "chunk", fileName: "assets/entry.js", isEntry: true, code: "entry();" },
+    "assets/chunk.js": { type: "chunk", fileName: "assets/chunk.js", isEntry: false, code: "chunk();" },
+  };
+  const plugin = {
+    name: "synthetic-bundle-reporter",
+    generateBundle(_options, output) {
+      const chunks = Object.values(output).filter((entry) => entry.type === "chunk");
+      this.emitFile({ type: "asset", fileName: "report.txt", source: `chunks:${chunks.length}` });
+      for (const chunk of chunks) {
+        if (chunk.isEntry) chunk.code = `/* generated */${chunk.code}`;
+      }
+    },
+  };
+
+  await createPluginContainer({}, [plugin], { command: "build" })
+    .generateBundle((asset) => emitted.push(asset), bundle);
+
+  assert.deepEqual(emitted, [{ type: "asset", fileName: "report.txt", source: "chunks:2" }]);
+  assert.equal(bundle["assets/entry.js"].code, "/* generated */entry();");
 });


### PR DESCRIPTION
Pass actual production client output to Rollup/Vite generateBundle hooks instead of an empty object. This allows existing plugins to inspect generated chunks, emit accurate build reports, and modify entry output; changed chunk source is persisted after hook completion. The public playground report plugin already relies on each of these behaviors. A wholly synthetic fail-first regression passes two generated chunks into the plugin bridge, verifies the emitted report counts both, and confirms the entry chunk is modified. Verification: node --test e2e/unit/plugin-gating.test.mjs (12 passing; synthetic regression fails on test-only commit with chunks:0 instead of chunks:2); node --test e2e/unit/asset-routing.test.mjs e2e/unit/rolldown-assets.test.mjs e2e/unit/resolve-pkg.test.mjs (19 passing, 7 optional fixture-dependent skips).