### PR TITLE
fix(start): let package.json "imports" override the framework-seam conventions

### DIFF
--- a/crates/oj_server/src/assets/start/build.mjs
+++ b/crates/oj_server/src/assets/start/build.mjs
@@ -63,7 +63,24 @@ const SERVER = [
   '',
 ].join("\n");
 
+// The app's package.json "imports" wins over the src/router convention, the
+// way it does in the SSR loader: the framework makes this path configurable
+// (`router.entry`), and an app that moved it has to be able to say so.
+function declaredRouterEntry() {
+  try {
+    const target = JSON.parse(readFileSync(resolve(APP, "package.json"), "utf8"))
+      .imports?.["#tanstack-router-entry"];
+    if (typeof target !== "string") return null;
+    const p = resolve(APP, target);
+    return existsSync(p) ? p : null;
+  } catch {
+    return null;
+  }
+}
+
 function routerEntry() {
+  const declared = declaredRouterEntry();
+  if (declared) return declared;
   for (const ext of [".tsx", ".ts", ".jsx", ".js"]) {
     const p = resolve(APP, "src/router" + ext);
     if (existsSync(p)) return p;

--- a/crates/oj_server/src/assets/start/bundle-client.mjs
+++ b/crates/oj_server/src/assets/start/bundle-client.mjs
@@ -39,7 +39,24 @@ function rewriteServerFns(code, id) {
   return `import { createClientRpc } from "@tanstack/react-start/client-rpc";\n${out}`;
 }
 
+// The app's package.json "imports" wins over the src/router convention, the
+// way it does in the SSR loader: the framework makes this path configurable
+// (`router.entry`), and an app that moved it has to be able to say so.
+function declaredRouterEntry() {
+  try {
+    const target = JSON.parse(readFileSync(resolve(APP, "package.json"), "utf8"))
+      .imports?.["#tanstack-router-entry"];
+    if (typeof target !== "string") return null;
+    const p = resolve(APP, target);
+    return existsSync(p) ? p : null;
+  } catch {
+    return null;
+  }
+}
+
 function routerEntry() {
+  const declared = declaredRouterEntry();
+  if (declared) return declared;
   for (const ext of [".tsx", ".ts", ".jsx", ".js"]) {
     const p = resolve(APP, "src/router" + ext);
     if (existsSync(p)) return p;

--- a/crates/oj_server/src/assets/start/loader.mjs
+++ b/crates/oj_server/src/assets/start/loader.mjs
@@ -553,10 +553,10 @@ function resolveUncached(spec, context, next) {
     let abs = null;
     if (clean.startsWith(".") && context.parentURL) {
       abs = probe(pathResolve(dirname(fileURLToPath(context.parentURL)), clean));
-    } else if (ALIASES[clean]) {
-      abs = probe(ALIASES[clean]);
+    } else if (clean.startsWith("#")) {
+      abs = resolveImports(clean);
     }
-    if (!abs && clean.startsWith("#")) abs = resolveImports(clean);
+    if (!abs && ALIASES[clean]) abs = probe(ALIASES[clean]);
     if (!abs) {
       try { abs = fileURLToPath(stripQ(next(clean, context).url)); } catch {}
     }
@@ -577,12 +577,15 @@ function resolveUncached(spec, context, next) {
     }
     if (abs) return { url: pathToFileURL(abs).href + "?ojsvg=react", shortCircuit: true };
   }
-  if (ALIASES[spec]) {
-    const hit = probe(ALIASES[spec]);
-    if (hit) return { url: withV(pathToFileURL(hit).href), shortCircuit: true, _ojv: true };
-  }
+  // The app's own package.json "imports" first: ALIASES below is a set of
+  // conventions for the framework seam, and a convention must not overrule a
+  // declaration.
   if (spec.startsWith("#")) {
     const hit = resolveImports(spec);
+    if (hit) return { url: withV(pathToFileURL(hit).href), shortCircuit: true, _ojv: true };
+  }
+  if (ALIASES[spec]) {
+    const hit = probe(ALIASES[spec]);
     if (hit) return { url: withV(pathToFileURL(hit).href), shortCircuit: true, _ojv: true };
   }
   if (!spec.startsWith(".") && !spec.startsWith("/")) {

--- a/e2e/unit/start-router-entry.test.mjs
+++ b/e2e/unit/start-router-entry.test.mjs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+
+// Where `#tanstack-router-entry` points. The framework makes it configurable
+// (`router.entry`, resolved against `srcDirectory`), and the adapter resolves it
+// by convention at src/router. An app that moved its router entry has to be
+// able to say so, and package.json "imports" is the mechanism the loader
+// already implements -- so a declaration has to beat the convention.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { repo } from "./harness.mjs";
+
+const fixture = join(repo, "e2e/fixtures/start-app");
+const installed = existsSync(join(fixture, "node_modules/rolldown"));
+
+// The app declares its router entry somewhere the convention would never look,
+// and also has a src/router.ts, so a pass cannot come from the convention
+// happening to find the same file.
+const app = mkdtempSync(join(tmpdir(), "oj-router-entry-"));
+mkdirSync(join(app, "src", "lib"), { recursive: true });
+mkdirSync(join(app, "src", "routes"), { recursive: true });
+writeFileSync(join(app, "src", "lib", "router.ts"), "export function getRouter() {}\n");
+writeFileSync(join(app, "src", "router.ts"), "export function getRouter() {}\n");
+writeFileSync(
+  join(app, "package.json"),
+  JSON.stringify({
+    name: "app",
+    type: "module",
+    imports: { "#tanstack-router-entry": "./src/lib/router.ts" },
+  }),
+);
+if (installed) symlinkSync(join(fixture, "node_modules"), join(app, "node_modules"), "dir");
+process.env.OJ_APP_ROOT = app;
+process.on("exit", () => rmSync(app, { recursive: true, force: true }));
+
+const maybe = installed ? test : test.skip;
+const loader = installed
+  ? await import(pathToFileURL(join(repo, "crates/oj_server/src/assets/start/loader.mjs")).href)
+  : null;
+
+maybe("a declared #tanstack-router-entry beats the src/router convention", () => {
+  const resolved = loader.resolve("#tanstack-router-entry", { parentURL: undefined }, () => {
+    throw new Error("the loader deferred a specifier it aliases");
+  });
+  assert.equal(resolved.url.split("?")[0], pathToFileURL(join(app, "src", "lib", "router.ts")).href);
+});


### PR DESCRIPTION
## The failure

An app that configures its router entry builds under Vite and fails under `oj`:

```
[RESOLVE_ERROR] Could not resolve '#tanstack-router-entry' in
  .../@tanstack/start-client-core/dist/esm/client/hydrateStart.js
  Matched alias not found for '#tanstack-router-entry'
```

`tanstackStart({ router: { entry: "lib/router" } })` is a supported framework
option — `start-plugin-core/plugin.js` resolves it through `resolveEntry` with
`defaultEntry: "router"` against `srcDirectory`, then aliases
`#tanstack-router-entry` at the resolved file.

## Why

The adapter hardcodes `<app>/src/router` — the framework default — in three
places:

| site | what it feeds |
| --- | --- |
| `loader.mjs` `ALIASES` | SSR resolution |
| `bundle-client.mjs` `routerEntry()` | rolldown `resolve.alias`, dev client bundle |
| `build.mjs` `routerEntry()` | rolldown `resolve.alias`, production build |

## The fix

`loader.mjs` already implements package.json `imports`, and an app declaring
`"#tanstack-router-entry"` there is the standard way to name a subpath. The only
problem is precedence: `ALIASES` is consulted first, so a *declaration* loses to
a *convention*. This inverts those two for `#`-prefixed specifiers, in the module
path and the asset path, and gives the two `routerEntry()`s the same rule.

An app with no `imports` entry resolves exactly as before.

## What this is not

The complete fix is for the adapter to read the app's Start configuration —
that would settle `srcDirectory` and the client/server/start entries too, not
just the router. But `start_dev(root, port, host)` takes no config and builds
its `DevServer` with `config: None`, so the app's Vite config never reaches this
code at all. I'd be glad to attempt that separately if you'd want it; this is the
smaller half that unblocks an app today.

## Tests

`e2e/unit/start-router-entry.test.mjs`, skipping when the `start-app` fixture
has no `node_modules`. The fixture app declares its entry at `src/lib/router.ts`
**and** has a `src/router.ts`, so a pass cannot come from the convention
happening to find the same file. Fails on `main`, passes here.

## How I hit it

Building Bazel rules that run `oj dev` and `vite dev` from one generated config,
to find where the two diverge.