### PR TITLE
Honor server.strictPort with Vite's auto-increment default

### DIFF
--- a/crates/oj/src/ssr_dev.rs
+++ b/crates/oj/src/ssr_dev.rs
@@ -67,17 +67,15 @@ pub async fn ssr_dev(
         ssr_route,
     ));
 
-    let addr = std::net::SocketAddr::from((built.host, built.port));
-    let listener = tokio::net::TcpListener::bind(addr)
-        .await
-        .map_err(|e| anyhow::anyhow!("cannot bind {addr}: {e}"))?;
+    let (listener, port) =
+        oj_server::bind_dev_listener(built.host, built.port, built.strict_port).await?;
     println!("  {} dev (ssr + module runner)", oj_server::oj_brand());
     println!("  entry:  {entry}");
     match &client_url {
         Some(u) => println!("  client: {u} (hydration + hmr on)"),
         None => println!("  client: none (SSR only; add a *-client entry to hydrate)"),
     }
-    let url = format!("http://localhost:{}/", built.port);
+    let url = format!("http://localhost:{}/", port);
     println!("  {}", oj_server::link(&url, &oj_server::cell(&url)));
     axum::serve(listener, app).await?;
     Ok(())

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -136,10 +136,8 @@ pub async fn start_dev(
         start_route,
     ));
 
-    let addr = std::net::SocketAddr::from((built.host, built.port));
-    let listener = tokio::net::TcpListener::bind(addr)
-        .await
-        .map_err(|e| anyhow::anyhow!("cannot bind {addr}: {e}"))?;
+    let (listener, port) =
+        oj_server::bind_dev_listener(built.host, built.port, built.strict_port).await?;
     oj_server::boot_phase("listening");
     {
         let root = root.clone();
@@ -150,7 +148,7 @@ pub async fn start_dev(
         });
     }
     println!("  {} dev (tanstack start)", oj_server::oj_brand());
-    let url = format!("http://localhost:{}/", built.port);
+    let url = format!("http://localhost:{}/", port);
     println!("  {}", oj_server::link(&url, &oj_server::cell(&url)));
     axum::serve(listener, app).await?;
     Ok(())

--- a/crates/oj_config/src/lib.rs
+++ b/crates/oj_config/src/lib.rs
@@ -41,6 +41,14 @@ pub fn rolldown_options(config: &OjConfig) -> Option<&serde_json::Value> {
         .or(build.rollup_options.as_ref())
 }
 
+pub fn server_strict_port(config: &OjConfig) -> bool {
+    config
+        .server
+        .as_ref()
+        .and_then(|s| s.strict_port)
+        .unwrap_or(false)
+}
+
 pub fn env_prefixes(config: &OjConfig) -> Vec<String> {
     config
         .env_prefix
@@ -531,6 +539,17 @@ mod tests {
         // Absent server / fs / deny is an empty list (defaults applied elsewhere).
         let empty: OjConfig = serde_json::from_str("{}").unwrap();
         assert!(server_fs_deny(&empty).is_empty());
+    }
+
+    #[test]
+    fn server_strict_port_accessor_defaults_false() {
+        let on: OjConfig = serde_json::from_str(r#"{"server":{"strictPort":true}}"#).unwrap();
+        assert!(server_strict_port(&on));
+        // Vite's default is false (auto-increment) when unset.
+        let off: OjConfig = serde_json::from_str(r#"{"server":{"port":3000}}"#).unwrap();
+        assert!(!server_strict_port(&off));
+        let empty: OjConfig = serde_json::from_str("{}").unwrap();
+        assert!(!server_strict_port(&empty));
     }
 
     #[test]

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -277,6 +277,7 @@ pub struct BuiltApp {
     pub router: Router,
     pub host: std::net::IpAddr,
     pub port: u16,
+    pub strict_port: bool,
     pub proxy_prefixes: Vec<String>,
     pub plugin_mw_port: Option<u16>,
     pub root: PathBuf,
@@ -286,16 +287,39 @@ pub struct BuiltApp {
     pub reload_tx: broadcast::Sender<String>,
 }
 
+pub async fn bind_dev_listener(
+    host: std::net::IpAddr,
+    preferred: u16,
+    strict: bool,
+) -> anyhow::Result<(tokio::net::TcpListener, u16)> {
+    for port in preferred..=u16::MAX {
+        let addr = SocketAddr::from((host, port));
+        match tokio::net::TcpListener::bind(addr).await {
+            Ok(listener) => {
+                let bound = listener.local_addr().map(|a| a.port()).unwrap_or(port);
+                return Ok((listener, bound));
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+                if strict {
+                    return Err(anyhow::anyhow!("Port {port} is already in use"));
+                }
+                eprintln!("Port {port} is in use, trying another one...");
+            }
+            Err(e) => return Err(e).with_context(|| format!("cannot bind {addr}")),
+        }
+    }
+    Err(anyhow::anyhow!(
+        "no available port found between {preferred} and 65535"
+    ))
+}
+
 impl DevServer {
     pub async fn run(self) -> anyhow::Result<()> {
         let built = self.build_app().await?;
-        let addr = SocketAddr::from((built.host, built.port));
-        let listener = tokio::net::TcpListener::bind(addr)
-            .await
-            .with_context(|| format!("cannot bind {addr}"))?;
+        let (listener, port) = bind_dev_listener(built.host, built.port, built.strict_port).await?;
         println!("  {} dev server", oj_brand());
         println!("  root: {}", built.root.display());
-        let url = format!("http://localhost:{}/", built.port);
+        let url = format!("http://localhost:{}/", port);
         println!("  {}", link(&url, &cell(&url)));
         if !built.proxy_prefixes.is_empty() {
             println!("  proxy: {}", built.proxy_prefixes.join(", "));
@@ -377,6 +401,7 @@ impl DevServer {
 
         let server_cfg = config.server.clone().unwrap_or_default();
         let port = self.port.or(server_cfg.port).unwrap_or(5199);
+        let strict_port = oj_config::server_strict_port(&config);
         let bundle = self.bundle || config.bundle.unwrap_or(false);
         // The on-disk module cache is experimental and off by default. Opt in
         // with `oj dev --enable-cache` (or OJ_ENABLE_CACHE=1); `--no-cache`
@@ -727,6 +752,7 @@ impl DevServer {
             router: app,
             host,
             port,
+            strict_port,
             proxy_prefixes,
             plugin_mw_port,
             root,
@@ -953,10 +979,7 @@ pub async fn preview(
         .collect();
     let state = Arc::new((dir.clone(), base, headers));
     let app = Router::new().fallback(get(preview_serve)).with_state(state);
-    let addr = SocketAddr::from((resolve_host(host.as_deref()), port));
-    let listener = tokio::net::TcpListener::bind(addr)
-        .await
-        .with_context(|| format!("cannot bind {addr}"))?;
+    let (listener, port) = bind_dev_listener(resolve_host(host.as_deref()), port, false).await?;
     println!("  {} preview", oj_brand());
     println!("  serving: {}", dir.display());
     let url = format!("http://localhost:{port}/");
@@ -4562,6 +4585,26 @@ async fn decide(state: &ServerState, paths: &[PathBuf]) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn bind_dev_listener_increments_unless_strict() {
+        use std::net::{IpAddr, Ipv4Addr};
+        let host = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        // Hold an ephemeral port so the preferred one is busy.
+        let occupied = tokio::net::TcpListener::bind((host, 0)).await.unwrap();
+        let taken = occupied.local_addr().unwrap().port();
+
+        // strict: a busy preferred port is a hard error, never moved.
+        assert!(
+            bind_dev_listener(host, taken, true).await.is_err(),
+            "strict must reject a busy port",
+        );
+
+        // non-strict (Vite default): hop to the next free port.
+        let (listener, port) = bind_dev_listener(host, taken, false).await.unwrap();
+        assert_ne!(port, taken, "non-strict must pick a different port");
+        assert_eq!(listener.local_addr().unwrap().port(), port);
+    }
 
     #[tokio::test]
     async fn css_inline_returns_compiled_css_not_a_data_uri() {


### PR DESCRIPTION
Track 1 of the Vite-parity backlog. oj previously **hard-errored on any busy port** on every serving path (dev, ssr-dev, tanstack-start, preview) — effectively `strictPort: true` always, with no way to opt out. This adds Vite's default behavior.

## What changed
- New `oj_server::bind_dev_listener(host, preferred, strict)` mirroring Vite's `httpServerStart` (`node/http.ts:249`): binds `preferred`, and on `EADDRINUSE` either errors (`strict`) with `Port N is already in use`, or logs `Port N is in use, trying another one...` and increments to the next free port up to 65535. Non-EADDRINUSE errors propagate. Returns the actually-bound port (handles `port: 0` ephemeral).
- `server.strictPort` is now honored via `oj_config::server_strict_port` (default **false** = Vite parity: auto-increment). `strict_port` is carried on `BuiltApp`.
- Wired into all four bind sites: `DevServer::run`, `ssr_dev`, `start_dev`, and `preview` (preview auto-increments like Vite's preview). Printed URLs now use the actual bound port.

HMR is unaffected by a moved port: the client dials `location.host` (same-origin), so it always matches the served port.

## Coordination
Companion to lovablelabs/lovable#89246, which pins `strictPort: true` in Lovable's generated override. **That PR should merge first** so the Lovable preview keeps failing-loud on a busy `:8080` rather than silently moving once oj gains auto-increment.

## Tests
- `oj_server`: `bind_dev_listener` errors on a held port when `strict`, and picks a different free port when not.
- `oj_config`: `server_strict_port` reads the flag and defaults to false.