### PR TITLE
fix(plugins): retain configuration-only initializer plugins

### DIFF
--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -108,7 +108,7 @@ export function findConfig(app) {
 export function createPluginContainer(vite, allPlugins, { command = "serve", mode = "development", environment = "client" } = {}) {
   const plugins = ordered(
     allPlugins.filter(
-      (p) => (p.resolveId || p.load || p.transform || p.generateBundle) && applyMatches(p, command, mode),
+      (p) => (p.configResolved || p.resolveId || p.load || p.transform || p.generateBundle) && applyMatches(p, command, mode),
     ),
   );
 

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { __test, createPluginContainer } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -108,4 +108,21 @@ test("hookHandler / hookFilter: function form and object form", () => {
 
   assert.equal(hookHandler(undefined), null);
   assert.equal(hookHandler({ handler: "not-a-fn" }), null);
+});
+
+test("retains configResolved-only plugins alongside operational consumers", () => {
+  const initializer = {
+    name: "synthetic-lifecycle-initializer",
+    configResolved() {},
+  };
+  const consumer = {
+    name: "synthetic-lifecycle-consumer",
+    load(id) {
+      return id === "virtual:synthetic" ? "export default true" : null;
+    },
+  };
+
+  const container = createPluginContainer({}, [initializer, consumer]);
+
+  assert.equal(container.pluginCount, 2);
 });


### PR DESCRIPTION
## Summary

- Preserve valid Vite plugins that expose only a configResolved lifecycle callback when the TanStack Start bridge filters its plugin list.
- Keep these initializer plugins alongside operational plugins so multi-plugin integrations do not silently lose their shared initialization component.
- Scope this PR strictly to plugin retention: actual configResolved callback execution is provided separately by #68, and the two changes compose without duplicating its implementation.

## Regression

A synthetic configResolved-only initializer paired with a load-capable consumer produces pluginCount 1 before this change and pluginCount 2 afterward. The regression commit precedes the one-line fix.

## Verification

- Focused regression and related public plugin, asset, Rollup-asset, and package-resolution suites: 31 passing; seven optional fixture-dependent cases skipped.