### PR TITLE
Bridge plugin emitFile({type:'chunk'}) to rolldown emit_chunk (Phase B of #75)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,8 @@ jobs:
           ! grep -rq __OJ_DEFINE_ playground/dist/assets/*.js
       - name: explicit build inputs (multi-page, no root index.html)
         run: node e2e/multi-html-input.mjs
+      - name: plugin emitFile chunk spine (getFileName resolves hashed name)
+        run: node e2e/emit-chunk-build.mjs
       - name: library build
         run: |
           mkdir -p /tmp/lib/src

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `?worker&inline` emits an inline Blob worker (with a `data:` URI fallback) in bundle mode, matching Vite; in dev it serves a working module worker instead of a broken data URI.
 - Plugin `handleHotUpdate` now receives the full Vite `HmrContext` (`file`, `timestamp`, `type`, `modules`, `read()`) and its returned module list is honored to narrow (or, when empty, suppress) the update, folded across plugins as in Vite.
 - `build.rollupOptions`/`rolldownOptions.input` is honored (string, array, or `{ name: path }` object), so multi-page projects and projects without a root `index.html` build. HTML entries under nested directories are emitted at their root-relative path and their page-relative `<script>` sources are resolved against the page, matching Vite's `input` resolution.
+- Plugins can call `this.emitFile({ type: "chunk", id })` during `transform`; the chunk is bundled as an entry and `this.getFileName(referenceId)` resolves to its final hashed name in `generateBundle` (the emit-chunk mechanism CRXJS-style plugins use to add content scripts and pages).
 
 ### Changed
 - Plugin `transform` sourcemaps are now composed with oj's own transform map, so dev sourcemaps trace back to the original source through plugins that rewrite code.

--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -785,6 +785,10 @@ fn copy_public_dir(src: &Path, dest: &Path) -> anyhow::Result<()> {
 struct OjUserPlugin {
     host: Arc<PluginHost>,
     render_chunk_enabled: Arc<tokio::sync::OnceCell<bool>>,
+    // Maps a plugin-facing chunk reference id (`oj-chunk-N`, minted in the
+    // sidecar) to rolldown's own reference id, so `this.getFileName(refId)` can
+    // be answered with the final hashed name once chunks are generated.
+    emitted_chunk_refs: Arc<std::sync::Mutex<std::collections::HashMap<String, String>>>,
 }
 
 impl OjUserPlugin {
@@ -792,6 +796,7 @@ impl OjUserPlugin {
         Self {
             host,
             render_chunk_enabled: Arc::new(tokio::sync::OnceCell::new()),
+            emitted_chunk_refs: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         }
     }
 }
@@ -853,18 +858,38 @@ impl Plugin for OjUserPlugin {
 
     fn transform(
         &self,
-        _ctx: SharedTransformPluginContext,
+        ctx: SharedTransformPluginContext,
         args: &HookTransformArgs<'_>,
     ) -> impl std::future::Future<Output = HookTransformReturn> + Send {
         let host = Arc::clone(&self.host);
+        let refs = Arc::clone(&self.emitted_chunk_refs);
         let code = args.code.to_string();
         let id = args.id.to_string();
         async move {
             match host.transform(&code, &id).await {
-                Ok((out, _, _)) if out != code => Ok(Some(HookTransformOutput {
-                    code: Some(out),
-                    ..Default::default()
-                })),
+                Ok((out, _, _, chunks)) => {
+                    for c in &chunks {
+                        let emitted = rolldown_common::EmittedChunk {
+                            id: c.id.clone(),
+                            name: c.name.clone().map(Into::into),
+                            file_name: c.file_name.clone().map(Into::into),
+                            ..Default::default()
+                        };
+                        if let Ok(rd_ref) = ctx.inner.emit_chunk(emitted) {
+                            refs.lock()
+                                .unwrap()
+                                .insert(c.ref_id.clone(), rd_ref.to_string());
+                        }
+                    }
+                    if out != code {
+                        Ok(Some(HookTransformOutput {
+                            code: Some(out),
+                            ..Default::default()
+                        }))
+                    } else {
+                        Ok(None)
+                    }
+                }
                 _ => Ok(None),
             }
         }
@@ -872,9 +897,33 @@ impl Plugin for OjUserPlugin {
 
     async fn generate_bundle(
         &self,
-        _ctx: &PluginContext,
+        ctx: &PluginContext,
         args: &mut rolldown_plugin::HookGenerateBundleArgs<'_>,
     ) -> rolldown_plugin::HookNoopReturn {
+        // Resolve the final hashed name of every chunk the plugin emitted and
+        // seed them into the sidecar so `this.getFileName(refId)` (read here in
+        // generateBundle) returns the real output filename.
+        let refs: Vec<(String, String)> = self
+            .emitted_chunk_refs
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(a, b)| (a.clone(), b.clone()))
+            .collect();
+        if !refs.is_empty() {
+            let mut map = serde_json::Map::new();
+            for (oj_ref, rd_ref) in refs {
+                if let Ok(name) = ctx.get_file_name(&rd_ref) {
+                    map.insert(oj_ref, serde_json::Value::String(name.to_string()));
+                }
+            }
+            if !map.is_empty() {
+                let _ = self
+                    .host
+                    .seed_chunk_names(&serde_json::Value::Object(map).to_string())
+                    .await;
+            }
+        }
         if !self.host.has_generate_bundle().await {
             return Ok(());
         }

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -348,6 +348,13 @@ function ctxRpc(method, args) {
 
 let emitCounter = 0;
 const emitted = [];
+// Chunks a plugin asks oj to emit via `this.emitFile({ type: "chunk" })`.
+// The reference id is minted here and returned synchronously (Rollup's emitFile
+// is sync); the chunk is forwarded to rolldown as a build root by the Rust side,
+// and its final hashed name is seeded back into `chunkFileNames` before
+// generateBundle so `this.getFileName(refId)` resolves.
+const chunkFileNames = new Map();
+const transformEmitStore = new AsyncLocalStorage();
 
 const moduleInfoCache = new Map();
 
@@ -377,8 +384,26 @@ const ctx = {
     return id == null ? null : { id };
   },
   emitFile(file) {
-    if (file == null || (file.type && file.type !== "asset")) {
-      throw new Error("oj: this.emitFile supports { type: 'asset' } only");
+    if (file == null) {
+      throw new Error("oj: this.emitFile requires a file descriptor");
+    }
+    if (file.type === "chunk") {
+      if (!file.id) {
+        throw new Error("oj: this.emitFile({ type: 'chunk' }) requires an id");
+      }
+      const referenceId = `oj-chunk-${emitCounter++}`;
+      const rec = {
+        referenceId,
+        id: file.id,
+        name: file.name ?? null,
+        fileName: file.fileName ?? null,
+      };
+      const bucket = transformEmitStore.getStore();
+      if (bucket) bucket.push(rec);
+      return referenceId;
+    }
+    if (file.type && file.type !== "asset") {
+      throw new Error("oj: this.emitFile supports { type: 'asset' | 'chunk' }");
     }
     const fileName = file.fileName ?? `assets/${file.name ?? `asset-${emitCounter}`}`;
     const referenceId = `oj-ref-${emitCounter++}`;
@@ -386,6 +411,7 @@ const ctx = {
     return referenceId;
   },
   getFileName(referenceId) {
+    if (chunkFileNames.has(referenceId)) return chunkFileNames.get(referenceId);
     const f = emitted.find((e) => e.referenceId === referenceId);
     if (!f) throw new Error(`oj: unknown emit reference ${referenceId}`);
     return f.fileName;
@@ -589,29 +615,37 @@ if (ssrBridgeDir) {
 
 async function transform(code, id) {
   const bucket = new Set();
-  return transformWatchStore.run(bucket, async () => {
-    if (id) seenIds.add(id);
-    let current = code;
-    const maps = [];
-    for (const p of plugins) {
-      if (typeof p.transform !== "function") continue;
-      const r = await p.transform.call(ctx, current, id);
-      if (r == null) continue;
-      if (typeof r === "string") {
-        current = r;
-        continue;
+  const chunkBucket = [];
+  return transformWatchStore.run(bucket, () =>
+    transformEmitStore.run(chunkBucket, async () => {
+      if (id) seenIds.add(id);
+      let current = code;
+      const maps = [];
+      for (const p of plugins) {
+        if (typeof p.transform !== "function") continue;
+        const r = await p.transform.call(ctx, current, id);
+        if (r == null) continue;
+        if (typeof r === "string") {
+          current = r;
+          continue;
+        }
+        if (r.code != null) current = r.code;
+        if (r.map != null) maps.push(typeof r.map === "string" ? r.map : JSON.stringify(r.map));
       }
-      if (r.code != null) current = r.code;
-      if (r.map != null) maps.push(typeof r.map === "string" ? r.map : JSON.stringify(r.map));
-    }
-    const info = { id, code: current, importedIds: [] };
-    moduleInfoCache.set(id, info);
-    seenIds.add(id);
-    for (const p of plugins) {
-      if (typeof p.moduleParsed === "function") await p.moduleParsed.call(ctx, info);
-    }
-    return JSON.stringify({ code: current, watchFiles: [...bucket], maps });
-  });
+      const info = { id, code: current, importedIds: [] };
+      moduleInfoCache.set(id, info);
+      seenIds.add(id);
+      for (const p of plugins) {
+        if (typeof p.moduleParsed === "function") await p.moduleParsed.call(ctx, info);
+      }
+      return JSON.stringify({
+        code: current,
+        watchFiles: [...bucket],
+        maps,
+        emittedChunks: chunkBucket,
+      });
+    }),
+  );
 }
 
 async function replayModuleParsed(id) {
@@ -796,6 +830,13 @@ async function writeBundle(bundleJson, isWrite) {
 }
 
 async function run(hook, args) {
+  if (hook === "seedChunkNames") {
+    try {
+      const m = JSON.parse(args[0] ?? "{}");
+      for (const [k, v] of Object.entries(m)) chunkFileNames.set(k, v);
+    } catch {}
+    return null;
+  }
   if (hook === "transform") return transform(args[0], args[1]);
   if (hook === "resolveId") return resolveId(args[0], args[1]);
   if (hook === "load") return load(args[0]);

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -880,7 +880,7 @@ async fn ssr_module(
         Some(host) => host
             .transform(&source, id)
             .await
-            .map(|(code, _, _)| code)
+            .map(|(code, _, _, _)| code)
             .unwrap_or(source),
         None => source,
     };
@@ -1918,7 +1918,7 @@ async fn ensure_module(
     let source = match &state.plugins {
         Some(host) if !is_dep && state.plugins_have_transform => {
             match host.transform(&source, &file.to_string_lossy()).await {
-                Ok((code, watches, maps)) => {
+                Ok((code, watches, maps, _)) => {
                     plugin_watch_files = watches;
                     plugin_maps = maps;
                     code

--- a/crates/oj_server/src/plugins.rs
+++ b/crates/oj_server/src/plugins.rs
@@ -20,6 +20,26 @@ pub struct EmittedFile {
     pub source: String,
 }
 
+/// A chunk a plugin asked oj to emit via `this.emitFile({ type: "chunk" })`.
+#[derive(Debug, Clone)]
+pub struct ChunkEmit {
+    pub ref_id: String,
+    pub id: String,
+    pub name: Option<String>,
+    pub file_name: Option<String>,
+}
+
+impl ChunkEmit {
+    fn from_value(m: &serde_json::Value) -> Option<Self> {
+        Some(Self {
+            ref_id: m.get("referenceId")?.as_str()?.to_string(),
+            id: m.get("id")?.as_str()?.to_string(),
+            name: m.get("name").and_then(|x| x.as_str()).map(str::to_string),
+            file_name: m.get("fileName").and_then(|x| x.as_str()).map(str::to_string),
+        })
+    }
+}
+
 #[inline]
 pub fn plugins_file(root: &Path) -> Option<std::path::PathBuf> {
     ["oj.plugins.mjs", "oj.plugins.js"]
@@ -573,9 +593,9 @@ impl PluginHost {
         &self,
         code: &str,
         id: &str,
-    ) -> Result<(String, Vec<String>, Vec<String>), String> {
+    ) -> Result<(String, Vec<String>, Vec<String>, Vec<ChunkEmit>), String> {
         let Some(raw) = self.call("transform", &[code, id]).await? else {
-            return Ok((code.to_string(), Vec::new(), Vec::new()));
+            return Ok((code.to_string(), Vec::new(), Vec::new(), Vec::new()));
         };
         match serde_json::from_str::<serde_json::Value>(&raw) {
             Ok(v) => {
@@ -594,10 +614,19 @@ impl PluginHost {
                         })
                         .unwrap_or_default()
                 };
-                Ok((out, str_array("watchFiles"), str_array("maps")))
+                let chunks = v
+                    .get("emittedChunks")
+                    .and_then(|c| c.as_array())
+                    .map(|a| a.iter().filter_map(ChunkEmit::from_value).collect())
+                    .unwrap_or_default();
+                Ok((out, str_array("watchFiles"), str_array("maps"), chunks))
             }
-            Err(_) => Ok((raw, Vec::new(), Vec::new())),
+            Err(_) => Ok((raw, Vec::new(), Vec::new(), Vec::new())),
         }
+    }
+
+    pub async fn seed_chunk_names(&self, map_json: &str) -> Result<Option<String>, String> {
+        self.call("seedChunkNames", &[map_json]).await
     }
 
     #[inline]

--- a/e2e/emit-chunk-build.mjs
+++ b/e2e/emit-chunk-build.mjs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repo = path.join(here, "..");
+const oj = path.join(repo, "target", "debug", "oj");
+
+execSync("cargo build -p oj", { cwd: repo, stdio: "inherit" });
+
+// A plugin emits an extra chunk from a real source file during transform, then
+// reads that chunk's final hashed name via getFileName() in generateBundle and
+// writes it into an asset. This is the crx spine: emitFile({type:'chunk'}) ->
+// the chunk becomes a bundled entry -> getFileName(refId) resolves to its name.
+const app = fs.mkdtempSync(path.join(os.tmpdir(), "oj-emitchunk-"));
+fs.mkdirSync(path.join(app, "src"), { recursive: true });
+fs.writeFileSync(path.join(app, "package.json"), JSON.stringify({ name: "ec-app", version: "1.0.0" }));
+fs.writeFileSync(path.join(app, "src", "entry.js"), `console.log("entry");\n`);
+fs.writeFileSync(path.join(app, "src", "content.js"), `export const marker = "content-chunk-loaded";\n`);
+fs.writeFileSync(
+  path.join(app, "index.html"),
+  `<!doctype html><html><head><title>t</title></head><body><script type="module" src="/src/entry.js"></script></body></html>`,
+);
+fs.writeFileSync(
+  path.join(app, "oj.plugins.mjs"),
+  `import path from "node:path";
+   import { fileURLToPath } from "node:url";
+   const root = path.dirname(fileURLToPath(import.meta.url));
+   let ref;
+   export default [{
+     name: "chunk-emitter",
+     transform(code, id) {
+       if (id.endsWith("entry.js")) {
+         ref = this.emitFile({ type: "chunk", id: path.join(root, "src", "content.js"), name: "content" });
+       }
+       return null;
+     },
+     generateBundle() {
+       this.emitFile({ type: "asset", fileName: "emitted-chunk-name.txt", source: this.getFileName(ref) });
+     },
+   }];\n`,
+);
+
+let failed = false;
+try {
+  execSync(`${oj} build ${app}`, { stdio: "ignore" });
+
+  const namePath = path.join(app, "dist", "emitted-chunk-name.txt");
+  assert.ok(fs.existsSync(namePath), "generateBundle wrote the chunk name asset");
+  const chunkName = fs.readFileSync(namePath, "utf8").trim();
+  assert.match(chunkName, /content/, "getFileName resolved to the emitted chunk's name");
+  assert.match(chunkName, /\.js$/, "the resolved name is a js chunk");
+
+  const chunkPath = path.join(app, "dist", chunkName);
+  assert.ok(fs.existsSync(chunkPath), `emitted chunk ${chunkName} was actually bundled`);
+  const chunkCode = fs.readFileSync(chunkPath, "utf8");
+  assert.match(chunkCode, /content-chunk-loaded/, "the emitted chunk contains its source");
+
+  console.log("EMIT-CHUNK-BUILD E2E PASSED");
+} catch (err) {
+  failed = true;
+  console.error("EMIT-CHUNK-BUILD E2E FAILED:", err.message || err);
+} finally {
+  fs.rmSync(app, { recursive: true, force: true });
+}
+process.exit(failed ? 1 : 0);

--- a/e2e/unit/emit-chunk.test.mjs
+++ b/e2e/unit/emit-chunk.test.mjs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { rpcSidecar, tmpProject } from "./harness.mjs";
+
+// The plugin host must accept `this.emitFile({ type: "chunk" })` from a transform
+// hook, mint a reference id, report the request back to Rust (which forwards it
+// to rolldown), and later answer `this.getFileName(refId)` with the hashed name
+// seeded via `seedChunkNames`.
+test("plugin-host forwards emitFile chunk requests and resolves getFileName after seeding", async () => {
+  const fx = tmpProject({ prefix: "oj-chunk-" });
+  fx.write(
+    "oj.plugins.mjs",
+    `let ref;
+     export default [{
+       name: "emits-chunk",
+       transform(code, id) {
+         if (id.endsWith("entry.js")) {
+           ref = this.emitFile({ type: "chunk", id: "/src/content.js", name: "content" });
+           return null;
+         }
+         if (id.endsWith("probe.js")) {
+           return "export const name = " + JSON.stringify(this.getFileName(ref)) + ";";
+         }
+         return null;
+       },
+     }];\n`,
+  );
+  const host = rpcSidecar("plugin-host.mjs", {
+    args: [path.join(fx.root, "oj.plugins.mjs"), JSON.stringify({ root: fx.root })],
+    env: { OJ_CACHE_ROOT: fx.root },
+    cwd: fx.root,
+  });
+  try {
+    // A chunk emitted during transform is reported back, with the id/name kept.
+    const t1 = await host.send({
+      id: 1,
+      hook: "transform",
+      args: ["let a = 1;", path.join(fx.root, "entry.js")],
+    });
+    const out1 = JSON.parse(t1.result);
+    assert.equal(out1.emittedChunks.length, 1, "the emitted chunk is reported");
+    assert.equal(out1.emittedChunks[0].id, "/src/content.js");
+    assert.equal(out1.emittedChunks[0].name, "content");
+    const ref = out1.emittedChunks[0].referenceId;
+    assert.match(ref, /^oj-chunk-/, "a chunk reference id was minted");
+
+    // Rust seeds the resolved hashed name for that reference id.
+    await host.send({
+      id: 2,
+      hook: "seedChunkNames",
+      args: [JSON.stringify({ [ref]: "assets/content-abc123.js" })],
+    });
+
+    // getFileName(refId) now resolves to the seeded name.
+    const t2 = await host.send({
+      id: 3,
+      hook: "transform",
+      args: ["", path.join(fx.root, "probe.js")],
+    });
+    const out2 = JSON.parse(t2.result);
+    assert.match(out2.code, /assets\/content-abc123\.js/, "getFileName returns the seeded hashed name");
+  } finally {
+    host.close();
+    fx.cleanup();
+  }
+});
+
+// emitFile still rejects an unknown descriptor type, and an asset emit keeps
+// working (returns a reference id resolvable by getFileName).
+test("plugin-host still supports asset emits and rejects unknown emit types", async () => {
+  const fx = tmpProject({ prefix: "oj-chunk-" });
+  fx.write(
+    "oj.plugins.mjs",
+    `export default [{
+       name: "emits",
+       transform(code, id) {
+         if (id.endsWith("bad.js")) {
+           try { this.emitFile({ type: "prefetch" }); return "export const ok = false;"; }
+           catch { return "export const ok = true;"; }
+         }
+         if (id.endsWith("asset.js")) {
+           const r = this.emitFile({ type: "asset", name: "note.txt", source: "hi" });
+           return "export const name = " + JSON.stringify(this.getFileName(r)) + ";";
+         }
+         return null;
+       },
+     }];\n`,
+  );
+  const host = rpcSidecar("plugin-host.mjs", {
+    args: [path.join(fx.root, "oj.plugins.mjs"), JSON.stringify({ root: fx.root })],
+    env: { OJ_CACHE_ROOT: fx.root },
+    cwd: fx.root,
+  });
+  try {
+    const bad = await host.send({ id: 1, hook: "transform", args: ["", path.join(fx.root, "bad.js")] });
+    assert.match(JSON.parse(bad.result).code, /ok = true/, "unknown emit type throws");
+    const asset = await host.send({ id: 2, hook: "transform", args: ["", path.join(fx.root, "asset.js")] });
+    assert.match(JSON.parse(asset.result).code, /note\.txt/, "asset emit + getFileName still works");
+  } finally {
+    host.close();
+    fx.cleanup();
+  }
+});


### PR DESCRIPTION
Phase B (the spine) of #75.

## Why

The CRXJS research showed `@crxjs/vite-plugin` roots its **entire build on emitted chunks**: in `buildStart`/`transform` it calls `this.emitFile({type:'chunk', id})` (manifest, background service worker, content scripts, HTML pages) and later, in `generateBundle`, reads each chunk's hashed name via `this.getFileName(referenceId)` to rewrite `manifest.json`. oj's `emitFile` previously rejected everything but `type:'asset'`, so this whole pattern was impossible.

This PR lands the core mechanism: **emitFile chunk -> bundled entry -> getFileName resolves the hashed name**, for chunks emitted during `transform`.

## How

Rollup's `emitFile`/`getFileName` are synchronous, but oj's plugins run in a separate process, so:

- **Sidecar** (`plugin-host.mjs`): `emitFile({type:'chunk', id, name})` mints a reference id (`oj-chunk-N`) and returns it synchronously, recording the request in a per-invocation `AsyncLocalStorage` bucket (mirroring the existing `transformWatchStore`). The `transform` response now carries `emittedChunks`. `getFileName(refId)` reads a `chunkFileNames` map seeded via a new `seedChunkNames` message. Asset emits are unchanged.
- **Rust** (`OjUserPlugin`): after `host.transform`, each emitted chunk is forwarded to rolldown via `ctx.inner.emit_chunk(EmittedChunk{ id, name, .. })` (rolldown makes it a build root), recording `ojRefId -> rolldownRefId`. Before `generate_bundle`, each ref is resolved with `ctx.get_file_name(rolldownRefId)` and the `{refId: hashedName}` map is seeded back into the sidecar, so the plugin's `getFileName` in `generateBundle` returns the real output filename.
- `host.transform` now returns the emitted chunks alongside code/watchFiles/maps; the two dev-server callers ignore them.

Scope: chunks emitted from `transform`. `buildStart`-time emission and the `options`-hook stub (crx's manifest root) are the next slice; this PR establishes and tests the reusable spine.

## Tests

- Host unit (`e2e/unit/emit-chunk.test.mjs`): a transform emit is reported with its id/name and a minted ref; after `seedChunkNames`, `getFileName(ref)` returns the seeded hashed name; asset emits still work and an unknown emit type still throws.
- E2e build (`e2e/emit-chunk-build.mjs`, wired into the prod-build CI job): a plugin emits a chunk from a real source file in `transform` and reads its hashed name in `generateBundle` — the chunk is actually bundled and the resolved name points at it.
- Regression: full unit e2e suite (103 pass), `cargo test`, and the playground build (transform + emitFile asset + generateBundle) pass unchanged.