### PR TITLE
Type plugin-loaded modules by id extension, not always JS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,8 @@ jobs:
         run: node e2e/generate-bundle-fidelity.mjs
       - name: plugin emitFile .html chunk (crx page pattern)
         run: node e2e/emit-html-chunk.mjs
+      - name: plugin-loaded virtual .jsx keeps JSX semantics
+        run: node e2e/plugin-load-jsx.mjs
       - name: library build
         run: |
           mkdir -p /tmp/lib/src

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Plugin `configResolved` now runs before `applyToEnvironment`, matching Vite; plugins that populate state in `configResolved` and read it from `applyToEnvironment` (for example `@tanstack/router-plugin`) no longer crash the plugin host, and a throwing `applyToEnvironment` keeps the plugin active instead of failing config load ([#37](https://github.com/raphamorim/oj/issues/37)).
 - The `config` and `configResolved` hooks now receive `config.plugins` (the flat plugin array) and a defaulted `config.build` (`outDir`, `assetsDir`, `rollupOptions`, ...), matching Vite's resolved config. Plugins that read these in their config hooks (`@crxjs/vite-plugin` reads `config.plugins`; UnoCSS resolves `config.build.outDir`) no longer throw and get skipped.
+- A module returned from a plugin `load` hook in the build is now typed from its id's extension (`.jsx`/`.tsx`/`.ts`/`.json`) instead of always JavaScript, matching how Vite derives the transform language from the id. Virtual modules like unplugin-icons' `~icons/*.jsx` are parsed as JSX again instead of failing with "JSX syntax is disabled". Build errors also now render with their source file and location rather than an opaque diagnostic dump.
 
 ### Security
 - `server.fs.deny` is enforced, and oj blocks `.env`, `.env.*`, `*.crt`, `*.pem`, and `**/.git/**` by default (Vite parity).

--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -824,6 +824,21 @@ impl OjUserPlugin {
     }
 }
 
+// The rolldown module type a plugin-loaded id should parse as, from its
+// extension (query stripped). Defaults to Js, matching Rollup/Vite treating an
+// extensionless virtual id as JavaScript.
+fn module_type_for_id(id: &str) -> rolldown_common::ModuleType {
+    use rolldown_common::ModuleType;
+    let path = id.split(['?', '#']).next().unwrap_or(id);
+    match Path::new(path).extension().and_then(|e| e.to_str()) {
+        Some("jsx") => ModuleType::Jsx,
+        Some("tsx") => ModuleType::Tsx,
+        Some("ts" | "mts" | "cts") => ModuleType::Ts,
+        Some("json") => ModuleType::Json,
+        _ => ModuleType::Js,
+    }
+}
+
 // Forward chunks a plugin emitted (in buildStart or transform) to rolldown as
 // build roots. A `.html` id is not a JS module: its `<script type=module>` are
 // emitted as JS entries instead and the page is queued for rendering, with the
@@ -967,7 +982,11 @@ impl Plugin for OjUserPlugin {
                 .flatten()
                 .map(|code| HookLoadOutput {
                     code: arcstr::ArcStr::from(code),
-                    module_type: Some(rolldown_common::ModuleType::Js),
+                    // Infer the type from the id so a plugin-served virtual
+                    // module keeps its JSX/TS semantics (e.g. unplugin-icons'
+                    // `~icons/*.jsx`); a hardcoded Js made oxc parse the JSX as
+                    // plain JS and fail.
+                    module_type: Some(module_type_for_id(&id)),
                     ..Default::default()
                 }))
         }
@@ -1486,10 +1505,15 @@ pub async fn build(
         .build()
         .map_err(|errs| anyhow::anyhow!("rolldown init failed: {errs:?}"))?;
 
-    let output = bundler
-        .write()
-        .await
-        .map_err(|errs| anyhow::anyhow!("build failed:\n{errs:?}"))?;
+    let output = bundler.write().await.map_err(|errs| {
+        let detail = errs
+            .into_vec()
+            .iter()
+            .map(|e| e.to_diagnostic().to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        anyhow::anyhow!("build failed:\n{detail}")
+    })?;
     bundler
         .close()
         .await
@@ -2941,6 +2965,23 @@ fn build_manifest(entries: &[ManifestEntry]) -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn module_type_for_id_infers_from_extension() {
+        use rolldown_common::ModuleType;
+        // Vite derives the transform lang from the id's extension (query
+        // stripped); oj mirrors it for plugin-loaded/virtual modules.
+        assert!(matches!(module_type_for_id("~icons/ph/x.jsx"), ModuleType::Jsx));
+        assert!(matches!(module_type_for_id("/v/comp.tsx?used"), ModuleType::Tsx));
+        assert!(matches!(module_type_for_id("virtual:mod.ts"), ModuleType::Ts));
+        assert!(matches!(module_type_for_id("a.mts"), ModuleType::Ts));
+        assert!(matches!(module_type_for_id("a.cts"), ModuleType::Ts));
+        assert!(matches!(module_type_for_id("data.json#x"), ModuleType::Json));
+        assert!(matches!(module_type_for_id("mod.mjs"), ModuleType::Js));
+        assert!(matches!(module_type_for_id("plain.js"), ModuleType::Js));
+        // Extensionless virtual ids default to JavaScript.
+        assert!(matches!(module_type_for_id("\0virtual:store"), ModuleType::Js));
+    }
 
     #[test]
     fn normalize_input_entries_covers_string_array_object() {

--- a/e2e/plugin-load-jsx.mjs
+++ b/e2e/plugin-load-jsx.mjs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repo = path.join(here, "..");
+const oj = path.join(repo, "target", "debug", "oj");
+
+execSync("cargo build -p oj", { cwd: repo, stdio: "inherit" });
+
+// A plugin-served virtual module with a `.jsx` id must be parsed as JSX (not
+// plain JS). Regression for the unplugin-icons `~icons/*.jsx` case: oj used to
+// hardcode module type Js for every plugin `load`, so oxc rejected the JSX.
+const app = fs.mkdtempSync(path.join(os.tmpdir(), "oj-loadjsx-"));
+fs.mkdirSync(path.join(app, "src"), { recursive: true });
+fs.writeFileSync(path.join(app, "package.json"), JSON.stringify({ name: "lj-app", version: "1.0.0" }));
+fs.writeFileSync(
+  path.join(app, "src", "entry.js"),
+  `import { Icon } from "virtual:icon.jsx";\nwindow.__icon = Icon();\n`,
+);
+fs.writeFileSync(
+  path.join(app, "index.html"),
+  `<!doctype html><html><head><title>t</title></head><body><script type="module" src="/src/entry.js"></script></body></html>`,
+);
+fs.writeFileSync(
+  path.join(app, "oj.plugins.mjs"),
+  `export default [{
+     name: "virtual-jsx",
+     resolveId(id) {
+       if (id === "virtual:icon.jsx") return "\\0virtual:icon.jsx";
+       if (id === "react/jsx-runtime") return "\\0jsx-runtime";
+       return null;
+     },
+     load(id) {
+       if (id === "\\0virtual:icon.jsx") return "export const Icon = () => <svg width=\\"1em\\" data-mark=\\"icon-ok\\" />;";
+       if (id === "\\0jsx-runtime") return "export const jsx = (t, p) => ({ t, p }); export const jsxs = jsx; export const Fragment = 'F';";
+       return null;
+     },
+   }];\n`,
+);
+
+let failed = false;
+try {
+  execSync(`${oj} build ${app}`, { stdio: "pipe" });
+
+  const jsFiles = fs
+    .readdirSync(path.join(app, "dist", "assets"))
+    .filter((f) => f.endsWith(".js"))
+    .map((f) => fs.readFileSync(path.join(app, "dist", "assets", f), "utf8"));
+  const all = jsFiles.join("\n");
+
+  // JSX was transformed to a runtime call, not left as raw markup.
+  assert.ok(!all.includes("<svg"), "raw JSX must not survive into the bundle");
+  assert.ok(all.includes("icon-ok"), "the component's props made it through the JSX transform");
+
+  console.log("PLUGIN-LOAD-JSX E2E PASSED");
+} catch (err) {
+  failed = true;
+  console.error("PLUGIN-LOAD-JSX E2E FAILED:", (err.stderr && err.stderr.toString()) || err.message || err);
+} finally {
+  fs.rmSync(app, { recursive: true, force: true });
+}
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Found by running the real `@crxjs` extension build (#75).

## Problem

`OjUserPlugin::load` set `module_type: ModuleType::Js` for **every** module a plugin's `load` hook returned. So a plugin-served virtual module whose id carries a real extension was still parsed as plain JavaScript. In the CRXJS build this produced ~38 `Unexpected JSX expression` errors: unplugin-icons serves `~icons/*.jsx` virtual modules whose JSX oxc then refused to parse ("JSX syntax is disabled").

## Vite reference

Vite derives the transform language from the id's extension (`vite/src/node/plugins/oxc.ts:128-142`): query stripped, `cjs/mjs`→`js`, `cts/mts`→`ts`, otherwise the extension itself (`js`/`jsx`/`ts`/`tsx`). Virtual modules opt into a language by giving their id that extension.

## Fix

- `module_type_for_id(id)` maps the id's extension (query/fragment stripped) to the rolldown `ModuleType` — `.jsx`→Jsx, `.tsx`→Tsx, `.ts`/`.mts`/`.cts`→Ts, `.json`→Json, everything else (including extensionless virtual ids and `.mjs`/`.cjs`) → Js — mirroring Vite.
- `OjUserPlugin::load` uses it instead of the hardcoded `Js`. Real source files are intercepted earlier (`OjCssPlugin`, rolldown's fs load), so this only affects plugin-returned virtual code; a `.jsx`/`.ts` virtual module that used to fail now parses correctly.
- Build failures now render each diagnostic with its source file and location (via `to_diagnostic()`) instead of an opaque `Debug` dump — this is what made the CRXJS failures diagnosable.

## Tests

- Rust unit (`module_type_for_id_infers_from_extension`): extension → module type mapping, including query-stripping and the extensionless-default-to-Js case.
- E2e (`e2e/plugin-load-jsx.mjs`, wired into CI): a plugin serves a virtual `virtual:icon.jsx` module containing JSX (with a self-contained jsx-runtime stub); the build succeeds and the bundle contains the transformed call, not raw `<svg>`.
- Regression: playground build, full unit suite (105), and the emit-chunk/generate-bundle/html-chunk e2es pass.

## CRXJS status

This clears all JSX parse errors in the UT-Registration-Plus build (0, from ~38). The remaining blockers are CSS-only: the virtual `__uno.css` module (rolldown 1.2.5 removed CSS bundling, so it must route through oj's CSS pipeline) and a `.module.scss` load — tracked as the next slice of #75.