### PR TITLE
Enrich handleHotUpdate context and honor plugin-filtered modules

### DIFF
--- a/crates/oj_graph/src/lib.rs
+++ b/crates/oj_graph/src/lib.rs
@@ -95,6 +95,28 @@ impl ModuleGraph {
         }
     }
 
+    pub fn node(&self, path: &Path) -> Option<&ModuleNode> {
+        self.modules.get(path)
+    }
+
+    pub fn propagate_from_seeds(&self, seeds: &[&Path]) -> HmrDecision {
+        for seed in seeds {
+            if !self.modules.contains_key(*seed) {
+                return HmrDecision::FullReload {
+                    reason: format!("{} is not in the module graph", seed.display()),
+                };
+            }
+        }
+        match self.collect_boundaries(seeds, &[]) {
+            Ok(mut boundaries) => {
+                boundaries.sort();
+                boundaries.dedup();
+                HmrDecision::Update { boundaries }
+            }
+            Err(reason) => HmrDecision::FullReload { reason },
+        }
+    }
+
     pub fn update_plan(&self, changed: &Path) -> Result<UpdatePlan, String> {
         match self.propagate_update(changed) {
             HmrDecision::FullReload { reason } => Err(reason),
@@ -274,6 +296,53 @@ mod tests {
                 boundaries: vec![p("Button.tsx")]
             }
         );
+    }
+
+    #[test]
+    fn propagate_from_seeds_matches_single_seed_propagation() {
+        let mut g = graph();
+        g.add_import(&p("Button.tsx"), &p("utils.ts"));
+        let seed = p("utils.ts");
+        let via_seeds = g.propagate_from_seeds(&[seed.as_path()]);
+        assert_eq!(
+            via_seeds,
+            HmrDecision::Update {
+                boundaries: vec![p("Button.tsx")]
+            }
+        );
+    }
+
+    #[test]
+    fn propagate_from_seeds_dedupes_shared_boundaries() {
+        let mut g = graph();
+        g.add_import(&p("Button.tsx"), &p("a.ts"));
+        g.add_import(&p("Button.tsx"), &p("b.ts"));
+        let a = p("a.ts");
+        let b = p("b.ts");
+        let decision = g.propagate_from_seeds(&[a.as_path(), b.as_path()]);
+        assert_eq!(
+            decision,
+            HmrDecision::Update {
+                boundaries: vec![p("Button.tsx")]
+            }
+        );
+    }
+
+    #[test]
+    fn propagate_from_seeds_unknown_seed_forces_full_reload() {
+        let g = graph();
+        let missing = p("does-not-exist.ts");
+        assert!(matches!(
+            g.propagate_from_seeds(&[missing.as_path()]),
+            HmrDecision::FullReload { .. }
+        ));
+    }
+
+    #[test]
+    fn node_returns_known_modules_only() {
+        let g = graph();
+        assert!(g.node(&p("App.tsx")).is_some());
+        assert!(g.node(&p("never-seen.ts")).is_none());
     }
 
     #[test]

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -3,6 +3,7 @@
 
 import http from "node:http";
 import { createReadStream, existsSync, fstatSync, openSync, statSync, write as fsWrite, writeFileSync } from "node:fs";
+import { readFile, stat as fsStat } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname, isAbsolute, join, resolve as pathResolve } from "node:path";
@@ -649,15 +650,47 @@ async function load(id) {
   return null;
 }
 
-async function handleHotUpdate(file, timestamp) {
-  let suppress = false;
+async function readModifiedFile(file) {
+  const content = await readFile(file, "utf8");
+  if (content) return content;
+  const mtime = (await fsStat(file)).mtimeMs;
+  for (let n = 0; n < 10; n++) {
+    await new Promise((r) => setTimeout(r, 10));
+    const newMtime = (await fsStat(file)).mtimeMs;
+    if (newMtime !== mtime) break;
+  }
+  return readFile(file, "utf8");
+}
+
+async function handleHotUpdate(file, timestamp, type, modulesJson) {
+  let modules;
+  try {
+    modules = modulesJson ? JSON.parse(modulesJson) : [];
+  } catch {
+    modules = [];
+  }
+  const hmrContext = {
+    file,
+    timestamp: Number(timestamp),
+    type: type || "update",
+    modules,
+    read: () => readModifiedFile(file),
+  };
+  let filtered = null;
   for (const p of plugins) {
     if (typeof p.handleHotUpdate !== "function") continue;
-    const r = await p.handleHotUpdate.call(ctx, { file, timestamp: Number(timestamp) });
+    const r = await p.handleHotUpdate.call(ctx, hmrContext);
     if (r === "full-reload") return "full-reload";
-    if (Array.isArray(r) && r.length === 0) suppress = true;
+    if (Array.isArray(r)) {
+      hmrContext.modules = r;
+      filtered = r
+        .map((m) => (typeof m === "string" ? m : m && (m.url ?? m.id)))
+        .filter((u) => typeof u === "string" && u.length > 0);
+    }
   }
-  return suppress ? "skip" : null;
+  if (filtered === null) return null;
+  if (filtered.length === 0) return "skip";
+  return JSON.stringify({ action: "filter", modules: filtered });
 }
 
 function escapeAttr(v) {
@@ -763,7 +796,7 @@ async function run(hook, args) {
   if (hook === "transform") return transform(args[0], args[1]);
   if (hook === "resolveId") return resolveId(args[0], args[1]);
   if (hook === "load") return load(args[0]);
-  if (hook === "handleHotUpdate") return handleHotUpdate(args[0], args[1]);
+  if (hook === "handleHotUpdate") return handleHotUpdate(args[0], args[1], args[2], args[3]);
   if (hook === "transformIndexHtml") return transformIndexHtml(args[0]);
   if (hook === "buildStart" || hook === "buildEnd" || hook === "renderStart" || hook === "closeBundle") {
     return runLifecycle(hook);

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -4422,6 +4422,19 @@ fn spawn_watcher(state: Arc<ServerState>) {
 // Async because it is reached both from the watcher thread (via block_on) and
 // from the async /__hmr_flush handler; using block_on here panicked ("runtime
 // within a runtime") when the gate flushed on an async worker thread.
+fn parse_hmr_filter(raw: &str) -> Option<Vec<PathBuf>> {
+    let v: serde_json::Value = serde_json::from_str(raw).ok()?;
+    if v.get("action")?.as_str()? != "filter" {
+        return None;
+    }
+    let arr = v.get("modules")?.as_array()?;
+    Some(
+        arr.iter()
+            .filter_map(|m| m.as_str().map(PathBuf::from))
+            .collect(),
+    )
+}
+
 async fn decide(state: &ServerState, paths: &[PathBuf]) -> Vec<String> {
     let mut messages: Vec<String> = Vec::new();
     let mut updates: Vec<serde_json::Value> = Vec::new();
@@ -4476,9 +4489,30 @@ async fn decide(state: &ServerState, paths: &[PathBuf]) -> Vec<String> {
             if state.plugins_watch_change {
                 let _ = host.watch_change(&file, "update").await;
             }
-            if state.plugins_hot_update {
+            if state.plugins_hot_update && path.exists() {
                 let ts = now_millis() as u64;
-                match host.handle_hot_update(&file, ts).await {
+                let hmr_url = url_of(&state.root, path);
+                let modules_json = {
+                    let g = state.graph.lock().unwrap();
+                    match g.node(Path::new(&hmr_url)) {
+                        Some(n) => serde_json::json!([{
+                            "url": hmr_url,
+                            "id": hmr_url,
+                            "isSelfAccepting": n.is_self_accepting,
+                            "importers": n
+                                .importers
+                                .iter()
+                                .map(|p| p.display().to_string())
+                                .collect::<Vec<_>>(),
+                        }])
+                        .to_string(),
+                        None => "[]".to_string(),
+                    }
+                };
+                match host
+                    .handle_hot_update(&file, ts, "update", &modules_json)
+                    .await
+                {
                     Ok(Some(d)) if d == "skip" => {
                         println!("oj: change {file} -> HMR suppressed by plugin");
                         continue;
@@ -4490,6 +4524,40 @@ async fn decide(state: &ServerState, paths: &[PathBuf]) -> Vec<String> {
                                 .to_string(),
                         );
                         return messages;
+                    }
+                    Ok(Some(d)) => {
+                        if let Some(seeds) = parse_hmr_filter(&d) {
+                            if !state.bundle {
+                                let seed_refs: Vec<&Path> =
+                                    seeds.iter().map(PathBuf::as_path).collect();
+                                let decision =
+                                    state.graph.lock().unwrap().propagate_from_seeds(&seed_refs);
+                                match decision {
+                                    HmrDecision::Update { boundaries } => {
+                                        println!(
+                                            "oj: change {file} -> plugin-filtered update {boundaries:?}"
+                                        );
+                                        let timestamp = now_millis() as u64;
+                                        updates.extend(boundaries.iter().map(|b| {
+                                            let mut p = format!("{}", b.display());
+                                            if is_style_url(&p) {
+                                                p.push_str("?import");
+                                            }
+                                            serde_json::json!({ "path": p, "timestamp": timestamp })
+                                        }));
+                                        continue;
+                                    }
+                                    HmrDecision::FullReload { reason } => {
+                                        println!("oj: change {file} -> full-reload ({reason})");
+                                        messages.push(
+                                            serde_json::json!({ "type": "full-reload", "reason": reason })
+                                                .to_string(),
+                                        );
+                                        return messages;
+                                    }
+                                }
+                            }
+                        }
                     }
                     _ => {}
                 }
@@ -4613,6 +4681,25 @@ async fn decide(state: &ServerState, paths: &[PathBuf]) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_hmr_filter_reads_filter_module_urls() {
+        let seeds =
+            parse_hmr_filter(r#"{"action":"filter","modules":["/src/a.tsx","/src/b.tsx"]}"#).unwrap();
+        assert_eq!(
+            seeds,
+            vec![PathBuf::from("/src/a.tsx"), PathBuf::from("/src/b.tsx")]
+        );
+    }
+
+    #[test]
+    fn parse_hmr_filter_ignores_non_filter_payloads() {
+        assert!(parse_hmr_filter("skip").is_none());
+        assert!(parse_hmr_filter("full-reload").is_none());
+        assert!(parse_hmr_filter(r#"{"action":"reload"}"#).is_none());
+        assert!(parse_hmr_filter(r#"{"action":"filter"}"#).is_none());
+        assert!(parse_hmr_filter("not json at all").is_none());
+    }
 
     #[tokio::test]
     async fn bind_dev_listener_increments_unless_strict() {

--- a/crates/oj_server/src/plugins.rs
+++ b/crates/oj_server/src/plugins.rs
@@ -625,9 +625,14 @@ impl PluginHost {
         &self,
         file: &str,
         timestamp: u64,
+        change_type: &str,
+        modules_json: &str,
     ) -> Result<Option<String>, String> {
-        self.call("handleHotUpdate", &[file, &timestamp.to_string()])
-            .await
+        self.call(
+            "handleHotUpdate",
+            &[file, &timestamp.to_string(), change_type, modules_json],
+        )
+        .await
     }
 
     #[inline]

--- a/e2e/unit/handle-hot-update-ctx.test.mjs
+++ b/e2e/unit/handle-hot-update-ctx.test.mjs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { rpcSidecar, tmpProject } from "./harness.mjs";
+
+// The plugin host must pass a Vite-shaped HmrContext ({ file, timestamp, type,
+// modules, read }) to handleHotUpdate and honor a returned filtered module list.
+// Before, the ctx was only { file, timestamp } and a non-empty array was ignored.
+test("plugin-host enriches the handleHotUpdate ctx and honors a filtered return", async () => {
+  const fx = tmpProject({ prefix: "oj-hmr-" });
+  fx.write("a.tsx", "export const x = 1;\n");
+  fx.write(
+    "oj.plugins.mjs",
+    `export default [{
+      name: "hmr",
+      async handleHotUpdate(ctx) {
+        const content = await ctx.read();
+        const ok =
+          ctx.type === "update" &&
+          typeof ctx.timestamp === "number" &&
+          Array.isArray(ctx.modules) &&
+          ctx.modules[0] && ctx.modules[0].url === "/a.tsx" &&
+          ctx.modules[0].isSelfAccepting === true &&
+          content.includes("export const x");
+        // Only narrow to the module set when the whole ctx was delivered; a
+        // wrong ctx forces a full-reload, which the test detects as a failure.
+        return ok ? ctx.modules : "full-reload";
+      },
+    }];\n`,
+  );
+  const host = rpcSidecar("plugin-host.mjs", {
+    args: [path.join(fx.root, "oj.plugins.mjs"), JSON.stringify({ root: fx.root })],
+    env: { OJ_CACHE_ROOT: fx.root },
+    cwd: fx.root,
+  });
+  try {
+    const modules = JSON.stringify([{ url: "/a.tsx", isSelfAccepting: true, importers: ["/b.tsx"] }]);
+    const res = await host.send({
+      id: 1,
+      hook: "handleHotUpdate",
+      args: [path.join(fx.root, "a.tsx"), "123", "update", modules],
+    });
+    assert.equal(res.id, 1);
+    const parsed = JSON.parse(res.result);
+    assert.equal(parsed.action, "filter", "the ctx was fully delivered and the return honored");
+    assert.deepEqual(parsed.modules, ["/a.tsx"], "returned module urls forwarded as the filter set");
+  } finally {
+    host.close();
+    fx.cleanup();
+  }
+});
+
+// A plugin returning an empty array suppresses HMR entirely (Vite: no modules
+// to update). The host must surface that as "skip", not a filter or a reload.
+test("plugin-host treats an empty handleHotUpdate array as a suppressed update", async () => {
+  const fx = tmpProject({ prefix: "oj-hmr-" });
+  fx.write("a.tsx", "export const x = 1;\n");
+  fx.write(
+    "oj.plugins.mjs",
+    `export default [{
+      name: "hmr-suppress",
+      handleHotUpdate() {
+        return [];
+      },
+    }];\n`,
+  );
+  const host = rpcSidecar("plugin-host.mjs", {
+    args: [path.join(fx.root, "oj.plugins.mjs"), JSON.stringify({ root: fx.root })],
+    env: { OJ_CACHE_ROOT: fx.root },
+    cwd: fx.root,
+  });
+  try {
+    const res = await host.send({
+      id: 1,
+      hook: "handleHotUpdate",
+      args: [path.join(fx.root, "a.tsx"), "123", "update", "[]"],
+    });
+    assert.equal(res.result, "skip", "empty array suppresses the update");
+  } finally {
+    host.close();
+    fx.cleanup();
+  }
+});
+
+// Vite folds the return across plugins: each returned array becomes the next
+// plugin's ctx.modules and the FINAL set decides. An earlier empty array must
+// not latch a suppression that a later plugin overrides.
+test("plugin-host folds handleHotUpdate returns so the last plugin decides", async () => {
+  const fx = tmpProject({ prefix: "oj-hmr-" });
+  fx.write("a.tsx", "export const x = 1;\n");
+  fx.write(
+    "oj.plugins.mjs",
+    `export default [
+      { name: "empty-first", handleHotUpdate() { return []; } },
+      { name: "narrow-last", handleHotUpdate() { return [{ url: "/a.tsx" }]; } },
+    ];\n`,
+  );
+  const host = rpcSidecar("plugin-host.mjs", {
+    args: [path.join(fx.root, "oj.plugins.mjs"), JSON.stringify({ root: fx.root })],
+    env: { OJ_CACHE_ROOT: fx.root },
+    cwd: fx.root,
+  });
+  try {
+    const res = await host.send({
+      id: 1,
+      hook: "handleHotUpdate",
+      args: [path.join(fx.root, "a.tsx"), "123", "update", "[]"],
+    });
+    const parsed = JSON.parse(res.result);
+    assert.equal(parsed.action, "filter", "a later non-empty return overrides an earlier empty one");
+    assert.deepEqual(parsed.modules, ["/a.tsx"]);
+  } finally {
+    host.close();
+    fx.cleanup();
+  }
+});
+
+// The mirror of the fold: a later empty array overrides an earlier filter and
+// suppresses the update.
+test("plugin-host lets a later empty handleHotUpdate return suppress an earlier filter", async () => {
+  const fx = tmpProject({ prefix: "oj-hmr-" });
+  fx.write("a.tsx", "export const x = 1;\n");
+  fx.write(
+    "oj.plugins.mjs",
+    `export default [
+      { name: "narrow-first", handleHotUpdate() { return [{ url: "/a.tsx" }]; } },
+      { name: "empty-last", handleHotUpdate() { return []; } },
+    ];\n`,
+  );
+  const host = rpcSidecar("plugin-host.mjs", {
+    args: [path.join(fx.root, "oj.plugins.mjs"), JSON.stringify({ root: fx.root })],
+    env: { OJ_CACHE_ROOT: fx.root },
+    cwd: fx.root,
+  });
+  try {
+    const res = await host.send({
+      id: 1,
+      hook: "handleHotUpdate",
+      args: [path.join(fx.root, "a.tsx"), "123", "update", "[]"],
+    });
+    assert.equal(res.result, "skip", "the last plugin's empty array wins");
+  } finally {
+    host.close();
+    fx.cleanup();
+  }
+});


### PR DESCRIPTION
## What

Track 6 of the Vite-parity series. Brings oj's `handleHotUpdate` plugin hook to Vite parity, verified line-by-line against `vite/src/node/server/hmr.ts`.

### Before
The hook was called with only `{ file, timestamp }`, and a returned non-empty array was ignored (only `"full-reload"` and empty-array suppression were honored).

### After
- The plugin receives the Vite runtime `HmrContext`: `{ file, timestamp, type, modules, read() }`.
  - `modules` is the affected module node (`url`, `id`, `isSelfAccepting`, `importers`) from the graph, or `[]` when unknown.
  - `read()` mirrors Vite's `readModifiedFile`: re-reads on empty content with an mtime poll to survive atomic-save editors.
  - `type` is `"update"` (Vite's `contextMeta.type` for this hook).
- The hook is invoked **only for updates** (file exists), exactly like Vite, where the legacy `handleHotUpdate` runs only when `type === 'update'`; create/delete never reach it. This also means `read()` is never called on a missing file.
- The return value is **folded across plugins exactly like Vite**: each returned array becomes `context.modules` for the next plugin, and the FINAL set decides.
  - `"full-reload"` -> full reload.
  - final array empty -> update suppressed (`skip`); an earlier empty array does not latch if a later plugin returns modules.
  - final array non-empty -> the update is narrowed to those module URLs, propagated to their nearest HMR boundaries.

### Rust-native propagation
The plugin-returned module set is propagated through oj's own module graph (`ModuleGraph::propagate_from_seeds`), reusing the existing boundary-collection logic. Unknown seeds force a full reload. No JS round-trip for the graph walk.

### Known deltas from Vite (by design)
- `ctx.server` (the `ViteDevServer`) is not provided — it cannot cross the sidecar process boundary. Plugins reading `ctx.server` get `undefined`; closing this needs a server-RPC proxy (out of scope).
- `ctx.modules[].importers` is a `string[]` of graph keys rather than a `Set<ModuleNode>`; the commonly-used `url`/`id` fields match.

## Tests
- `oj_graph`: `propagate_from_seeds` (single seed, shared-boundary dedup, unknown seed -> full reload) and the new `node()` accessor.
- `oj_server`: `parse_hmr_filter` (reads filter payloads, ignores `skip`/`full-reload`/garbage).
- `e2e/unit/handle-hot-update-ctx.test.mjs`: drives the real plugin host and asserts the enriched ctx is delivered (`type`, `timestamp`, `modules`, `read`), a returned array becomes a `filter`, an empty array becomes `skip`, and the multi-plugin fold lets the last plugin decide in both directions.

Full workspace `cargo test`, fuzz `cargo check`, and the unit e2e suite all pass.