### PR TITLE
fix(start): let tsr.config.json configure the route generator

### DIFF
--- a/crates/oj_server/src/assets/start/generate.mjs
+++ b/crates/oj_server/src/assets/start/generate.mjs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MIT
 
+import { readFileSync } from "node:fs";
+import { join as pathJoin } from "node:path";
+
 import { importPkg } from "./resolve-pkg.mjs";
 
 const root = process.env.OJ_APP_ROOT ?? process.cwd();
@@ -34,13 +37,30 @@ const { Generator, getConfig } = await importPkg(root, "@tanstack/router-generat
   "@tanstack/react-start",
 ]);
 
+// getConfig merges as { ...tsr.config.json, ...inline }, so anything passed
+// inline cannot be configured by the app. Only `target` is genuinely ours to
+// decide; the rest are the generator's own documented settings, and an app that
+// keeps its route tree somewhere other than src/routeTree.gen.ts has to be able
+// to say so. Pass them as defaults under the file rather than overrides above it.
+const OJ_DEFAULTS = {
+  routesDirectory: "./src/routes",
+  generatedRouteTree: "./src/routeTree.gen.ts",
+  autoCodeSplitting: false,
+  routeFileIgnorePattern: "\\.(test|spec|stories|bench)\\.|\\.d\\.ts$",
+};
+const configured = (() => {
+  try {
+    return JSON.parse(readFileSync(pathJoin(root, "tsr.config.json"), "utf8"));
+  } catch {
+    return {};
+  }
+})();
 const config = getConfig(
   {
+    ...Object.fromEntries(
+      Object.entries(OJ_DEFAULTS).filter(([k]) => !(k in configured)),
+    ),
     target: "react",
-    routesDirectory: "./src/routes",
-    generatedRouteTree: "./src/routeTree.gen.ts",
-    autoCodeSplitting: false,
-    routeFileIgnorePattern: "\\.(test|spec|stories|bench)\\.|\\.d\\.ts$",
   },
   root,
 );

--- a/e2e/unit/start-route-generator.test.mjs
+++ b/e2e/unit/start-route-generator.test.mjs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+
+// The route generator's configuration surface. `@tanstack/router-generator`
+// reads tsr.config.json and merges it as { ...file, ...inline }, so every key
+// the adapter passes inline is a key the app cannot set. These pin which keys
+// the adapter still decides and which it leaves to the app.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { asset, repo } from "./harness.mjs";
+
+const fixture = join(repo, "e2e/fixtures/start-app");
+const installed = existsSync(join(fixture, "node_modules/@tanstack/router-generator"));
+const maybe = installed ? test : test.skip;
+
+// The generator resolves @tanstack/router-generator from the app root, so the
+// app needs a node_modules; everything else about the fixture is irrelevant here.
+function app(label, { tsrConfig } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "oj-routegen-" + label + "-"));
+  mkdirSync(join(dir, "src", "routes"), { recursive: true });
+  symlinkSync(join(fixture, "node_modules"), join(dir, "node_modules"), "dir");
+  writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "app", type: "module" }));
+  writeFileSync(
+    join(dir, "src", "routes", "__root.tsx"),
+    'import { createRootRoute } from "@tanstack/react-router";\n' +
+      "export const Route = createRootRoute();\n",
+  );
+  writeFileSync(
+    join(dir, "src", "routes", "index.tsx"),
+    'import { createFileRoute } from "@tanstack/react-router";\n' +
+      'export const Route = createFileRoute("/")({});\n',
+  );
+  if (tsrConfig) writeFileSync(join(dir, "tsr.config.json"), JSON.stringify(tsrConfig));
+  return dir;
+}
+
+const generate = (dir) =>
+  execFileSync(process.execPath, [asset("start/generate.mjs")], {
+    env: { ...process.env, OJ_APP_ROOT: dir },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+maybe("the route tree lands at the default path when the app configures nothing", () => {
+  const dir = app("default");
+  try {
+    generate(dir);
+    assert.ok(existsSync(join(dir, "src", "routeTree.gen.ts")));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+maybe("tsr.config.json decides where the route tree is written", () => {
+  const dir = app("configured", {
+    tsrConfig: {
+      routesDirectory: "./src/routes",
+      generatedRouteTree: "./src/routes/routeTree.gen.ts",
+    },
+  });
+  try {
+    generate(dir);
+    assert.ok(
+      existsSync(join(dir, "src", "routes", "routeTree.gen.ts")),
+      "the tree was not written where tsr.config.json asked for it",
+    );
+    assert.ok(
+      !existsSync(join(dir, "src", "routeTree.gen.ts")),
+      "the tree was also written at the default path, so the app got two of them",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## The failure

An app whose route tree is not at the default path gets a second one it never
asked for. `oj dev` writes `src/routeTree.gen.ts`; the app goes on importing the
tree it configured; the two drift apart immediately, and for an app that checks
its route tree in, every `oj dev` dirties the working tree.

## Why

`generate.mjs` passes its settings to `getConfig` **inline**, and
`@tanstack/router-generator` merges them the way that makes inline win:

```js
const merged = { ...fileConfigRaw, ...inlineConfig };
```

So `routesDirectory`, `generatedRouteTree`, `autoCodeSplitting` and
`routeFileIgnorePattern` — every one of them a documented `tsr.config.json`
setting — cannot be set by the app at all. `routeTreeFileFooter` is in the same
schema and equally unreachable.

## The fix

Only `target` is genuinely the adapter's to decide. The other four become
*defaults*: supplied when the app has not set them, dropped when it has. An app
with no `tsr.config.json` resolves exactly as before.

## Tests

`e2e/unit/start-route-generator.test.mjs`, skipping when the `start-app` fixture
has no `node_modules`, following the convention in `optimize-deps.test.mjs`:

- the default path still applies when the app configures nothing — this is the
  no-regression half, and it passes on `main` too;
- `tsr.config.json` decides where the tree is written, and the default path does
  **not** also get one. This fails on `main` and passes here.

Verified by reverting `generate.mjs` and re-running: the first test passes, the
second fails.

## How I hit it

Building Bazel rules that run `oj dev` and `vite dev` from one generated config,
to find where the two diverge. The app in question keeps its tree at
`src/routes/routeTree.gen.ts` so the tree and the routes it types sit in one
compilation unit.