### PR TITLE
Compose plugin transform sourcemaps with oj's map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1856,6 +1856,7 @@ dependencies = [
  "oxc_minifier",
  "oxc_parser",
  "oxc_semantic",
+ "oxc_sourcemap",
  "oxc_span",
  "oxc_syntax",
  "oxc_transformer",

--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -861,7 +861,7 @@ impl Plugin for OjUserPlugin {
         let id = args.id.to_string();
         async move {
             match host.transform(&code, &id).await {
-                Ok((out, _)) if out != code => Ok(Some(HookTransformOutput {
+                Ok((out, _, _)) if out != code => Ok(Some(HookTransformOutput {
                     code: Some(out),
                     ..Default::default()
                 })),

--- a/crates/oj_compiler/Cargo.toml
+++ b/crates/oj_compiler/Cargo.toml
@@ -21,6 +21,7 @@ glob = "0.3.4"
 memchr.workspace = true
 serde_json.workspace = true
 oxc_codegen.workspace = true
+oxc_sourcemap = "8.0.2"
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/oj_compiler/src/lib.rs
+++ b/crates/oj_compiler/src/lib.rs
@@ -199,7 +199,17 @@ pub fn compile_module(
     path: &Path,
     source_text: &str,
     opts: &CompileOptions,
+    rewriter: Option<&mut ImportRewriter>,
+) -> Result<CompileOutput, CompileError> {
+    compile_module_with_maps(path, source_text, opts, rewriter, &[])
+}
+
+pub fn compile_module_with_maps(
+    path: &Path,
+    source_text: &str,
+    opts: &CompileOptions,
     mut rewriter: Option<&mut ImportRewriter>,
+    input_maps: &[String],
 ) -> Result<CompileOutput, CompileError> {
     let source_type = SourceType::from_path(path)
         .map_err(|_| CompileError::UnsupportedFileType(path.to_path_buf()))?;
@@ -300,13 +310,70 @@ pub fn compile_module(
     let CodegenReturn { code, map, .. } =
         Codegen::new().with_options(codegen_options).build(&program);
 
+    let map_data_url = map.map(|oj_map| {
+        if input_maps.is_empty() {
+            oj_map.to_data_url()
+        } else {
+            compose_input_maps_data_url(&oj_map, input_maps)
+        }
+    });
+
     Ok(CompileOutput {
         code,
-        map_data_url: map.map(|m| m.to_data_url()),
+        map_data_url,
         imports,
         dynamic_imports,
         is_refresh_boundary,
     })
+}
+
+fn compose_input_maps_data_url(oj_map: &oxc_sourcemap::SourceMap, input_maps: &[String]) -> String {
+    let mut acc = oj_map.to_json_string();
+    for pm in input_maps.iter().rev() {
+        let outer = match oxc_sourcemap::SourceMap::from_json_string(&acc) {
+            Ok(m) => m,
+            Err(_) => return oj_map.to_data_url(),
+        };
+        let inner = match oxc_sourcemap::SourceMap::from_json_string(pm) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        acc = compose_two(&outer, &inner).to_json_string();
+    }
+    match oxc_sourcemap::SourceMap::from_json_string(&acc) {
+        Ok(m) => m.to_data_url(),
+        Err(_) => oj_map.to_data_url(),
+    }
+}
+
+fn compose_two<'i>(
+    outer: &oxc_sourcemap::SourceMap,
+    inner: &'i oxc_sourcemap::SourceMap,
+) -> oxc_sourcemap::SourceMap<'i> {
+    let lut = inner.generate_lookup_table();
+    let mut b = oxc_sourcemap::SourceMapBuilder::default();
+    for t in outer.get_tokens() {
+        if t.get_source_id().is_none() {
+            continue;
+        }
+        if let Some(vt) =
+            inner.lookup_source_view_token_approx(&lut, t.get_src_line(), t.get_src_col())
+        {
+            let src_id = vt
+                .get_source()
+                .map(|s| b.add_source_and_content(s, vt.get_source_content().unwrap_or("")));
+            let name_id = vt.get_name().map(|n| b.add_name(n));
+            b.add_token(
+                t.get_dst_line(),
+                t.get_dst_col(),
+                vt.get_src_line(),
+                vt.get_src_col(),
+                src_id,
+                name_id,
+            );
+        }
+    }
+    b.into_sourcemap()
 }
 
 pub(crate) fn rewrite_module_specifiers_pub<'a>(
@@ -376,6 +443,61 @@ impl<'a> oxc_ast_visit::VisitMut<'a> for DynamicImportRewriter<'a, '_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn compose_two_traces_served_position_back_to_original_source() {
+        use oxc_sourcemap::SourceMapBuilder;
+        // inner (plugin map): intermediate (0,0) -> original src.tsx (5,2).
+        let mut ib = SourceMapBuilder::default();
+        let sid = ib.add_source_and_content("src.tsx", "original source");
+        ib.add_token(0, 0, 5, 2, Some(sid), None);
+        let inner = ib.into_sourcemap();
+        // outer (oj/oxc map): served (1,4) -> intermediate (0,0).
+        let mut ob = SourceMapBuilder::default();
+        let iid = ob.add_source_and_content("intermediate.js", "intermediate");
+        ob.add_token(1, 4, 0, 0, Some(iid), None);
+        let outer = ob.into_sourcemap();
+
+        let composed = compose_two(&outer, &inner);
+        let lut = composed.generate_lookup_table();
+        let vt = composed
+            .lookup_source_view_token(&lut, 1, 4)
+            .expect("served (1,4) should map");
+        // The served position now points at the ORIGINAL source, not the intermediate.
+        assert_eq!(vt.get_source(), Some("src.tsx"), "source is the original file");
+        assert_eq!(vt.get_src_line(), 5, "original line preserved through compose");
+        assert_eq!(vt.get_src_col(), 2, "original column preserved through compose");
+    }
+
+    #[test]
+    fn compose_input_maps_data_url_folds_and_degrades_gracefully() {
+        use oxc_sourcemap::{SourceMap, SourceMapBuilder};
+        let mut ib = SourceMapBuilder::default();
+        let sid = ib.add_source_and_content("app.tsx", "let x = 1;");
+        ib.add_token(0, 0, 9, 3, Some(sid), None);
+        let plugin_map = ib.into_sourcemap().to_json_string();
+
+        let mut ob = SourceMapBuilder::default();
+        let iid = ob.add_source_and_content("app.plugin.js", "intermediate");
+        ob.add_token(0, 0, 0, 0, Some(iid), None);
+        let oj_map = ob.into_sourcemap();
+
+        // The fold traces through the plugin map to the original file.
+        let folded =
+            compose_two(&oj_map, &SourceMap::from_json_string(&plugin_map).unwrap()).to_json_string();
+        assert!(folded.contains("app.tsx"), "folded map references the original source: {folded}");
+
+        // The public entry point emits an inline JSON sourcemap data URL and never panics.
+        let url = compose_input_maps_data_url(&oj_map, &[plugin_map]);
+        assert!(
+            url.starts_with("data:application/json") && url.contains("base64,"),
+            "emits an inline data URL: {url}",
+        );
+
+        // Garbage input maps degrade to oj's own map rather than erroring.
+        let fallback = compose_input_maps_data_url(&oj_map, &["not json".to_string()]);
+        assert!(fallback.starts_with("data:application/json") && fallback.contains("base64,"));
+    }
 
     #[test]
     fn defines_apply_after_jsx_transform_without_reference_id_panic() {

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -588,11 +588,17 @@ async function transform(code, id) {
   return transformWatchStore.run(bucket, async () => {
     if (id) seenIds.add(id);
     let current = code;
+    const maps = [];
     for (const p of plugins) {
       if (typeof p.transform !== "function") continue;
       const r = await p.transform.call(ctx, current, id);
       if (r == null) continue;
-      current = typeof r === "string" ? r : (r.code ?? current);
+      if (typeof r === "string") {
+        current = r;
+        continue;
+      }
+      if (r.code != null) current = r.code;
+      if (r.map != null) maps.push(typeof r.map === "string" ? r.map : JSON.stringify(r.map));
     }
     const info = { id, code: current, importedIds: [] };
     moduleInfoCache.set(id, info);
@@ -600,7 +606,7 @@ async function transform(code, id) {
     for (const p of plugins) {
       if (typeof p.moduleParsed === "function") await p.moduleParsed.call(ctx, info);
     }
-    return JSON.stringify({ code: current, watchFiles: [...bucket] });
+    return JSON.stringify({ code: current, watchFiles: [...bucket], maps });
   });
 }
 

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -880,7 +880,7 @@ async fn ssr_module(
         Some(host) => host
             .transform(&source, id)
             .await
-            .map(|(code, _)| code)
+            .map(|(code, _, _)| code)
             .unwrap_or(source),
         None => source,
     };
@@ -1914,11 +1914,13 @@ async fn ensure_module(
 
     let is_dep = is_dep_module(url, file);
     let mut plugin_watch_files: Vec<String> = Vec::new();
+    let mut plugin_maps: Vec<String> = Vec::new();
     let source = match &state.plugins {
         Some(host) if !is_dep && state.plugins_have_transform => {
             match host.transform(&source, &file.to_string_lossy()).await {
-                Ok((code, watches)) => {
+                Ok((code, watches, maps)) => {
                     plugin_watch_files = watches;
+                    plugin_maps = maps;
                     code
                 }
                 Err(e) => {
@@ -2127,11 +2129,12 @@ async fn ensure_module(
                 } else {
                     oj_compiler::CompileOptions::dev()
                 };
-                oj_compiler::compile_module(
+                oj_compiler::compile_module_with_maps(
                     &file_owned,
                     interopped.as_deref().unwrap_or(&source),
                     &opts,
                     Some(&mut rewrite),
+                    &plugin_maps,
                 )
             }
             .map_err(|err| format!("compile error:\n{err}"))?;

--- a/crates/oj_server/src/plugins.rs
+++ b/crates/oj_server/src/plugins.rs
@@ -569,9 +569,13 @@ impl PluginHost {
         }
     }
 
-    pub async fn transform(&self, code: &str, id: &str) -> Result<(String, Vec<String>), String> {
+    pub async fn transform(
+        &self,
+        code: &str,
+        id: &str,
+    ) -> Result<(String, Vec<String>, Vec<String>), String> {
         let Some(raw) = self.call("transform", &[code, id]).await? else {
-            return Ok((code.to_string(), Vec::new()));
+            return Ok((code.to_string(), Vec::new(), Vec::new()));
         };
         match serde_json::from_str::<serde_json::Value>(&raw) {
             Ok(v) => {
@@ -580,18 +584,19 @@ impl PluginHost {
                     .and_then(|c| c.as_str())
                     .unwrap_or(code)
                     .to_string();
-                let watch = v
-                    .get("watchFiles")
-                    .and_then(|w| w.as_array())
-                    .map(|a| {
-                        a.iter()
-                            .filter_map(|x| x.as_str().map(str::to_string))
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                Ok((out, watch))
+                let str_array = |key: &str| {
+                    v.get(key)
+                        .and_then(|w| w.as_array())
+                        .map(|a| {
+                            a.iter()
+                                .filter_map(|x| x.as_str().map(str::to_string))
+                                .collect()
+                        })
+                        .unwrap_or_default()
+                };
+                Ok((out, str_array("watchFiles"), str_array("maps")))
             }
-            Err(_) => Ok((raw, Vec::new())),
+            Err(_) => Ok((raw, Vec::new(), Vec::new())),
         }
     }
 

--- a/e2e/unit/plugin-transform-sourcemap.test.mjs
+++ b/e2e/unit/plugin-transform-sourcemap.test.mjs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { rpcSidecar, tmpProject } from "./harness.mjs";
+
+// The plugin host must forward each plugin transform's sourcemap to Rust (in a
+// `maps` array), so oj can compose it with its own oxc map. Before, only
+// `code`/`watchFiles` were returned and the map was dropped.
+test("plugin-host forwards plugin transform sourcemaps to Rust", async () => {
+  const fx = tmpProject({ prefix: "oj-pmap-" });
+  fx.write(
+    "oj.plugins.mjs",
+    `export default [{
+      name: "adds-map",
+      transform(code, id) {
+        return { code: code + "\\n/* transformed */", map: { version: 3, sources: [id], names: [], mappings: "AAAA" } };
+      },
+    }];\n`,
+  );
+  const host = rpcSidecar("plugin-host.mjs", {
+    args: [path.join(fx.root, "oj.plugins.mjs"), JSON.stringify({ root: fx.root })],
+    env: { OJ_CACHE_ROOT: fx.root },
+    cwd: fx.root,
+  });
+  try {
+    const res = await host.send({
+      id: 1,
+      hook: "transform",
+      args: ["let a = 1;", path.join(fx.root, "a.js")],
+    });
+    assert.equal(res.id, 1, "reply keyed by request id");
+    const out = JSON.parse(res.result);
+    assert.match(out.code, /transformed/, "the transform ran");
+    assert.equal(out.maps.length, 1, "the plugin's map is captured");
+    assert.match(out.maps[0], /"mappings":"AAAA"/, "the plugin's map is forwarded verbatim");
+  } finally {
+    host.close();
+    fx.cleanup();
+  }
+});


### PR DESCRIPTION
Track 5 of the Vite-parity backlog. oj dropped plugin `transform`/`load` sourcemaps entirely (`plugin-host.mjs` never emitted `r.map`; `plugins.rs` never parsed it), so for any module a Vite plugin rewrote (lovable-tagger, wyw, mockup-preview…), oj's served map pointed at the post-plugin intermediate rather than the original source.

## Approach (Rust-native)
Confirmed against Vite's source: `pluginContainer` keeps a `sourcemapChain` and folds it pairwise with `combineSourcemaps` (`@ampproject/remapping`); the composed map is served inline. oj's pipeline is `source → plugin transforms (JS host) → oxc transform (Rust) → served`, and **oxc codegen can't ingest an input map**, so the compose must happen after codegen.

Kept it Rust-native: the JS host only **captures** each plugin's map (no JS composition, no `@ampproject/remapping` dependency), and Rust does all composition via `oxc_sourcemap` (added as a direct dep of `oj_compiler`, same 8.x the codegen already pulls):
- `compile_module_with_maps(..., input_maps)` (new; `compile_module` delegates with `&[]`, so all other callers are unchanged). After oxc codegen, it folds the plugin maps onto oj's oxc map — outermost-first (reverse application order) so served positions trace back to the original source — via `compose_two`, which traces each oxc token through the plugin map with `lookup_source_view_token_approx` (oxc's purpose-built compose primitive, matching Rollup's `traceSegment`).
- Plugin maps flow host → `plugins.rs` transform RPC (now returns `(code, watchFiles, maps)`) → `ensure_module` → `compile_module_with_maps`. The composed map rides oj's existing `map_data_url` → `serve_compiled` inline-serve path.
- Safe by construction: unparseable input maps degrade to oj's own map; a plugin that transforms without a map is skipped (Vite does the same); the fold only runs when both a plugin map and an oj map exist.

Scope: the dev-serve path (where maps are served). The `oj build` path still discards maps (pre-existing) and is a separate follow-up.

## Tests
- `oj_compiler`: `compose_two` traces a served position back to the original file/line/col through a plugin map; `compose_input_maps_data_url` folds a real plugin map (result references the original source) and degrades gracefully on garbage input.
- `e2e/unit` (via the Track 2 harness): the plugin host forwards a plugin transform's map to Rust in the `maps` array.

Workspace + fuzz green; the 4-arg `compile_module` callers are untouched.