### PR TITLE
fix(start): thread --config through to the TanStack Start dev server

### DIFF
--- a/crates/oj/src/main.rs
+++ b/crates/oj/src/main.rs
@@ -106,7 +106,7 @@ async fn run() -> anyhow::Result<()> {
             if let Some(entry) = ssr {
                 ssr_dev::ssr_dev(root, entry, port, host).await
             } else if oj_server::is_tanstack_start_app(&root) {
-                start_dev::start_dev(root, port, host).await
+                start_dev::start_dev(root, port, host, config).await
             } else {
                 oj_server::DevServer {
                     root,

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -37,14 +37,29 @@ struct StartState {
     css_host: Option<Arc<tokio::sync::Mutex<Runner>>>,
 }
 
+// A --config path is resolved against the app root, the way `build` resolves
+// it, so `oj dev --config vite.config.mjs app` and `oj build --config ... app`
+// mean the same file. An absolute path is already the answer.
+fn config_path(root: &Path, config: Option<PathBuf>) -> Option<PathBuf> {
+    config.map(|c| if c.is_absolute() { c } else { root.join(c) })
+}
+
 pub async fn start_dev(
     root: PathBuf,
     port: Option<u16>,
     host: Option<String>,
+    config: Option<PathBuf>,
 ) -> anyhow::Result<()> {
     let root = root
         .canonicalize()
         .map_err(|e| anyhow::anyhow!("app root not found: {}: {e}", root.display()))?;
+
+    // Same order `build` uses: pin the override before anything reads a config,
+    // so the Rust side and the plugin host agree on which file is the config.
+    let config = config_path(&root, config);
+    if let Some(cfg) = &config {
+        oj_server::plugins::set_vite_config_override(cfg.clone());
+    }
     let cache = oj_cache::cache_root(&root).join("start");
     oj_server::prepare_cache_root(&root);
     oj_server::write_start_assets(&cache)?;
@@ -57,7 +72,7 @@ pub async fn start_dev(
             port,
             bundle: false,
             host,
-            config: None,
+            config,
             enable_cache: false,
             no_cache: false,
             lazy: false,
@@ -1228,5 +1243,19 @@ mod tests {
             !out.iter().any(|(k, _)| k == "x-bin"),
             "non-utf8 value dropped: {out:?}"
         );
+    }
+
+    #[test]
+    fn a_relative_config_path_resolves_against_the_app_root() {
+        let root = Path::new("/srv/app");
+        assert_eq!(
+            config_path(root, Some(PathBuf::from("build/vite.config.mjs"))),
+            Some(PathBuf::from("/srv/app/build/vite.config.mjs")),
+        );
+        assert_eq!(
+            config_path(root, Some(PathBuf::from("/out/vite.config.mjs"))),
+            Some(PathBuf::from("/out/vite.config.mjs")),
+        );
+        assert_eq!(config_path(root, None), None);
     }
 }


### PR DESCRIPTION
## The failure

`oj dev --config <PATH> <ROOT>` is accepted, and then dropped, when the app is a
TanStack Start app.

The one you notice first is the port. A config that sets `server.port` is
ignored, so oj serves on its default 5199 with no diagnostic — the caller thinks
it asked for a port and got one:

```
$ oj dev --config /out/vite.config.mjs /srv/app     # config sets port 5174
  oj dev (tanstack start)
  http://localhost:5199/
```

Everything else the config carries goes the same way: `server.fs.allow`,
`resolve.alias`, `resolve.dedupe`, `define`, and the app's own plugins.

## Why

```rust
// crates/oj/src/main.rs
} else if oj_server::is_tanstack_start_app(&root) {
    start_dev::start_dev(root, port, host).await     // `config` is in scope, and not passed
}
```

`start_dev` takes only `(root, port, host)` and constructs its `DevServer` with
`config: None`. Both halves then fall back to the convention search for
`vite.config.{ts,mts,mjs,js}` *inside the served root*, so a config anywhere else
is invisible. That is the normal case for a build system that generates one — it
has an output tree, not a spot in the app.

The non-Start path already threads it: `DevServer { config, .. }`.

## The fix

Threaded exactly the way `build` does it — resolve a relative path against the
app root, pin `set_vite_config_override` before anything reads a config, then
hand the same path to `DevServer`. So `oj dev --config X app` and
`oj build --config X app` cannot disagree about which file is the config.

The path resolution is pulled into a `config_path` helper with a unit test
beside the other private path helpers in `start_dev.rs`, which is where
`document_url` and `percent_decode` live.

## How I hit it

Building Bazel rules that run `oj dev` and `vite dev` from one generated config.
The config is generated into the build's output tree, so the convention search
can never find it; the port being silently 5199 is what made it visible.

Related to my other Start PRs (#115, #116, #117, #118) but independent of them —
this one applies to `main` on its own.