### PR TITLE
feat(cache): let OJ_CACHE_DIR relocate the cache root

### DIFF
--- a/crates/oj_cache/src/lib.rs
+++ b/crates/oj_cache/src/lib.rs
@@ -17,10 +17,30 @@ pub const CACHE_FORMAT: u32 = 5;
 
 pub const CACHE_ROOT_VERSION: u32 = 1;
 
+/// Where everything oj caches for an app goes.
+///
+/// `<app>/.oj-cache` by default, and `OJ_CACHE_DIR` when the caller has
+/// somewhere else for it. A build system serving a source tree it does not own
+/// -- read-only, shared between concurrent builds, or checked for cleanliness
+/// afterwards -- needs the writes to land outside it, and `OJ_SSR_BRIDGE_DIR`
+/// already works this way for the SSR bridge.
+///
+/// The version segment is appended either way: it is what makes an older
+/// layout inert rather than misread, and a caller pointing at one directory for
+/// several apps still gets that.
 pub fn cache_root(app_root: &Path) -> PathBuf {
-    app_root
-        .join(".oj-cache")
-        .join(format!("v{CACHE_ROOT_VERSION}"))
+    cache_base(app_root).join(format!("v{CACHE_ROOT_VERSION}"))
+}
+
+/// The directory `cache_root` versions inside. Callers that manage the cache
+/// area itself -- creating it, marking it ignored, healing an older layout --
+/// want this rather than the versioned path, and they have to agree with
+/// `cache_root` about where it is.
+pub fn cache_base(app_root: &Path) -> PathBuf {
+    match std::env::var_os("OJ_CACHE_DIR") {
+        Some(dir) if !dir.is_empty() => PathBuf::from(dir),
+        _ => app_root.join(".oj-cache"),
+    }
 }
 
 const LEGACY_TOP_LEVEL: &[&str] = &[
@@ -47,7 +67,7 @@ const LEGACY_TOP_LEVEL: &[&str] = &[
 ];
 
 pub fn heal_legacy_layout(app_root: &Path) {
-    let root = app_root.join(".oj-cache");
+    let root = cache_base(app_root);
     for name in LEGACY_TOP_LEVEL {
         let path = root.join(name);
         if path.is_dir() {
@@ -297,5 +317,43 @@ mod tests {
         assert!(cache.join(".gitignore").exists());
         assert!(cache_root(&app).join("start").exists());
         assert!(cache.join("user-stuff").exists(), "unknown dirs are left alone");
+    }
+
+    #[test]
+    fn cache_root_is_relocatable_and_stays_versioned() {
+        let app = Path::new("/srv/app");
+        let versioned = format!("v{CACHE_ROOT_VERSION}");
+
+        temp_env_var("OJ_CACHE_DIR", None, || {
+            assert_eq!(cache_root(app), app.join(".oj-cache").join(&versioned));
+        });
+        temp_env_var("OJ_CACHE_DIR", Some("/out/oj"), || {
+            assert_eq!(cache_root(app), Path::new("/out/oj").join(&versioned));
+        });
+        // An empty value is not a directory; it must not put the cache at "/v1".
+        temp_env_var("OJ_CACHE_DIR", Some(""), || {
+            assert_eq!(cache_root(app), app.join(".oj-cache").join(&versioned));
+        });
+        // Whoever creates and marks the cache area has to land in the same
+        // place, or a relocated cache still leaves a directory in the app.
+        temp_env_var("OJ_CACHE_DIR", Some("/out/oj"), || {
+            assert_eq!(cache_base(app), Path::new("/out/oj"));
+            assert!(cache_root(app).starts_with(cache_base(app)));
+        });
+    }
+
+    // The env is process-wide; this keeps the case above from leaking into any
+    // other test that reads it.
+    fn temp_env_var(key: &str, value: Option<&str>, f: impl FnOnce()) {
+        let previous = std::env::var_os(key);
+        match value {
+            Some(v) => unsafe { std::env::set_var(key, v) },
+            None => unsafe { std::env::remove_var(key) },
+        }
+        f();
+        match previous {
+            Some(v) => unsafe { std::env::set_var(key, v) },
+            None => unsafe { std::env::remove_var(key) },
+        }
     }
 }

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -183,7 +183,7 @@ pub fn node_compile_cache_opt_in(root: &Path) -> Option<std::ffi::OsString> {
 }
 
 pub fn prepare_cache_root(root: &Path) {
-    let dir = root.join(".oj-cache");
+    let dir = oj_cache::cache_base(root);
     if std::fs::create_dir_all(&dir).is_err() {
         return;
     }


### PR DESCRIPTION
## What

`oj_cache::cache_root` is `<app>/.oj-cache` with no way to move it, so serving
an app writes into the app.

That is fine for a checkout you own. It is wrong for a source tree you do not:

- **read-only or shared** — a build system may serve a source tree it did not
  create, or one several concurrent builds share;
- **checked for cleanliness** — a tree that is expected to be unmodified after a
  command runs;
- **walked by the build's own tooling** — in my case Gazelle generated a
  `BUILD.bazel` per cached blob under `.oj-cache/v1/**` until the directory was
  explicitly ignored, which is a fairly loud symptom of an artefact landing
  somewhere it is not expected.

`OJ_SSR_BRIDGE_DIR` already lets the SSR bridge move for the same reason, so
this follows it rather than inventing a convention.

## Details

- Unset → unchanged: `<app>/.oj-cache/v<N>`.
- Set → `$OJ_CACHE_DIR/v<N>`.
- Empty → falls back. An unset and a blank environment variable mean the same
  thing to most shells that construct one, and `/v1` would be a bad answer.

The version segment is appended either way: it is what makes an older layout
inert rather than misread, and a caller pointing one directory at several apps
still gets that.

## Tests

`cache_root_is_relocatable_and_stays_versioned` in `oj_cache`, covering the
three cases above. The existing `cache_root_is_versioned` still passes. The env
is process-wide, so the test restores whatever it found.

## How I hit it

Building Bazel rules that run `oj dev`. Bazel's model is that a build writes to
its own output tree and leaves the source tree alone, so `.oj-cache` appearing
in the workspace is the one artefact I could not keep out of it.