### PR TITLE
accept vite-hmr websocket; add server.hmr:false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to oj are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `server.hmr: false` disables HMR, matching Vite: file edits stop broadcasting reloads (the page holds until a manual refresh) while the dev server and plugin WebSocket keep running. Honored from both a `vite.config` and an `oj.config`.
+
+### Fixed
+- oj now accepts the Vite HMR WebSocket. A Vite HMR client dials the origin root with the `vite-hmr` subprotocol, but oj served its HMR socket only at `/__ws`, so that dial never upgraded and the client could not connect. oj now intercepts a `vite-hmr` upgrade on any path (matching Vite's subprotocol-based dispatch), echoes the subprotocol, and sends `{ "type": "connected" }` first, so the client connects and receives oj's existing Vite-shaped reload frames. The `vite-ping` liveness-probe subprotocol is accepted and closed immediately, as Vite does. This runs entirely on oj's native Rust WebSocket path, with no Node plugin host on the HMR path.
+
 ## [0.1.6] - 2026-08-26
 
 ### Fixed

--- a/crates/oj_config/src/lib.rs
+++ b/crates/oj_config/src/lib.rs
@@ -542,6 +542,18 @@ mod tests {
     }
 
     #[test]
+    fn server_hmr_false_parses_as_disabled() {
+        let off: OjConfig = serde_json::from_str(r#"{"server":{"hmr":false}}"#).unwrap();
+        assert!(off.server.unwrap().hmr.unwrap().is_disabled());
+        let on: OjConfig = serde_json::from_str(r#"{"server":{"hmr":true}}"#).unwrap();
+        assert!(!on.server.unwrap().hmr.unwrap().is_disabled());
+        let obj: OjConfig = serde_json::from_str(r#"{"server":{"hmr":{"overlay":false}}}"#).unwrap();
+        assert!(!obj.server.unwrap().hmr.unwrap().is_disabled());
+        let empty: OjConfig = serde_json::from_str(r#"{"server":{"port":3000}}"#).unwrap();
+        assert!(empty.server.unwrap().hmr.is_none());
+    }
+
+    #[test]
     fn server_strict_port_accessor_defaults_false() {
         let on: OjConfig = serde_json::from_str(r#"{"server":{"strictPort":true}}"#).unwrap();
         assert!(server_strict_port(&on));

--- a/crates/oj_config/src/schema.rs
+++ b/crates/oj_config/src/schema.rs
@@ -86,12 +86,34 @@ pub struct ServerConfig {
     pub strict_port: Option<bool>,
     pub open: Option<bool>,
     pub cors: Option<bool>,
+    pub hmr: Option<HmrConfig>,
     pub hmr_gate: Option<bool>,
     pub allowed_hosts: Option<Vec<String>>,
     pub headers: Option<BTreeMap<String, String>>,
     pub proxy: Option<BTreeMap<String, ProxyEntry>>,
     pub fs: Option<FsConfig>,
     pub warmup: Option<WarmupConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum HmrConfig {
+    Toggle(bool),
+    Options(HmrOptions),
+}
+
+impl HmrConfig {
+    pub fn is_disabled(&self) -> bool {
+        matches!(self, HmrConfig::Toggle(false))
+    }
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct HmrOptions {
+    pub path: Option<String>,
+    pub port: Option<u16>,
+    pub overlay: Option<bool>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/crates/oj_server/src/assets/vite-extract.mjs
+++ b/crates/oj_server/src/assets/vite-extract.mjs
@@ -192,6 +192,7 @@ if (isMainRun) try {
       publicDir: typeof c.publicDir === "string" ? c.publicDir : null,
       port: typeof c.server?.port === "number" ? c.server.port : null,
       host: typeof c.server?.host === "string" ? c.server.host : null,
+      hmr: c.server?.hmr === false ? false : null,
       fsAllow: Array.isArray(c.server?.fs?.allow)
         ? c.server.fs.allow.filter((x) => typeof x === "string")
         : null,

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use anyhow::Context;
 use axum::{
     body::Body,
-    extract::{ws::Message, Query, State, WebSocketUpgrade},
+    extract::{ws::Message, FromRequestParts, Query, State, WebSocketUpgrade},
     http::{header, HeaderMap, Method, StatusCode, Uri},
     response::{IntoResponse, Redirect, Response},
     routing::{get, post},
@@ -257,6 +257,7 @@ struct ServerState {
     virtual_modules: std::collections::BTreeMap<String, String>,
     jsx_overrides: std::collections::BTreeMap<String, String>,
     hmr_gate: Option<Arc<HmrGate>>,
+    hmr_enabled: bool,
     plugins: Option<std::sync::Arc<PluginHost>>,
     plugin_mw_port: Option<u16>,
     plugins_ssr: tokio::sync::OnceCell<Option<std::sync::Arc<PluginHost>>>,
@@ -555,6 +556,15 @@ impl DevServer {
             }
         };
 
+        let hmr_enabled = server_cfg
+            .hmr
+            .as_ref()
+            .map(|h| !h.is_disabled())
+            .unwrap_or(true);
+        if !hmr_enabled {
+            println!("  hmr: disabled (server.hmr: false)");
+        }
+
         let started = Instant::now();
         let (reload_tx, _) = broadcast::channel::<String>(64);
         let (crawl_tx, crawl_rx) = tokio::sync::watch::channel(false);
@@ -637,6 +647,7 @@ impl DevServer {
             virtual_modules: config.virtual_modules.clone().unwrap_or_default(),
             jsx_overrides,
             hmr_gate,
+            hmr_enabled,
             plugins: plugin_host,
             plugin_mw_port,
             plugins_ssr: tokio::sync::OnceCell::new(),
@@ -723,6 +734,10 @@ impl DevServer {
             .route("/__hmr_flush", post(hmr_flush))
             .route("/__hmr_gate", get(hmr_gate_status))
             .fallback(serve_fallback);
+        app = app.layer(axum::middleware::from_fn_with_state(
+            Arc::clone(&state),
+            vite_hmr_upgrade,
+        ));
         let extra_headers: Vec<(header::HeaderName, header::HeaderValue)> = config
             .server
             .as_ref()
@@ -1112,9 +1127,59 @@ pub fn update_progress_frame(
 async fn ws_upgrade(
     State(state): State<Arc<ServerState>>,
     upgrade: WebSocketUpgrade,
-) -> impl IntoResponse {
+) -> Response {
+    hmr_socket(upgrade, state, false)
+}
+
+fn vite_ws_subprotocol(h: &HeaderMap) -> Option<&'static str> {
+    let is_ws = h
+        .get(header::UPGRADE)
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.eq_ignore_ascii_case("websocket"))
+        .unwrap_or(false);
+    if !is_ws {
+        return None;
+    }
+    let raw = h.get(header::SEC_WEBSOCKET_PROTOCOL)?.to_str().ok()?;
+    raw.split(',').map(|p| p.trim()).find_map(|p| match p {
+        "vite-hmr" => Some("vite-hmr"),
+        "vite-ping" => Some("vite-ping"),
+        _ => None,
+    })
+}
+
+async fn vite_hmr_upgrade(
+    State(state): State<Arc<ServerState>>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Response {
+    let Some(proto) = vite_ws_subprotocol(req.headers()) else {
+        return next.run(req).await;
+    };
+    let (mut parts, body) = req.into_parts();
+    match WebSocketUpgrade::from_request_parts(&mut parts, &state).await {
+        Ok(upgrade) if proto == "vite-ping" => upgrade
+            .protocols(["vite-ping"])
+            .on_upgrade(|mut socket| async move {
+                let _ = socket.send(Message::Close(None)).await;
+            }),
+        Ok(upgrade) => hmr_socket(upgrade, state, true),
+        Err(_) => next.run(axum::extract::Request::from_parts(parts, body)).await,
+    }
+}
+
+fn hmr_socket(upgrade: WebSocketUpgrade, state: Arc<ServerState>, vite: bool) -> Response {
+    let upgrade = if vite {
+        upgrade.protocols(["vite-hmr"])
+    } else {
+        upgrade
+    };
     upgrade.on_upgrade(move |mut socket| async move {
         let mut rx = state.reload_tx.subscribe();
+        if vite {
+            let connected = serde_json::json!({ "type": "connected" }).to_string();
+            let _ = socket.send(Message::Text(connected.into())).await;
+        }
         if state.hmr_gate.is_some() {
             let mode = serde_json::json!({
                 "type": "custom",
@@ -4430,6 +4495,9 @@ fn spawn_watcher(state: Arc<ServerState>) {
             if paths.iter().any(|p| is_restart_trigger(p)) {
                 restart_process();
             }
+            if !state.hmr_enabled {
+                continue;
+            }
             if let Some(gate) = &state.hmr_gate {
                 if gate.hold(&state, &paths) {
                     continue;
@@ -4465,6 +4533,9 @@ fn parse_hmr_filter(raw: &str) -> Option<Vec<PathBuf>> {
 }
 
 async fn decide(state: &ServerState, paths: &[PathBuf]) -> Vec<String> {
+    if !state.hmr_enabled {
+        return Vec::new();
+    }
     let mut messages: Vec<String> = Vec::new();
     let mut updates: Vec<serde_json::Value> = Vec::new();
 

--- a/crates/oj_server/src/plugins.rs
+++ b/crates/oj_server/src/plugins.rs
@@ -180,6 +180,7 @@ pub struct ViteValues {
     pub public_dir: Option<String>,
     pub port: Option<u16>,
     pub host: Option<String>,
+    pub hmr_disabled: bool,
     pub fs_allow: Option<Vec<String>>,
     pub define: Option<serde_json::Map<String, serde_json::Value>>,
     pub alias: Option<serde_json::Map<String, serde_json::Value>>,
@@ -272,6 +273,7 @@ fn parse_vite_values(json: &serde_json::Value) -> ViteValues {
             .get("host")
             .and_then(|v| v.as_str())
             .map(str::to_string),
+        hmr_disabled: json.get("hmr").and_then(|v| v.as_bool()) == Some(false),
         fs_allow: json.get("fsAllow").and_then(|v| v.as_array()).map(|a| {
             a.iter()
                 .filter_map(|x| x.as_str().map(str::to_string))
@@ -311,6 +313,12 @@ fn merge_vite_values(config: &mut oj_config::OjConfig, v: ViteValues) {
         let def = config.define.get_or_insert_with(Default::default);
         for (k, val) in vdef {
             def.entry(k).or_insert(val);
+        }
+    }
+    if v.hmr_disabled {
+        let sc = config.server.get_or_insert_with(Default::default);
+        if sc.hmr.is_none() {
+            sc.hmr = Some(oj_config::HmrConfig::Toggle(false));
         }
     }
     if v.port.is_some() || v.host.is_some() || v.headers.is_some() || v.fs_allow.is_some() {

--- a/e2e/hmr-disabled.mjs
+++ b/e2e/hmr-disabled.mjs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+import { spawn, execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repo = path.join(here, "..");
+const oj = path.join(repo, "target", "debug", "oj");
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+execSync("cargo build -p oj", { cwd: repo, stdio: "inherit" });
+
+const app = fs.mkdtempSync(path.join(os.tmpdir(), "oj-hmroff-"));
+fs.mkdirSync(path.join(app, "src"), { recursive: true });
+fs.writeFileSync(path.join(app, "package.json"), JSON.stringify({ name: "hmr-off-app", version: "1.0.0" }));
+fs.writeFileSync(path.join(app, "vite.config.mjs"), `export default { server: { hmr: false } };\n`);
+fs.writeFileSync(path.join(app, "src", "main.js"), `document.title = "v1";\n`);
+fs.writeFileSync(
+  path.join(app, "index.html"),
+  `<!doctype html><html><head><title>t</title></head><body><script type="module" src="/src/main.js"></script></body></html>`,
+);
+
+const port = 5491;
+let failed = false;
+let log = "";
+const srv = spawn(oj, ["dev", app, "--port", String(port)], { stdio: ["ignore", "pipe", "pipe"] });
+srv.stdout.on("data", (d) => (log += d));
+srv.stderr.on("data", (d) => (log += d));
+try {
+  for (let i = 0; i < 100; i++) { try { if ((await fetch(`http://localhost:${port}/`)).ok) break; } catch {} await sleep(200); }
+
+  assert.match(log, /hmr: disabled/, "server did not report hmr disabled");
+
+  const frames = [];
+  const ws = new WebSocket(`ws://localhost:${port}/__ws`);
+  ws.addEventListener("message", (ev) => { try { frames.push(JSON.parse(ev.data)); } catch {} });
+  await new Promise((res, rej) => { ws.addEventListener("open", res); ws.addEventListener("error", rej); });
+
+  // seed the module into the graph, then edit it; with hmr off no reload frame
+  // should be broadcast.
+  await (await fetch(`http://localhost:${port}/src/main.js`)).text();
+  await sleep(300);
+  fs.writeFileSync(path.join(app, "src", "main.js"), `document.title = "v2";\n`);
+  await sleep(2500);
+
+  const reloads = frames.filter((f) => f.type === "full-reload" || f.type === "update");
+  assert.equal(reloads.length, 0, `expected no reload frames, got ${JSON.stringify(reloads)}`);
+  ws.close();
+
+  console.log("HMR-DISABLED E2E PASSED");
+} catch (err) {
+  failed = true;
+  console.error("HMR-DISABLED E2E FAILED:", err.message);
+} finally {
+  srv.kill("SIGKILL");
+  await sleep(300);
+  fs.rmSync(app, { recursive: true, force: true });
+}
+process.exit(failed ? 1 : 0);

--- a/e2e/plugin-ws.mjs
+++ b/e2e/plugin-ws.mjs
@@ -64,6 +64,28 @@ try {
 
   assert.deepEqual(pong, { echo: { hello: "world" } }, "plugin ws.on -> ws.send round-trips to the client");
   ws.close();
+
+  // the same relay must work for a client on the vite-hmr socket (origin root)
+  const vws = new WebSocket(`ws://localhost:${port}/`, ["vite-hmr"]);
+  await new Promise((res, rej) => {
+    vws.addEventListener("open", res);
+    vws.addEventListener("error", () => rej(new Error("vite-hmr socket open failed")));
+  });
+  const pong2 = await new Promise((res, rej) => {
+    const timer = setTimeout(() => rej(new Error("timed out waiting for server:pong over vite-hmr")), 8000);
+    vws.addEventListener("message", (e) => {
+      let m;
+      try { m = JSON.parse(e.data); } catch { return; }
+      if (m.type === "custom" && m.event === "server:pong") {
+        clearTimeout(timer);
+        res(m.data);
+      }
+    });
+    vws.send(JSON.stringify({ type: "custom", event: "client:ping", data: { hello: "vite" } }));
+  });
+  assert.deepEqual(pong2, { echo: { hello: "vite" } }, "plugin ws relay round-trips over the vite-hmr socket");
+  vws.close();
+
   console.log("PLUGIN-WS E2E PASSED");
 } catch (err) {
   failed = true;

--- a/e2e/vite-hmr-socket.mjs
+++ b/e2e/vite-hmr-socket.mjs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+import { spawn, execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repo = path.join(here, "..");
+const oj = path.join(repo, "target", "debug", "oj");
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+execSync("cargo build -p oj", { cwd: repo, stdio: "inherit" });
+
+const app = fs.mkdtempSync(path.join(os.tmpdir(), "oj-vitehmr-"));
+fs.mkdirSync(path.join(app, "src"), { recursive: true });
+fs.writeFileSync(path.join(app, "package.json"), JSON.stringify({ name: "vite-hmr-app", version: "1.0.0" }));
+fs.writeFileSync(path.join(app, "src", "main.js"), `document.title = "v1";\n`);
+fs.writeFileSync(
+  path.join(app, "index.html"),
+  `<!doctype html><html><head><title>t</title></head><body><script type="module" src="/src/main.js"></script></body></html>`,
+);
+
+async function waitFor(pred, label, ms = 10000) {
+  for (let i = 0; i < ms / 100; i++) {
+    if (pred()) return;
+    await sleep(100);
+  }
+  throw new Error(`timeout: ${label}`);
+}
+
+const port = 5479;
+const srv = spawn(oj, ["dev", app, "--port", String(port)], { stdio: "ignore" });
+let failed = false;
+try {
+  for (let i = 0; i < 80; i++) { try { if ((await fetch(`http://localhost:${port}/`)).ok) break; } catch {} await sleep(200); }
+
+  // Vite's client dials the origin root with the "vite-hmr" subprotocol; the
+  // socket route lives at /__ws, so a root dial must still upgrade.
+  const frames = [];
+  const ws = new WebSocket(`ws://localhost:${port}/`, ["vite-hmr"]);
+  ws.addEventListener("message", (ev) => { try { frames.push(JSON.parse(ev.data)); } catch {} });
+  await new Promise((resolve, reject) => {
+    const to = setTimeout(() => reject(new Error("vite-hmr socket did not open on /")), 8000);
+    ws.addEventListener("open", () => { clearTimeout(to); resolve(); });
+    ws.addEventListener("error", () => { clearTimeout(to); reject(new Error("vite-hmr socket errored on /")); });
+  });
+
+  assert.equal(ws.protocol, "vite-hmr", "server echoes the vite-hmr subprotocol");
+  await waitFor(() => frames.some((f) => f.type === "connected"), "connected frame");
+  assert.equal(frames[0]?.type, "connected", "connected is the first frame");
+
+  // seed the module into the graph, then edit it; the reload frame must reach
+  // the root-dialed vite-hmr client.
+  await (await fetch(`http://localhost:${port}/src/main.js`)).text();
+  await sleep(300);
+  const before = frames.length;
+  fs.writeFileSync(path.join(app, "src", "main.js"), `document.title = "v2";\n`);
+  await waitFor(
+    () => frames.slice(before).some((f) => f.type === "full-reload" || f.type === "update"),
+    "reload frame after edit",
+  );
+  ws.close();
+
+  // a real Vite client's reconnect liveness probe uses the vite-ping
+  // subprotocol; the server accepts it, then closes it.
+  const ping = new WebSocket(`ws://localhost:${port}/`, ["vite-ping"]);
+  const pingClosed = await new Promise((resolve, reject) => {
+    const to = setTimeout(() => reject(new Error("vite-ping socket did not open")), 8000);
+    let opened = false;
+    ping.addEventListener("open", () => { opened = true; });
+    ping.addEventListener("close", () => { clearTimeout(to); resolve(opened); });
+    ping.addEventListener("error", () => { clearTimeout(to); reject(new Error("vite-ping socket errored")); });
+  });
+  assert.equal(pingClosed, true, "vite-ping socket opened then was closed by the server");
+
+  console.log("VITE-HMR-SOCKET E2E PASSED");
+} catch (err) {
+  failed = true;
+  console.error("VITE-HMR-SOCKET E2E FAILED:", err.message);
+} finally {
+  srv.kill("SIGKILL");
+  await sleep(300);
+  fs.rmSync(app, { recursive: true, force: true });
+}
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
## Problem

A Vite HMR client dials the **origin root** with the `vite-hmr` subprotocol. oj served its HMR socket only at `/__ws`, so the root dial never upgraded and the client could not connect.

It was never a payload problem: oj already broadcasts Vite-shaped `full-reload`/`update`/`error`/`custom` frames. It was a transport-handshake mismatch (path + subprotocol + no `connected` frame).

## Changes

**Accept the Vite HMR WebSocket** (verified against Vite 8.2.1 `server/ws.ts`). A middleware intercepts a Vite HMR upgrade on any path, matching Vite's subprotocol-based dispatch:
- `vite-hmr`: serve oj's HMR socket, echo the subprotocol, send `{"type":"connected"}` first, then oj's existing reload frames.
- `vite-ping`: accept the liveness-probe upgrade and close it immediately, as Vite does.

Entirely on oj's native Rust WebSocket path. No Node plugin host on the HMR path.

**`server.hmr: false`** (Vite parity): file edits stop broadcasting reloads (the page holds until a manual refresh) while the dev server and plugin WebSocket keep running. Honored from both a `vite.config` (via the config-extract path) and an `oj.config` (schema).

## Tests

- `e2e/vite-hmr-socket.mjs`: root `vite-hmr` dial upgrades, subprotocol echoed, `connected` first, reload frame after an edit, `vite-ping` opens-then-closes.
- `e2e/plugin-ws.mjs`: the plugin `server.ws` custom-event roundtrip also works over the vite-hmr socket.
- `e2e/hmr-disabled.mjs`: with `server.hmr:false`, the server reports it and no reload frame fires on edit.
- `oj_config`: unit test for `server.hmr` `false`/`true`/object parsing.
- Existing `hmr-protocol`/`hmr-gate`/`config-proxy` still pass.