### PR TITLE
Add vite:css-post shim so UnoCSS-style CSS reaches the build output (CSS epic, Phase 2a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,8 @@ jobs:
         run: node e2e/plugin-load-jsx.mjs
       - name: plugin transform runs on CSS sources before compile
         run: node e2e/css-plugin-transform.mjs
+      - name: vite:css-post shim routes plugin CSS into output (UnoCSS pattern)
+        run: node e2e/vite-css-post-shim.mjs
       - name: library build
         run: |
           mkdir -p /tmp/lib/src

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `generateBundle` bundle now exposes the full Rollup chunk shape (`facadeModuleId`, `moduleIds`, `modules`, `imports`, `dynamicImports`, `exports`, `isDynamicEntry`, `sourcemapFileName`; assets carry `name`/`names`), and plugins can rename an output by setting its `fileName` and delete an output with `delete bundle[key]` (used by CRXJS to rename pages and drop its manifest JS chunk).
 - A plugin emitting an HTML page as a chunk (`this.emitFile({ type: "chunk", id: "...page.html" })`) now gets the Vite HTML treatment: the page's `<script type=module>` are bundled as entries, the processed page is written at its root-relative output path, and `getFileName(referenceId)` resolves to that page path (how CRXJS emits the extension's popup/options pages from its manifest).
 
+### Added
+- oj provides a `vite:css-post` plugin shim during the build. Plugins that look one up in `config.plugins` and hand it their generated CSS in `renderChunk` (UnoCSS, and similar) now have that CSS folded into the build's stylesheet output. `renderChunk` hooks also receive the full chunk shape (`modules`, `moduleIds`, `facadeModuleId`, ...) and a `NormalizedOutputOptions`-style `options` with a resolved `dir`, and a plugin-served virtual `.css` module is kept in the graph as a side-effect stub so those hooks can find it.
+
 ### Changed
 - Plugin `transform` hooks now run on CSS and preprocessor (`.css`/`.scss`/`.less`/`.stylus`) sources during the build before oj compiles them, matching Vite where CSS is a real module in the graph. This lets directive transformers such as UnoCSS's `@apply`/`@unocss-include` resolve before Sass/lightningcss run.
 - Plugin `transform` sourcemaps are now composed with oj's own transform map, so dev sourcemaps trace back to the original source through plugins that rewrite code.

--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -1000,14 +1000,32 @@ impl Plugin for OjUserPlugin {
                 .await
                 .ok()
                 .flatten()
-                .map(|code| HookLoadOutput {
-                    code: arcstr::ArcStr::from(code),
-                    // Infer the type from the id so a plugin-served virtual
-                    // module keeps its JSX/TS semantics (e.g. unplugin-icons'
-                    // `~icons/*.jsx`); a hardcoded Js made oxc parse the JSX as
-                    // plain JS and fail.
-                    module_type: Some(module_type_for_id(&id)),
-                    ..Default::default()
+                .map(|code| {
+                    let path = id.split(['?', '#']).next().unwrap_or(&id);
+                    if path.ends_with(".css") {
+                        // A plugin-served virtual CSS module (e.g. UnoCSS's layer
+                        // placeholder): its real CSS is routed through the
+                        // `vite:css-post` shim, so keep an empty side-effect stub
+                        // in the graph (so the plugin's build hook still sees the
+                        // module) rather than parsing CSS as JS.
+                        return HookLoadOutput {
+                            code: arcstr::ArcStr::from("export {};\n"),
+                            module_type: Some(rolldown_common::ModuleType::Js),
+                            side_effects: Some(
+                                rolldown_common::side_effects::HookSideEffects::NoTreeshake,
+                            ),
+                            ..Default::default()
+                        };
+                    }
+                    HookLoadOutput {
+                        code: arcstr::ArcStr::from(code),
+                        // Infer the type from the id so a plugin-served virtual
+                        // module keeps its JSX/TS semantics (e.g. unplugin-icons'
+                        // `~icons/*.jsx`); a hardcoded Js made oxc parse the JSX
+                        // as plain JS and fail.
+                        module_type: Some(module_type_for_id(&id)),
+                        ..Default::default()
+                    }
                 }))
         }
     }
@@ -1150,13 +1168,33 @@ impl Plugin for OjUserPlugin {
 }
 
 fn serialize_rendered_chunk(chunk: &rolldown_common::RollupRenderedChunk) -> String {
+    // `chunk.modules` (keyed by module id) is read by renderChunk hooks such as
+    // UnoCSS's `unocss:global:build:generate` to find their virtual layer module.
+    let mut modules = serde_json::Map::new();
+    for (id, rm) in chunk.modules.keys.iter().zip(chunk.modules.values.iter()) {
+        modules.insert(
+            id.as_str().to_string(),
+            serde_json::json!({
+                "renderedExports": rm
+                    .rendered_exports
+                    .iter()
+                    .map(|e| e.to_string())
+                    .collect::<Vec<_>>(),
+            }),
+        );
+    }
     serde_json::json!({
         "type": "chunk",
         "fileName": chunk.filename.to_string(),
         "name": chunk.name.to_string(),
         "isEntry": chunk.is_entry,
         "isDynamicEntry": chunk.is_dynamic_entry,
+        "facadeModuleId": chunk.facade_module_id.as_ref().map(|f| f.as_str().to_string()),
+        "moduleIds": chunk.module_ids.iter().map(|m| m.as_str().to_string()).collect::<Vec<_>>(),
+        "modules": serde_json::Value::Object(modules),
         "imports": chunk.imports.iter().map(|i| i.to_string()).collect::<Vec<_>>(),
+        "dynamicImports": chunk.dynamic_imports.iter().map(|i| i.to_string()).collect::<Vec<_>>(),
+        "exports": chunk.exports.iter().map(|e| e.to_string()).collect::<Vec<_>>(),
     })
     .to_string()
 }
@@ -1544,6 +1582,16 @@ pub async fn build(
     if let Some(host) = &plugin_host {
         if let Err(e) = host.build_end().await {
             eprintln!("oj build: plugin buildEnd failed: {e}");
+        }
+        // CSS a plugin routed through the vite:css-post shim (e.g. UnoCSS's
+        // generated utilities) joins the build's stylesheet output.
+        for (id, css) in host.get_plugin_css().await {
+            let src = if id.is_empty() {
+                root.join("__plugin_css__").display().to_string()
+            } else {
+                id.split(['?', '#']).next().unwrap_or(&id).to_string()
+            };
+            collected_css.lock().unwrap().push((src, css));
         }
         match host.emitted_files().await {
             Ok(files) => {

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -370,6 +370,24 @@ const emitted = [];
 const chunkFileNames = new Map();
 const transformEmitStore = new AsyncLocalStorage();
 
+// A minimal stand-in for Vite's `vite:css-post` plugin. UnoCSS (and similar)
+// look up a plugin named "vite:css-post" in `config.plugins` during their build
+// hook and call its `transform` with the CSS they generate, to route it into
+// the output. oj collects that CSS here and folds it into the build stylesheet
+// (see getPluginCss). Only relevant fields are implemented.
+const ojPluginCss = [];
+const cssPostShim = {
+  name: "vite:css-post",
+  transform: {
+    handler(code, id) {
+      if (typeof code === "string" && code.length > 0) {
+        ojPluginCss.push({ id: typeof id === "string" ? id : "", css: code });
+      }
+      return null;
+    },
+  },
+};
+
 const moduleInfoCache = new Map();
 
 const watchedFiles = new Set();
@@ -468,7 +486,10 @@ async function runConfigHooks() {
   // Vite hands the config hook the user config, whose `plugins` is the flat
   // plugin array; plugins like @crxjs read `config.plugins` to find sibling
   // plugins. oj keeps the loaded set in `allPlugins`.
-  if (!Array.isArray(config.plugins)) config.plugins = allPlugins;
+  if (!Array.isArray(config.plugins)) config.plugins = allPlugins.slice();
+  if (!config.plugins.some((p) => p && p.name === "vite:css-post")) {
+    config.plugins.push(cssPostShim);
+  }
   for (const p of plugins) {
     if (typeof p.config !== "function") continue;
     try {
@@ -480,7 +501,7 @@ async function runConfigHooks() {
     }
   }
   resolvedConfig = withResolvedDefaults(config);
-  if (!Array.isArray(resolvedConfig.plugins)) resolvedConfig.plugins = allPlugins;
+  if (!Array.isArray(resolvedConfig.plugins)) resolvedConfig.plugins = config.plugins;
   for (const p of plugins) {
     if (typeof p.configResolved !== "function") continue;
     try {
@@ -842,11 +863,17 @@ async function generateBundle(bundleJson, isWrite) {
 
 async function renderChunk(code, chunkJson) {
   const chunk = JSON.parse(chunkJson || "{}");
+  // Rollup passes NormalizedOutputOptions as the 3rd arg; renderChunk hooks such
+  // as UnoCSS's read `options.dir` (the resolved output dir) to key their
+  // vite:css-post lookup, so provide it resolved against the root.
+  const outDir = resolvedConfig?.build?.outDir ?? "dist";
+  const root = resolvedConfig?.root ?? initial.config?.root ?? process.cwd();
+  const options = { dir: pathResolve(root, outDir), format: "es" };
   let current = code;
   for (const p of plugins) {
     const fn = typeof p.renderChunk === "function" ? p.renderChunk : p.renderChunk?.handler;
     if (typeof fn !== "function") continue;
-    const r = await fn.call(ctx, current, chunk);
+    const r = await fn.call(ctx, current, chunk, options);
     if (r == null) continue;
     current = typeof r === "string" ? r : (r.code ?? current);
   }
@@ -885,6 +912,7 @@ async function run(hook, args) {
   if (hook === "getEmittedFiles") {
     return JSON.stringify(emitted.map(({ fileName, source }) => ({ fileName, source })));
   }
+  if (hook === "getPluginCss") return JSON.stringify(ojPluginCss);
   if (hook === "getWatchFiles") return JSON.stringify([...watchedFiles]);
   if (hook === "hasModuleParsed") return String(anyModuleParsed());
   if (hook === "replayModuleParsed") return replayModuleParsed(args[0]);

--- a/crates/oj_server/src/plugins.rs
+++ b/crates/oj_server/src/plugins.rs
@@ -847,6 +847,28 @@ impl PluginHost {
             })
             .collect())
     }
+
+    /// CSS that plugins (e.g. UnoCSS) routed through oj's `vite:css-post` shim.
+    /// Returned as `(source_id, css)` pairs.
+    pub async fn get_plugin_css(&self) -> Vec<(String, String)> {
+        let Some(json) = self.call("getPluginCss", &[]).await.ok().flatten() else {
+            return Vec::new();
+        };
+        serde_json::from_str::<serde_json::Value>(&json)
+            .ok()
+            .and_then(|v| {
+                v.as_array().map(|a| {
+                    a.iter()
+                        .filter_map(|e| {
+                            let css = e.get("css")?.as_str()?.to_string();
+                            let id = e.get("id").and_then(|x| x.as_str()).unwrap_or("").to_string();
+                            Some((id, css))
+                        })
+                        .collect()
+                })
+            })
+            .unwrap_or_default()
+    }
 }
 
 #[cfg(test)]

--- a/e2e/unit/config-resolved-defaults.test.mjs
+++ b/e2e/unit/config-resolved-defaults.test.mjs
@@ -48,8 +48,9 @@ test("config and configResolved expose config.plugins and build defaults", async
       args: ["", path.join(fx.root, "probe.js")],
     });
     const seen = JSON.parse(JSON.parse(res.result).code.replace(/^export default /, "").replace(/;$/, ""));
-    assert.equal(seen.configPlugins, 3, "the config hook sees the flat plugin array");
-    assert.equal(seen.resolvedPlugins, 3, "configResolved sees the plugin array too");
+    // The 3 user plugins are visible (oj also injects a vite:css-post shim, so >= 3).
+    assert.ok(seen.configPlugins >= 3, "the config hook sees the flat plugin array");
+    assert.ok(seen.resolvedPlugins >= 3, "configResolved sees the plugin array too");
     assert.equal(seen.outDir, "dist", "build.outDir defaults to dist");
     assert.equal(seen.assetsDir, "assets", "build.assetsDir defaults to assets");
     assert.equal(seen.hasRollupOptions, true, "build.rollupOptions is present");

--- a/e2e/vite-css-post-shim.mjs
+++ b/e2e/vite-css-post-shim.mjs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repo = path.join(here, "..");
+const oj = path.join(repo, "target", "debug", "oj");
+
+execSync("cargo build -p oj", { cwd: repo, stdio: "inherit" });
+
+// UnoCSS-style plugins find a `vite:css-post` plugin in config.plugins and, in
+// renderChunk, hand it their generated CSS to route into the output. This test
+// mimics that pattern (no UnoCSS dependency): a virtual `.css` layer module kept
+// as a stub, then renderChunk hands generated CSS to oj's vite:css-post shim.
+const app = fs.mkdtempSync(path.join(os.tmpdir(), "oj-csspost-"));
+fs.mkdirSync(path.join(app, "src"), { recursive: true });
+fs.writeFileSync(path.join(app, "package.json"), JSON.stringify({ name: "csspost-app", version: "1.0.0" }));
+fs.writeFileSync(path.join(app, "src", "entry.js"), `import "virtual:layer.css";\ndocument.body.className = "gen";\n`);
+fs.writeFileSync(
+  path.join(app, "index.html"),
+  `<!doctype html><html><head><title>t</title></head><body><script type="module" src="/src/entry.js"></script></body></html>`,
+);
+fs.writeFileSync(
+  path.join(app, "oj.plugins.mjs"),
+  `let allPlugins;
+   export default [{
+     name: "fake-uno",
+     configResolved(config) { allPlugins = config.plugins; },
+     resolveId(id) { return id === "virtual:layer.css" ? "\\0virtual:layer.css" : null; },
+     load(id) { return id === "\\0virtual:layer.css" ? "/* layer placeholder */" : null; },
+     renderChunk(code, chunk) {
+       const hasLayer = Object.keys(chunk.modules || {}).some((m) => m.includes("layer.css"));
+       if (!hasLayer) return null;
+       const cssPost = (allPlugins || []).find((p) => p && p.name === "vite:css-post");
+       if (!cssPost) throw new Error("vite:css-post shim not found in config.plugins");
+       const handler = typeof cssPost.transform === "function" ? cssPost.transform : cssPost.transform.handler;
+       handler.call(this, ".gen{color:green}", "\\0virtual:layer.css");
+       return null;
+     },
+   }];\n`,
+);
+
+let failed = false;
+try {
+  execSync(`${oj} build ${app}`, { stdio: "pipe" });
+
+  const cssDir = path.join(app, "dist", "assets");
+  const css = fs.existsSync(cssDir)
+    ? fs.readdirSync(cssDir).filter((f) => f.endsWith(".css")).map((f) => fs.readFileSync(path.join(cssDir, f), "utf8")).join("\n")
+    : "";
+
+  assert.ok(css.includes(".gen"), "CSS handed to the vite:css-post shim reached the output stylesheet");
+  const html = fs.readFileSync(path.join(app, "dist", "index.html"), "utf8");
+  assert.match(html, /rel="stylesheet"/, "the page links the generated stylesheet");
+
+  console.log("VITE-CSS-POST-SHIM E2E PASSED");
+} catch (err) {
+  failed = true;
+  console.error("VITE-CSS-POST-SHIM E2E FAILED:", (err.stderr && err.stderr.toString()) || err.message || err);
+} finally {
+  fs.rmSync(app, { recursive: true, force: true });
+}
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Phase 2a of the CSS-pipeline epic (#75).

## Why

UnoCSS's build path doesn't rewrite a placeholder — it looks up a plugin named `vite:css-post` in `config.plugins` and, in `renderChunk`, hands it the generated CSS to route into the output (`@unocss/vite` lines 553-594). oj had no such plugin, and its `renderChunk` bridge was missing the data these hooks read, so UnoCSS generated nothing and its `__uno.css` placeholder module failed to parse.

## Change

- **`vite:css-post` shim**: oj injects a minimal plugin named `vite:css-post` into `config.plugins`/`resolvedConfig.plugins`. Its `transform(css, id)` collects the CSS a plugin hands it; after the build, oj folds that CSS into the same stylesheet output real CSS uses (`collected_css`), so it is written and linked from the pages.
- **Richer `renderChunk` bridge**: `serialize_rendered_chunk` now includes `modules`, `moduleIds`, `facadeModuleId`, `dynamicImports`, `exports` (UnoCSS filters `chunk.modules` for its layer id), and the sidecar passes a third `options` argument with a resolved `dir` (UnoCSS keys its `vite:css-post` lookup on `options.dir`).
- **Virtual CSS module**: a plugin-served virtual `.css` id (e.g. UnoCSS's `__uno.css` placeholder) is loaded as an empty side-effect stub kept in the graph, so the plugin's `renderChunk` still finds the module while its real CSS arrives via the shim (rather than oj parsing the placeholder as JS).

## Validation

- Minimal UnoCSS fixture (`@unocss/vite`, a `p-4` rule + safelist): the output `dist/assets/*.css` contains `.p-4{padding:1rem;}` and the page links it — UnoCSS's generated CSS now flows through oj.
- **CRXJS**: the `__uno.css` parse error is gone; the extension build's only remaining blocker is the `.module.scss` (Sass `@apply` + `@include meta.load-css` + root `@use`), tracked as Phase 2b.

## Tests

- E2e (`e2e/vite-css-post-shim.mjs`, wired into CI): a UnoCSS-shaped plugin (no UnoCSS dependency) keeps a virtual `.css` layer module as a stub and, in `renderChunk`, hands generated CSS to oj's `vite:css-post` shim; the CSS reaches the output stylesheet and the page links it.
- Regression: playground build, the CSS e2es (`css-code-split`, `css-rebase`, `preprocessors`, `manifest`), the full unit suite (105), and the emit-chunk/generate-bundle e2es pass. (`config-resolved-defaults` updated: `config.plugins` now includes the injected shim.)