### PR TITLE
expand nested-generic import.meta.glob in start ssr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to oj are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- `import.meta.glob` with a TypeScript type argument is now expanded in the TanStack Start SSR path even when the type argument is nested (`import.meta.glob<Record<string, unknown>>(...)`) or an object literal (`import.meta.glob<{ default: T }>(...)`). The Start transform located the call with a regex that stopped at the first `>`, so a nested generic slipped through unrewritten and reached the SSR runtime as a real `import.meta.glob(...)` call, throwing `TypeError: (intermediate value).glob is not a function` and 500ing the route. The detector now skips a balanced, string-aware type argument before the call, matching the AST-based compiler path.
+
 ## [0.1.7] - 2026-08-29
 
 ### Added

--- a/crates/oj_server/src/assets/start/glob-transform.mjs
+++ b/crates/oj_server/src/assets/start/glob-transform.mjs
@@ -3,7 +3,27 @@
 import { readdirSync, statSync } from "node:fs";
 import { resolve, dirname, relative, sep } from "node:path";
 
-const GLOB_CALL = /import\.meta\.glob\s*(?:<[^>]*>)?\s*\(/g;
+const GLOB_HEAD = /import\.meta\.glob\b/g;
+
+// Skip whitespace, then an optional balanced TypeScript type argument
+// (`<...>`, nesting- and string-aware, e.g. `<Record<string, unknown>>`), then
+// require `(`. Returns the index just past `(`, or -1 if this is not a call.
+function callArgsStart(code, from) {
+  let i = from;
+  while (i < code.length && /\s/.test(code[i])) i++;
+  if (code[i] === "<") {
+    let depth = 0, str = "";
+    for (; i < code.length; i++) {
+      const c = code[i];
+      if (str) { if (c === "\\") i++; else if (c === str) str = ""; continue; }
+      if (c === '"' || c === "'" || c === "`") str = c;
+      else if (c === "<") depth++;
+      else if (c === ">") { depth--; if (depth === 0) { i++; break; } }
+    }
+    while (i < code.length && /\s/.test(code[i])) i++;
+  }
+  return code[i] === "(" ? i + 1 : -1;
+}
 
 function globToRegExp(absGlob) {
   let re = "";
@@ -64,9 +84,11 @@ export function transformGlob(code, filePath) {
   const fileDir = dirname(filePath);
   const prelude = [];
   let g = 0, out = "", last = 0, m;
-  GLOB_CALL.lastIndex = 0;
-  while ((m = GLOB_CALL.exec(code))) {
-    let i = GLOB_CALL.lastIndex, depth = 1, str = "";
+  GLOB_HEAD.lastIndex = 0;
+  while ((m = GLOB_HEAD.exec(code))) {
+    const argsStart = callArgsStart(code, GLOB_HEAD.lastIndex);
+    if (argsStart === -1) continue;
+    let i = argsStart, depth = 1, str = "";
     for (; i < code.length && depth > 0; i++) {
       const c = code[i];
       if (str) { if (c === "\\") i++; else if (c === str) str = ""; continue; }
@@ -74,9 +96,10 @@ export function transformGlob(code, filePath) {
       else if (c === "(") depth++;
       else if (c === ")") depth--;
     }
-    const argsSrc = code.slice(GLOB_CALL.lastIndex, i - 1);
+    const argsSrc = code.slice(argsStart, i - 1);
     let args;
     try { args = new Function("return [" + argsSrc + "]")(); } catch { continue; }
+    GLOB_HEAD.lastIndex = i;
     const patterns = (Array.isArray(args[0]) ? args[0] : [args[0]]).filter((p) => typeof p === "string");
     const opts = args[1] && typeof args[1] === "object" ? args[1] : {};
     const includes = patterns.filter((p) => !p.startsWith("!"));

--- a/e2e/fixtures/start-app/src/generated/glob-generic.ts
+++ b/e2e/fixtures/start-app/src/generated/glob-generic.ts
@@ -1,0 +1,13 @@
+// A .ts module with a NESTED generic import.meta.glob, the exact shape that
+// broke oj's start SSR (data.ts's `import.meta.glob<Record<...>>`). It must be
+// expanded at transform time, not reach the SSR runtime as a real call.
+const mods = import.meta.glob<Record<string, { default: { title: string } }>>(
+  "../content/*.json",
+  { eager: true },
+);
+export const genericGlobTitles =
+  "tsglob:" +
+  Object.values(mods)
+    .map((m) => m.default.title)
+    .sort()
+    .join("|");

--- a/e2e/fixtures/start-app/src/routes/index.tsx
+++ b/e2e/fixtures/start-app/src/routes/index.tsx
@@ -28,6 +28,7 @@ import * as gen from "../generated/stale.js";
 // be expanded by the start SSR loader (the .tsx path already is).
 import { GlobWidget } from "../widgets/glob-widget.jsx";
 import { plainGlobTitles } from "../generated/glob-plain.js";
+import { genericGlobTitles } from "../generated/glob-generic";
 
 // svgr: a bare .svg import yields a React component (exportType "default")...
 import Logo from "../logo.svg";
@@ -73,6 +74,7 @@ function Index() {
       <p data-testid="glob">{titles}</p>
       <p data-testid="glob-jsx"><GlobWidget /></p>
       <p data-testid="glob-js">{plainGlobTitles}</p>
+      <p data-testid="glob-ts-generic">{genericGlobTitles}</p>
       <p data-testid="raw">{notes.trim()}</p>
       <img data-testid="url" src={heroUrl} alt="hero" />
       <span data-testid="svg"><Logo /></span>

--- a/e2e/start.mjs
+++ b/e2e/start.mjs
@@ -66,6 +66,7 @@ async function assertApp(port, label) {
     ["import.meta.glob", "Alpha Widget, Beta Widget"],
     ["import.meta.glob in .jsx", "jsxglob:Alpha Widget|Beta Widget"],
     ["import.meta.glob in unclaimed .js", "jsglob:Alpha Widget|Beta Widget"],
+    ["import.meta.glob nested generic (.ts)", "tsglob:Alpha Widget|Beta Widget"],
     ["?raw import", "raw-notes-marker"],
     ["svgr bare .svg component", "<rect"],
     ["svgr ?react component", "<polygon"],

--- a/e2e/unit/glob-transform.test.mjs
+++ b/e2e/unit/glob-transform.test.mjs
@@ -50,6 +50,68 @@ test("handles the <T> type argument and a single-star segment", () => {
   }
 });
 
+// Mirrors web/shared/pulse/components/data.ts, which broke oj's start SSR: a
+// nested generic argument the old <[^>]*> regex could not skip.
+test("handles a nested generic type argument (Record<string, unknown>)", () => {
+  const dir = fixture();
+  try {
+    const out = transformGlob(
+      'const m = import.meta.glob<Record<string, unknown>>(["./content/*.md"]);',
+      join(dir, "index.ts"),
+    );
+    assert.match(out, /"\.\/content\/a\.md":/);
+    assert.doesNotMatch(out, /import\.meta\.glob/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("handles an object-literal generic type argument", () => {
+  const dir = fixture();
+  try {
+    const out = transformGlob(
+      'const m = import.meta.glob<{ default: string }>("./content/*.md", { eager: true });',
+      join(dir, "index.ts"),
+    );
+    assert.match(out, /^import\s+\*\s+as\s+\w+\s+from\s+"\.\/content\/a\.md";/m);
+    assert.doesNotMatch(out, /import\.meta\.glob/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("expands every call when a module has several generic globs at module scope", () => {
+  const dir = fixture();
+  try {
+    const code = [
+      'const a = import.meta.glob<{ default: Foo }>("./content/*.json");',
+      'const b = import.meta.glob<SidecarModule>("./pages/**/*.tsx");',
+      'const c = import.meta.glob<Record<string, unknown>>(["./content/*.md"]);',
+    ].join("\n");
+    const out = transformGlob(code, join(dir, "index.ts"));
+    assert.doesNotMatch(out, /import\.meta\.glob/);
+    assert.match(out, /"\.\/pages\/home\/page\.tsx":/);
+    assert.match(out, /"\.\/content\/a\.md":/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("expands a pattern that climbs above the importer directory", () => {
+  const dir = fixture();
+  try {
+    mkdirSync(join(dir, "app", "deep"), { recursive: true });
+    const out = transformGlob(
+      'const m = import.meta.glob<Record<string, unknown>>("../../content/*.md");',
+      join(dir, "app", "deep", "index.ts"),
+    );
+    assert.match(out, /"\.\.\/\.\.\/content\/a\.md":/);
+    assert.doesNotMatch(out, /import\.meta\.glob/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("eager + query + import:default produces static imports of the ?query", () => {
   const dir = fixture();
   try {


### PR DESCRIPTION
In the TanStack Start SSR path, `import.meta.glob` calls carrying a **nested** TypeScript type argument were left unrewritten and reached the SSR runtime as real calls, throwing `TypeError: (intermediate value).glob is not a function` and 500ing the route.

The Start transform (`glob-transform.mjs`) located calls with a regex whose type-argument group was `<[^>]*>`, it stops at the first `>`, so:
- `import.meta.glob<Record<string, unknown>>(...)` → **missed** (nested `>`)
- `import.meta.glob<{ default: T }>(...)` → matched, but fragile

Only the Start path was affected. The compiler's AST-based path (browser dev, `oj dev --ssr` module-runner, and the non-Start build) parses the call and handles type arguments naturally.