### PR TITLE
fix(plugins): invoke production closeBundle finalizers

### DIFF
--- a/crates/oj_server/src/assets/start/build.mjs
+++ b/crates/oj_server/src/assets/start/build.mjs
@@ -269,4 +269,7 @@ if (prerender.length) {
   process.stderr.write(`${OJ}${_ojTTY ? "" : ":"} prerendered ${prerender.length} route(s)\n`);
 }
 
+await clientContainer?.closeBundle();
+await serverContainer?.closeBundle();
+
 process.stderr.write(`${OJ}${_ojTTY ? "" : ":"} built dist (client ${clientUrl})\n`);

--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -108,7 +108,8 @@ export function findConfig(app) {
 export function createPluginContainer(vite, allPlugins, { command = "serve", mode = "development", environment = "client" } = {}) {
   const plugins = ordered(
     allPlugins.filter(
-      (p) => (p.resolveId || p.load || p.transform || p.generateBundle) && applyMatches(p, command, mode),
+      (p) => (p.resolveId || p.load || p.transform || p.generateBundle || p.closeBundle)
+        && applyMatches(p, command, mode),
     ),
   );
 
@@ -209,6 +210,15 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
     }
   }
 
+  async function closeBundle() {
+    for (const plugin of plugins) {
+      if (!envAllows(plugin, environment)) continue;
+      const hook = hookHandler(plugin.closeBundle);
+      if (!hook) continue;
+      try { await hook.call(ctx); } catch {}
+    }
+  }
+
   // Vite runs buildStart once before any module loads; plugins that compile
   // sources (e.g. i18n message compilers) populate their state here and serve
   // it from load(). oj's SSR loader is a separate process with its own plugin
@@ -238,7 +248,10 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
     });
   }
 
-  return { resolveId, load, transform, transformUserCode, buildStart, generateBundle, pluginCount: plugins.length, watchFiles };
+  return {
+    resolveId, load, transform, transformUserCode, buildStart, generateBundle, closeBundle,
+    pluginCount: plugins.length, watchFiles,
+  };
 }
 
 export async function loadPluginContainer(app, opts = {}) {

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,8 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { readFileSync } from "node:fs";
+import { __test, createPluginContainer } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -108,4 +109,50 @@ test("hookHandler / hookFilter: function form and object form", () => {
 
   assert.equal(hookHandler(undefined), null);
   assert.equal(hookHandler({ handler: "not-a-fn" }), null);
+});
+
+test("closeBundle runs finalizer-only plugins in their matching environment", async () => {
+  const finalized = [];
+  const plugin = {
+    name: "synthetic-build-finalizer",
+    applyToEnvironment: (environment) => environment.name === "client",
+    closeBundle() { finalized.push(this.environment.name); },
+  };
+
+  const client = createPluginContainer({}, [plugin], { command: "build", environment: "client" });
+  const server = createPluginContainer({}, [plugin], { command: "build", environment: "ssr" });
+
+  assert.equal(client.pluginCount, 1);
+  await client.closeBundle();
+  await server.closeBundle();
+
+  assert.deepEqual(finalized, ["client"]);
+});
+
+test("closeBundle supports object-form finalizers and continues past failed hooks", async () => {
+  const finalized = [];
+  const container = createPluginContainer({}, [
+    {
+      name: "synthetic-failed-finalizer",
+      closeBundle() { throw new Error("synthetic finalizer failure"); },
+    },
+    {
+      name: "synthetic-object-finalizer",
+      closeBundle: { handler() { finalized.push(this.environment.config.consumer); } },
+    },
+  ], { command: "build", environment: "ssr" });
+
+  await container.closeBundle();
+
+  assert.deepEqual(finalized, ["server"]);
+});
+
+test("production Start builds close both environment plugin containers", () => {
+  const source = readFileSync(
+    new URL("../../crates/oj_server/src/assets/start/build.mjs", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(source, /await clientContainer\?\.closeBundle\(\)/);
+  assert.match(source, /await serverContainer\?\.closeBundle\(\)/);
 });


### PR DESCRIPTION
## Summary
- retain plugins whose only supported lifecycle callback is closeBundle
- invoke function-form and object-form finalizers for the correct client or server environment, continuing past an incompatible callback
- close both production Start plugin containers after output generation and prerendering

## Regression coverage
- committed three synthetic failing regressions before the implementation; upstream main discarded finalizer-only plugins, omitted the container callback, and never finalized production environments
- verified all 33 plugin, package-resolution, and output-asset unit tests pass inside the isolated Lima VM