### PR TITLE
Run plugin transforms on CSS sources before compiling (CSS epic, Phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,8 @@ jobs:
         run: node e2e/emit-html-chunk.mjs
       - name: plugin-loaded virtual .jsx keeps JSX semantics
         run: node e2e/plugin-load-jsx.mjs
+      - name: plugin transform runs on CSS sources before compile
+        run: node e2e/css-plugin-transform.mjs
       - name: library build
         run: |
           mkdir -p /tmp/lib/src

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A plugin emitting an HTML page as a chunk (`this.emitFile({ type: "chunk", id: "...page.html" })`) now gets the Vite HTML treatment: the page's `<script type=module>` are bundled as entries, the processed page is written at its root-relative output path, and `getFileName(referenceId)` resolves to that page path (how CRXJS emits the extension's popup/options pages from its manifest).
 
 ### Changed
+- Plugin `transform` hooks now run on CSS and preprocessor (`.css`/`.scss`/`.less`/`.stylus`) sources during the build before oj compiles them, matching Vite where CSS is a real module in the graph. This lets directive transformers such as UnoCSS's `@apply`/`@unocss-include` resolve before Sass/lightningcss run.
 - Plugin `transform` sourcemaps are now composed with oj's own transform map, so dev sourcemaps trace back to the original source through plugins that rewrite code.
 - CSS imported with `?inline` returns the compiled CSS string instead of a base64 `data:` URI.
 - Dev-served CSS rewrites relative `url()` and `@import` references to server-absolute paths so injected styles resolve them.

--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -50,6 +50,11 @@ struct OjCssPlugin {
     client: bool,
     inline_limit: u64,
     css_code_split: bool,
+    // The user plugin host, so CSS sources pass through the plugin `transform`
+    // chain (e.g. UnoCSS's directive transformer resolving `@apply`) before oj
+    // preprocesses/compiles them, matching Vite where CSS is a real module.
+    host: Option<Arc<PluginHost>>,
+    css_transform_enabled: Arc<tokio::sync::OnceCell<bool>>,
 }
 
 fn assets_inline_limit_of(config: &oj_config::OjConfig) -> u64 {
@@ -385,6 +390,8 @@ impl Plugin for OjCssPlugin {
         let routes_id = root.join("oj-routes.tsx").to_string_lossy().into_owned();
         let client = self.client;
         let inline_limit = self.inline_limit;
+        let host = self.host.clone();
+        let css_transform_enabled = Arc::clone(&self.css_transform_enabled);
         async move {
             if let Some(file) = id.strip_suffix("?url") {
                 let bytes =
@@ -542,6 +549,19 @@ impl Plugin for OjCssPlugin {
             }
             let mut source = std::fs::read_to_string(path)
                 .map_err(|e| anyhow::anyhow!("cannot read {path}: {e}"))?;
+            // Run the plugin transform chain on the raw CSS source first, so
+            // directive transformers (UnoCSS `@apply`/`@unocss-include`, etc.)
+            // resolve before oj preprocesses and compiles it.
+            if let Some(host) = &host {
+                let on = *css_transform_enabled
+                    .get_or_init(|| async { host.has_transform().await })
+                    .await;
+                if on {
+                    if let Ok((out, _, _, _)) = host.transform(&source, &id).await {
+                        source = out;
+                    }
+                }
+            }
             if oj_css::is_sass(path) {
                 let dir = std::path::Path::new(path).parent();
                 source = oj_css::compile_sass(&source, dir).map_err(|e| anyhow::anyhow!(e))?;
@@ -1458,6 +1478,8 @@ pub async fn build(
         inline_limit: assets_inline_limit_of(&config),
         client: true,
         css_code_split: css_split,
+        host: plugin_host.clone(),
+        css_transform_enabled: Arc::new(tokio::sync::OnceCell::new()),
     }));
     let mut bundler = BundlerBuilder::default()
         .with_plugins(oj_plugins)
@@ -1926,6 +1948,8 @@ pub(crate) async fn build_ssr(
         inline_limit: assets_inline_limit_of(&config),
         client: false,
         css_code_split: false,
+        host: plugin_host.clone(),
+        css_transform_enabled: Arc::new(tokio::sync::OnceCell::new()),
     }));
     let mut bundler = BundlerBuilder::default()
         .with_plugins(oj_plugins)
@@ -2062,6 +2086,8 @@ async fn build_server_fns(root: &Path, out_dir: &Path) -> anyhow::Result<()> {
                 inline_limit: 4096,
                 client: false,
                 css_code_split: false,
+                host: None,
+                css_transform_enabled: Arc::new(tokio::sync::OnceCell::new()),
             })])
             .with_options(BundlerOptions {
                 input: Some(vec![InputItem {
@@ -2425,6 +2451,8 @@ async fn build_client_entry(
         inline_limit: assets_inline_limit_of(&config),
         client: true,
         css_code_split: false,
+        host: plugin_host.clone(),
+        css_transform_enabled: Arc::new(tokio::sync::OnceCell::new()),
     }));
 
     let mut bundler = BundlerBuilder::default()
@@ -2565,6 +2593,8 @@ async fn build_library(
                 inline_limit: 4096,
                 client: true,
                 css_code_split: false,
+                host: None,
+                css_transform_enabled: Arc::new(tokio::sync::OnceCell::new()),
             })])
             .with_options(BundlerOptions {
                 input: Some(vec![InputItem {

--- a/e2e/css-plugin-transform.mjs
+++ b/e2e/css-plugin-transform.mjs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repo = path.join(here, "..");
+const oj = path.join(repo, "target", "debug", "oj");
+
+execSync("cargo build -p oj", { cwd: repo, stdio: "inherit" });
+
+// A plugin `transform` must run on CSS/preprocessor sources before oj compiles
+// them, so directive transformers (UnoCSS `@apply`, etc.) resolve. Here a plugin
+// rewrites a marker in a .scss source; the rewrite must reach the output CSS.
+const app = fs.mkdtempSync(path.join(os.tmpdir(), "oj-csstx-"));
+fs.mkdirSync(path.join(app, "src"), { recursive: true });
+fs.writeFileSync(path.join(app, "package.json"), JSON.stringify({ name: "csstx-app", version: "1.0.0" }));
+// Nested SCSS + a marker only a plugin transform can resolve.
+fs.writeFileSync(path.join(app, "src", "styles.scss"), `.card { __BRAND__ .inner { font-weight: bold; } }\n`);
+fs.writeFileSync(path.join(app, "src", "entry.js"), `import "./styles.scss";\nconsole.log("app");\n`);
+fs.writeFileSync(
+  path.join(app, "index.html"),
+  `<!doctype html><html><head><title>t</title></head><body><script type="module" src="/src/entry.js"></script></body></html>`,
+);
+fs.writeFileSync(
+  path.join(app, "oj.plugins.mjs"),
+  `export default [{
+     name: "css-directive",
+     transform(code, id) {
+       if (id.endsWith(".scss") || id.endsWith(".css")) {
+         return { code: code.replace("__BRAND__", "color: rebeccapurple;"), map: null };
+       }
+       return null;
+     },
+   }];\n`,
+);
+
+let failed = false;
+try {
+  execSync(`${oj} build ${app}`, { stdio: "pipe" });
+
+  const cssDir = path.join(app, "dist", "assets");
+  const css = fs
+    .readdirSync(cssDir)
+    .filter((f) => f.endsWith(".css"))
+    .map((f) => fs.readFileSync(path.join(cssDir, f), "utf8"))
+    .join("\n");
+
+  // lightningcss minifies `rebeccapurple` to `#639`.
+  assert.ok(
+    css.includes("rebeccapurple") || css.includes("#639"),
+    "the plugin transform ran on the CSS source before compilation",
+  );
+  assert.ok(!css.includes("__BRAND__"), "the source marker was resolved, not left raw");
+  // The surrounding SCSS still compiled (nesting flattened).
+  assert.ok(/\.card \.inner/.test(css) || /\.inner/.test(css), "the SCSS around the injected rule still compiled");
+
+  console.log("CSS-PLUGIN-TRANSFORM E2E PASSED");
+} catch (err) {
+  failed = true;
+  console.error("CSS-PLUGIN-TRANSFORM E2E FAILED:", (err.stderr && err.stderr.toString()) || err.message || err);
+} finally {
+  fs.rmSync(app, { recursive: true, force: true });
+}
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Phase 1 of the CSS-pipeline epic (surfaced by the `@crxjs` build, #75).

## Why

oj compiles CSS/preprocessor files itself in `OjCssPlugin::load` (grass + lightningcss + sidecar) and never runs the plugin `transform` chain on them. Vite treats CSS as a real module that flows through every plugin's `transform` (`vite/src/node/plugins/css.ts` → `compileCSS`), which is how directive transformers like UnoCSS's `@apply`/`@unocss-include` resolve. Without this, such directives reach the Sass compiler unresolved.

## Change

`OjCssPlugin::load` now, after reading a `.css`/`.scss`/`.less`/`.stylus` source and before preprocessing/compiling it, runs the source through the user plugin host's `transform` chain (gated by a cached `has_transform` check). The plugin host is threaded into `OjCssPlugin` on the client, SSR, and library build paths; sub-builds that have no host pass `None`.

## Tests

- E2e (`e2e/css-plugin-transform.mjs`, wired into CI): a plugin `transform` rewrites a marker inside a nested `.scss`; the rewrite reaches the output CSS (`rebeccapurple`/`#639`) and the surrounding SCSS still compiles — proving plugin transforms now run on CSS sources before compilation.
- Regression: playground build, the CSS e2es (`css-code-split`, `css-rebase`, `css-modules`, `preprocessors`, `manifest`, `modulepreload`), the full unit suite (105), and the emit-chunk/generate-bundle e2es all pass.

## Scope

This is the self-contained first phase. It does not by itself unblock the CRXJS `.module.scss`/`__uno.css` cases — those additionally need Phase 2 (CSS emitted as in-bundle assets so UnoCSS's `generateBundle` can rewrite its placeholder) and deeper Sass-feature support (`@include meta.load-css`, root-relative `@use`). It is the prerequisite plumbing and a general Vite-parity improvement for any project using CSS-directive transformers.