### PR TITLE
Run configResolved before applyToEnvironment (#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSS imported with `?inline` returns the compiled CSS string instead of a base64 `data:` URI.
 - Dev-served CSS rewrites relative `url()` and `@import` references to server-absolute paths so injected styles resolve them.
 
+### Fixed
+- Plugin `configResolved` now runs before `applyToEnvironment`, matching Vite; plugins that populate state in `configResolved` and read it from `applyToEnvironment` (for example `@tanstack/router-plugin`) no longer crash the plugin host, and a throwing `applyToEnvironment` keeps the plugin active instead of failing config load ([#37](https://github.com/raphamorim/oj/issues/37)).
+
 ### Security
 - `server.fs.deny` is enforced, and oj blocks `.env`, `.env.*`, `*.crt`, `*.pem`, and `**/.git/**` by default (Vite parity).
 

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -330,20 +330,8 @@ try {
       throw e;
     }
   });
-  plugins = plugins.filter((p) => {
-    if (typeof p.applyToEnvironment !== "function") return true;
-    try {
-      return !!p.applyToEnvironment(environment);
-    } catch (e) {
-      if (ojStartMode) return true;
-      throw e;
-    }
-  });
   const rank = (p) => (p.enforce === "pre" ? -1 : p.enforce === "post" ? 1 : 0);
   plugins.sort((a, b) => rank(a) - rank(b));
-  process.stderr.write(
-    `${OJ} plugin host: ${plugins.length} plugin(s) active for ${env.command}: ${plugins.map((p) => `${p.name}[${p.enforce ?? "-"}]`).join(",")}\n`,
-  );
 } catch (e) {
   process.stderr.write(`${OJ} plugin host: failed to load ${pluginsPath}: ${(e && e.stack) || e}\n`);
 }
@@ -459,6 +447,21 @@ async function runConfigHooks() {
   }
 }
 await runConfigHooks();
+
+plugins = plugins.filter((p) => {
+  if (typeof p.applyToEnvironment !== "function") return true;
+  try {
+    return !!p.applyToEnvironment(environment);
+  } catch (e) {
+    process.stderr.write(
+      `${OJ} plugin host: applyToEnvironment(${p.name ?? "?"}) threw; keeping the plugin active: ${(e && e.message) || e}\n`,
+    );
+    return true;
+  }
+});
+process.stderr.write(
+  `${OJ} plugin host: ${plugins.length} plugin(s) active for ${env.command}: ${plugins.map((p) => `${p.name}[${p.enforce ?? "-"}]`).join(",")}\n`,
+);
 
 const wsListeners = new Map();
 function ojWsSend(event, data) {

--- a/e2e/unit/apply-to-environment-order.test.mjs
+++ b/e2e/unit/apply-to-environment-order.test.mjs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { rpcSidecar, tmpProject } from "./harness.mjs";
+
+// Regression for #37: oj must run `configResolved` before it evaluates
+// `applyToEnvironment`, matching Vite (config.ts resolves environment plugins
+// "after configResolved because there are downstream projects modifying the
+// plugins in it"). Plugins such as @tanstack/router-plugin populate a closure
+// variable in `configResolved` and read it from `applyToEnvironment`.
+test("configResolved runs before applyToEnvironment so the plugin stays active", async () => {
+  const fx = tmpProject({ prefix: "oj-ate-" });
+  // `applyToEnvironment` returns false until `configResolved` has flipped the
+  // flag; if oj evaluated it first the plugin would be filtered out and its
+  // transform would never run.
+  fx.write(
+    "oj.plugins.mjs",
+    `let ready = false;
+     export default [{
+       name: "order-sensitive",
+       configResolved() { ready = true; },
+       applyToEnvironment() { return ready; },
+       transform(code, id) {
+         return id.endsWith("target.js") ? { code: code + "\\n/*ACTIVE*/", map: null } : null;
+       },
+     }];\n`,
+  );
+  const host = rpcSidecar("plugin-host.mjs", {
+    args: [path.join(fx.root, "oj.plugins.mjs"), JSON.stringify({ root: fx.root })],
+    env: { OJ_CACHE_ROOT: fx.root },
+    cwd: fx.root,
+  });
+  try {
+    const res = await host.send({
+      id: 1,
+      hook: "transform",
+      args: ["let a = 1;", path.join(fx.root, "target.js")],
+    });
+    const out = JSON.parse(res.result);
+    assert.match(out.code, /ACTIVE/, "the plugin was applied to the environment after configResolved ran");
+  } finally {
+    host.close();
+    fx.cleanup();
+  }
+});
+
+// The exact @tanstack/router-plugin shape: `applyToEnvironment` reads
+// `userConfig.plugin?...` where `userConfig` is only assigned in
+// `configResolved`. With the correct order it never throws.
+test("a tanstack-style applyToEnvironment reading configResolved state does not throw", async () => {
+  const fx = tmpProject({ prefix: "oj-ate-" });
+  fx.write(
+    "oj.plugins.mjs",
+    `let userConfig;
+     export default [{
+       name: "tanstack-like",
+       configResolved() { userConfig = { plugin: { vite: {} } }; },
+       applyToEnvironment(environment) {
+         if (userConfig.plugin?.vite?.environmentName)
+           return userConfig.plugin.vite.environmentName === environment.name;
+         return true;
+       },
+       transform(code, id) {
+         return id.endsWith("target.js") ? { code: code + "\\n/*ACTIVE*/", map: null } : null;
+       },
+     }];\n`,
+  );
+  const host = rpcSidecar("plugin-host.mjs", {
+    args: [path.join(fx.root, "oj.plugins.mjs"), JSON.stringify({ root: fx.root })],
+    env: { OJ_CACHE_ROOT: fx.root },
+    cwd: fx.root,
+  });
+  try {
+    const res = await host.send({
+      id: 1,
+      hook: "transform",
+      args: ["let a = 1;", path.join(fx.root, "target.js")],
+    });
+    const out = JSON.parse(res.result);
+    assert.match(out.code, /ACTIVE/, "the plugin loaded and applied without a TypeError");
+  } finally {
+    host.close();
+    fx.cleanup();
+  }
+});
+
+// A plugin whose applyToEnvironment genuinely throws must not take down the
+// host: oj warns and keeps the plugin active, and the host keeps serving RPC.
+test("a throwing applyToEnvironment does not crash the plugin host", async () => {
+  const fx = tmpProject({ prefix: "oj-ate-" });
+  fx.write(
+    "oj.plugins.mjs",
+    `export default [{
+       name: "throws-in-ate",
+       applyToEnvironment() { throw new Error("boom"); },
+       transform(code, id) {
+         return id.endsWith("target.js") ? { code: code + "\\n/*ACTIVE*/", map: null } : null;
+       },
+     }];\n`,
+  );
+  const host = rpcSidecar("plugin-host.mjs", {
+    args: [path.join(fx.root, "oj.plugins.mjs"), JSON.stringify({ root: fx.root })],
+    env: { OJ_CACHE_ROOT: fx.root },
+    cwd: fx.root,
+  });
+  try {
+    const first = await host.send({
+      id: 1,
+      hook: "transform",
+      args: ["let a = 1;", path.join(fx.root, "target.js")],
+    });
+    assert.match(JSON.parse(first.result).code, /ACTIVE/, "the plugin stayed active despite throwing");
+    const second = await host.send({
+      id: 2,
+      hook: "transform",
+      args: ["let b = 2;", path.join(fx.root, "other.js")],
+    });
+    assert.equal(second.id, 2, "the host still answers a second request");
+  } finally {
+    host.close();
+    fx.cleanup();
+  }
+});


### PR DESCRIPTION
Fixes #37.

## Problem

`oj dev` crashes the plugin host on `@tanstack/router-plugin` (with `autoCodeSplitting: true`):

```
oj plugin host: failed to load .../vite.config.ts: TypeError: Cannot read properties of undefined (reading 'plugin')
    at Object.applyToEnvironment (.../router-code-splitter-plugin.js:169)
    at .../plugin-host.mjs (Array.filter)
```

The TanStack code-splitter's `applyToEnvironment` reads `userConfig.plugin?.vite?.environmentName`, but `userConfig` is only assigned in that plugin's `configResolved` hook. oj evaluated `applyToEnvironment` at plugin-load time — **before** running `config`/`configResolved` — so `userConfig` was `undefined` and `.plugin` threw.

## Vite reference

Vite resolves environment plugins strictly after `configResolved` (`vite/src/node/config.ts`):

```js
// run configResolved hooks
await Promise.all(getSortedPluginHooks('configResolved').map((hook) => hook.call(...)))

// Resolve environment plugins after configResolved because there are
// downstream projects modifying the plugins in it.
resolved.environments[name].plugins = await resolveEnvironmentPlugins(...)  // calls applyToEnvironment
```

## Fix

- Move the `applyToEnvironment` filter to run **after** `runConfigHooks()` (which runs `config` then `configResolved`), matching Vite's order. `config`/`configResolved` still run on every plugin, as in Vite; `applyToEnvironment` only gates the per-environment pipeline.
- A throwing `applyToEnvironment` now warns and keeps the plugin active instead of failing the whole config load, so one misbehaving plugin can't take down the dev server.

## Tests

`e2e/unit/apply-to-environment-order.test.mjs` (drives the real plugin host):
- **Ordering (regression):** a plugin whose `applyToEnvironment` returns a flag set in `configResolved` stays active — this test fails on the pre-fix code (plugin filtered out) and passes after.
- **TanStack shape:** the exact `userConfig.plugin?...` pattern loads and applies without a `TypeError`.
- **Resilience:** a plugin that throws in `applyToEnvironment` does not crash the host, and a second RPC still succeeds.

Full unit e2e suite (116 tests) and `cargo build -p oj_server` pass.