### PR TITLE
fix(plugins): invoke Rollup buildEnd lifecycle hooks

### DIFF
--- a/crates/oj_server/src/assets/start/rolldown-assets.mjs
+++ b/crates/oj_server/src/assets/start/rolldown-assets.mjs
@@ -90,6 +90,9 @@ export function makeVitePlugins({ container, fallback, appRoot, mode = "dev", fs
       if (container?.buildStart) await container.buildStart();
       if (fallback?.buildStart && fallback !== container) await fallback.buildStart();
     },
+    async buildEnd(error) {
+      if (container?.buildEnd) await container.buildEnd(error);
+    },
     resolveId: {
       filter: { id: { include: [/\.svg\?react$/, /^virtual:/, /^\0/] } },
       async handler(source, importer, options) {

--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -108,7 +108,8 @@ export function findConfig(app) {
 export function createPluginContainer(vite, allPlugins, { command = "serve", mode = "development", environment = "client" } = {}) {
   const plugins = ordered(
     allPlugins.filter(
-      (p) => (p.resolveId || p.load || p.transform || p.generateBundle) && applyMatches(p, command, mode),
+      (p) => (p.resolveId || p.load || p.transform || p.generateBundle || p.buildEnd)
+        && applyMatches(p, command, mode),
     ),
   );
 
@@ -209,6 +210,15 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
     }
   }
 
+  async function buildEnd(error) {
+    for (const plugin of plugins) {
+      if (!envAllows(plugin, environment)) continue;
+      const hook = hookHandler(plugin.buildEnd);
+      if (!hook) continue;
+      try { await hook.call(ctx, error); } catch {}
+    }
+  }
+
   // Vite runs buildStart once before any module loads; plugins that compile
   // sources (e.g. i18n message compilers) populate their state here and serve
   // it from load(). oj's SSR loader is a separate process with its own plugin
@@ -238,7 +248,10 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
     });
   }
 
-  return { resolveId, load, transform, transformUserCode, buildStart, generateBundle, pluginCount: plugins.length, watchFiles };
+  return {
+    resolveId, load, transform, transformUserCode, buildStart, buildEnd, generateBundle,
+    pluginCount: plugins.length, watchFiles,
+  };
 }
 
 export async function loadPluginContainer(app, opts = {}) {

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { __test, createPluginContainer } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -108,4 +108,41 @@ test("hookHandler / hookFilter: function form and object form", () => {
 
   assert.equal(hookHandler(undefined), null);
   assert.equal(hookHandler({ handler: "not-a-fn" }), null);
+});
+
+test("buildEnd runs completion-only plugins in their matching environment", async () => {
+  const completed = [];
+  const failure = new Error("synthetic build failure");
+  const plugin = {
+    name: "synthetic-build-completion",
+    applyToEnvironment: (environment) => environment.name === "ssr",
+    buildEnd(error) { completed.push({ environment: this.environment.name, error }); },
+  };
+
+  const client = createPluginContainer({}, [plugin], { command: "build", environment: "client" });
+  const server = createPluginContainer({}, [plugin], { command: "build", environment: "ssr" });
+
+  assert.equal(server.pluginCount, 1);
+  await client.buildEnd();
+  await server.buildEnd(failure);
+
+  assert.deepEqual(completed, [{ environment: "ssr", error: failure }]);
+});
+
+test("buildEnd supports object-form hooks and continues past failed callbacks", async () => {
+  const completed = [];
+  const container = createPluginContainer({}, [
+    {
+      name: "synthetic-failed-completion",
+      buildEnd() { throw new Error("synthetic completion failure"); },
+    },
+    {
+      name: "synthetic-object-completion",
+      buildEnd: { handler(error) { completed.push({ consumer: this.environment.config.consumer, error }); } },
+    },
+  ], { command: "build", environment: "client" });
+
+  await container.buildEnd();
+
+  assert.deepEqual(completed, [{ consumer: "client", error: undefined }]);
 });

--- a/e2e/unit/rolldown-assets.test.mjs
+++ b/e2e/unit/rolldown-assets.test.mjs
@@ -10,6 +10,7 @@ import {
   workspaceRoot,
   pnpmStorePaths,
   contentHashEmitter,
+  makeVitePlugins,
 } from "../../crates/oj_server/src/assets/start/rolldown-assets.mjs";
 
 const tmp = (p) => mkdtempSync(join(tmpdir(), "oj-assets-" + p + "-"));
@@ -145,4 +146,17 @@ test("emit does not compile plain CSS (no markers)", async () => {
   } finally {
     rmSync(base, { recursive: true, force: true });
   }
+});
+
+test("the Rolldown adapter forwards build completion only to its active container", async () => {
+  const completed = [];
+  const failure = new Error("synthetic bundle failure");
+  const adapter = makeVitePlugins({
+    container: { buildEnd(error) { completed.push({ environment: "active", error }); } },
+    fallback: { buildEnd(error) { completed.push({ environment: "fallback", error }); } },
+  });
+
+  await adapter.buildEnd(failure);
+
+  assert.deepEqual(completed, [{ environment: "active", error: failure }]);
 });


### PR DESCRIPTION
## Summary
- retain plugins whose only supported Rollup lifecycle callback is buildEnd
- invoke function-form and object-form build completion hooks only for their matching environment while preserving the original build error
- forward Rolldown buildEnd callbacks exclusively to the active Vite plugin container

## Regression coverage
- committed three synthetic failing regressions before the implementation; upstream main discarded buildEnd-only plugins, omitted the container callback, and never forwarded Rolldown completion
- verified all 22 plugin and output-asset unit tests pass inside a separate isolated Lima VM directory