### PR TITLE
Expose config.plugins and build defaults to config hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Plugin `configResolved` now runs before `applyToEnvironment`, matching Vite; plugins that populate state in `configResolved` and read it from `applyToEnvironment` (for example `@tanstack/router-plugin`) no longer crash the plugin host, and a throwing `applyToEnvironment` keeps the plugin active instead of failing config load ([#37](https://github.com/raphamorim/oj/issues/37)).
+- The `config` and `configResolved` hooks now receive `config.plugins` (the flat plugin array) and a defaulted `config.build` (`outDir`, `assetsDir`, `rollupOptions`, ...), matching Vite's resolved config. Plugins that read these in their config hooks (`@crxjs/vite-plugin` reads `config.plugins`; UnoCSS resolves `config.build.outDir`) no longer throw and get skipped.
 
 ### Security
 - `server.fs.deny` is enforced, and oj blocks `.env`, `.env.*`, `*.crt`, `*.pem`, and `**/.git/**` by default (Vite parity).

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -201,7 +201,21 @@ function withResolvedDefaults(config) {
       base: "/",
       isProduction: env.mode === "production",
       experimental: {},
-      build: {},
+      // Vite's resolved `build` carries defaults plugins read in configResolved
+      // (e.g. UnoCSS resolves `config.build.outDir` and reads
+      // `config.build.rollupOptions.output`). User config overrides these.
+      build: {
+        target: "modules",
+        outDir: "dist",
+        assetsDir: "assets",
+        assetsInlineLimit: 4096,
+        cssCodeSplit: true,
+        sourcemap: false,
+        rollupOptions: {},
+        minify: "esbuild",
+        reportCompressedSize: true,
+        chunkSizeWarningLimit: 500,
+      },
       server: {},
       define: {},
       resolve: {},
@@ -451,6 +465,10 @@ function deepMerge(a, b) {
 
 async function runConfigHooks() {
   let config = initial.config ?? {};
+  // Vite hands the config hook the user config, whose `plugins` is the flat
+  // plugin array; plugins like @crxjs read `config.plugins` to find sibling
+  // plugins. oj keeps the loaded set in `allPlugins`.
+  if (!Array.isArray(config.plugins)) config.plugins = allPlugins;
   for (const p of plugins) {
     if (typeof p.config !== "function") continue;
     try {
@@ -462,6 +480,7 @@ async function runConfigHooks() {
     }
   }
   resolvedConfig = withResolvedDefaults(config);
+  if (!Array.isArray(resolvedConfig.plugins)) resolvedConfig.plugins = allPlugins;
   for (const p of plugins) {
     if (typeof p.configResolved !== "function") continue;
     try {

--- a/e2e/unit/config-resolved-defaults.test.mjs
+++ b/e2e/unit/config-resolved-defaults.test.mjs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { rpcSidecar, tmpProject } from "./harness.mjs";
+
+// Vite hands the `config` hook the user config (whose `plugins` is the flat
+// plugin array) and `configResolved` a fully-defaulted config. Plugins such as
+// @crxjs read `config.plugins`, and UnoCSS resolves `config.build.outDir` /
+// reads `config.build.rollupOptions.output`. oj must supply both.
+test("config and configResolved expose config.plugins and build defaults", async () => {
+  const fx = tmpProject({ prefix: "oj-cfg-" });
+  fx.write(
+    "oj.plugins.mjs",
+    `let seen = {};
+     export default [
+       {
+         name: "reader",
+         config(config) {
+           seen.configPlugins = Array.isArray(config.plugins) ? config.plugins.length : -1;
+         },
+         configResolved(config) {
+           seen.outDir = config.build.outDir;
+           seen.assetsDir = config.build.assetsDir;
+           seen.hasRollupOptions = config.build.rollupOptions !== undefined;
+           seen.resolvedPlugins = Array.isArray(config.plugins) ? config.plugins.length : -1;
+         },
+         transform(code, id) {
+           if (id.endsWith("probe.js")) return "export default " + JSON.stringify(seen) + ";";
+           return null;
+         },
+       },
+       { name: "sibling-a" },
+       { name: "sibling-b" },
+     ];\n`,
+  );
+  const host = rpcSidecar("plugin-host.mjs", {
+    args: [path.join(fx.root, "oj.plugins.mjs"), JSON.stringify({ root: fx.root })],
+    env: { OJ_CACHE_ROOT: fx.root },
+    cwd: fx.root,
+  });
+  try {
+    const res = await host.send({
+      id: 1,
+      hook: "transform",
+      args: ["", path.join(fx.root, "probe.js")],
+    });
+    const seen = JSON.parse(JSON.parse(res.result).code.replace(/^export default /, "").replace(/;$/, ""));
+    assert.equal(seen.configPlugins, 3, "the config hook sees the flat plugin array");
+    assert.equal(seen.resolvedPlugins, 3, "configResolved sees the plugin array too");
+    assert.equal(seen.outDir, "dist", "build.outDir defaults to dist");
+    assert.equal(seen.assetsDir, "assets", "build.assetsDir defaults to assets");
+    assert.equal(seen.hasRollupOptions, true, "build.rollupOptions is present");
+  } finally {
+    host.close();
+    fx.cleanup();
+  }
+});


### PR DESCRIPTION
Surfaced while running a real `@crxjs/vite-plugin` extension build (part of #75), but these are general Vite resolved-config fidelity fixes.

## Problem

Two plugin `config`/`configResolved` hooks crashed (and were skipped) because oj's config object was missing fields Vite's always carries:

- `@crxjs/vite-plugin`'s `config` hook reads `config.plugins` (to find sibling plugins) — oj passed a config with no `plugins` array → `config.plugins is undefined`.
- UnoCSS's `configResolved` resolves `config.build.outDir` and reads `config.build.rollupOptions.output` — oj's resolved `build` was `{}` → `path.resolve(root, undefined)` threw.

## Fix

- `runConfigHooks` seeds `config.plugins` (and `resolvedConfig.plugins`) with the loaded plugin array before running the hooks, matching Vite handing the config hook the user config whose `plugins` is the flat plugin list.
- `withResolvedDefaults` now fills `build` with Vite's defaults (`target`, `outDir: "dist"`, `assetsDir: "assets"`, `assetsInlineLimit`, `cssCodeSplit`, `sourcemap`, `rollupOptions: {}`, `minify`, `reportCompressedSize`, `chunkSizeWarningLimit`). User config still overrides via the existing deep-merge.

## Tests

- Host unit (`e2e/unit/config-resolved-defaults.test.mjs`): a plugin reads `config.plugins` in its `config` hook and `config.build.outDir`/`assetsDir`/`rollupOptions` plus `config.plugins` in `configResolved`, then surfaces them through a transform — asserts the plugin array is visible (count 3) in both hooks and the build defaults are present.
- Regression: playground build and the full unit suite (105) pass.

## Context

With these two fixes, the CRXJS extension build (`@crxjs/vite-plugin` 2.4.0, Vite 8) advances from crashing during plugin config-load to loading all 39 plugins and running their `buildStart` emissions; the remaining failures are JSX/TSX and `.module.scss` transforms on the crx-emitted module graph, tracked as the next slice of #75.