### PR TITLE
fix(plugins): apply production renderChunk hooks

### DIFF
--- a/crates/oj_server/src/assets/start/build.mjs
+++ b/crates/oj_server/src/assets/start/build.mjs
@@ -172,6 +172,10 @@ const client = await build({
   resolve: { conditionNames: ["browser", "module", "import"], alias: clientAlias },
   plugins: [
     makeVitePlugins({ container: clientContainer, appRoot: APP, mode: "prod", emit }),
+    {
+      name: "oj-client-render-chunk",
+      renderChunk: (code, chunk) => clientContainer?.renderChunk(code, chunk) ?? null,
+    },
     clientFnPlugin,
     assetsPlugin({ mode: "prod", server: false, emit }),
     nodeBuiltinShims,

--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -108,7 +108,8 @@ export function findConfig(app) {
 export function createPluginContainer(vite, allPlugins, { command = "serve", mode = "development", environment = "client" } = {}) {
   const plugins = ordered(
     allPlugins.filter(
-      (p) => (p.resolveId || p.load || p.transform || p.generateBundle) && applyMatches(p, command, mode),
+      (p) => (p.resolveId || p.load || p.transform || p.renderChunk || p.generateBundle)
+        && applyMatches(p, command, mode),
     ),
   );
 
@@ -194,6 +195,20 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
     return changed ? current : null;
   }
 
+  async function renderChunk(code, chunk) {
+    let current = code, changed = false;
+    for (const p of plugins) {
+      if (!envAllows(p, environment)) continue;
+      const h = hookHandler(p.renderChunk);
+      if (!h) continue;
+      let result;
+      try { result = await h.call(ctx, current, chunk, { format: "es" }); } catch { continue; }
+      const next = typeof result === "string" ? result : result?.code;
+      if (next != null) { current = next; changed = true; }
+    }
+    return changed ? current : null;
+  }
+
   async function generateBundle(emit) {
     const genCtx = { ...ctx, emitFile: (f) => (emit(f), "oj-emit-ref") };
     for (const p of plugins) {
@@ -238,7 +253,10 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
     });
   }
 
-  return { resolveId, load, transform, transformUserCode, buildStart, generateBundle, pluginCount: plugins.length, watchFiles };
+  return {
+    resolveId, load, transform, transformUserCode, buildStart, renderChunk, generateBundle,
+    pluginCount: plugins.length, watchFiles,
+  };
 }
 
 export async function loadPluginContainer(app, opts = {}) {

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { __test, createPluginContainer } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -108,4 +108,36 @@ test("hookHandler / hookFilter: function form and object form", () => {
 
   assert.equal(hookHandler(undefined), null);
   assert.equal(hookHandler({ handler: "not-a-fn" }), null);
+});
+
+test("renderChunk retains chunk-only plugins and chains applicable hooks", async () => {
+  const plugins = [
+    {
+      name: "synthetic-server-only",
+      applyToEnvironment: (environment) => environment.config.consumer === "server",
+      renderChunk: () => "incorrect server chunk",
+    },
+    {
+      name: "synthetic-post-chunk",
+      enforce: "post",
+      renderChunk: {
+        handler(code, chunk) {
+          return chunk.isEntry ? { code: `${code}/*post*/` } : null;
+        },
+      },
+    },
+    {
+      name: "synthetic-pre-chunk",
+      enforce: "pre",
+      renderChunk(code, chunk) {
+        return chunk.isEntry ? `/*${this.environment.config.consumer}*/${code}` : null;
+      },
+    },
+  ];
+  const container = createPluginContainer({}, plugins, { command: "build", environment: "client" });
+  const entry = { type: "chunk", fileName: "assets/entry.js", isEntry: true, code: "entry();" };
+
+  assert.equal(container.pluginCount, 3);
+  assert.equal(await container.renderChunk(entry.code, entry), "/*client*/entry();/*post*/");
+  assert.equal(await container.renderChunk("chunk();", { ...entry, isEntry: false }), null);
 });


### PR DESCRIPTION
## Summary

- Retain plugins whose only operational hook is renderChunk in the TanStack Start bridge.
- Chain function-form and object-form hooks in plugin order while honoring environment consumers and exposing the normal plugin context.
- Route hooks through the real Rolldown client renderChunk lifecycle, before generateBundle and output writing, preserving bundler-managed asset hashes and output handling.

OJ already checks in a concrete example: playground/oj.plugins.mjs reportPlugin injects a production entry marker from renderChunk, and the regular plugin host supports that hook, but the Start bridge previously discarded it.

## Regression

A synthetic pre hook, object-form post hook, and server-only hook reproduce the failure: the bridge initially retains zero of three chunk-only plugins. After the fix, client entry code becomes /*client*/entry();/*post*/, the server-only hook stays gated, and non-entry chunks remain unchanged. The failing regression is committed before the implementation.

## Verification

- All public JavaScript unit suites: 93 passing; 11 optional fixture-dependent cases skipped.