### PR TITLE
fix(config): say when a vite config produced no values

### DIFF
--- a/crates/oj_server/src/plugins.rs
+++ b/crates/oj_server/src/plugins.rs
@@ -192,11 +192,46 @@ pub struct ViteValues {
     pub optimize_deps: Option<serde_json::Value>,
 }
 
+/// Why a run of the extractor produced nothing usable, or None when it did.
+///
+/// Kept separate from the reporting so the classification can be tested: the
+/// interesting cases are a subprocess that wrote nothing at all and one that
+/// wrote something that is not JSON, and reproducing either through a real
+/// `node` is harder than it is worth.
+fn extraction_failure(status: std::process::ExitStatus, stdout: &[u8], parse: Option<&str>) -> Option<String> {
+    match parse {
+        None => None,
+        Some(_) if stdout.is_empty() => Some(format!(
+            "wrote nothing at all and exited with {status}"
+        )),
+        Some(e) => Some(format!(
+            "wrote {} bytes that are not JSON ({e}) and exited with {status}",
+            stdout.len()
+        )),
+    }
+}
+
 pub fn extract_vite_values(root: &Path) -> Option<ViteValues> {
     if plugins_file(root).is_some() {
         return None;
     }
-    let vite = vite_config_file(root)?;
+    // Every way this function declines to produce values looks the same from
+    // the outside: the server starts and serves, with `server.fs.allow`,
+    // `resolve.alias`, `define` and the rest quietly absent. A config that was
+    // named and then not read is a mistake, not a configuration.
+    let vite = match vite_config_file(root) {
+        Some(v) => v,
+        None => {
+            if let Some(named) = VITE_CONFIG_OVERRIDE.get() {
+                eprintln!(
+                    "oj: --config named {} and it is not a readable file; continuing \
+                     without any of the values it would have carried",
+                    named.display()
+                );
+            }
+            return None;
+        }
+    };
     let store = oj_cache::config_extract::ConfigExtractStore::new(
         root,
         &format!(
@@ -233,7 +268,16 @@ pub fn extract_vite_values(root: &Path) -> Option<ViteValues> {
     if !stderr.is_empty() {
         eprint!("{stderr}");
     }
-    let json: serde_json::Value = serde_json::from_slice(&out.stdout).ok()?;
+    let parsed = serde_json::from_slice::<serde_json::Value>(&out.stdout);
+    let parse_err = parsed.as_ref().err().map(|e| e.to_string());
+    if let Some(why) = extraction_failure(out.status, &out.stdout, parse_err.as_deref()) {
+        eprintln!(
+            "oj: extracting {} {why}; server.fs.allow, resolve.alias, define and the \
+             rest of that config are not in effect",
+            vite.display()
+        );
+    }
+    let json: serde_json::Value = parsed.ok()?;
     if json.get("__ok").and_then(|v| v.as_bool()) == Some(true) {
         let deps: Vec<PathBuf> = json
             .get("__deps")
@@ -920,6 +964,42 @@ mod ssr_bridge_tests {
         cleanup_ssr_bridge(&root);
         assert!(!dir.exists());
         let _ = std::fs::remove_dir_all(&root);
+    }
+}
+
+#[cfg(test)]
+mod extraction_failure_tests {
+    use super::extraction_failure;
+
+    // A status is only constructible by running something, and `true`/`false`
+    // are the two the classification cares about.
+    fn status(ok: bool) -> std::process::ExitStatus {
+        std::process::Command::new(if ok { "true" } else { "false" })
+            .status()
+            .expect("a shell builtin binary")
+    }
+
+    #[test]
+    fn valid_json_is_not_a_failure() {
+        assert_eq!(extraction_failure(status(true), b"{}", None), None);
+    }
+
+    // The one that hid a real bug: the extractor skipped its own body and
+    // exited 0, which is indistinguishable from a config with nothing in it
+    // unless somebody says so.
+    #[test]
+    fn a_silent_successful_run_is_a_failure() {
+        let why = extraction_failure(status(true), b"", Some("EOF while parsing a value"))
+            .expect("nothing on stdout is not a config");
+        assert!(why.contains("wrote nothing at all"), "{why}");
+    }
+
+    #[test]
+    fn unparseable_output_reports_its_size_and_the_parse_error() {
+        let why = extraction_failure(status(false), b"not json", Some("expected value"))
+            .expect("output that is not JSON is not a config");
+        assert!(why.contains("8 bytes"), "{why}");
+        assert!(why.contains("expected value"), "{why}");
     }
 }
 


### PR DESCRIPTION
## What

`extract_vite_values` has three ways to decline, and none of them says anything.
The server starts, serves, and has `server.fs.allow`, `resolve.alias`, `define`,
`dedupe` and `optimizeDeps` quietly absent — which looks exactly like a config
that had none of those in it.

| path | what happens today |
| --- | --- |
| `--config` names a file that is not readable | `vite_config_file` → `None`, so does this |
| the extractor writes something that is not JSON | `from_slice(...).ok()?` swallows it |
| the extractor writes nothing at all and exits 0 | `{}`-shaped absence, indistinguishable from an empty config |

## Why the third one matters

That is what a run looks like when the extractor skips its own body. It is
reachable today: `vite-extract.mjs` guards everything behind

```js
const isMainRun = import.meta.url === pathToFileURL(process.argv[1] || "").href;
```

Node canonicalises the entry module, so `import.meta.url` is symlink-free while
`argv[1]` is whatever the caller passed. Any symlink in that path makes them
disagree — every path under `/var` on macOS arrives as `/private/var` — and the
script then does nothing, writes nothing, and exits 0.

I hit that for real: `server.fs.allow` and `resolve.alias` silently stopped
being applied on macOS only, and it took four rounds of bisecting CI to find,
because nothing anywhere said the config had not been read. With this patch it
is one line:

```
oj: extracting /…/vite.config.mjs wrote nothing at all and exited with exit status: 0;
server.fs.allow, resolve.alias, define and the rest of that config are not in effect
```

I have a separate one-line fix for the `isMainRun` comparison itself (compare
realpaths) and am happy to send it — but the silence is the more valuable fix,
because it is what let a two-line bug hide.

## Tests

The classification is pulled into `extraction_failure` so it can be tested
without provoking a real `node` into failing three different ways:
`valid_json_is_not_a_failure`, `a_silent_successful_run_is_a_failure`,
`unparseable_output_reports_its_size_and_the_parse_error`.

## How I hit it

Building Bazel rules that run `oj dev` and `vite dev` from one generated config,
which means the config lives in a build output directory rather than beside the
app — so the extractor's path is one I construct, and it had a symlink in it.