### PR TITLE
Expose Vite build manifest in the bundle + stabilize build config.plugins (crx manifest, step 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,8 @@ jobs:
         run: node e2e/css-plugin-transform.mjs
       - name: vite:css-post shim routes plugin CSS into output (UnoCSS pattern)
         run: node e2e/vite-css-post-shim.mjs
+      - name: .vite/manifest.json is present in the generateBundle bundle
+        run: node e2e/vite-build-manifest-in-bundle.mjs
       - name: library build
         run: |
           mkdir -p /tmp/lib/src

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - oj provides a `vite:css-post` plugin shim during the build. Plugins that look one up in `config.plugins` and hand it their generated CSS in `renderChunk` (UnoCSS, and similar) now have that CSS folded into the build's stylesheet output. `renderChunk` hooks also receive the full chunk shape (`modules`, `moduleIds`, `facadeModuleId`, ...) and a `NormalizedOutputOptions`-style `options` with a resolved `dir`, and a plugin-served virtual `.css` module is kept in the graph as a side-effect stub so those hooks can find it.
+- The Vite build manifest is now present in the `generateBundle` bundle as a `.vite/manifest.json` asset, so plugins that read it there (for example `@crxjs`'s web-accessible-resources) can find it.
 
 ### Changed
 - Plugin `transform` hooks now run on CSS and preprocessor (`.css`/`.scss`/`.less`/`.stylus`) sources during the build before oj compiles them, matching Vite where CSS is a real module in the graph. This lets directive transformers such as UnoCSS's `@apply`/`@unocss-include` resolve before Sass/lightningcss run.
@@ -30,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dev-served CSS rewrites relative `url()` and `@import` references to server-absolute paths so injected styles resolve them.
 
 ### Fixed
+- The `config`/`configResolved` hooks now see only the command-applicable plugins in `config.plugins` (serve-only plugins are excluded from a build, matching Vite), and `config.plugins` is no longer duplicated by config hooks that return their own `plugins` (the array is pinned across the config-hook merge). A plugin's `generateBundle` error is now surfaced instead of silently swallowed. Together these let `@crxjs`'s build-time manifest plugins (`transformCrxManifest`/`renderCrxManifest` fan-outs) run once and without a serve-only `crx:hmr` crashing them.
 - Sass now resolves a relative dotted `@use`/`@forward`/`@import` (e.g. `@use 'colors.module.scss'`) made from inside another dotted `.module.scss` stylesheet: the nested import resolves against the imported file's real directory instead of the phantom directory grass sees a dotted basename through, so cross-directory CSS-modules stylesheets compile.
 - Plugin `configResolved` now runs before `applyToEnvironment`, matching Vite; plugins that populate state in `configResolved` and read it from `applyToEnvironment` (for example `@tanstack/router-plugin`) no longer crash the plugin host, and a throwing `applyToEnvironment` keeps the plugin active instead of failing config load ([#37](https://github.com/raphamorim/oj/issues/37)).
 - The `config` and `configResolved` hooks now receive `config.plugins` (the flat plugin array) and a defaulted `config.build` (`outDir`, `assetsDir`, `rollupOptions`, ...), matching Vite's resolved config. Plugins that read these in their config hooks (`@crxjs/vite-plugin` reads `config.plugins`; UnoCSS resolves `config.build.outDir`) no longer throw and get skipped.

--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -1102,7 +1102,7 @@ impl Plugin for OjUserPlugin {
         if !self.host.has_generate_bundle().await {
             return Ok(());
         }
-        let bundle_json = serialize_bundle(args.bundle);
+        let bundle_json = serialize_bundle_with_vite_manifest(args.bundle, &self.emit.root);
         if let Ok(Some(mutated)) = self.host.generate_bundle(&bundle_json, args.is_write).await {
             apply_bundle_mutations(args.bundle, &mutated);
         }
@@ -2991,6 +2991,75 @@ struct ManifestEntry {
     imports: Vec<String>,
     dynamic_imports: Vec<String>,
     css: Vec<String>,
+}
+
+// Build Vite-manifest entries directly from a bundle (chunks only; CSS is added
+// later in the output stage). Used to expose `.vite/manifest.json` inside the
+// generateBundle bundle for plugins that read it (e.g. @crxjs).
+fn manifest_entries_from_bundle(
+    bundle: &[rolldown_common::Output],
+    root: &Path,
+) -> Vec<ManifestEntry> {
+    use rolldown_common::Output;
+    let mut entries = Vec::new();
+    for out in bundle {
+        let Output::Chunk(chunk) = out else { continue };
+        let filename = chunk.filename.to_string();
+        let src = if chunk.is_entry {
+            chunk.facade_module_id.as_ref().and_then(|f| {
+                Path::new(f.as_ref())
+                    .strip_prefix(root)
+                    .ok()
+                    .map(|p| p.to_string_lossy().replace('\\', "/"))
+            })
+        } else {
+            None
+        };
+        let key = src.clone().unwrap_or_else(|| {
+            format!(
+                "_{}",
+                Path::new(&filename)
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or(&filename)
+            )
+        });
+        entries.push(ManifestEntry {
+            key,
+            name: chunk.name.to_string(),
+            file: filename,
+            src,
+            is_entry: chunk.is_entry,
+            is_dynamic_entry: chunk.is_dynamic_entry,
+            imports: chunk.imports.iter().map(|i| i.to_string()).collect(),
+            dynamic_imports: chunk.dynamic_imports.iter().map(|i| i.to_string()).collect(),
+            css: Vec::new(),
+        });
+    }
+    entries
+}
+
+// serialize_bundle plus a synthetic `.vite/manifest.json` asset, so a plugin's
+// generateBundle can read the Vite build manifest from the bundle the way it
+// would under Vite (with build.manifest enabled).
+fn serialize_bundle_with_vite_manifest(bundle: &[rolldown_common::Output], root: &Path) -> String {
+    let base = serialize_bundle(bundle);
+    let entries = manifest_entries_from_bundle(bundle, root);
+    let manifest = build_manifest(&entries).to_string();
+    let mut val: serde_json::Value =
+        serde_json::from_str(&base).unwrap_or_else(|_| serde_json::json!({}));
+    if let Some(obj) = val.as_object_mut() {
+        obj.insert(
+            ".vite/manifest.json".to_string(),
+            serde_json::json!({
+                "type": "asset",
+                "fileName": ".vite/manifest.json",
+                "name": "manifest.json",
+                "source": manifest,
+            }),
+        );
+    }
+    val.to_string()
 }
 
 fn build_manifest(entries: &[ManifestEntry]) -> serde_json::Value {

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -485,11 +485,18 @@ async function runConfigHooks() {
   let config = initial.config ?? {};
   // Vite hands the config hook the user config, whose `plugins` is the flat
   // plugin array; plugins like @crxjs read `config.plugins` to find sibling
-  // plugins. oj keeps the loaded set in `allPlugins`.
-  if (!Array.isArray(config.plugins)) config.plugins = allPlugins.slice();
-  if (!config.plugins.some((p) => p && p.name === "vite:css-post")) {
-    config.plugins.push(cssPostShim);
+  // plugins. Use the apply-filtered active set (not allPlugins) so command-
+  // inappropriate plugins are absent, matching Vite's resolved config — e.g.
+  // `@crxjs`'s serve-only `crx:hmr` must not appear during a build, or crx calls
+  // its `transformCrxManifest` (which reads an unset `config`) and throws.
+  // The exposed plugin array: the apply-filtered active set plus the css-post
+  // shim. Pinned across the config-hook merges below so deepMerge (which
+  // concatenates arrays) can't accumulate it into duplicates.
+  const configPlugins = plugins.slice();
+  if (!configPlugins.some((p) => p && p.name === "vite:css-post")) {
+    configPlugins.push(cssPostShim);
   }
+  config.plugins = configPlugins;
   for (const p of plugins) {
     if (typeof p.config !== "function") continue;
     try {
@@ -499,9 +506,11 @@ async function runConfigHooks() {
       if (!ojStartMode) throw e;
       process.stderr.write(`${OJ} plugin host: config(${p.name ?? "?"}) skipped: ${(e && e.message) || e}\n`);
     }
+    // Keep the plugin array stable regardless of what a config hook returned.
+    config.plugins = configPlugins;
   }
   resolvedConfig = withResolvedDefaults(config);
-  if (!Array.isArray(resolvedConfig.plugins)) resolvedConfig.plugins = config.plugins;
+  resolvedConfig.plugins = configPlugins;
   for (const p of plugins) {
     if (typeof p.configResolved !== "function") continue;
     try {
@@ -856,7 +865,13 @@ async function generateBundle(bundleJson, isWrite) {
   for (const p of plugins) {
     const fn = typeof p.generateBundle === "function" ? p.generateBundle : p.generateBundle?.handler;
     if (typeof fn !== "function") continue;
-    await fn.call(ctx, outputOptions, bundle, isWrite);
+    try {
+      await fn.call(ctx, outputOptions, bundle, isWrite);
+    } catch (e) {
+      process.stderr.write(
+        `${OJ} plugin host: generateBundle(${p.name ?? "?"}) failed: ${(e && (e.stack || e.message)) || e}\n`,
+      );
+    }
   }
   return JSON.stringify(bundle);
 }

--- a/e2e/unit/config-resolved-defaults.test.mjs
+++ b/e2e/unit/config-resolved-defaults.test.mjs
@@ -26,6 +26,7 @@ test("config and configResolved expose config.plugins and build defaults", async
            seen.assetsDir = config.build.assetsDir;
            seen.hasRollupOptions = config.build.rollupOptions !== undefined;
            seen.resolvedPlugins = Array.isArray(config.plugins) ? config.plugins.length : -1;
+           seen.names = (config.plugins || []).map((p) => p && p.name);
          },
          transform(code, id) {
            if (id.endsWith("probe.js")) return "export default " + JSON.stringify(seen) + ";";
@@ -34,10 +35,22 @@ test("config and configResolved expose config.plugins and build defaults", async
        },
        { name: "sibling-a" },
        { name: "sibling-b" },
+       // A serve-only plugin must not appear in the build's config.plugins.
+       { name: "dev-only", apply: "serve" },
+       // A config hook returning a partial with its own plugins must not
+       // accumulate into config.plugins across the config-hook merge.
+       { name: "adds-config", config() { return { define: { X: "1" } }; } },
      ];\n`,
   );
   const host = rpcSidecar("plugin-host.mjs", {
-    args: [path.join(fx.root, "oj.plugins.mjs"), JSON.stringify({ root: fx.root })],
+    args: [
+      path.join(fx.root, "oj.plugins.mjs"),
+      JSON.stringify({
+        config: { root: fx.root },
+        env: { command: "build", mode: "production" },
+        environment: { name: "client" },
+      }),
+    ],
     env: { OJ_CACHE_ROOT: fx.root },
     cwd: fx.root,
   });
@@ -48,12 +61,19 @@ test("config and configResolved expose config.plugins and build defaults", async
       args: ["", path.join(fx.root, "probe.js")],
     });
     const seen = JSON.parse(JSON.parse(res.result).code.replace(/^export default /, "").replace(/;$/, ""));
-    // The 3 user plugins are visible (oj also injects a vite:css-post shim, so >= 3).
+    // The build-applicable plugins are visible (oj also injects a vite:css-post shim).
     assert.ok(seen.configPlugins >= 3, "the config hook sees the flat plugin array");
     assert.ok(seen.resolvedPlugins >= 3, "configResolved sees the plugin array too");
     assert.equal(seen.outDir, "dist", "build.outDir defaults to dist");
     assert.equal(seen.assetsDir, "assets", "build.assetsDir defaults to assets");
     assert.equal(seen.hasRollupOptions, true, "build.rollupOptions is present");
+    // A serve-only plugin is excluded from the build's config.plugins.
+    assert.ok(!seen.names.includes("dev-only"), "serve-only plugin excluded from build config.plugins");
+    // The vite:css-post shim is present.
+    assert.ok(seen.names.includes("vite:css-post"), "vite:css-post shim injected");
+    // No duplicates: config.plugins is pinned across config-hook merges.
+    const dupes = seen.names.filter((n, i) => n && seen.names.indexOf(n) !== i);
+    assert.deepEqual(dupes, [], "config.plugins has no duplicate entries");
   } finally {
     host.close();
     fx.cleanup();

--- a/e2e/vite-build-manifest-in-bundle.mjs
+++ b/e2e/vite-build-manifest-in-bundle.mjs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repo = path.join(here, "..");
+const oj = path.join(repo, "target", "debug", "oj");
+
+execSync("cargo build -p oj", { cwd: repo, stdio: "inherit" });
+
+// The Vite build manifest must be present in the generateBundle bundle as a
+// `.vite/manifest.json` asset, so plugins that read it there (e.g. @crxjs's
+// web-accessible-resources) can. Here a plugin reads it and re-emits it.
+const app = fs.mkdtempSync(path.join(os.tmpdir(), "oj-vitemanifest-"));
+fs.mkdirSync(path.join(app, "src"), { recursive: true });
+fs.writeFileSync(path.join(app, "package.json"), JSON.stringify({ name: "vm-app", version: "1.0.0" }));
+fs.writeFileSync(path.join(app, "src", "entry.js"), `export const v = 1;\nconsole.log(v);\n`);
+fs.writeFileSync(
+  path.join(app, "index.html"),
+  `<!doctype html><html><head><title>t</title></head><body><script type="module" src="/src/entry.js"></script></body></html>`,
+);
+fs.writeFileSync(
+  path.join(app, "oj.plugins.mjs"),
+  `export default [{
+     name: "reads-vite-manifest",
+     generateBundle(options, bundle) {
+       const m = bundle[".vite/manifest.json"];
+       if (m && m.type === "asset" && typeof m.source === "string") {
+         this.emitFile({ type: "asset", fileName: "seen-manifest.json", source: m.source });
+       }
+     },
+   }];\n`,
+);
+
+let failed = false;
+try {
+  execSync(`${oj} build ${app}`, { stdio: "pipe" });
+
+  const seenPath = path.join(app, "dist", "seen-manifest.json");
+  assert.ok(fs.existsSync(seenPath), "the plugin read .vite/manifest.json from the generateBundle bundle");
+  const manifest = JSON.parse(fs.readFileSync(seenPath, "utf8"));
+  const entry = Object.values(manifest).find((e) => e.isEntry);
+  assert.ok(entry, "the manifest lists an entry");
+  assert.match(entry.file, /\.js$/, "the entry maps to a js chunk");
+
+  console.log("VITE-BUILD-MANIFEST-IN-BUNDLE E2E PASSED");
+} catch (err) {
+  failed = true;
+  console.error("VITE-BUILD-MANIFEST-IN-BUNDLE E2E FAILED:", (err.stderr && err.stderr.toString()) || err.message || err);
+} finally {
+  fs.rmSync(app, { recursive: true, force: true });
+}
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Investigating why `oj build` didn't emit the CRX `manifest.json` surfaced three concrete, general bugs, all fixed here. (The `generateBundle` errors were being silently swallowed, so this also surfaces them.)

## Fixes

1. **Serve-only plugins in build `config.plugins`.** oj exposed `allPlugins` (unfiltered) as `config.plugins`, so a plugin like `@crxjs`'s `apply:"serve"` `crx:hmr` was present during a build. crx iterates `config.plugins` calling each plugin's `transformCrxManifest`, and `crx:hmr`'s reads an unset `config.root` and throws. Now `config.plugins` is the apply-filtered active set (serve-only excluded in a build), matching Vite.

2. **`config.plugins` duplicated by `deepMerge`.** A config hook returning a partial config caused oj's `deepMerge` (which concatenates arrays) to accumulate `config.plugins`, so crx's `renderCrxManifest` fan-out ran over the plugin list 4×. `config.plugins` is now pinned to a stable array across the config-hook merge.

3. **`.vite/manifest.json` missing from the bundle.** `@crxjs`'s web-accessible-resources reads the Vite build manifest from the `generateBundle` bundle (`parseJsonAsset(bundle, ".vite/manifest.json")`). oj only wrote it to disk after the build. It's now injected into the serialized generateBundle bundle as a `.vite/manifest.json` asset (read-only; oj still writes its own to disk). `renderChunk`/`generateBundle` bundles already carry the richer chunk shape from earlier work.

Plus: a plugin's `generateBundle` that throws is now logged rather than silently swallowed.

## Tests

- Unit (`config-resolved-defaults.test.mjs`, extended): in a build, a `apply:"serve"` plugin is absent from `config.plugins`, the `vite:css-post` shim is present, and there are no duplicate entries even when a config hook returns its own partial.
- E2e (`vite-build-manifest-in-bundle.mjs`, wired into CI): a plugin reads `.vite/manifest.json` from the `generateBundle` bundle and re-emits it; the manifest lists the entry chunk.
- Regression: playground build, full unit suite (105), CSS/emit e2es pass.

## CRXJS status

These carry the UT-Registration-Plus build from the `crx:hmr` crash, through the (previously 4×) `renderCrxManifest` fan-out running once, to `web-accessible-resources` successfully reading `.vite/manifest.json`. The next remaining step is crx reading manifest **icon/asset files** relative to the wrong directory (publicDir resolution) — a further follow-up. So this is real progress toward a loadable extension, not yet the finish line.