### PR TITLE
Run plugin buildStart as a rolldown hook that can emit chunks (Phase B.2 of #75)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,8 @@ jobs:
         run: node e2e/multi-html-input.mjs
       - name: plugin emitFile chunk spine (getFileName resolves hashed name)
         run: node e2e/emit-chunk-build.mjs
+      - name: plugin emitFile chunk from buildStart (crx manifest-root pattern)
+        run: node e2e/emit-chunk-buildstart.mjs
       - name: library build
         run: |
           mkdir -p /tmp/lib/src

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `?worker&inline` emits an inline Blob worker (with a `data:` URI fallback) in bundle mode, matching Vite; in dev it serves a working module worker instead of a broken data URI.
 - Plugin `handleHotUpdate` now receives the full Vite `HmrContext` (`file`, `timestamp`, `type`, `modules`, `read()`) and its returned module list is honored to narrow (or, when empty, suppress) the update, folded across plugins as in Vite.
 - `build.rollupOptions`/`rolldownOptions.input` is honored (string, array, or `{ name: path }` object), so multi-page projects and projects without a root `index.html` build. HTML entries under nested directories are emitted at their root-relative path and their page-relative `<script>` sources are resolved against the page, matching Vite's `input` resolution.
-- Plugins can call `this.emitFile({ type: "chunk", id })` during `transform`; the chunk is bundled as an entry and `this.getFileName(referenceId)` resolves to its final hashed name in `generateBundle` (the emit-chunk mechanism CRXJS-style plugins use to add content scripts and pages).
+- Plugins can call `this.emitFile({ type: "chunk", id })` during `buildStart` or `transform`; the chunk is bundled as a build root and `this.getFileName(referenceId)` resolves to its final hashed name in `generateBundle`. Plugin `buildStart` now runs as a rolldown build hook and receives an `options` object with `input` (the emit-chunk mechanism CRXJS-style plugins use to emit their manifest root, content scripts, and pages).
 
 ### Changed
 - Plugin `transform` sourcemaps are now composed with oj's own transform map, so dev sourcemaps trace back to the original source through plugins that rewrite code.

--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -799,6 +799,32 @@ impl OjUserPlugin {
             emitted_chunk_refs: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         }
     }
+
+}
+
+// Forward chunks a plugin emitted (in buildStart or transform) to rolldown as
+// build roots, remembering the plugin ref id -> rolldown ref id mapping so
+// getFileName can be answered later.
+fn forward_emitted_chunks(
+    ctx: &PluginContext,
+    chunks: &[oj_server::plugins::ChunkEmit],
+    refs: &std::sync::Mutex<std::collections::HashMap<String, String>>,
+) {
+    if chunks.is_empty() {
+        return;
+    }
+    let mut refs = refs.lock().unwrap();
+    for c in chunks {
+        let emitted = rolldown_common::EmittedChunk {
+            id: c.id.clone(),
+            name: c.name.clone().map(Into::into),
+            file_name: c.file_name.clone().map(Into::into),
+            ..Default::default()
+        };
+        if let Ok(rd_ref) = ctx.emit_chunk(emitted) {
+            refs.insert(c.ref_id.clone(), rd_ref.to_string());
+        }
+    }
 }
 
 impl Plugin for OjUserPlugin {
@@ -807,7 +833,8 @@ impl Plugin for OjUserPlugin {
     }
 
     fn register_hook_usage(&self) -> rolldown_plugin::HookUsage {
-        rolldown_plugin::HookUsage::ResolveId
+        rolldown_plugin::HookUsage::BuildStart
+            | rolldown_plugin::HookUsage::ResolveId
             | rolldown_plugin::HookUsage::Load
             | rolldown_plugin::HookUsage::Transform
             | rolldown_plugin::HookUsage::GenerateBundle
@@ -815,6 +842,18 @@ impl Plugin for OjUserPlugin {
             | rolldown_plugin::HookUsage::WriteBundle
             | rolldown_plugin::HookUsage::RenderStart
             | rolldown_plugin::HookUsage::CloseBundle
+    }
+
+    async fn build_start(
+        &self,
+        ctx: &PluginContext,
+        _args: &rolldown_plugin::HookBuildStartArgs<'_>,
+    ) -> rolldown_plugin::HookNoopReturn {
+        match self.host.build_start().await {
+            Ok(chunks) => forward_emitted_chunks(ctx, &chunks, &self.emitted_chunk_refs),
+            Err(e) => eprintln!("oj build: plugin buildStart failed: {e}"),
+        }
+        Ok(())
     }
 
     fn resolve_id(
@@ -868,19 +907,7 @@ impl Plugin for OjUserPlugin {
         async move {
             match host.transform(&code, &id).await {
                 Ok((out, _, _, chunks)) => {
-                    for c in &chunks {
-                        let emitted = rolldown_common::EmittedChunk {
-                            id: c.id.clone(),
-                            name: c.name.clone().map(Into::into),
-                            file_name: c.file_name.clone().map(Into::into),
-                            ..Default::default()
-                        };
-                        if let Ok(rd_ref) = ctx.inner.emit_chunk(emitted) {
-                            refs.lock()
-                                .unwrap()
-                                .insert(c.ref_id.clone(), rd_ref.to_string());
-                        }
-                    }
+                    forward_emitted_chunks(&ctx.inner, &chunks, &refs);
                     if out != code {
                         Ok(Some(HookTransformOutput {
                             code: Some(out),
@@ -1262,9 +1289,6 @@ pub async fn build(
     .await;
     let mut oj_plugins: Vec<SharedPluginable> = Vec::new();
     if let Some(host) = &plugin_host {
-        if let Err(e) = host.build_start().await {
-            eprintln!("oj build: plugin buildStart failed: {e}");
-        }
         oj_plugins.push(Arc::new(OjUserPlugin::new(Arc::clone(host))));
     }
     oj_plugins.push(Arc::new(OjCssPlugin {
@@ -1715,9 +1739,6 @@ pub(crate) async fn build_ssr(
 
     let mut oj_plugins: Vec<SharedPluginable> = Vec::new();
     if let Some(host) = &plugin_host {
-        if let Err(e) = host.build_start().await {
-            eprintln!("oj build (ssr): plugin buildStart failed: {e}");
-        }
         oj_plugins.push(Arc::new(OjUserPlugin::new(Arc::clone(host))));
     }
     oj_plugins.push(Arc::new(OjCssPlugin {
@@ -2213,9 +2234,6 @@ async fn build_client_entry(
     .await;
     let mut oj_plugins: Vec<SharedPluginable> = Vec::new();
     if let Some(host) = &plugin_host {
-        if let Err(e) = host.build_start().await {
-            eprintln!("oj build (client): plugin buildStart failed: {e}");
-        }
         oj_plugins.push(Arc::new(OjUserPlugin::new(Arc::clone(host))));
     }
     oj_plugins.push(Arc::new(OjCssPlugin {

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -794,6 +794,22 @@ async function runLifecycle(hook) {
   return null;
 }
 
+async function runBuildStart() {
+  const chunkBucket = [];
+  // Rollup passes NormalizedInputOptions; plugins such as @crxjs read
+  // `options.input` to decide whether to emit their root chunk, so it must be
+  // present. Chunks emitted here are drained to Rust as rolldown build roots.
+  const options = {
+    input: resolvedConfig?.build?.rollupOptions?.input ?? "index.html",
+  };
+  await transformEmitStore.run(chunkBucket, async () => {
+    for (const p of plugins) {
+      if (typeof p.buildStart === "function") await p.buildStart.call(ctx, options);
+    }
+  });
+  return JSON.stringify({ emittedChunks: chunkBucket });
+}
+
 async function generateBundle(bundleJson, isWrite) {
   const bundle = JSON.parse(bundleJson || "{}");
   const outputOptions = environment.config?.build ?? {};
@@ -842,7 +858,8 @@ async function run(hook, args) {
   if (hook === "load") return load(args[0]);
   if (hook === "handleHotUpdate") return handleHotUpdate(args[0], args[1], args[2], args[3]);
   if (hook === "transformIndexHtml") return transformIndexHtml(args[0]);
-  if (hook === "buildStart" || hook === "buildEnd" || hook === "renderStart" || hook === "closeBundle") {
+  if (hook === "buildStart") return runBuildStart();
+  if (hook === "buildEnd" || hook === "renderStart" || hook === "closeBundle") {
     return runLifecycle(hook);
   }
   if (hook === "watchChange") return watchChange(args[0], args[1]);

--- a/crates/oj_server/src/plugins.rs
+++ b/crates/oj_server/src/plugins.rs
@@ -673,8 +673,19 @@ impl PluginHost {
     }
 
     #[inline]
-    pub async fn build_start(&self) -> Result<(), String> {
-        self.call("buildStart", &[]).await.map(|_| ())
+    pub async fn build_start(&self) -> Result<Vec<ChunkEmit>, String> {
+        let Some(raw) = self.call("buildStart", &[]).await? else {
+            return Ok(Vec::new());
+        };
+        let chunks = serde_json::from_str::<serde_json::Value>(&raw)
+            .ok()
+            .and_then(|v| {
+                v.get("emittedChunks")
+                    .and_then(|c| c.as_array())
+                    .map(|a| a.iter().filter_map(ChunkEmit::from_value).collect())
+            })
+            .unwrap_or_default();
+        Ok(chunks)
     }
 
     #[inline]

--- a/e2e/emit-chunk-buildstart.mjs
+++ b/e2e/emit-chunk-buildstart.mjs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repo = path.join(here, "..");
+const oj = path.join(repo, "target", "debug", "oj");
+
+execSync("cargo build -p oj", { cwd: repo, stdio: "inherit" });
+
+// A plugin emits its root chunk in buildStart (the way @crxjs emits its manifest
+// chunk) and reads that chunk's hashed name via getFileName() in generateBundle.
+// buildStart runs as a rolldown hook, so the emitted chunk becomes a build root.
+const app = fs.mkdtempSync(path.join(os.tmpdir(), "oj-bsemit-"));
+fs.mkdirSync(path.join(app, "src"), { recursive: true });
+fs.writeFileSync(path.join(app, "package.json"), JSON.stringify({ name: "bs-app", version: "1.0.0" }));
+fs.writeFileSync(path.join(app, "src", "entry.js"), `console.log("entry");\n`);
+fs.writeFileSync(path.join(app, "src", "background.js"), `export const bg = "background-chunk-loaded";\n`);
+fs.writeFileSync(
+  path.join(app, "index.html"),
+  `<!doctype html><html><head><title>t</title></head><body><script type="module" src="/src/entry.js"></script></body></html>`,
+);
+fs.writeFileSync(
+  path.join(app, "oj.plugins.mjs"),
+  `import path from "node:path";
+   import { fileURLToPath } from "node:url";
+   const root = path.dirname(fileURLToPath(import.meta.url));
+   let ref;
+   export default [{
+     name: "buildstart-emitter",
+     buildStart(options) {
+       // Emit only when input is defined, mirroring @crxjs's manifest-loader.
+       if (typeof options.input !== "undefined") {
+         ref = this.emitFile({ type: "chunk", id: path.join(root, "src", "background.js"), name: "background" });
+       }
+     },
+     generateBundle() {
+       this.emitFile({ type: "asset", fileName: "bg-name.txt", source: this.getFileName(ref) });
+     },
+   }];\n`,
+);
+
+let failed = false;
+try {
+  execSync(`${oj} build ${app}`, { stdio: "ignore" });
+
+  const namePath = path.join(app, "dist", "bg-name.txt");
+  assert.ok(fs.existsSync(namePath), "generateBundle wrote the chunk name asset");
+  const chunkName = fs.readFileSync(namePath, "utf8").trim();
+  assert.match(chunkName, /background/, "getFileName resolved the buildStart-emitted chunk");
+  assert.match(chunkName, /\.js$/, "the resolved name is a js chunk");
+
+  const chunkPath = path.join(app, "dist", chunkName);
+  assert.ok(fs.existsSync(chunkPath), `emitted chunk ${chunkName} was bundled as a build root`);
+  assert.match(fs.readFileSync(chunkPath, "utf8"), /background-chunk-loaded/, "chunk contains its source");
+
+  console.log("EMIT-CHUNK-BUILDSTART E2E PASSED");
+} catch (err) {
+  failed = true;
+  console.error("EMIT-CHUNK-BUILDSTART E2E FAILED:", err.message || err);
+} finally {
+  fs.rmSync(app, { recursive: true, force: true });
+}
+process.exit(failed ? 1 : 0);

--- a/e2e/unit/emit-chunk.test.mjs
+++ b/e2e/unit/emit-chunk.test.mjs
@@ -69,6 +69,38 @@ test("plugin-host forwards emitFile chunk requests and resolves getFileName afte
   }
 });
 
+// Chunks emitted from buildStart (how @crxjs emits its manifest root) are
+// reported back too, and buildStart receives an options object with `input`.
+test("plugin-host reports chunks emitted from buildStart", async () => {
+  const fx = tmpProject({ prefix: "oj-chunk-" });
+  fx.write(
+    "oj.plugins.mjs",
+    `export default [{
+       name: "bs-emitter",
+       buildStart(options) {
+         if (typeof options.input !== "undefined") {
+           this.emitFile({ type: "chunk", id: "/src/background.js", name: "background" });
+         }
+       },
+     }];\n`,
+  );
+  const host = rpcSidecar("plugin-host.mjs", {
+    args: [path.join(fx.root, "oj.plugins.mjs"), JSON.stringify({ root: fx.root })],
+    env: { OJ_CACHE_ROOT: fx.root },
+    cwd: fx.root,
+  });
+  try {
+    const res = await host.send({ id: 1, hook: "buildStart", args: [] });
+    const out = JSON.parse(res.result);
+    assert.equal(out.emittedChunks.length, 1, "the buildStart-emitted chunk is reported");
+    assert.equal(out.emittedChunks[0].id, "/src/background.js");
+    assert.equal(out.emittedChunks[0].name, "background");
+  } finally {
+    host.close();
+    fx.cleanup();
+  }
+});
+
 // emitFile still rejects an unknown descriptor type, and an asset emit keeps
 // working (returns a reference id resolvable by getFileName).
 test("plugin-host still supports asset emits and rejects unknown emit types", async () => {


### PR DESCRIPTION
Phase B.2 of #75, building on the emit-chunk spine (#97).

## Why

`@crxjs/vite-plugin` emits its **root** chunk in `buildStart` (`this.emitFile({type:'chunk', id:'/@crx/manifest'})`) — that chunk is what pulls the background service worker, content scripts, and HTML pages into the graph. B.1 handled chunks emitted from `transform`; this PR handles `buildStart`, where crx's build actually begins.

## How

- Plugin `buildStart` now runs as a **rolldown `build_start` hook** on `OjUserPlugin` (previously oj called it out-of-band, before the bundler, where `emit_chunk` isn't available). The three build paths (client, ssr, library) drop their standalone `host.build_start()` calls so it fires exactly once, inside the build.
- Chunks emitted during `buildStart` are drained (via the same per-invocation `AsyncLocalStorage` bucket as `transform`) and forwarded to rolldown with `ctx.emit_chunk`, so they become build roots; the `refId -> hashedName` mapping is seeded back before `generateBundle` (as in B.1).
- The sidecar passes `buildStart` a Rollup-shaped `options` object with `input` defined — crx's manifest-loader only emits its root chunk when `typeof options.input !== "undefined"`.
- `host.build_start` now returns the emitted chunks; the shared chunk-forwarding logic is factored into one helper used by both hooks.

## Tests

- Host unit (`emit-chunk.test.mjs`): a chunk emitted from `buildStart` is reported with its id/name, and `buildStart` receives `options.input`.
- E2e build (`e2e/emit-chunk-buildstart.mjs`, wired into CI): a plugin emits its root chunk in `buildStart` (guarded on `options.input`, exactly like crx) and reads its hashed name in `generateBundle` — the chunk is bundled as a build root and the name resolves to it.
- Regression: the playground build confirms `buildStart`/`buildEnd` still fire (now via the hook) and transform/generateBundle/emitFile-asset are unchanged; full unit suite (104) and `cargo test` pass. SSR/library build paths keep their `buildStart` via the same hook.