### PR TITLE
Enforce server.fs.deny (and Vite's default deny list)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1926,6 +1926,7 @@ dependencies = [
  "anyhow",
  "axum",
  "blake3",
+ "glob",
  "libc",
  "notify",
  "oj_cache",

--- a/crates/oj_config/src/lib.rs
+++ b/crates/oj_config/src/lib.rs
@@ -59,6 +59,16 @@ pub fn css_additional_data(config: &OjConfig, lang: &str) -> Option<String> {
         .and_then(|e| e.additional_data.clone())
 }
 
+pub fn server_fs_deny(config: &OjConfig) -> Vec<String> {
+    config
+        .server
+        .as_ref()
+        .and_then(|s| s.fs.as_ref())
+        .and_then(|f| f.deny.as_ref())
+        .cloned()
+        .unwrap_or_default()
+}
+
 pub fn config_defines(config: &OjConfig) -> Vec<(String, String)> {
     config
         .define
@@ -508,6 +518,19 @@ mod tests {
         assert!(css_additional_data(&cfg, "less").is_none());
         let empty: OjConfig = serde_json::from_str("{}").unwrap();
         assert!(css_additional_data(&empty, "scss").is_none());
+    }
+
+    #[test]
+    fn server_fs_deny_accessor() {
+        let json = r#"{"server":{"fs":{"deny":["secrets/**","*.key"]}}}"#;
+        let cfg: OjConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            server_fs_deny(&cfg),
+            vec!["secrets/**".to_string(), "*.key".to_string()]
+        );
+        // Absent server / fs / deny is an empty list (defaults applied elsewhere).
+        let empty: OjConfig = serde_json::from_str("{}").unwrap();
+        assert!(server_fs_deny(&empty).is_empty());
     }
 
     #[test]

--- a/crates/oj_server/Cargo.toml
+++ b/crates/oj_server/Cargo.toml
@@ -20,6 +20,7 @@ notify.workspace = true
 serde_json.workspace = true
 blake3.workspace = true
 simdutf8.workspace = true
+glob = "0.3.4"
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 rolldown = "1.2.5"
 rolldown_common = "1.2.5"

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -239,6 +239,7 @@ struct ServerState {
     compile_locks: Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
     crawl_done: tokio::sync::watch::Receiver<bool>,
     fs_allow: Arc<Mutex<std::collections::HashSet<PathBuf>>>,
+    fs_deny: Vec<(glob::Pattern, bool)>,
     dir_cache: Arc<Mutex<DirCache>>,
     patch_seq: std::sync::atomic::AtomicU64,
     chunk_cache: Mutex<Option<(String, Arc<String>)>>,
@@ -600,6 +601,7 @@ impl DevServer {
                     })
                     .unwrap_or_default(),
             )),
+            fs_deny: compile_fs_deny(&oj_config::server_fs_deny(&config)),
             dir_cache: Arc::new(Mutex::new(DirCache::new())),
             patch_seq: std::sync::atomic::AtomicU64::new(0),
             chunk_cache: Mutex::new(None),
@@ -1478,6 +1480,10 @@ async fn serve_path(
             }
         }
     };
+
+    if path_is_denied(&file, &state.root, &state.fs_deny) {
+        return (StatusCode::FORBIDDEN, "oj: path denied by server.fs.deny").into_response();
+    }
 
     let ext = file.extension().and_then(|e| e.to_str()).unwrap_or("");
     if let Some(kind) = query_asset_kind(uri.query()) {
@@ -2434,6 +2440,43 @@ fn is_dep_module(url: &str, file: &Path) -> bool {
 
 fn is_style_ext(ext: &str) -> bool {
     matches!(ext, "css" | "scss" | "sass" | "less" | "styl" | "stylus")
+}
+
+fn compile_fs_deny(user: &[String]) -> Vec<(glob::Pattern, bool)> {
+    const DEFAULTS: &[&str] = &[".env", ".env.*", "*.crt", "*.pem", "**/.git/**"];
+    DEFAULTS
+        .iter()
+        .map(|s| s.to_string())
+        .chain(user.iter().cloned())
+        .filter_map(|p| {
+            let base_only = !p.contains('/');
+            glob::Pattern::new(&p).ok().map(|pat| (pat, base_only))
+        })
+        .collect()
+}
+
+fn path_is_denied(file: &Path, root: &Path, deny: &[(glob::Pattern, bool)]) -> bool {
+    if deny.is_empty() {
+        return false;
+    }
+    let rel = file.strip_prefix(root).unwrap_or(file);
+    let rel_str = rel.to_string_lossy().replace('\\', "/");
+    let abs_str = file.to_string_lossy().replace('\\', "/");
+    let base = file
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    for (pat, base_only) in deny {
+        let hit = if *base_only {
+            pat.matches(&base)
+        } else {
+            pat.matches(&rel_str) || pat.matches(&abs_str)
+        };
+        if hit {
+            return true;
+        }
+    }
+    false
 }
 
 // The browser stamps every request with Sec-Fetch-Dest describing what it will
@@ -4556,6 +4599,30 @@ mod tests {
             .await
             .unwrap();
         assert!(out.contains("data:"), "binary asset stays a data URI: {out}");
+    }
+
+    #[test]
+    fn fs_deny_blocks_dotenv_and_git_by_default() {
+        // No user config: Vite's default deny set still protects secrets.
+        let root = Path::new("/proj");
+        let deny = compile_fs_deny(&[]);
+        assert!(path_is_denied(&root.join(".env"), root, &deny));
+        assert!(path_is_denied(&root.join(".env.local"), root, &deny));
+        assert!(path_is_denied(&root.join("certs/server.pem"), root, &deny));
+        assert!(path_is_denied(&root.join(".git/config"), root, &deny));
+        assert!(path_is_denied(&root.join("packages/app/.git/HEAD"), root, &deny));
+        // Ordinary source is served.
+        assert!(!path_is_denied(&root.join("src/main.tsx"), root, &deny));
+        assert!(!path_is_denied(&root.join("src/env.ts"), root, &deny));
+    }
+
+    #[test]
+    fn fs_deny_honors_user_patterns() {
+        let root = Path::new("/proj");
+        let deny = compile_fs_deny(&["secrets/**".to_string(), "*.key".to_string()]);
+        assert!(path_is_denied(&root.join("secrets/token.txt"), root, &deny));
+        assert!(path_is_denied(&root.join("id_rsa.key"), root, &deny));
+        assert!(!path_is_denied(&root.join("public/logo.svg"), root, &deny));
     }
 
     #[test]


### PR DESCRIPTION
oj honored `server.fs.allow` but never enforced `server.fs.deny` — the deny list was parsed and dropped. It also served `.env`, `.git/`, and key/cert files over HTTP, which Vite blocks by default. That's a real dev-server info-leak (a preview could hand out `.env` to anyone who requests `/.env`).

## What changed
- A single deny check at the file-resolution choke point (covers both `/@fs/` and normal file serving) returns 403 for denied paths.
- `compile_fs_deny` merges Vite's default deny set — `.env`, `.env.*`, `*.crt`, `*.pem`, `**/.git/**` — with the user's `server.fs.deny`, precompiling each into a `glob::Pattern`. Patterns without a slash match by basename (matchBase); patterns with a slash match the root-relative and absolute path.
- New `oj_config::server_fs_deny()` accessor.

Note: `glob::Pattern` has no brace-expansion, so Vite's `*.{crt,pem}` is expressed here as `*.crt` + `*.pem`. Reading `.env` for `import.meta.env` is unaffected (that reads from disk, not over HTTP).

## Tests
- `path_is_denied`: `.env`, `.env.local`, `*.pem`, top-level and nested `.git/*` are denied by default; ordinary source (`src/main.tsx`, `src/env.ts`) is not; user patterns (`secrets/**`, `*.key`) are honored.
- `oj_config`: `server_fs_deny` reads the list and defaults to empty.