### PR TITLE
Serve a plugin-resolved file from disk when no load hook claims it (+ test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
       - name: request paths (encoded filenames, traversal containment)
         if: matrix.mode == 'unbundled'
         run: node e2e/awkward-paths.mjs
+      - name: plugin resolveId without a load hook serves from disk
+        if: matrix.mode == 'unbundled'
+        run: node e2e/plugin-resolve-no-load.mjs
 
   # i need to fix this or automate
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to oj are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- A module a plugin resolves via `resolveId` but does not serve from a `load` hook is now read from disk in the dev server, matching Rollup's contract (a `resolveId` result naming a real file is that module; a `load` returning nothing means read it from disk). Previously such a module 404'd — which broke a pure resolver plugin, the natural way to reach a `node_modules` tree that is not above the importer.
+
 ## [0.1.5] - 2026-08-26
 
 ### Added

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -12,7 +12,7 @@ use axum::{
     body::Body,
     extract::{ws::Message, Query, State, WebSocketUpgrade},
     http::{header, HeaderMap, Method, StatusCode, Uri},
-    response::{IntoResponse, Response},
+    response::{IntoResponse, Redirect, Response},
     routing::{get, post},
     Router,
 };
@@ -3145,6 +3145,29 @@ async fn resolve_jsx_overrides(
     overrides
 }
 
+// Rollup's contract, which the rest of this host follows: `resolveId` returning a
+// path means that file IS the module, and a `load` returning nothing means read it
+// from disk. Only the second half was implemented, so a plugin that maps a
+// specifier to a path without also serving its bytes -- which is what a resolver
+// plugin is -- got a 404 for every module it resolved correctly.
+//
+// Redirecting to the file's normal dep URL rather than reading it here keeps every
+// downstream behaviour identical to any other dependency: the fs.allow check,
+// partial bundling, and the specifier rewriting applied inside the served file.
+fn serve_resolved_from_disk(state: &Arc<ServerState>, id: &str) -> Option<Response> {
+    let resolved = Path::new(id);
+    if !resolved.is_absolute() || !resolved.is_file() {
+        return None;
+    }
+    state
+        .fs_allow
+        .lock()
+        .unwrap()
+        .insert(package_root(resolved));
+    let url = dep_serve_url(resolved, &state.root);
+    Some(Redirect::temporary(&url).into_response())
+}
+
 async fn serve_plugin_resolve(state: &Arc<ServerState>, id: &str) -> Response {
     let Some(host) = &state.plugins else {
         return (StatusCode::NOT_FOUND, "oj: no plugin host").into_response();
@@ -3152,7 +3175,10 @@ async fn serve_plugin_resolve(state: &Arc<ServerState>, id: &str) -> Response {
     let source = match host.load(id).await {
         Ok(Some(src)) => src,
         Ok(None) => {
-            return (StatusCode::NOT_FOUND, format!("oj: no plugin loaded {id}")).into_response()
+            if let Some(response) = serve_resolved_from_disk(state, id) {
+                return response;
+            }
+            return (StatusCode::NOT_FOUND, format!("oj: no plugin loaded {id}")).into_response();
         }
         Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
     };
@@ -3245,6 +3271,9 @@ async fn serve_plugin_id(state: &Arc<ServerState>, spec: &str, importer: &str) -
     let source = match host.load(&id).await {
         Ok(Some(src)) => src,
         Ok(None) => {
+            if let Some(response) = serve_resolved_from_disk(state, &id) {
+                return response;
+            }
             return (StatusCode::NOT_FOUND, format!("oj: no plugin loaded {id}")).into_response();
         }
         Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),

--- a/e2e/plugin-resolve-no-load.mjs
+++ b/e2e/plugin-resolve-no-load.mjs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+import { spawn, execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repo = path.join(here, "..");
+const oj = path.join(repo, "target", "debug", "oj");
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+execSync("cargo build -p oj", { cwd: repo, stdio: "inherit" });
+
+// A resolver plugin maps a bare specifier to a real file the on-disk resolver
+// would never reach (outside the project tree), and has NO load hook. Rollup's
+// contract: a resolveId result naming a real file IS the module, and a load hook
+// returning nothing means read it from disk. oj used to 404 that module.
+const app = fs.mkdtempSync(path.join(os.tmpdir(), "oj-resolve-noload-"));
+const ext = fs.mkdtempSync(path.join(os.tmpdir(), "oj-ext-dep-"));
+fs.mkdirSync(path.join(app, "src"), { recursive: true });
+fs.writeFileSync(path.join(app, "package.json"), JSON.stringify({ name: "rnl-app", version: "1.0.0" }));
+// The resolved file lives outside the project root, so only the plugin can reach it.
+fs.writeFileSync(path.join(ext, "external-dep.js"), `export const MARK = "external-dep-served-ok";\n`);
+fs.writeFileSync(path.join(app, "src", "entry.js"), `import { MARK } from "my-external-dep";\nwindow.__mark = MARK;\n`);
+fs.writeFileSync(
+  path.join(app, "index.html"),
+  `<!doctype html><html><head><title>t</title></head><body><script type="module" src="/src/entry.js"></script></body></html>`,
+);
+fs.writeFileSync(
+  path.join(app, "oj.plugins.mjs"),
+  `import path from "node:path";
+   const target = ${JSON.stringify(path.join(ext, "external-dep.js"))};
+   export default [{
+     name: "external-resolver",
+     enforce: "pre",
+     // Resolution is the whole job — no load hook.
+     resolveId(id) { return id === "my-external-dep" ? target : null; },
+   }];\n`,
+);
+
+const port = 5493;
+const base = `http://127.0.0.1:${port}`;
+async function reachable() {
+  for (let i = 0; i < 50; i++) {
+    try {
+      const r = await fetch(`${base}/`, { signal: AbortSignal.timeout(1500) });
+      if (r.ok) return true;
+    } catch {}
+    await sleep(200);
+  }
+  return false;
+}
+
+let failed = false;
+const srv = spawn(oj, ["dev", app, "--port", String(port)], { stdio: "ignore" });
+try {
+  assert.ok(await reachable(), "dev server came up");
+
+  const entry = await (await fetch(`${base}/src/entry.js`)).text();
+  const idUrl = entry.match(/\/@id\/[a-f0-9]+\?importer=[a-f0-9]+/)?.[0];
+  assert.ok(idUrl, "the bare specifier was rewritten to a /@id/ URL:\n" + entry);
+
+  const res = await fetch(`${base}${idUrl}`); // fetch follows the redirect
+  assert.equal(res.status, 200, `the resolved-but-unloaded module must be served, got ${res.status}`);
+  const mod = await res.text();
+  assert.match(mod, /external-dep-served-ok/, "the resolved file's bytes were served from disk:\n" + mod);
+
+  console.log("PLUGIN-RESOLVE-NO-LOAD E2E PASSED");
+} catch (e) {
+  failed = true;
+  console.error("PLUGIN-RESOLVE-NO-LOAD E2E FAILED:", e.message || e);
+} finally {
+  srv.kill("SIGKILL");
+  await sleep(200);
+  fs.rmSync(app, { recursive: true, force: true });
+  fs.rmSync(ext, { recursive: true, force: true });
+}
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Supersedes #108 (by @mikn) — carries their fix unchanged (their commit is preserved) and adds the regression test and CI coverage it was missing.

## The bug

Rollup's contract, which the rest of oj's plugin host follows, has two halves:
1. `resolveId` returning a path means that file **is** the module.
2. A `load` hook returning nothing means **read it from disk**.

oj's dev server implemented only the second half: `serve_plugin_resolve` and `serve_plugin_id` both 404'd on `Ok(None)` from `load`. So a plugin that maps a specifier to a real path *without* also serving its bytes 404'd for every module it resolved — and a pure resolver plugin is exactly that shape (resolution is the whole job). This is the natural way to reach a `node_modules` tree that isn't above the importer (build-output layouts, non-standard monorepos, virtual filesystems), so it bit real setups.

## The fix (@mikn's commit)

On `load` returning `None`, if the resolved id is an absolute existing file, redirect to that file's normal dep URL. Routing it back through the standard dep pipeline (rather than reading it inline) keeps every downstream behaviour identical to any other dependency — the `fs.allow` check, partial bundling, and the specifier rewriting applied to the served file. (The plugin handlers compile loaded source under a synthetic `plugin.tsx` name, so an inline read there would use the wrong path; the redirect gives the file its real-path handling.)

Vite reaches the same outcome by reading the file inline in its load fallback (`transformRequest.ts`: `loadResult == null` → `fsp.readFile(id)`); oj's redirect is the equivalent that fits its architecture.

## Test (added here)

`e2e/plugin-resolve-no-load.mjs` (wired into the unbundled e2e job): a `pre` resolver plugin maps a bare specifier to a real file **outside the project root** and has no `load` hook. It starts `oj dev`, fetches the entry, follows the `/@id/` URL for the resolved module, and asserts it is served (200, with the file's bytes) rather than 404.

I verified this test **fails on `main` today** (404) and **passes with this change** — a genuine regression guard.