### PR TITLE
fix(plugins): invoke production writeBundle hooks

### DIFF
--- a/crates/oj_server/src/assets/start/build.mjs
+++ b/crates/oj_server/src/assets/start/build.mjs
@@ -196,6 +196,7 @@ if (clientContainer) {
     mkdirSync(dirname(outFile), { recursive: true });
     writeFileSync(outFile, source);
   });
+  await clientContainer.writeBundle(Object.fromEntries(client.output.map((output) => [output.fileName, output])));
 }
 
 const rootManifest = {

--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -108,7 +108,8 @@ export function findConfig(app) {
 export function createPluginContainer(vite, allPlugins, { command = "serve", mode = "development", environment = "client" } = {}) {
   const plugins = ordered(
     allPlugins.filter(
-      (p) => (p.resolveId || p.load || p.transform || p.generateBundle) && applyMatches(p, command, mode),
+      (p) => (p.resolveId || p.load || p.transform || p.generateBundle || p.writeBundle)
+        && applyMatches(p, command, mode),
     ),
   );
 
@@ -209,6 +210,15 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
     }
   }
 
+  async function writeBundle(bundle) {
+    for (const p of plugins) {
+      if (!envAllows(p, environment)) continue;
+      const h = hookHandler(p.writeBundle);
+      if (!h) continue;
+      try { await h.call(ctx, { format: "es" }, bundle, true); } catch {}
+    }
+  }
+
   // Vite runs buildStart once before any module loads; plugins that compile
   // sources (e.g. i18n message compilers) populate their state here and serve
   // it from load(). oj's SSR loader is a separate process with its own plugin
@@ -238,7 +248,10 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
     });
   }
 
-  return { resolveId, load, transform, transformUserCode, buildStart, generateBundle, pluginCount: plugins.length, watchFiles };
+  return {
+    resolveId, load, transform, transformUserCode, buildStart, generateBundle, writeBundle,
+    pluginCount: plugins.length, watchFiles,
+  };
 }
 
 export async function loadPluginContainer(app, opts = {}) {

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { __test, createPluginContainer } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -108,4 +108,54 @@ test("hookHandler / hookFilter: function form and object form", () => {
 
   assert.equal(hookHandler(undefined), null);
   assert.equal(hookHandler({ handler: "not-a-fn" }), null);
+});
+
+test("writeBundle observes emitted chunks after generation in the client environment", async () => {
+  const lifecycle = [];
+  const bundle = {
+    "assets/entry.js": { type: "chunk", fileName: "assets/entry.js", isEntry: true, code: "entry();" },
+    "assets/chunk.js": { type: "chunk", fileName: "assets/chunk.js", isEntry: false, code: "chunk();" },
+  };
+  const plugins = [
+    {
+      name: "synthetic-post-writer",
+      enforce: "post",
+      writeBundle: {
+        handler(options, output, isWrite) {
+          lifecycle.push(`post:${options.format}:${Object.keys(output).sort().join(",")}:${isWrite}`);
+        },
+      },
+    },
+    {
+      name: "synthetic-server-writer",
+      applyToEnvironment: (environment) => environment.config.consumer === "server",
+      writeBundle() {
+        lifecycle.push("server");
+      },
+    },
+    {
+      name: "synthetic-pre-writer",
+      enforce: "pre",
+      writeBundle(_options, output) {
+        lifecycle.push(`pre:${this.environment.config.consumer}:${output["assets/entry.js"].code}`);
+      },
+    },
+    {
+      name: "synthetic-generator",
+      generateBundle() {
+        lifecycle.push("generate");
+      },
+    },
+  ];
+  const container = createPluginContainer({}, plugins, { command: "build", environment: "client" });
+
+  assert.equal(container.pluginCount, 4);
+  await container.generateBundle(() => {});
+  await container.writeBundle(bundle);
+
+  assert.deepEqual(lifecycle, [
+    "generate",
+    "pre:client:entry();",
+    "post:es:assets/chunk.js,assets/entry.js:true",
+  ]);
 });


### PR DESCRIPTION
## Summary

- Retain standard Rollup/Vite plugins whose only operational hook is writeBundle in the TanStack Start plugin bridge.
- Run function-form and object-form writeBundle hooks in plugin order with the normal plugin context, environment gating, output options, and real emitted client bundle metadata.
- Invoke the post-write lifecycle after generateBundle and the client output has been written.

The checked-in playground already demonstrates the missing behavior: its reportPlugin writes a build report from writeBundle, and the regular OJ plugin host supports the hook, while the TanStack Start bridge previously discarded it.

## Regression

A synthetic pre writer, object-form post writer, server-only writer, and bundle generator reproduce the failure: only one of four plugins survives before the fix. Afterward generation precedes both applicable writers, the server-only hook remains gated, and writers receive actual entry/chunk output plus the client environment. The failing regression is committed before the implementation.

## Verification

- All public JavaScript unit suites: 93 passing; 11 optional fixture-dependent cases skipped.