### PR TITLE
Serve a plugin-resolved file from disk when no load hook claims it

### DIFF
--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -12,7 +12,7 @@ use axum::{
     body::Body,
     extract::{ws::Message, Query, State, WebSocketUpgrade},
     http::{header, HeaderMap, Method, StatusCode, Uri},
-    response::{IntoResponse, Response},
+    response::{IntoResponse, Redirect, Response},
     routing::{get, post},
     Router,
 };
@@ -3145,6 +3145,29 @@ async fn resolve_jsx_overrides(
     overrides
 }
 
+// Rollup's contract, which the rest of this host follows: `resolveId` returning a
+// path means that file IS the module, and a `load` returning nothing means read it
+// from disk. Only the second half was implemented, so a plugin that maps a
+// specifier to a path without also serving its bytes -- which is what a resolver
+// plugin is -- got a 404 for every module it resolved correctly.
+//
+// Redirecting to the file's normal dep URL rather than reading it here keeps every
+// downstream behaviour identical to any other dependency: the fs.allow check,
+// partial bundling, and the specifier rewriting applied inside the served file.
+fn serve_resolved_from_disk(state: &Arc<ServerState>, id: &str) -> Option<Response> {
+    let resolved = Path::new(id);
+    if !resolved.is_absolute() || !resolved.is_file() {
+        return None;
+    }
+    state
+        .fs_allow
+        .lock()
+        .unwrap()
+        .insert(package_root(resolved));
+    let url = dep_serve_url(resolved, &state.root);
+    Some(Redirect::temporary(&url).into_response())
+}
+
 async fn serve_plugin_resolve(state: &Arc<ServerState>, id: &str) -> Response {
     let Some(host) = &state.plugins else {
         return (StatusCode::NOT_FOUND, "oj: no plugin host").into_response();
@@ -3152,7 +3175,10 @@ async fn serve_plugin_resolve(state: &Arc<ServerState>, id: &str) -> Response {
     let source = match host.load(id).await {
         Ok(Some(src)) => src,
         Ok(None) => {
-            return (StatusCode::NOT_FOUND, format!("oj: no plugin loaded {id}")).into_response()
+            if let Some(response) = serve_resolved_from_disk(state, id) {
+                return response;
+            }
+            return (StatusCode::NOT_FOUND, format!("oj: no plugin loaded {id}")).into_response();
         }
         Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
     };
@@ -3245,6 +3271,9 @@ async fn serve_plugin_id(state: &Arc<ServerState>, spec: &str, importer: &str) -
     let source = match host.load(&id).await {
         Ok(Some(src)) => src,
         Ok(None) => {
+            if let Some(response) = serve_resolved_from_disk(state, &id) {
+                return response;
+            }
             return (StatusCode::NOT_FOUND, format!("oj: no plugin loaded {id}")).into_response();
         }
         Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),


### PR DESCRIPTION
### The problem

`resolveId` and `load` are two halves of one contract. Rollup's rule — which the
rest of this plugin host follows — is that a `resolveId` result naming a real file
*is* the module, and a `load` hook that returns nothing means "read it from disk".

`oj_server` implements only the second half. Both load sites return 404 on
`Ok(None)`:

- `serve_plugin_resolve` — `oj: no plugin loaded {id}`
- `serve_plugin_id` — same, after `resolve_id` succeeded

So a plugin that maps a specifier to a path *without* also serving its bytes gets a
404 for every module it resolved correctly. A resolver plugin is precisely that
shape: resolution is the whole job, and there is nothing it wants to do in `load`.

### Why this comes up

A resolver plugin is how a `node_modules` tree that is not above the importer gets
reached at all. oj's on-disk resolver walks up from the importing file, so any setup
that keeps `node_modules` out of the source tree — a build system that treats it as a
build output, a monorepo with a non-standard layout, a virtual filesystem — has
nothing there for the walk to find. A `pre` plugin that resolves the specifier and
hands the path back is the natural fix, and today it 404s.

### The change

One helper, used by both load sites: if the resolved id is an absolute path to a
file that exists, add its package root to `fs_allow` and redirect to that file's
normal dep URL via `dep_serve_url`.

### Why redirect rather than return the bytes

Redirecting re-enters the ordinary dependency path, so everything downstream stays
identical to any other dep: the `fs.allow` check, partial bundling, and the
specifier rewriting applied inside the served file.

Returning the contents from the `load` path instead would compile them as a
*virtual* module — `serve_plugin_resolve` compiles with `Path::new("plugin.tsx")`
and `importer_abs = "\0{id}"`, and its `rewrite` closure calls
`rewrite_specifier(&root, &root, …)`. Both rewrite bases are the app root, so a
package's own relative imports (`./helpers.js` inside a dependency) would resolve
against the wrong directory. That is also why working around this in a plugin's own
`load` hook is not equivalent — it is reachable, but it resolves transitive imports
incorrectly and bypasses `fs.allow` and the bundling path.

### Verification

- `cargo check -p oj_server` — clean
- `cargo test -p oj_server` — 71 passed, 0 failed
- `cargo fmt` — the touched region is clean (a few pre-existing hunks elsewhere in
  this file are untouched and not from this change)
- Exercised against oj 0.1.4 in a Bazel-based build for the last several weeks,
  where it is the difference between `import "zod"` resolving and 404ing. The
  version here is a fresh port onto `main`, which had since split the load path
  into two functions — hence the shared helper rather than one inline branch.

I am happy to add a regression test if you can point me at the right harness for the
plugin-host routes; I did not find an existing one covering `serve_plugin_id`.
