### PR TITLE
fix(plugins): expose environment-scoped module graphs

### DIFF
--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -124,11 +124,47 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
   // import. Mirror Vite's shape so those plugins take their intended branch.
   const consumer = environment === "client" ? "client" : "server";
   const watchFiles = new Set();
+  const environmentModules = new Map();
+  const modulesByUrl = new Map();
+  const modulesByFile = new Map();
+  const moduleGraph = {
+    environment,
+    idToModuleMap: environmentModules,
+    urlToModuleMap: modulesByUrl,
+    fileToModulesMap: modulesByFile,
+    getModuleById(id) { return environmentModules.get(id); },
+    async getModuleByUrl(url) { return modulesByUrl.get(url); },
+    getModulesByFile(file) { return modulesByFile.get(file); },
+  };
+
+  function trackEnvironmentModule(id, code) {
+    let node = environmentModules.get(id);
+    if (!node) {
+      const file = id.split("?")[0];
+      node = {
+        id,
+        url: id,
+        file,
+        environment,
+        type: file.endsWith(".css") ? "css" : "js",
+        importedModules: new Set(),
+        importers: new Set(),
+      };
+      environmentModules.set(id, node);
+      modulesByUrl.set(id, node);
+      if (!modulesByFile.has(file)) modulesByFile.set(file, new Set());
+      modulesByFile.get(file).add(node);
+    }
+    node.transformResult = { code, map: null };
+    return node;
+  }
+
   const ctx = {
     environment: {
       name: environment,
       mode: command === "build" ? "build" : "dev",
       config: { command, consumer, mode: command === "build" ? "production" : "development" },
+      moduleGraph,
     },
     meta: { rollupVersion: "4.0.0", watchMode: command !== "build", framework: "oj" },
     warn() {}, info() {}, debug() {},
@@ -160,12 +196,17 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
       if (!h || !idAllowed(hookFilter(p.load), id)) continue;
       let r;
       try { r = await h.call(ctx, id); } catch { continue; }
-      if (r != null) return typeof r === "string" ? r : r.code;
+      if (r != null) {
+        const code = typeof r === "string" ? r : r.code;
+        trackEnvironmentModule(id, code);
+        return code;
+      }
     }
     return null;
   }
 
   async function transform(code, id) {
+    trackEnvironmentModule(id, code);
     let current = code, changed = false;
     for (const p of plugins) {
       if (!envAllows(p, environment)) continue;
@@ -176,10 +217,12 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
       const next = r == null ? null : typeof r === "string" ? r : r.code;
       if (next != null) { current = next; changed = true; }
     }
+    trackEnvironmentModule(id, current);
     return changed ? current : null;
   }
 
   async function transformUserCode(code, id) {
+    trackEnvironmentModule(id, code);
     const ssr = environment === "ssr";
     let current = code, changed = false;
     for (const p of plugins) {
@@ -191,6 +234,7 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
       const next = r == null ? null : typeof r === "string" ? r : r.code;
       if (next != null) { current = next; changed = true; }
     }
+    trackEnvironmentModule(id, current);
     return changed ? current : null;
   }
 

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { __test, createPluginContainer } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -108,4 +108,76 @@ test("hookHandler / hookFilter: function form and object form", () => {
 
   assert.equal(hookHandler(undefined), null);
   assert.equal(hookHandler({ handler: "not-a-fn" }), null);
+});
+
+test("plugin hooks inspect environment modules by ID, URL, and shared source file", async () => {
+  const file = "/synthetic/dependency.ts";
+  const first = `${file}?first`;
+  const second = `${file}?second`;
+  const container = createPluginContainer({}, [
+    {
+      name: "synthetic-environment-module-source",
+      load(id) {
+        return id.startsWith(file) ? `export default ${JSON.stringify(id)};` : null;
+      },
+    },
+    {
+      name: "synthetic-environment-module-inspector",
+      async transform(code, id) {
+        const graph = this.environment.moduleGraph;
+        const byId = graph.getModuleById(first);
+        const byUrl = await graph.getModuleByUrl(first);
+        const byFile = graph.getModulesByFile(file);
+        const current = graph.getModuleById(id);
+        return JSON.stringify({
+          sameModule: byId === byUrl,
+          environment: byId.environment,
+          file: byId.file,
+          loadedCode: byId.transformResult.code,
+          fileVariants: byFile.size,
+          includesBoth: byFile.has(byId) && byFile.has(graph.getModuleById(second)),
+          currentCode: current.transformResult.code,
+          missingId: graph.getModuleById("/missing.ts") === undefined,
+          missingFile: graph.getModulesByFile("/missing.ts") === undefined,
+        });
+      },
+    },
+  ]);
+
+  await container.load(first);
+  await container.load(second);
+
+  assert.equal(await container.transform("export default 1;", "/synthetic/entry.ts"), JSON.stringify({
+    sameModule: true,
+    environment: "client",
+    file,
+    loadedCode: `export default ${JSON.stringify(first)};`,
+    fileVariants: 2,
+    includesBoth: true,
+    currentCode: "export default 1;",
+    missingId: true,
+    missingFile: true,
+  }));
+});
+
+test("client and SSR plugin environments maintain independent module graphs", async () => {
+  const observed = [];
+  const plugin = {
+    name: "synthetic-environment-isolation",
+    transform(code, id) {
+      const graph = this.environment.moduleGraph;
+      observed.push({ environment: this.environment.name, graph, code: graph.getModuleById(id).transformResult.code });
+      return `${this.environment.name}:${code}`;
+    },
+  };
+  const client = createPluginContainer({}, [plugin], { environment: "client" });
+  const ssr = createPluginContainer({}, [plugin], { environment: "ssr" });
+
+  assert.equal(await client.transform("browser", "/shared.ts"), "client:browser");
+  assert.equal(await ssr.transformUserCode("server", "/shared.ts"), "ssr:server");
+  assert.deepEqual(observed.map(({ environment, code }) => ({ environment, code })), [
+    { environment: "client", code: "browser" },
+    { environment: "ssr", code: "server" },
+  ]);
+  assert.notEqual(observed[0].graph, observed[1].graph);
 });


### PR DESCRIPTION
## Summary
- expose the documented Vite environment module graph to TanStack Start plugin hooks
- support lookup by module ID, asynchronous served URL, and source files shared by queried module variants
- preserve independent client and server module graphs while tracking loaded and transformed source records
- remain independent from Rollup-style plugin-context getModuleInfo and getModuleIds support

## Regression
- the first commit adds two failing synthetic plugin regressions: graph-based transforms currently disappear because the missing environment.moduleGraph throws inside the guarded hook
- the fix verifies loaded module identity, queried source variants, transformed source, missing-module semantics, and client/server isolation across both transform entry points
- official Vite environment API: https://vite.dev/guide/api-environment-plugins
- focused regressions: 13 passing; complete public unit suite: 94 passing, 11 optional fixture tests skipped