### PR TITLE
fix(start): emit TanStack Start's declare-module footer from the generator

### DIFF
--- a/crates/oj_server/src/assets/start/generate.mjs
+++ b/crates/oj_server/src/assets/start/generate.mjs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MIT
 
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join as pathJoin, relative as pathRelative, resolve as pathResolve, sep } from "node:path";
+
 import { importPkg } from "./resolve-pkg.mjs";
 
 const root = process.env.OJ_APP_ROOT ?? process.cwd();
@@ -34,13 +37,52 @@ const { Generator, getConfig } = await importPkg(root, "@tanstack/router-generat
   "@tanstack/react-start",
 ]);
 
+const GENERATED_ROUTE_TREE = "./src/routeTree.gen.ts";
+
+// The framework's own Vite plugin appends a `declare module` block naming the
+// router entry; the app's Register interface, and so every typed route, is
+// keyed off it. Without the same block the tree written here is a different
+// file from the one the framework's tooling produces.
+function routerEntry() {
+  try {
+    const declared = JSON.parse(readFileSync(pathJoin(root, "package.json"), "utf8"))
+      .imports?.["#tanstack-router-entry"];
+    if (typeof declared === "string") {
+      const p = pathResolve(root, declared);
+      if (existsSync(p)) return p;
+    }
+  } catch {}
+  for (const ext of [".tsx", ".ts", ".jsx", ".js"]) {
+    const p = pathResolve(root, "src/router" + ext);
+    if (existsSync(p)) return p;
+  }
+  return pathResolve(root, "src/router.tsx");
+}
+
+function moduleDeclaration() {
+  let rel = pathRelative(dirname(pathResolve(root, GENERATED_ROUTE_TREE)), routerEntry());
+  if (!rel.startsWith(".")) rel = "./" + rel;
+  rel = rel.split(sep).join("/");
+  return [
+    `import type { getRouter } from '${rel}'`,
+    "import type { createStart } from '@tanstack/react-start'",
+    "declare module '@tanstack/react-start' {",
+    "  interface Register {",
+    "    ssr: true",
+    "    router: Awaited<ReturnType<typeof getRouter>>",
+    "  }",
+    "}",
+  ].join("\n");
+}
+
 const config = getConfig(
   {
     target: "react",
     routesDirectory: "./src/routes",
-    generatedRouteTree: "./src/routeTree.gen.ts",
+    generatedRouteTree: GENERATED_ROUTE_TREE,
     autoCodeSplitting: false,
     routeFileIgnorePattern: "\\.(test|spec|stories|bench)\\.|\\.d\\.ts$",
+    routeTreeFileFooter: [moduleDeclaration()],
   },
   root,
 );

--- a/e2e/unit/start-route-tree-footer.test.mjs
+++ b/e2e/unit/start-route-tree-footer.test.mjs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+
+// The `declare module` block the framework's Vite plugin appends to every
+// generated route tree (moduleDeclaration in start-plugin-core's
+// start-router-plugin). The app's Register interface is keyed off it, and so is
+// every createFileRoute in the app -- so a tree generated without it is a
+// different file from the one the framework's own tooling produces.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { asset, repo } from "./harness.mjs";
+
+const fixture = join(repo, "e2e/fixtures/start-app");
+const installed = existsSync(join(fixture, "node_modules/@tanstack/router-generator"));
+const maybe = installed ? test : test.skip;
+
+// The generator resolves @tanstack/router-generator from the app root, so the
+// app needs a node_modules; nothing else about the fixture matters here.
+function app(label, { pkg } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "oj-tree-footer-" + label + "-"));
+  mkdirSync(join(dir, "src", "routes"), { recursive: true });
+  symlinkSync(join(fixture, "node_modules"), join(dir, "node_modules"), "dir");
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({ name: "app", type: "module", ...pkg }),
+  );
+  writeFileSync(
+    join(dir, "src", "routes", "__root.tsx"),
+    'import { createRootRoute } from "@tanstack/react-router";\n' +
+      "export const Route = createRootRoute();\n",
+  );
+  writeFileSync(
+    join(dir, "src", "routes", "index.tsx"),
+    'import { createFileRoute } from "@tanstack/react-router";\n' +
+      'export const Route = createFileRoute("/")({});\n',
+  );
+  return dir;
+}
+
+const generate = (dir) =>
+  execFileSync(process.execPath, [asset("start/generate.mjs")], {
+    env: { ...process.env, OJ_APP_ROOT: dir },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+maybe("the generated tree carries the framework's declare-module footer", () => {
+  const dir = app("default");
+  try {
+    writeFileSync(join(dir, "src", "router.ts"), "export function getRouter() {}\n");
+    generate(dir);
+    const tree = readFileSync(join(dir, "src", "routeTree.gen.ts"), "utf8");
+    assert.match(tree, /import type \{ getRouter \} from '\.\/router\.ts'/);
+    assert.match(tree, /import type \{ createStart \} from '@tanstack\/react-start'/);
+    assert.match(tree, /declare module '@tanstack\/react-start'/);
+    assert.match(tree, /router: Awaited<ReturnType<typeof getRouter>>/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+maybe("the footer names the router entry the app declared", () => {
+  const dir = app("declared", {
+    pkg: { imports: { "#tanstack-router-entry": "./src/lib/router.ts" } },
+  });
+  try {
+    mkdirSync(join(dir, "src", "lib"), { recursive: true });
+    writeFileSync(join(dir, "src", "lib", "router.ts"), "export function getRouter() {}\n");
+    generate(dir);
+    const tree = readFileSync(join(dir, "src", "routeTree.gen.ts"), "utf8");
+    assert.match(tree, /import type \{ getRouter \} from '\.\/lib\/router\.ts'/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## The failure

`oj dev` rewrites a checked-in `routeTree.gen.ts` on every boot, stripping the
`declare module` block the framework's own tooling puts there. The tree the
adapter generates and the tree `@tanstack/react-start`'s Vite plugin generates
are different files.

## Why

`start-plugin-core`'s `start-router-plugin` passes a `routeTreeFileFooter` to
the generator, built by `moduleDeclaration()`:

```ts
import type { getRouter } from './router.ts'
import type { createStart } from '@tanstack/react-start'
declare module '@tanstack/react-start' {
  interface Register {
    ssr: true
    router: Awaited<ReturnType<typeof getRouter>>
  }
}
```

`Register` is what types every `createFileRoute()` in the app. `generate.mjs`
passes no footer at all, so the block is absent from anything it writes.

This matters most when the type-check is a separate step from the bundler, so
the tree is checked in and guarded — then the adapter and the framework fight
over the file.

## The fix

Build the footer the same way the plugin does: the router entry relative to the
generated tree's directory, POSIX-separated, `./`-prefixed when needed. The
no-start-entry form is emitted, matching the adapter's synthesized start entry.

The router entry is resolved by the `src/router` convention **and** by the app's
`package.json` `imports` when it has one — the same two sources the seam is
resolved from elsewhere, so the footer cannot name a different file from the one
`#tanstack-router-entry` actually resolves to.

## Tests

`e2e/unit/start-route-tree-footer.test.mjs`, skipping when the `start-app`
fixture has no `node_modules` (the convention `optimize-deps.test.mjs` uses):
the footer is present and well-formed, and it follows a declared router entry.
Both fail on `main` and pass here.

## Relationship to my other PRs

Independent of #115, #116 and #117 — this applies to `main` on its own. If #116
(tsr.config.json) lands first there is a small textual conflict in the same
`getConfig` call, which I'll happily rebase; the footer would then want the
*configured* tree path rather than the constant, and I can follow up with that.

## How I hit it

Building Bazel rules that run `oj dev` and `vite dev` from one generated config,
to find where the two diverge.