### PR TITLE
fix(start): provide the injected-head-scripts virtual module

### DIFF
--- a/crates/oj_server/src/assets/start/injected-head-scripts.ts
+++ b/crates/oj_server/src/assets/start/injected-head-scripts.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+
+// The scripts TanStack Start asks a dev server to put in the document head
+// before the client entry. Vite fills this by running transformIndexHtml over
+// an empty document and collecting the inline scripts it gets back -- the
+// @vitejs/plugin-react refresh preamble, plus whatever a user's
+// transformIndexHtml added.
+//
+// Neither applies here: the adapter applies Fast Refresh itself through the
+// preamble its own client entry carries, and the Start path has no
+// transformIndexHtml. So there is nothing to inject, which is what
+// start-server-core does with a falsy value anyway. What it does not tolerate
+// is the module failing to resolve, and it imports this one unconditionally
+// whenever TSS_DEV_SERVER is set -- which runner.mjs sets.
+export const injectedHeadScripts: string | undefined = undefined;

--- a/crates/oj_server/src/assets/start/loader.mjs
+++ b/crates/oj_server/src/assets/start/loader.mjs
@@ -434,6 +434,7 @@ const ALIASES = {
   "#tanstack-start-plugin-adapters": pathResolve(HERE, "plugin-adapters.ts"),
   "#tanstack-start-server-fn-resolver": pathResolve(HERE, "server-fn-resolver.mjs"),
   "tanstack-start-manifest:v": pathResolve(HERE, "manifest-dev.ts"),
+  "tanstack-start-injected-head-scripts:v": pathResolve(HERE, "injected-head-scripts.ts"),
   "@cloudflare/vite-plugin/server": pathResolve(HERE, "cf-server.mjs"),
 };
 

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -96,6 +96,10 @@ const COMPILABLE: &[&str] = &["tsx", "ts", "jsx", "js", "mjs", "svelte"];
 
 const START_ASSETS: &[(&str, &str)] = &[
     (
+        "injected-head-scripts.ts",
+        include_str!("assets/start/injected-head-scripts.ts"),
+    ),
+    (
         "resolve-pkg.mjs",
         include_str!("assets/start/resolve-pkg.mjs"),
     ),
@@ -5112,6 +5116,39 @@ mod adapter_tests {
         let _ = std::fs::remove_dir_all(&d);
         std::fs::create_dir_all(&d).unwrap();
         d
+    }
+
+    // The framework seam, from the consumer's side. start-server-core imports
+    // these by bare specifier and expects the bundler to answer; one the loader
+    // does not map reaches Node's ESM loader as an unknown URL scheme, and every
+    // document request then fails with ERR_UNSUPPORTED_ESM_URL_SCHEME. The two
+    // scheme-shaped ones are imported unconditionally under TSS_DEV_SERVER,
+    // which runner.mjs sets, so this is the ordinary dev path.
+    #[test]
+    fn the_loader_maps_every_framework_virtual_module() {
+        let loader = include_str!("assets/start/loader.mjs");
+        for spec in [
+            "tanstack-start-manifest:v",
+            "tanstack-start-injected-head-scripts:v",
+            "#tanstack-router-entry",
+            "#tanstack-start-entry",
+            "#tanstack-start-plugin-adapters",
+            "#tanstack-start-server-fn-resolver",
+        ] {
+            assert!(
+                loader.contains(&format!("\"{spec}\":")),
+                "the SSR loader has no alias for {spec}",
+            );
+        }
+    }
+
+    #[test]
+    fn write_start_assets_writes_every_module_the_loader_aliases() {
+        let dir = tmp("assets");
+        write_start_assets(&dir).unwrap();
+        for name in ["injected-head-scripts.ts", "manifest-dev.ts", "loader.mjs"] {
+            assert!(dir.join(name).is_file(), "{name} was not written");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## The failure

Every document request to `oj dev` on a TanStack Start app (`@tanstack/react-start` 1.166) answers 500:

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data,
and node are supported by the default ESM loader.
Received protocol 'tanstack-start-injected-head-scripts:'
    at load (.../.oj-cache/v1/start/loader.mjs:751:10)
```

## Why

`@tanstack/start-server-core` declares three virtual modules:

```ts
export const VIRTUAL_MODULES = {
  startManifest: 'tanstack-start-manifest:v',
  injectedHeadScripts: 'tanstack-start-injected-head-scripts:v',
  serverFnResolver: '#tanstack-start-server-fn-resolver',
}
```

`loader.mjs`'s `ALIASES` maps the first and the third. The second is imported by
`router-manifest.js` **unconditionally** whenever `TSS_DEV_SERVER === "true"`,
and `runner.mjs` sets exactly that — so it is on the ordinary dev path, not a
configuration-specific one.

An app cannot work around it: `resolveUncached` consults the plugin container
only for `virtual:`-prefixed and `\0` ids, so no vite-config plugin is ever
asked for this specifier.

## The fix

A stub module, aliased like its two siblings.

Vite fills `injectedHeadScripts` by running `transformIndexHtml` over an empty
document and joining the inline scripts it gets back (see
`start-plugin-core/dev-server-plugin/plugin.js`) — in practice the
`@vitejs/plugin-react` refresh preamble plus anything a user's
`transformIndexHtml` added. Neither applies to this adapter: it applies Fast
Refresh itself through the preamble its own client entry carries, and the Start
path has no `transformIndexHtml`. So there is nothing to inject, and
`start-server-core` already handles that — `if (mod.injectedHeadScripts)`. What
it cannot handle is the module not resolving.

## Tests

Both in `oj_server`'s `adapter_tests`, so they need no fixture install:

- `the_loader_maps_every_framework_virtual_module` — asserts `ALIASES` has an
  entry for every specifier the framework imports. This is the invariant that
  was broken; it fails on `main` and passes here.
- `write_start_assets_writes_every_module_the_loader_aliases` — asserts the new
  module is actually emitted, so a `START_ASSETS` registration missed alongside
  an alias fails as loudly as a missing alias.

Verified the first test fails with the alias reverted and passes with it.

## How I hit it

Building Bazel rules that run `oj dev` and `vite dev` from one generated config,
as a way of finding where the two diverge. Happy to fold in whatever shape you
prefer for the stub.