### PR TITLE
fix(build): honor Vite module preload configuration

### DIFF
--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -2599,6 +2599,67 @@ fn build_manifest(entries: &[ManifestEntry]) -> serde_json::Value {
 mod tests {
     use super::*;
 
+    #[tokio::test]
+    async fn module_preload_configuration_controls_production_links() {
+        for (index, (config_name, config, expected)) in [
+            ("oj.config.json", r#"{"build":{"modulePreload":false}}"#, false),
+            (
+                "vite.config.mjs",
+                "export default { build: { modulePreload: false } };",
+                false,
+            ),
+            (
+                "oj.config.json",
+                r#"{"build":{"modulePreload":{"polyfill":false}}}"#,
+                true,
+            ),
+            ("oj.config.json", "{}", true),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let suffix = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let root = std::env::temp_dir().join(format!("oj-module-preload-{suffix}-{index}"));
+            fs::create_dir_all(&root).unwrap();
+            fs::write(root.join("package.json"), r#"{"type":"module"}"#).unwrap();
+            fs::write(root.join(config_name), config).unwrap();
+            fs::write(
+                root.join("index.html"),
+                r#"<html><head></head><body>
+                    <script type="module" src="/first.js"></script>
+                    <script type="module" src="/second.js"></script>
+                </body></html>"#,
+            )
+            .unwrap();
+            fs::write(
+                root.join("first.js"),
+                r#"import { shared } from "./shared.js"; window.first = shared;"#,
+            )
+            .unwrap();
+            fs::write(
+                root.join("second.js"),
+                r#"import { shared } from "./shared.js"; window.second = shared;"#,
+            )
+            .unwrap();
+            fs::write(root.join("shared.js"), r#"export const shared = "ready";"#).unwrap();
+
+            build(root.clone(), None, None, "production")
+                .await
+                .expect("synthetic shared-chunk fixture should build");
+
+            let html = fs::read_to_string(root.join("dist/index.html")).unwrap();
+            assert_eq!(
+                html.contains("rel=\"modulepreload\""),
+                expected,
+                "{config_name}: {config}\n{html}"
+            );
+            fs::remove_dir_all(root).unwrap();
+        }
+    }
+
     #[test]
     fn manifest_matches_vite_shape() {
         let mk = |key: &str,

--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -1325,7 +1325,13 @@ pub async fn build(
             preloads.insert(dep);
         }
     }
-    if !preloads.is_empty() {
+    if !preloads.is_empty()
+        && build_cfg
+            .module_preload
+            .as_ref()
+            .and_then(serde_json::Value::as_bool)
+            != Some(false)
+    {
         let links = preloads
             .iter()
             .map(|f| {
@@ -2602,7 +2608,11 @@ mod tests {
     #[tokio::test]
     async fn module_preload_configuration_controls_production_links() {
         for (index, (config_name, config, expected)) in [
-            ("oj.config.json", r#"{"build":{"modulePreload":false}}"#, false),
+            (
+                "oj.config.json",
+                r#"{"build":{"modulePreload":false}}"#,
+                false,
+            ),
             (
                 "vite.config.mjs",
                 "export default { build: { modulePreload: false } };",

--- a/crates/oj_config/src/schema.rs
+++ b/crates/oj_config/src/schema.rs
@@ -147,6 +147,7 @@ pub struct BuildConfig {
     pub rolldown_options: Option<serde_json::Value>,
     pub assets_inline_limit: Option<u64>,
     pub css_code_split: Option<bool>,
+    pub module_preload: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/oj_server/src/assets/vite-extract.mjs
+++ b/crates/oj_server/src/assets/vite-extract.mjs
@@ -202,6 +202,7 @@ if (isMainRun) try {
       rollupOptions: c.build?.rolldownOptions ?? c.build?.rollupOptions ?? null,
       assetsInlineLimit:
         typeof c.build?.assetsInlineLimit === "number" ? c.build.assetsInlineLimit : null,
+      modulePreload: c.build?.modulePreload ?? null,
       dedupe: Array.isArray(c.resolve?.dedupe)
         ? c.resolve.dedupe.filter((x) => typeof x === "string")
         : null,

--- a/crates/oj_server/src/plugins.rs
+++ b/crates/oj_server/src/plugins.rs
@@ -166,6 +166,7 @@ pub struct ViteValues {
     pub headers: Option<serde_json::Map<String, serde_json::Value>>,
     pub rollup_options: Option<serde_json::Value>,
     pub assets_inline_limit: Option<u64>,
+    pub module_preload: Option<serde_json::Value>,
     pub proxy: Option<serde_json::Value>,
     pub dedupe: Option<Vec<String>>,
     pub optimize_deps: Option<serde_json::Value>,
@@ -262,6 +263,7 @@ fn parse_vite_values(json: &serde_json::Value) -> ViteValues {
         headers: json.get("headers").and_then(|v| v.as_object()).cloned(),
         rollup_options: json.get("rollupOptions").filter(|v| !v.is_null()).cloned(),
         assets_inline_limit: json.get("assetsInlineLimit").and_then(|v| v.as_u64()),
+        module_preload: json.get("modulePreload").filter(|v| !v.is_null()).cloned(),
         proxy: json.get("proxy").filter(|v| !v.is_null()).cloned(),
         dedupe: json.get("dedupe").and_then(|v| v.as_array()).map(|a| {
             a.iter()
@@ -342,6 +344,10 @@ fn merge_vite_values(config: &mut oj_config::OjConfig, v: ViteValues) {
     if let Some(limit) = v.assets_inline_limit {
         let build = config.build.get_or_insert_with(Default::default);
         build.assets_inline_limit.get_or_insert(limit);
+    }
+    if let Some(module_preload) = v.module_preload {
+        let build = config.build.get_or_insert_with(Default::default);
+        build.module_preload.get_or_insert(module_preload);
     }
     if let Some(proxy) = v.proxy {
         let sc = config.server.get_or_insert_with(Default::default);
@@ -891,6 +897,7 @@ mod vite_values_tests {
             headers: None,
             rollup_options: None,
             assets_inline_limit: None,
+            module_preload: None,
             proxy: None,
             dedupe: None,
             optimize_deps: None,
@@ -917,6 +924,7 @@ mod vite_values_tests {
             headers: None,
             rollup_options: None,
             assets_inline_limit: None,
+            module_preload: None,
             proxy: None,
             dedupe: None,
             optimize_deps: None,


### PR DESCRIPTION
## Summary
- preserve Vite `build.modulePreload` from both `oj.config.json` and `vite.config.mjs`
- skip generated modulepreload links only when the option is explicitly `false`
- retain default preloading and object-form settings such as `{ polyfill: false }`

## Regression
The first commit adds a synthetic shared-chunk build test that fails on main because `modulePreload: false` still injects `<link rel="modulepreload">`. The second commit makes all four configuration cases pass.

## Verification
- Synthetic regression executed before the fix inside an isolated VM: failed as expected.
- All 37 OJ Rust tests passed inside the VM.
- All 92 available JavaScript unit tests passed inside the VM; 11 dependency-backed cases were skipped because their optional fixtures are not installed.