### PR TITLE
Add a Node sidecar test harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+      # The optimizer + sidecar-harness unit tests shell out to a real esbuild
+      # from the start-app fixture; install it so they run instead of skipping.
+      - name: install start-app fixture (esbuild for optimizer tests)
+        run: npm ci --prefix e2e/fixtures/start-app
       - name: js unit tests (adapter helpers)
         run: node --test e2e/unit/*.test.mjs
       - name: fuzz targets still build

--- a/e2e/unit/harness.mjs
+++ b/e2e/unit/harness.mjs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+// Shared test harness for driving oj's Node sidecars from `node --test`.
+// Two shapes, matching how the Rust side spawns them:
+//   - runSidecar:  one-shot `node <sidecar> <jsonArg>` -> parsed stdout JSON
+//                  (optimize-deps.mjs)
+//   - rpcSidecar:  long-lived newline-delimited JSON RPC over stdin/stdout
+//                  (plugin-host.mjs, runner.mjs)
+
+import { execFileSync, spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import readline from "node:readline";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+export const repo = path.join(here, "..", "..");
+export const asset = (rel) => path.join(repo, "crates/oj_server/src/assets", rel);
+
+const esbuildSrc = path.join(repo, "e2e/fixtures/start-app/node_modules/esbuild");
+export const hasEsbuildFixture = () => fs.existsSync(esbuildSrc);
+
+// Wrap `node:test`'s `test` so cases that need the pre-bundler's esbuild skip
+// (rather than hard-fail) when the start-app fixture has no node_modules, the
+// same convention optimize-deps.test.mjs uses.
+export function testWithEsbuild(test) {
+  return hasEsbuildFixture()
+    ? test
+    : (name, fn) => test(name, { skip: "fixture esbuild not installed" }, () => {});
+}
+
+// A throwaway project dir with a node_modules/ and package.json. `linkEsbuild`
+// symlinks the fixture's real esbuild (+ @esbuild binary) in, so the optimizer
+// resolves it without a per-test install.
+export function tmpProject({ prefix = "oj-fx-", pkgJson = { name: "fx" }, linkEsbuild = false } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  fs.mkdirSync(path.join(root, "node_modules"), { recursive: true });
+  fs.writeFileSync(path.join(root, "package.json"), JSON.stringify(pkgJson));
+  if (linkEsbuild) {
+    fs.symlinkSync(esbuildSrc, path.join(root, "node_modules", "esbuild"));
+    const scoped = path.join(repo, "e2e/fixtures/start-app/node_modules/@esbuild");
+    if (fs.existsSync(scoped)) fs.symlinkSync(scoped, path.join(root, "node_modules", "@esbuild"));
+  }
+  return {
+    root,
+    // Write a fake dependency under node_modules/<name>/.
+    pkg(name, main, files) {
+      const dir = path.join(root, "node_modules", name);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name, version: "1.0.0", main }));
+      for (const [f, c] of Object.entries(files)) fs.writeFileSync(path.join(dir, f), c);
+    },
+    // Write a file relative to the project root, creating parent dirs.
+    write(rel, content) {
+      const p = path.join(root, rel);
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      fs.writeFileSync(p, content);
+    },
+    cleanup() {
+      fs.rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+// Shape A: run a one-shot sidecar as `node <sidecar> <jsonConfig>` and return
+// its parsed stdout JSON. Throws on a non-zero exit; the thrown error carries
+// `.stdout`/`.stderr`/`.status` for error-path assertions.
+export function runSidecar(sidecarRel, config, { cwd, timeout = 30_000 } = {}) {
+  const out = execFileSync("node", [asset(sidecarRel), JSON.stringify(config)], {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout,
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return JSON.parse(out);
+}
+
+// Shape B: spawn a long-lived sidecar and speak newline-delimited JSON. `send`
+// writes one frame and resolves with the next stdout frame (parsed); a frame
+// that isn't the reply you expect is returned as-is, so callers that trigger
+// host->driver requests can dispatch on it. Always `close()` in a finally.
+export function rpcSidecar(sidecarRel, { args = [], env, cwd } = {}) {
+  const child = spawn("node", [asset(sidecarRel), ...args], {
+    cwd,
+    env: env ? { ...process.env, ...env } : process.env,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const frames = [];
+  let waiter = null;
+  readline.createInterface({ input: child.stdout }).on("line", (line) => {
+    if (!line.trim()) return;
+    if (waiter) {
+      const w = waiter;
+      waiter = null;
+      w(line);
+    } else {
+      frames.push(line);
+    }
+  });
+  let stderr = "";
+  child.stderr.on("data", (d) => {
+    stderr += d.toString();
+  });
+
+  const nextLine = (ms) =>
+    new Promise((res, rej) => {
+      if (frames.length) return res(frames.shift());
+      const to = setTimeout(() => rej(new Error(`sidecar rpc timeout after ${ms}ms; stderr:\n${stderr}`)), ms);
+      waiter = (line) => {
+        clearTimeout(to);
+        res(line);
+      };
+    });
+
+  return {
+    child,
+    stderr: () => stderr,
+    async nextFrame(ms = 10_000) {
+      return JSON.parse(await nextLine(ms));
+    },
+    async send(msg, ms = 10_000) {
+      child.stdin.write(JSON.stringify(msg) + "\n");
+      return JSON.parse(await nextLine(ms));
+    },
+    close() {
+      try {
+        child.stdin.end();
+        child.kill("SIGKILL");
+      } catch {
+        // already gone
+      }
+    },
+  };
+}

--- a/e2e/unit/harness.mjs
+++ b/e2e/unit/harness.mjs
@@ -104,6 +104,9 @@ export function rpcSidecar(sidecarRel, { args = [], env, cwd } = {}) {
   child.stderr.on("data", (d) => {
     stderr += d.toString();
   });
+  // If the sidecar dies mid-test, a write to its stdin would emit EPIPE; absorb
+  // it so the pending send's timeout reports the failure instead of crashing.
+  child.stdin.on("error", () => {});
 
   const nextLine = (ms) =>
     new Promise((res, rej) => {

--- a/e2e/unit/harness.test.mjs
+++ b/e2e/unit/harness.test.mjs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { runSidecar, rpcSidecar, tmpProject, testWithEsbuild } from "./harness.mjs";
+
+const itEsbuild = testWithEsbuild(test);
+
+// Shape A: the one-shot helper drives the real optimize-deps sidecar and returns
+// its parsed stdout. An explicit `include` is pre-bundled to an emitted file.
+itEsbuild("harness.runSidecar pre-bundles an included dep via optimize-deps", () => {
+  const fx = tmpProject({ prefix: "oj-harness-a-", linkEsbuild: true });
+  try {
+    fx.pkg("plaincjs", "index.js", { "index.js": "exports.a = 1;\n" });
+    fx.write("entry.js", `import { a } from "plaincjs";\nexport const out = a;\n`);
+    const outDir = path.join(fx.root, ".oj-cache", "deps");
+    const { metadata } = runSidecar("optimize-deps.mjs", {
+      root: fx.root,
+      outDir,
+      entries: [path.join(fx.root, "entry.js")],
+      include: ["plaincjs"],
+    });
+    assert.deepEqual(Object.keys(metadata), ["plaincjs"]);
+    assert.ok(fs.existsSync(path.join(outDir, metadata.plaincjs.file)), "emitted bundle file exists");
+  } finally {
+    fx.cleanup();
+  }
+});
+
+// Shape B: the RPC helper drives the real plugin-host over newline-JSON. An
+// empty plugins file needs no npm deps; getPluginCount is a hook that never
+// triggers a host->driver context request, so a single send/recv round-trips.
+test("harness.rpcSidecar round-trips a plugin-host hook", async () => {
+  const fx = tmpProject({ prefix: "oj-harness-b-" });
+  fx.write("oj.plugins.mjs", "export default [];\n");
+  const host = rpcSidecar("plugin-host.mjs", {
+    args: [path.join(fx.root, "oj.plugins.mjs"), JSON.stringify({ root: fx.root })],
+    env: { OJ_CACHE_ROOT: fx.root },
+    cwd: fx.root,
+  });
+  try {
+    const res = await host.send({ id: 1, hook: "getPluginCount", args: [] });
+    assert.equal(res.id, 1, "reply is keyed by the request id");
+    assert.equal(res.result, "0", "no plugins loaded from an empty plugins file");
+  } finally {
+    host.close();
+    fx.cleanup();
+  }
+});


### PR DESCRIPTION
Track 2 of the Vite-parity backlog: a small, shared harness so the remaining sidecar-facing tracks (optimizeDeps.esbuildOptions, plugin sourcemaps, handleHotUpdate) land with real assertions. CI already runs `node --test e2e/unit/*.test.mjs`.

`e2e/unit/harness.mjs` extracts the two spawn shapes oj already uses ad-hoc in `optimize-deps.test.mjs` and `runner-protocol.test.mjs`:

- **`runSidecar(rel, config)`** — one-shot `node <sidecar> <jsonArg>` returning parsed stdout (how the Rust side runs `optimize-deps.mjs`). High `maxBuffer`, stderr captured on the throw for error-path assertions.
- **`rpcSidecar(rel, {args, env, cwd})`** — long-lived newline-delimited JSON RPC over stdin/stdout (how the Rust side runs `plugin-host.mjs` / `runner.mjs`). `send()` writes a frame and resolves the next stdout frame; `nextFrame()` lets a driver dispatch host->driver requests; every `send` has a timeout so a wedged handler fails instead of hanging.
- **`tmpProject({ linkEsbuild })`** — a throwaway project dir with `pkg()`/`write()` helpers, symlinking the fixture's real esbuild in rather than installing per test.
- **`testWithEsbuild(test)`** — the existing skip-when-fixture-absent convention, shared.

Grounded in how Vite/esbuild/node test subprocess tooling: subprocess (not in-process) is correct here since oj's sidecars *are* the process boundary; synthesized temp fixtures + a symlinked real esbuild; assert on emitted bytes, not echoed config.

## Tests
`harness.test.mjs` self-tests both shapes against the real sidecars: `runSidecar` pre-bundles an included dep through `optimize-deps.mjs` and checks the emitted file (skips without the esbuild fixture, as usual); `rpcSidecar` round-trips a `getPluginCount` hook through `plugin-host.mjs`.

Existing `optimize-deps.test.mjs` / `runner-protocol.test.mjs` are left untouched; new tracks build on the harness.