### PR TITLE
accept an explicit config path on oj build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to oj are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `oj build --config <path>` names the config to build with, the same flag `oj dev` already takes. Without it the config could only be found by convention relative to the positional root, so a config generated outside the app tree was unreachable.
+
 ## [0.1.6] - 2026-08-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ node e2e/plugin-ws.mjs                             # plugin server.ws custom eve
 node e2e/plugin-ws-execute.mjs                     # post -> ws broadcast -> client reply -> collect (bridge execute)
 node e2e/plugin-middleware.mjs                     # configureServer post body forwarding + transformIndexHtml
 node e2e/hmr-gate.mjs                              # hmr gate holds updates until POST /__hmr_flush
-node e2e/config-flag.mjs                           # oj dev --config <path> loads an override config
+node e2e/config-flag.mjs                           # oj dev/build --config <path> loads an override config
 node e2e/config-wrapper.mjs                        # vite.config that calls an external defineConfig wrapper
 node e2e/awkward-paths.mjs                         # percent-encoded filenames served, traversal contained
 node bench/generate.mjs 1000                      # generate a benchmark app (then npm i inside it)

--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -1353,10 +1353,20 @@ pub async fn build(
     out: Option<PathBuf>,
     ssr: Option<String>,
     mode: &str,
+    config_path: Option<PathBuf>,
 ) -> anyhow::Result<()> {
     let root = root
         .canonicalize()
         .with_context(|| format!("app root not found: {}", root.display()))?;
+
+    if let Some(cfg) = &config_path {
+        let cfg = if cfg.is_absolute() {
+            cfg.clone()
+        } else {
+            root.join(cfg)
+        };
+        oj_server::plugins::set_vite_config_override(cfg);
+    }
 
     let mut config =
         oj_config::load_with(&root, "build", mode).map_err(|e| anyhow::anyhow!("{e}"))?;

--- a/crates/oj/src/main.rs
+++ b/crates/oj/src/main.rs
@@ -62,6 +62,8 @@ enum Command {
         ssr: Option<String>,
         #[arg(long)]
         mode: Option<String>,
+        #[arg(long)]
+        config: Option<PathBuf>,
     },
     Preview {
         root: Option<PathBuf>,
@@ -139,6 +141,7 @@ async fn run() -> anyhow::Result<()> {
             out,
             ssr,
             mode,
+            config,
         } => {
             let root = root.unwrap_or_else(|| {
                 let playground = PathBuf::from("playground");
@@ -152,7 +155,7 @@ async fn run() -> anyhow::Result<()> {
             if oj_server::is_tanstack_start_app(&root) {
                 start_dev::start_build(root).await
             } else {
-                build::build(root, out, ssr, &mode).await
+                build::build(root, out, ssr, &mode, config).await
             }
         }
         Command::Preview {

--- a/e2e/config-flag.mjs
+++ b/e2e/config-flag.mjs
@@ -51,6 +51,13 @@ async function htmlWith(args, port) {
   }
 }
 
+function buildHtmlWith(args) {
+  fs.rmSync(path.join(app, "dist"), { recursive: true, force: true });
+  fs.rmSync(path.join(app, ".oj-cache"), { recursive: true, force: true });
+  execSync([oj, ...args].join(" "), { cwd: app, stdio: "ignore" });
+  return fs.readFileSync(path.join(app, "dist", "index.html"), "utf8");
+}
+
 let failed = false;
 try {
   const base = await htmlWith(["dev", app, "--port", "5491"], 5491);
@@ -61,6 +68,16 @@ try {
     5492,
   );
   assert.match(overridden, /window\.__OVR = 1/, "--config loads plugins from the override config");
+
+  const builtBase = buildHtmlWith(["build", app]);
+  assert.ok(!/window\.__OVR = 1/.test(builtBase), "build with the root config has no override plugin");
+
+  const builtOverridden = buildHtmlWith(["build", app, "--config", ".lovable/vite.config.mjs"]);
+  assert.match(
+    builtOverridden,
+    /window\.__OVR = 1/,
+    "build --config loads plugins from the override config",
+  );
 
   console.log("CONFIG-FLAG E2E PASSED");
 } catch (err) {


### PR DESCRIPTION
`oj dev` takes `--config <PATH>`. `oj build` takes only `[ROOT] --out --ssr
--mode`, so the only way to tell a build which config to read is to put the file
where the ROOT-relative convention search looks. A tool that generates its
config outside the app tree has nothing to put there, and handing the path over
positionally makes oj read it as ROOT.

Both commands already share the mechanism. `set_vite_config_override` pins what
`vite_config_file` returns, and `build()` canonicalizes ROOT and then calls
`adopt_vite_config_values` in the same order `DevServer::build_app` does. The
flag goes into that same call and resolves a relative path against the canonical
ROOT the way dev does, so `dev` and `build` cannot disagree about which file is
the config. The added block in `crates/oj/src/build.rs` is the same shape as the
one already in `crates/oj_server/src/lib.rs`.

The TanStack Start branch is untouched, which is what dev does too: there the
flag reaches `DevServer` and not `start_dev`.

## Testing

`e2e/config-flag.mjs` was already the `--config` fixture — it builds an app with
a root `vite.config.mjs` plus an override config and asserts the override's
`transformIndexHtml` plugin fires only with `--config`. It now does the same for
`build`, reusing that fixture: one build with the root config asserts the
override marker is absent, one with `--config` asserts it is present. Without the
flag clap rejects the argument and the test throws; with the flag parsed but
inert the second assertion fails.

- `node e2e/config-flag.mjs` — passes
- `cargo test --workspace` — green
- `cargo build -p oj` — clean
- `cargo clippy -p oj` — no new warnings (`too_many_arguments` does not fire;
  `build()` is 5 args against a threshold of 7)

## One request

Please don't fold a `cargo fmt --all` into this branch. The checked-in tree is
not fmt-clean against rustfmt 1.95 (the version `rust-toolchain.toml` pins):
running it rewrites about 1100 lines across 37 files of unrelated code. The lines
added here are fmt-clean on their own — `rustfmt --check` reports no hunk
touching `config_path` or `set_vite_config_override`.