### PR TITLE
expand import.meta.glob in jsx and js start ssr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `server.hmr: false` disables HMR, matching Vite: file edits stop broadcasting reloads (the page holds until a manual refresh) while the dev server and plugin WebSocket keep running. Honored from both a `vite.config` and an `oj.config`.
 
 ### Fixed
+- `import.meta.glob` is now expanded in `.jsx` and plain `.js`/`.mjs` modules in the TanStack Start SSR path, not only `.ts`/`.tsx`. Previously a `.jsx` route/component (or an unclaimed on-disk `.js`) that used `import.meta.glob` reached the SSR runtime untransformed and threw `TypeError: (intermediate value).glob is not a function`, 500ing the route. The dev SSR loader and both the SSR-server and client production builds now run the glob transform for the full JS/TS family.
 - oj now accepts the Vite HMR WebSocket. A Vite HMR client dials the origin root with the `vite-hmr` subprotocol, but oj served its HMR socket only at `/__ws`, so that dial never upgraded and the client could not connect. oj now intercepts a `vite-hmr` upgrade on any path (matching Vite's subprotocol-based dispatch), echoes the subprotocol, and sends `{ "type": "connected" }` first, so the client connects and receives oj's existing Vite-shaped reload frames. The `vite-ping` liveness-probe subprotocol is accepted and closed immediately, as Vite does. This runs entirely on oj's native Rust WebSocket path, with no Node plugin host on the HMR path.
 
 ## [0.1.6] - 2026-08-26

--- a/crates/oj_server/src/assets/start/build.mjs
+++ b/crates/oj_server/src/assets/start/build.mjs
@@ -86,7 +86,7 @@ function serverFns(code) {
   return out;
 }
 
-const userTs = (id) => !id.includes("/node_modules/") && !id.startsWith("\0") && /\.(ts|tsx)$/.test(id);
+const userTs = (id) => !id.includes("/node_modules/") && !id.startsWith("\0") && /\.(tsx?|jsx?|mjs)$/.test(id);
 
 const clientFnPlugin = {
   name: "server-fn-client",

--- a/crates/oj_server/src/assets/start/bundle-client.mjs
+++ b/crates/oj_server/src/assets/start/bundle-client.mjs
@@ -63,9 +63,9 @@ const closureRecorder = {
 const serverFnClient = {
   name: "server-fn-client",
   transform: {
-    filter: { id: { include: /\.(ts|tsx)$/, exclude: [/\/node_modules\//, /^\0/] } },
+    filter: { id: { include: /\.(tsx?|jsx?|mjs)$/, exclude: [/\/node_modules\//, /^\0/] } },
     async handler(code, id) {
-      if (id.includes("/node_modules/") || id.startsWith("\0") || !/\.(ts|tsx)$/.test(id)) return null;
+      if (id.includes("/node_modules/") || id.startsWith("\0") || !/\.(tsx?|jsx?|mjs)$/.test(id)) return null;
       let out = code;
       if (container) {
         const t = await container.transformUserCode(out, id);

--- a/crates/oj_server/src/assets/start/loader.mjs
+++ b/crates/oj_server/src/assets/start/loader.mjs
@@ -648,7 +648,7 @@ export function load(url, context, next) {
   if (clean.endsWith(".json")) {
     return { format: "module", source: `export default ${readFileSync(fileURLToPath(clean), "utf8")};`, shortCircuit: true };
   }
-  if (clean.endsWith(".tsx") || clean.endsWith(".ts")) {
+  if (clean.endsWith(".tsx") || clean.endsWith(".ts") || clean.endsWith(".jsx")) {
     const path = fileURLToPath(clean);
     const userFile = container && !path.includes("/node_modules/");
     let diskRaw = null;
@@ -680,7 +680,7 @@ export function load(url, context, next) {
     }
     const src = transformServerFns(transformGlob(raw, path), path);
     const out = transformSync(path, src, {
-      lang: clean.endsWith("tsx") ? "tsx" : "ts",
+      lang: clean.endsWith("tsx") ? "tsx" : clean.endsWith("jsx") ? "jsx" : "ts",
       jsx: { runtime: "automatic" },
       define: DEFINE,
     });
@@ -727,6 +727,9 @@ export function load(url, context, next) {
       const loaded = container.load(path);
       if (loaded != null) {
         return { format: "module", source: transformGlob(loaded, path), shortCircuit: true };
+      }
+      if (diskRaw != null && diskRaw.includes("import.meta.glob")) {
+        return { format: "module", source: transformGlob(diskRaw, path), shortCircuit: true };
       }
       cachePut(key, "1");
     }

--- a/e2e/fixtures/start-app/src/generated/glob-plain.js
+++ b/e2e/fixtures/start-app/src/generated/glob-plain.js
@@ -1,0 +1,9 @@
+// A plain on-disk .js the fixture plugin does NOT claim; its import.meta.glob
+// must still be expanded by the start SSR loader's unclaimed-.js branch.
+const mods = import.meta.glob("../content/*.json", { eager: true });
+export const plainGlobTitles =
+  "jsglob:" +
+  Object.values(mods)
+    .map((m) => m.default.title)
+    .sort()
+    .join("|");

--- a/e2e/fixtures/start-app/src/routes/index.tsx
+++ b/e2e/fixtures/start-app/src/routes/index.tsx
@@ -24,6 +24,11 @@ import { buildTag } from "virtual:build-info";
 // export `m.freshMsg_cta()` survives oj's transform/bundle (the reported crash).
 import * as gen from "../generated/stale.js";
 
+// import.meta.glob in a .jsx file and in an unclaimed plain .js file: both must
+// be expanded by the start SSR loader (the .tsx path already is).
+import { GlobWidget } from "../widgets/glob-widget.jsx";
+import { plainGlobTitles } from "../generated/glob-plain.js";
+
 // svgr: a bare .svg import yields a React component (exportType "default")...
 import Logo from "../logo.svg";
 // ...and the explicit `?react` query yields one regardless of exportType.
@@ -66,6 +71,8 @@ function Index() {
       <p data-testid="fresh-module">{gen.LABEL}</p>
       <p data-testid="fresh-fn">{gen.freshMsg_cta()}</p>
       <p data-testid="glob">{titles}</p>
+      <p data-testid="glob-jsx"><GlobWidget /></p>
+      <p data-testid="glob-js">{plainGlobTitles}</p>
       <p data-testid="raw">{notes.trim()}</p>
       <img data-testid="url" src={heroUrl} alt="hero" />
       <span data-testid="svg"><Logo /></span>

--- a/e2e/fixtures/start-app/src/widgets/glob-widget.jsx
+++ b/e2e/fixtures/start-app/src/widgets/glob-widget.jsx
@@ -1,0 +1,10 @@
+// A .jsx file (JSX + import.meta.glob) exercised through the start SSR loader:
+// the loader must run the glob transform for .jsx, not fall through to Node.
+const mods = import.meta.glob("../content/*.json", { eager: true });
+const titles = Object.values(mods)
+  .map((m) => m.default.title)
+  .sort()
+  .join("|");
+export function GlobWidget() {
+  return <span>{"jsxglob:" + titles}</span>;
+}

--- a/e2e/start.mjs
+++ b/e2e/start.mjs
@@ -64,6 +64,8 @@ async function assertApp(port, label) {
     ["plugin virtual module", "fixture-virtual-ok"],
     ["plugin load override + buildStart + this.environment.config.consumer", "FRESH_via_buildStart_ssr-server"],
     ["import.meta.glob", "Alpha Widget, Beta Widget"],
+    ["import.meta.glob in .jsx", "jsxglob:Alpha Widget|Beta Widget"],
+    ["import.meta.glob in unclaimed .js", "jsglob:Alpha Widget|Beta Widget"],
     ["?raw import", "raw-notes-marker"],
     ["svgr bare .svg component", "<rect"],
     ["svgr ?react component", "<polygon"],


### PR DESCRIPTION
## Problem

In the TanStack Start SSR path, `import.meta.glob` was only expanded for `.ts`/`.tsx` modules. A `.jsx` route/component, or a plain on-disk `.js`/`.mjs` module no plugin claims, reached the SSR runtime with `import.meta.glob` intact and threw `TypeError: (intermediate value).glob is not a function`, 500ing the route.

The client browser path and the `oj dev --ssr` module-runner path already handled all extensions (they run the Rust `oj_compiler` glob transform). The gap was specific to the Start dev loader and the Start production builds, which use a JS `transformGlob` gated to `.ts`/`.tsx`.

## Fix

Extend the glob transform to the full JS/TS family (`.ts`/`.tsx`/`.js`/`.jsx`/`.mjs`) in the three Start seams:
- `loader.mjs` (dev SSR): add `.jsx` to the transform branch, and expand `import.meta.glob` in an unclaimed on-disk `.js`/`.mjs` before falling through to Node.
- `build.mjs` (SSR server build): widen the `userTs` id test.
- `bundle-client.mjs` (client build): widen the filter/handler id test.

`transformGlob` is a no-op when the source has no `import.meta.glob`, so widening the file filter is safe.

## Tests

The `start-app` fixture now exercises `import.meta.glob` from a `.jsx` component and from an unclaimed plain `.js` module (the fixture plugin only claims `stale.js`), rendered through SSR. `e2e/start.mjs` asserts both in **dev and prod**. `e2e/ssr-dev.mjs` (module-runner path) still passes.