### PR TITLE
fix(plugins): invoke Rollup renderStart lifecycle hooks

### DIFF
--- a/crates/oj_server/src/assets/start/rolldown-assets.mjs
+++ b/crates/oj_server/src/assets/start/rolldown-assets.mjs
@@ -90,6 +90,9 @@ export function makeVitePlugins({ container, fallback, appRoot, mode = "dev", fs
       if (container?.buildStart) await container.buildStart();
       if (fallback?.buildStart && fallback !== container) await fallback.buildStart();
     },
+    async renderStart(outputOptions, inputOptions) {
+      if (container?.renderStart) await container.renderStart(outputOptions, inputOptions);
+    },
     resolveId: {
       filter: { id: { include: [/\.svg\?react$/, /^virtual:/, /^\0/] } },
       async handler(source, importer, options) {

--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -108,7 +108,8 @@ export function findConfig(app) {
 export function createPluginContainer(vite, allPlugins, { command = "serve", mode = "development", environment = "client" } = {}) {
   const plugins = ordered(
     allPlugins.filter(
-      (p) => (p.resolveId || p.load || p.transform || p.generateBundle) && applyMatches(p, command, mode),
+      (p) => (p.resolveId || p.load || p.transform || p.renderStart || p.generateBundle)
+        && applyMatches(p, command, mode),
     ),
   );
 
@@ -209,6 +210,15 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
     }
   }
 
+  async function renderStart(outputOptions, inputOptions) {
+    for (const plugin of plugins) {
+      if (!envAllows(plugin, environment)) continue;
+      const hook = hookHandler(plugin.renderStart);
+      if (!hook) continue;
+      try { await hook.call(ctx, outputOptions, inputOptions); } catch {}
+    }
+  }
+
   // Vite runs buildStart once before any module loads; plugins that compile
   // sources (e.g. i18n message compilers) populate their state here and serve
   // it from load(). oj's SSR loader is a separate process with its own plugin
@@ -238,7 +248,10 @@ export function createPluginContainer(vite, allPlugins, { command = "serve", mod
     });
   }
 
-  return { resolveId, load, transform, transformUserCode, buildStart, generateBundle, pluginCount: plugins.length, watchFiles };
+  return {
+    resolveId, load, transform, transformUserCode, buildStart, renderStart, generateBundle,
+    pluginCount: plugins.length, watchFiles,
+  };
 }
 
 export async function loadPluginContainer(app, opts = {}) {

--- a/e2e/unit/plugin-gating.test.mjs
+++ b/e2e/unit/plugin-gating.test.mjs
@@ -2,7 +2,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { __test } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
+import { __test, createPluginContainer } from "../../crates/oj_server/src/assets/start/vite-plugin-bridge.mjs";
 
 const { matchOne, idAllowed, applyMatches, ordered, hookHandler, hookFilter, ojReimplemented, envAllows } = __test;
 
@@ -108,4 +108,45 @@ test("hookHandler / hookFilter: function form and object form", () => {
 
   assert.equal(hookHandler(undefined), null);
   assert.equal(hookHandler({ handler: "not-a-fn" }), null);
+});
+
+test("renderStart runs output-only plugins with their environment and bundle options", async () => {
+  const rendered = [];
+  const output = { format: "es", dir: "/synthetic/dist" };
+  const input = { input: "/synthetic/entry.ts" };
+  const plugin = {
+    name: "synthetic-render-initializer",
+    applyToEnvironment: (environment) => environment.name === "ssr",
+    renderStart(outputOptions, inputOptions) {
+      rendered.push({ environment: this.environment.name, outputOptions, inputOptions });
+    },
+  };
+
+  const client = createPluginContainer({}, [plugin], { command: "build", environment: "client" });
+  const server = createPluginContainer({}, [plugin], { command: "build", environment: "ssr" });
+
+  assert.equal(server.pluginCount, 1);
+  await client.renderStart(output, input);
+  await server.renderStart(output, input);
+
+  assert.deepEqual(rendered, [{ environment: "ssr", outputOptions: output, inputOptions: input }]);
+});
+
+test("renderStart supports object-form hooks and continues past failed initializers", async () => {
+  const rendered = [];
+  const container = createPluginContainer({}, [
+    {
+      name: "synthetic-failed-render",
+      renderStart() { throw new Error("synthetic render failure"); },
+    },
+    {
+      name: "synthetic-object-render",
+      renderStart: { handler(output) { rendered.push({ consumer: this.environment.config.consumer, output }); } },
+    },
+  ], { command: "build", environment: "client" });
+  const output = { format: "es" };
+
+  await container.renderStart(output, {});
+
+  assert.deepEqual(rendered, [{ consumer: "client", output }]);
 });

--- a/e2e/unit/rolldown-assets.test.mjs
+++ b/e2e/unit/rolldown-assets.test.mjs
@@ -10,6 +10,7 @@ import {
   workspaceRoot,
   pnpmStorePaths,
   contentHashEmitter,
+  makeVitePlugins,
 } from "../../crates/oj_server/src/assets/start/rolldown-assets.mjs";
 
 const tmp = (p) => mkdtempSync(join(tmpdir(), "oj-assets-" + p + "-"));
@@ -145,4 +146,18 @@ test("emit does not compile plain CSS (no markers)", async () => {
   } finally {
     rmSync(base, { recursive: true, force: true });
   }
+});
+
+test("the Rolldown adapter forwards render initialization only to its active container", async () => {
+  const rendered = [];
+  const output = { format: "es" };
+  const input = { input: "/synthetic/entry.ts" };
+  const adapter = makeVitePlugins({
+    container: { renderStart(...options) { rendered.push({ environment: "active", options }); } },
+    fallback: { renderStart(...options) { rendered.push({ environment: "fallback", options }); } },
+  });
+
+  await adapter.renderStart(output, input);
+
+  assert.deepEqual(rendered, [{ environment: "active", options: [output, input] }]);
 });


### PR DESCRIPTION
## Summary
- retain plugins whose only supported Rollup lifecycle callback is renderStart
- invoke function-form and object-form render initialization hooks only for their matching environment while preserving both output and input options
- forward Rolldown renderStart callbacks exclusively to the active Vite plugin container

## Regression coverage
- committed three synthetic failing regressions before the implementation; upstream main discarded renderStart-only plugins, omitted the container callback, and never forwarded Rolldown render initialization
- verified all 22 plugin and output-asset unit tests pass inside a separate isolated Lima VM directory