### PR TITLE
fix(build): respect Vite output directory cleanup setting

### DIFF
--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -1111,7 +1111,9 @@ pub async fn build(
 
     let base = normalize_base(config.base.as_deref().unwrap_or("/"));
 
-    let _ = fs::remove_dir_all(&out_dir);
+    if build_cfg.empty_out_dir.unwrap_or(true) {
+        let _ = fs::remove_dir_all(&out_dir);
+    }
     fs::create_dir_all(&out_dir)?;
 
     let started = Instant::now();

--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -2599,6 +2599,59 @@ fn build_manifest(entries: &[ManifestEntry]) -> serde_json::Value {
 mod tests {
     use super::*;
 
+    #[tokio::test]
+    async fn empty_out_dir_configuration_controls_existing_output() {
+        for (index, (config_name, config, retained)) in [
+            (
+                "oj.config.json",
+                r#"{"build":{"emptyOutDir":false}}"#,
+                true,
+            ),
+            (
+                "vite.config.mjs",
+                "export default { build: { emptyOutDir: false } };",
+                true,
+            ),
+            (
+                "oj.config.json",
+                r#"{"build":{"emptyOutDir":true}}"#,
+                false,
+            ),
+            ("oj.config.json", "{}", false),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let suffix = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let root = std::env::temp_dir().join(format!("oj-empty-out-dir-{suffix}-{index}"));
+            fs::create_dir_all(root.join("dist")).unwrap();
+            fs::write(root.join("package.json"), r#"{"type":"module"}"#).unwrap();
+            fs::write(root.join(config_name), config).unwrap();
+            fs::write(
+                root.join("index.html"),
+                r#"<html><body><script type="module" src="/main.js"></script></body></html>"#,
+            )
+            .unwrap();
+            fs::write(root.join("main.js"), "window.ready = true;").unwrap();
+            fs::write(root.join("dist/previous-output.txt"), "preserve me").unwrap();
+
+            build(root.clone(), None, None, "production")
+                .await
+                .expect("synthetic production fixture should build");
+
+            assert_eq!(
+                root.join("dist/previous-output.txt").exists(),
+                retained,
+                "{config_name}: {config}"
+            );
+            assert!(root.join("dist/index.html").is_file());
+            fs::remove_dir_all(root).unwrap();
+        }
+    }
+
     #[test]
     fn manifest_matches_vite_shape() {
         let mk = |key: &str,

--- a/crates/oj_config/src/schema.rs
+++ b/crates/oj_config/src/schema.rs
@@ -137,6 +137,7 @@ pub struct ResolveConfig {
 #[serde(default, rename_all = "camelCase")]
 pub struct BuildConfig {
     pub out_dir: Option<String>,
+    pub empty_out_dir: Option<bool>,
     pub target: Option<String>,
     pub minify: Option<bool>,
     pub sourcemap: Option<bool>,

--- a/crates/oj_server/src/assets/vite-extract.mjs
+++ b/crates/oj_server/src/assets/vite-extract.mjs
@@ -202,6 +202,7 @@ if (isMainRun) try {
       rollupOptions: c.build?.rolldownOptions ?? c.build?.rollupOptions ?? null,
       assetsInlineLimit:
         typeof c.build?.assetsInlineLimit === "number" ? c.build.assetsInlineLimit : null,
+      emptyOutDir: typeof c.build?.emptyOutDir === "boolean" ? c.build.emptyOutDir : null,
       dedupe: Array.isArray(c.resolve?.dedupe)
         ? c.resolve.dedupe.filter((x) => typeof x === "string")
         : null,

--- a/crates/oj_server/src/plugins.rs
+++ b/crates/oj_server/src/plugins.rs
@@ -166,6 +166,7 @@ pub struct ViteValues {
     pub headers: Option<serde_json::Map<String, serde_json::Value>>,
     pub rollup_options: Option<serde_json::Value>,
     pub assets_inline_limit: Option<u64>,
+    pub empty_out_dir: Option<bool>,
     pub proxy: Option<serde_json::Value>,
     pub dedupe: Option<Vec<String>>,
     pub optimize_deps: Option<serde_json::Value>,
@@ -262,6 +263,7 @@ fn parse_vite_values(json: &serde_json::Value) -> ViteValues {
         headers: json.get("headers").and_then(|v| v.as_object()).cloned(),
         rollup_options: json.get("rollupOptions").filter(|v| !v.is_null()).cloned(),
         assets_inline_limit: json.get("assetsInlineLimit").and_then(|v| v.as_u64()),
+        empty_out_dir: json.get("emptyOutDir").and_then(|v| v.as_bool()),
         proxy: json.get("proxy").filter(|v| !v.is_null()).cloned(),
         dedupe: json.get("dedupe").and_then(|v| v.as_array()).map(|a| {
             a.iter()
@@ -342,6 +344,10 @@ fn merge_vite_values(config: &mut oj_config::OjConfig, v: ViteValues) {
     if let Some(limit) = v.assets_inline_limit {
         let build = config.build.get_or_insert_with(Default::default);
         build.assets_inline_limit.get_or_insert(limit);
+    }
+    if let Some(empty_out_dir) = v.empty_out_dir {
+        let build = config.build.get_or_insert_with(Default::default);
+        build.empty_out_dir.get_or_insert(empty_out_dir);
     }
     if let Some(proxy) = v.proxy {
         let sc = config.server.get_or_insert_with(Default::default);
@@ -891,6 +897,7 @@ mod vite_values_tests {
             headers: None,
             rollup_options: None,
             assets_inline_limit: None,
+            empty_out_dir: None,
             proxy: None,
             dedupe: None,
             optimize_deps: None,
@@ -917,6 +924,7 @@ mod vite_values_tests {
             headers: None,
             rollup_options: None,
             assets_inline_limit: None,
+            empty_out_dir: None,
             proxy: None,
             dedupe: None,
             optimize_deps: None,


### PR DESCRIPTION
## Summary
- preserve `build.emptyOutDir` from both `oj.config.json` and `vite.config.mjs`
- retain existing output files when `emptyOutDir: false` is explicitly configured
- continue clearing previous output by default and when `emptyOutDir: true`

## Regression
The first commit adds a synthetic production-build test that fails on main because OJ always deletes the output directory. The second commit makes direct configuration, Vite configuration, explicitly enabled cleanup, and default cleanup all pass.

## Verification
- Synthetic regression executed before the fix inside an isolated VM: failed as expected.
- All 37 OJ Rust tests passed inside the VM.
- All 92 available JavaScript unit tests passed inside the VM; 11 optional dependency-backed cases were skipped.