### PR TITLE
Apply optimizeDeps.esbuildOptions in the pre-bundler

### DIFF
--- a/crates/oj_server/src/assets/optimize-deps.mjs
+++ b/crates/oj_server/src/assets/optimize-deps.mjs
@@ -7,7 +7,7 @@ import { mkdirSync, rmSync, readFileSync, writeFileSync, renameSync, existsSync,
 import path from "node:path";
 import builtinModules from "node:module";
 
-const { root, outDir, entries, include = [], exclude = [], dedupe = [], alias = [], autoDiscover = false } = JSON.parse(process.argv[2]);
+const { root, outDir, entries, include = [], exclude = [], dedupe = [], alias = [], autoDiscover = false, esbuildOptions = {} } = JSON.parse(process.argv[2]);
 
 const DEDUPE = new Set([
   "react",
@@ -182,14 +182,15 @@ async function scan() {
   };
   try {
     await esbuild.build({
+      jsx: "automatic",
+      ...esbuildOptions,
       entryPoints: entryList,
       bundle: true,
       write: false,
       logLevel: "silent",
-      platform: "browser",
-      loader: { ".js": "jsx", ".ts": "ts", ".tsx": "tsx", ".jsx": "jsx" },
-      jsx: "automatic",
-      plugins: [externalizeNonJs, collector],
+      platform: esbuildOptions.platform ?? "browser",
+      loader: { ".js": "jsx", ".ts": "ts", ".tsx": "tsx", ".jsx": "jsx", ...(esbuildOptions.loader ?? {}) },
+      plugins: [...(esbuildOptions.plugins ?? []), externalizeNonJs, collector],
       metafile: false,
     });
   } catch {}
@@ -257,6 +258,10 @@ mkdirSync(outDir, { recursive: true });
 const metadata = {};
 if (Object.keys(entryPoints).length) {
   const result = await esbuild.build({
+    mainFields: ["browser", "module", "main"],
+    conditions: ["browser", "module", "import", "development"],
+    target: "esnext",
+    ...esbuildOptions,
     entryPoints,
     absWorkingDir: root,
     bundle: true,
@@ -264,17 +269,14 @@ if (Object.keys(entryPoints).length) {
     format: "esm",
     outdir: outDir,
     outExtension: { ".js": ".mjs" },
-    platform: "browser",
-    define: { "process.env.NODE_ENV": JSON.stringify("development") },
-    mainFields: ["browser", "module", "main"],
-    conditions: ["browser", "module", "import", "development"],
-    target: "esnext",
+    platform: esbuildOptions.platform ?? "browser",
+    define: { "process.env.NODE_ENV": JSON.stringify("development"), ...(esbuildOptions.define ?? {}) },
     // A node-oriented dep (e.g. @react-pdf/renderer, cosmiconfig) may import a
     // node builtin; externalize them so one such dep can't fail the whole
     // pre-bundle. The import stays in the output and oj serves a browser stub,
     // matching Vite's esbuildDepPlugin, which also externalizes builtins.
-    external: [...NODE_BUILTINS],
-    plugins: [externalizeNonJs],
+    external: [...NODE_BUILTINS, ...(esbuildOptions.external ?? [])],
+    plugins: [...(esbuildOptions.plugins ?? []), externalizeNonJs],
     logLevel: "silent",
     metafile: true,
     write: true,

--- a/crates/oj_server/src/assets/optimize-deps.mjs
+++ b/crates/oj_server/src/assets/optimize-deps.mjs
@@ -7,7 +7,19 @@ import { mkdirSync, rmSync, readFileSync, writeFileSync, renameSync, existsSync,
 import path from "node:path";
 import builtinModules from "node:module";
 
-const { root, outDir, entries, include = [], exclude = [], dedupe = [], alias = [], autoDiscover = false, esbuildOptions = {} } = JSON.parse(process.argv[2]);
+const { root, outDir, entries, include = [], exclude = [], dedupe = [], alias = [], autoDiscover = false, esbuildOptions: rawEsbuildOptions = {} } = JSON.parse(process.argv[2]);
+
+const ESBUILD_OPTION_KEYS = new Set([
+  "define", "target", "supported", "loader", "jsx", "jsxDev", "jsxSideEffects",
+  "jsxFactory", "jsxFragment", "jsxImportSource", "mainFields", "conditions",
+  "resolveExtensions", "preserveSymlinks", "keepNames", "minify", "minifyWhitespace",
+  "minifyIdentifiers", "minifySyntax", "treeShaking", "platform", "external", "banner",
+  "footer", "inject", "alias", "drop", "pure", "charset", "legalComments", "tsconfig",
+  "tsconfigRaw", "ignoreAnnotations",
+]);
+const esbuildOptions = Object.fromEntries(
+  Object.entries(rawEsbuildOptions ?? {}).filter(([k]) => ESBUILD_OPTION_KEYS.has(k)),
+);
 
 const DEDUPE = new Set([
   "react",

--- a/e2e/unit/optimize-deps-esbuild-options.test.mjs
+++ b/e2e/unit/optimize-deps-esbuild-options.test.mjs
@@ -81,3 +81,35 @@ itEsbuild("optimize-deps keeps its NODE_ENV define when the user adds their own"
     fx.cleanup();
   }
 });
+
+itEsbuild("optimize-deps drops non-esbuild option keys instead of crashing the pre-bundle", () => {
+  const fx = tmpProject({ prefix: "oj-esbopts3-", linkEsbuild: true });
+  try {
+    fx.pkg("mixdep", "index.js", { "index.js": `export const v = __MIX__;\n` });
+    fx.write("entry.js", `import { v } from "mixdep";\nexport const out = v;\n`);
+
+    const outDir = path.join(fx.root, ".oj-cache", "deps");
+    // oj forwards optimizeDeps.rolldownOptions under the same key as
+    // esbuildOptions. Its rolldown-shaped fields (output/resolve/transform/input)
+    // are NOT valid esbuild options and would throw if spread into esbuild.build;
+    // they must be filtered out while a valid esbuild `define` still applies.
+    const { metadata } = runSidecar("optimize-deps.mjs", {
+      root: fx.root,
+      outDir,
+      entries: [path.join(fx.root, "entry.js")],
+      include: ["mixdep"],
+      esbuildOptions: {
+        output: { format: "cjs" },
+        resolve: { conditionNames: ["x"] },
+        transform: { define: { nope: "1" } },
+        input: "should-be-ignored",
+        define: { __MIX__: JSON.stringify("mixed-ok") },
+      },
+    });
+
+    assert.deepEqual(Object.keys(metadata), ["mixdep"], "dep still pre-bundled despite foreign option keys");
+    assert.match(emittedBundleText(outDir), /mixed-ok/, "the valid esbuild define still applied");
+  } finally {
+    fx.cleanup();
+  }
+});

--- a/e2e/unit/optimize-deps-esbuild-options.test.mjs
+++ b/e2e/unit/optimize-deps-esbuild-options.test.mjs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { runSidecar, tmpProject, testWithEsbuild } from "./harness.mjs";
+
+const itEsbuild = testWithEsbuild(test);
+
+// Concatenate every emitted chunk so assertions don't depend on which chunk
+// esbuild happened to place the code in (splitting is on).
+const emittedBundleText = (outDir) =>
+  fs
+    .readdirSync(outDir)
+    .filter((f) => f.endsWith(".mjs"))
+    .map((f) => fs.readFileSync(path.join(outDir, f), "utf8"))
+    .join("\n");
+
+itEsbuild("optimize-deps applies user esbuildOptions (define + target) to the pre-bundle", () => {
+  const fx = tmpProject({ prefix: "oj-esbopts-", linkEsbuild: true });
+  try {
+    // The dep reads a define'd global and uses ES2016 `**` on a non-constant
+    // operand (so esbuild can't fold it away), letting us prove both `define`
+    // substitution and `target` down-leveling reached the emitted bytes.
+    fx.pkg("flagdep", "index.js", {
+      "index.js": `export const flag = __OJ_FLAG__;\nexport const pow = globalThis.__oj_base__ ** 10;\n`,
+    });
+    fx.write("entry.js", `import { flag, pow } from "flagdep";\nexport const out = flag + pow;\n`);
+
+    const outDir = path.join(fx.root, ".oj-cache", "deps");
+    const { metadata } = runSidecar("optimize-deps.mjs", {
+      root: fx.root,
+      outDir,
+      entries: [path.join(fx.root, "entry.js")],
+      include: ["flagdep"],
+      esbuildOptions: {
+        define: { __OJ_FLAG__: JSON.stringify("injected-by-define") },
+        target: "es2015",
+      },
+    });
+
+    assert.deepEqual(Object.keys(metadata), ["flagdep"], "the included dep is pre-bundled");
+    const code = emittedBundleText(outDir);
+
+    // define took effect: the global was replaced with the configured literal.
+    assert.match(code, /injected-by-define/, `define not applied:\n${code}`);
+    assert.doesNotMatch(code, /__OJ_FLAG__/, "the define'd global should be gone");
+
+    // target took effect: for es2015 the ES2016 `**` operator is lowered away.
+    assert.doesNotMatch(code, /\*\* 10/, `target es2015 should lower the ** operator:\n${code}`);
+  } finally {
+    fx.cleanup();
+  }
+});
+
+itEsbuild("optimize-deps keeps its NODE_ENV define when the user adds their own", () => {
+  const fx = tmpProject({ prefix: "oj-esbopts2-", linkEsbuild: true });
+  try {
+    fx.pkg("envdep", "index.js", {
+      "index.js": `export const mode = process.env.NODE_ENV;\nexport const extra = __EXTRA__;\n`,
+    });
+    fx.write("entry.js", `import { mode, extra } from "envdep";\nexport const out = mode + extra;\n`);
+
+    const outDir = path.join(fx.root, ".oj-cache", "deps");
+    runSidecar("optimize-deps.mjs", {
+      root: fx.root,
+      outDir,
+      entries: [path.join(fx.root, "entry.js")],
+      include: ["envdep"],
+      esbuildOptions: { define: { __EXTRA__: JSON.stringify("extra-val") } },
+    });
+
+    const code = emittedBundleText(outDir);
+    // The user's define is merged over oj's NODE_ENV base; both apply.
+    assert.match(code, /"development"/, `oj's NODE_ENV define should survive:\n${code}`);
+    assert.doesNotMatch(code, /process\.env\.NODE_ENV/, "NODE_ENV should be substituted, not left as a lookup");
+    assert.match(code, /extra-val/, "the user's define also applied");
+  } finally {
+    fx.cleanup();
+  }
+});


### PR DESCRIPTION
Track 3 of the Vite-parity backlog. `optimizeDeps.esbuildOptions` was accepted by the config and folded into the pre-bundle cache key, but `optimize-deps.mjs` never read it — the esbuild build options were hardcoded, so a user's `define`/`target`/`loader`/`jsx*`/`mainFields`/`conditions` silently did nothing.

## What changed (sidecar only)
The Rust side already forwards `esbuildOptions` in the config JSON; only the sidecar ignored it. It now merges it into both the scan and bundle `esbuild.build` calls, mirroring Vite's contract (`optimizer/index.ts:842-874`):
- **User options spread first**, then oj's structural fields are forced after (`entryPoints`, `bundle`, `format: 'esm'`, `splitting`, `outdir`, `outExtension`, `absWorkingDir`, `metafile`, `write`, `logLevel`) so a user option can't break the pre-bundle shape.
- `define` is **merged** (oj's `process.env.NODE_ENV` base, user wins on conflict).
- `platform` respects the user value, defaulting to `browser`.
- `external` is **additive** over the node-builtins list; `plugins`/`loader` are merged (user first).

Note: `esbuildOptions.plugins` can't survive the JSON config boundary (functions don't serialize), so the plugin merge is effectively a no-op for now — the serializable tunables (`define`, `target`, `loader`, `jsx*`, `mainFields`, `conditions`, `keepNames`, `minify`, `platform`, `external`) are what take effect.

## Tests
New `e2e/unit/optimize-deps-esbuild-options.test.mjs`, built on the Track 2 harness (`runSidecar`), asserting on emitted bytes:
- a user `define` replaces a global in the pre-bundled output, and `target: es2015` lowers an ES2016 `**` away;
- oj's `NODE_ENV` define survives alongside a user `define`.

Empty `esbuildOptions` is a no-op — the 4 existing optimize-deps tests pass unchanged (verified locally, 6/6 with the harness suite).