### PR TITLE
fix(build): honor Vite public directory copy setting

### DIFF
--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -1440,7 +1440,9 @@ pub async fn build(
         .as_ref()
         .map(|p| root.join(p))
         .unwrap_or_else(|| root.join("public"));
-    copy_public_dir(&public_dir, &out_dir)?;
+    if build_cfg.copy_public_dir.unwrap_or(true) {
+        copy_public_dir(&public_dir, &out_dir)?;
+    }
 
     println!(
         "{} build: {} in {:?}",

--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -2599,6 +2599,59 @@ fn build_manifest(entries: &[ManifestEntry]) -> serde_json::Value {
 mod tests {
     use super::*;
 
+    #[tokio::test]
+    async fn copy_public_dir_configuration_controls_production_assets() {
+        for (index, (config_name, config, copied)) in [
+            (
+                "oj.config.json",
+                r#"{"build":{"copyPublicDir":false}}"#,
+                false,
+            ),
+            (
+                "vite.config.mjs",
+                "export default { build: { copyPublicDir: false } };",
+                false,
+            ),
+            (
+                "oj.config.json",
+                r#"{"build":{"copyPublicDir":true}}"#,
+                true,
+            ),
+            ("oj.config.json", "{}", true),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let suffix = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let root = std::env::temp_dir().join(format!("oj-copy-public-dir-{suffix}-{index}"));
+            fs::create_dir_all(root.join("public")).unwrap();
+            fs::write(root.join("package.json"), r#"{"type":"module"}"#).unwrap();
+            fs::write(root.join(config_name), config).unwrap();
+            fs::write(
+                root.join("index.html"),
+                r#"<html><body><script type="module" src="/main.js"></script></body></html>"#,
+            )
+            .unwrap();
+            fs::write(root.join("main.js"), "window.ready = true;").unwrap();
+            fs::write(root.join("public/asset.txt"), "public asset").unwrap();
+
+            build(root.clone(), None, None, "production")
+                .await
+                .expect("synthetic public-directory fixture should build");
+
+            assert_eq!(
+                root.join("dist/asset.txt").is_file(),
+                copied,
+                "{config_name}: {config}"
+            );
+            assert!(root.join("dist/index.html").is_file());
+            fs::remove_dir_all(root).unwrap();
+        }
+    }
+
     #[test]
     fn manifest_matches_vite_shape() {
         let mk = |key: &str,

--- a/crates/oj_config/src/schema.rs
+++ b/crates/oj_config/src/schema.rs
@@ -147,6 +147,7 @@ pub struct BuildConfig {
     pub rolldown_options: Option<serde_json::Value>,
     pub assets_inline_limit: Option<u64>,
     pub css_code_split: Option<bool>,
+    pub copy_public_dir: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/oj_server/src/assets/vite-extract.mjs
+++ b/crates/oj_server/src/assets/vite-extract.mjs
@@ -202,6 +202,8 @@ if (isMainRun) try {
       rollupOptions: c.build?.rolldownOptions ?? c.build?.rollupOptions ?? null,
       assetsInlineLimit:
         typeof c.build?.assetsInlineLimit === "number" ? c.build.assetsInlineLimit : null,
+      copyPublicDir:
+        typeof c.build?.copyPublicDir === "boolean" ? c.build.copyPublicDir : null,
       dedupe: Array.isArray(c.resolve?.dedupe)
         ? c.resolve.dedupe.filter((x) => typeof x === "string")
         : null,

--- a/crates/oj_server/src/plugins.rs
+++ b/crates/oj_server/src/plugins.rs
@@ -166,6 +166,7 @@ pub struct ViteValues {
     pub headers: Option<serde_json::Map<String, serde_json::Value>>,
     pub rollup_options: Option<serde_json::Value>,
     pub assets_inline_limit: Option<u64>,
+    pub copy_public_dir: Option<bool>,
     pub proxy: Option<serde_json::Value>,
     pub dedupe: Option<Vec<String>>,
     pub optimize_deps: Option<serde_json::Value>,
@@ -262,6 +263,7 @@ fn parse_vite_values(json: &serde_json::Value) -> ViteValues {
         headers: json.get("headers").and_then(|v| v.as_object()).cloned(),
         rollup_options: json.get("rollupOptions").filter(|v| !v.is_null()).cloned(),
         assets_inline_limit: json.get("assetsInlineLimit").and_then(|v| v.as_u64()),
+        copy_public_dir: json.get("copyPublicDir").and_then(|v| v.as_bool()),
         proxy: json.get("proxy").filter(|v| !v.is_null()).cloned(),
         dedupe: json.get("dedupe").and_then(|v| v.as_array()).map(|a| {
             a.iter()
@@ -342,6 +344,10 @@ fn merge_vite_values(config: &mut oj_config::OjConfig, v: ViteValues) {
     if let Some(limit) = v.assets_inline_limit {
         let build = config.build.get_or_insert_with(Default::default);
         build.assets_inline_limit.get_or_insert(limit);
+    }
+    if let Some(copy_public_dir) = v.copy_public_dir {
+        let build = config.build.get_or_insert_with(Default::default);
+        build.copy_public_dir.get_or_insert(copy_public_dir);
     }
     if let Some(proxy) = v.proxy {
         let sc = config.server.get_or_insert_with(Default::default);
@@ -891,6 +897,7 @@ mod vite_values_tests {
             headers: None,
             rollup_options: None,
             assets_inline_limit: None,
+            copy_public_dir: None,
             proxy: None,
             dedupe: None,
             optimize_deps: None,
@@ -917,6 +924,7 @@ mod vite_values_tests {
             headers: None,
             rollup_options: None,
             assets_inline_limit: None,
+            copy_public_dir: None,
             proxy: None,
             dedupe: None,
             optimize_deps: None,


### PR DESCRIPTION
## Summary
- preserve `build.copyPublicDir` from both `oj.config.json` and `vite.config.mjs`
- skip copying `public/` when `copyPublicDir: false` is explicitly configured
- continue copying public assets by default and when `copyPublicDir: true`

## Regression
The first commit adds a synthetic production-build test that fails on main because OJ copies public files even with `copyPublicDir: false`. The second commit makes direct configuration, Vite configuration, explicit copying, and default copying all pass.

## Verification
- Synthetic regression executed before the fix inside an isolated VM: failed as expected.
- All 37 OJ Rust tests passed inside the VM.
- All 92 available JavaScript unit tests passed inside the VM; 11 optional dependency-backed cases were skipped.