### PR TITLE
Rebase CSS url() and @import to server root in dev

### DIFF
--- a/crates/oj_css/src/lib.rs
+++ b/crates/oj_css/src/lib.rs
@@ -5,6 +5,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use lightningcss::css_modules;
+use lightningcss::dependencies::{Dependency, DependencyOptions};
 use lightningcss::printer::PrinterOptions;
 use lightningcss::stylesheet::{MinifyOptions, ParserOptions, StyleSheet};
 use lightningcss::targets::{Browsers, Targets};
@@ -148,6 +149,19 @@ fn default_targets() -> Targets {
 }
 
 pub fn compile_css(url: &str, source: &str, minify: bool) -> Result<CssOutput, String> {
+    compile_css_impl(url, source, minify, false)
+}
+
+pub fn compile_css_rebased(url: &str, source: &str, minify: bool) -> Result<CssOutput, String> {
+    compile_css_impl(url, source, minify, true)
+}
+
+fn compile_css_impl(
+    url: &str,
+    source: &str,
+    minify: bool,
+    rebase: bool,
+) -> Result<CssOutput, String> {
     let is_module = is_css_module(url);
     let options = ParserOptions {
         filename: url.to_string(),
@@ -169,13 +183,27 @@ pub fn compile_css(url: &str, source: &str, minify: bool) -> Result<CssOutput, S
         })
         .map_err(|err| format!("css transform error in {url}: {err}"))?;
 
+    let base = if rebase { css_base_dir(url) } else { None };
     let result = stylesheet
         .to_css(PrinterOptions {
             minify,
             targets,
+            analyze_dependencies: base.as_ref().map(|_| DependencyOptions::default()),
             ..PrinterOptions::default()
         })
         .map_err(|err| format!("css print error in {url}: {err}"))?;
+
+    let mut css = result.code;
+    if let (Some(base), Some(deps)) = (base, result.dependencies) {
+        for dep in deps {
+            let (placeholder, orig) = match dep {
+                Dependency::Url(u) => (u.placeholder, u.url),
+                Dependency::Import(i) => (i.placeholder, i.url),
+            };
+            let replacement = rebase_relative(&orig, &base).unwrap_or(orig);
+            css = css.replace(&placeholder, &replacement);
+        }
+    }
 
     let exports = result.exports.map(|map| {
         let mut pairs: Vec<(String, String)> = map
@@ -186,10 +214,50 @@ pub fn compile_css(url: &str, source: &str, minify: bool) -> Result<CssOutput, S
         pairs
     });
 
-    Ok(CssOutput {
-        css: result.code,
-        exports,
-    })
+    Ok(CssOutput { css, exports })
+}
+
+fn css_base_dir(url: &str) -> Option<String> {
+    let path = url.split(['?', '#']).next().unwrap_or(url);
+    if !path.starts_with('/') {
+        return None;
+    }
+    match path.rfind('/') {
+        Some(0) => Some("/".to_string()),
+        Some(i) => Some(path[..i].to_string()),
+        None => None,
+    }
+}
+
+fn rebase_relative(spec: &str, base_dir: &str) -> Option<String> {
+    if spec.is_empty()
+        || spec.starts_with('/')
+        || spec.starts_with('#')
+        || spec.starts_with("data:")
+        || spec.starts_with("//")
+        || spec.contains("://")
+    {
+        return None;
+    }
+    let (path, suffix) = match spec.find(['?', '#']) {
+        Some(i) => (&spec[..i], &spec[i..]),
+        None => (spec, ""),
+    };
+    Some(format!("{}{}", posix_join(base_dir, path), suffix))
+}
+
+fn posix_join(base_dir: &str, rel: &str) -> String {
+    let mut segments: Vec<&str> = base_dir.split('/').filter(|s| !s.is_empty()).collect();
+    for part in rel.split('/') {
+        match part {
+            "" | "." => {}
+            ".." => {
+                segments.pop();
+            }
+            other => segments.push(other),
+        }
+    }
+    format!("/{}", segments.join("/"))
 }
 
 #[cfg(test)]
@@ -201,6 +269,49 @@ mod tests {
         let out = compile_css("/styles.css", "body {\n  color: red;\n}\n", true).unwrap();
         assert_eq!(out.css, "body{color:red}");
         assert!(out.exports.is_none());
+    }
+
+    #[test]
+    fn rebases_relative_url_and_import_to_server_root() {
+        // A stylesheet served at /src/app.css: its relative @import and url()
+        // must become server-absolute so an injected <style> resolves them
+        // against the server root, not the page URL.
+        let src = "@import \"./base.css\";\n.a { background: url(./img/bg.png); }";
+        let out = compile_css_rebased("/src/app.css", src, true).unwrap();
+        assert!(out.css.contains("/src/base.css"), "import rebased: {}", out.css);
+        assert!(
+            out.css.contains("/src/img/bg.png"),
+            "url rebased: {}",
+            out.css
+        );
+        assert!(!out.css.contains("./"), "no relative refs remain: {}", out.css);
+    }
+
+    #[test]
+    fn rebase_resolves_parent_segments_and_skips_external_urls() {
+        let src = ".a { background: url(../assets/x.png); }\n\
+                   .b { background: url(https://cdn.test/y.png); }\n\
+                   .c { background: url(data:image/png;base64,AAAA); }";
+        let out = compile_css_rebased("/src/ui/card.css", src, true).unwrap();
+        assert!(out.css.contains("/src/assets/x.png"), "parent rebased: {}", out.css);
+        assert!(out.css.contains("https://cdn.test/y.png"), "external kept: {}", out.css);
+        assert!(
+            out.css.contains("data:image/png;base64,AAAA"),
+            "data URI kept: {}",
+            out.css
+        );
+    }
+
+    #[test]
+    fn plain_compile_does_not_rebase_urls() {
+        // The build/SSR path must be untouched: url() stays relative.
+        let src = ".a { background: url(./bg.png); }";
+        let out = compile_css("/src/app.css", src, true).unwrap();
+        assert!(
+            out.css.contains("./bg.png"),
+            "non-rebased keeps the relative url: {}",
+            out.css
+        );
     }
 
     #[test]

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -1987,7 +1987,7 @@ async fn ensure_module(
             } else {
                 source.clone()
             };
-            let output = oj_css::compile_css(&url_owned, &css_src, false)?;
+            let output = oj_css::compile_css_rebased(&url_owned, &css_src, false)?;
             return Ok(CachedModule {
                 is_boundary: true,
                 kind: "css".into(),


### PR DESCRIPTION
In dev, oj serves/injects CSS as-is, so a relative `url(./bg.png)` or `@import "./x.css"` in `/src/app.css` resolved against the **page** URL (the injected `<style>` has no base of its own), not the stylesheet — so nested imports and relative assets 404.

## What changed
- New `oj_css::compile_css_rebased(url, source, minify)`. Using lightningcss's dependency analysis (`analyze_dependencies`), it rewrites each relative `url()` and `@import` to a server-absolute path resolved against the stylesheet's own directory: `url(./img/bg.png)` in `/src/app.css` → `url(/src/img/bg.png)`, `../assets/x.png` → `/src/assets/x.png`. Absolute, `data:`, protocol, and `//` URLs are left untouched.
- `compile_css` is unchanged and now delegates to a shared impl with rebasing **off** — so the production build (which has its own `rebase_css_urls`) and the SSR path keep their current behavior. Only the dev-serving path (`ensure_module`) opts into rebasing.
- Works for `/@fs/...` served stylesheets too (base derived from the served URL).

Scope: top-level `url()`/`@import` in the served file. Full recursive `@import` inlining is a separate follow-up (a rebased `@import` is fetched by the browser and served by oj, so it resolves correctly; its own nested refs aren't yet rebased).

## Tests
- relative `url()` + `@import` become `/src/...`; no `./` remains.
- `../` parent segments resolve; `https://` and `data:` URLs are preserved.
- `compile_css` (non-rebased) still leaves `url(./bg.png)` relative — guards the build/SSR path.