### PR TITLE
fix(config): decide isMainRun on the real path, not the spelling

### DIFF
--- a/crates/oj_server/src/assets/vite-extract.mjs
+++ b/crates/oj_server/src/assets/vite-extract.mjs
@@ -4,7 +4,7 @@
 import { createRequire } from "node:module";
 import { pathToFileURL, fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
-import { writeFileSync, readFileSync } from "node:fs";
+import { writeFileSync, readFileSync, realpathSync } from "node:fs";
 
 const configPath = process.argv[2];
 const appRoot = process.argv[3];
@@ -177,7 +177,25 @@ function warnUnsupported(c) {
   }
 }
 
-const isMainRun = import.meta.url === pathToFileURL(process.argv[1] || "").href;
+// Whether this module is the entry, compared on the real path rather than the
+// spelling. Node canonicalizes the entry module, so import.meta.url is always
+// symlink-free while argv[1] is whatever the caller typed -- on macOS a path
+// under /var reaches us as /private/var, and the two never match. Getting this
+// wrong is silent: the body below is skipped, nothing is written, and the
+// process exits 0 as though the config simply had nothing in it.
+const isMainRun = (() => {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  const self = fileURLToPath(import.meta.url);
+  const real = (p) => {
+    try {
+      return realpathSync(p);
+    } catch {
+      return resolve(p);
+    }
+  };
+  return real(self) === real(entry);
+})();
 export { extractAlias };
 
 if (isMainRun) try {

--- a/e2e/unit/vite-extract-main-run.test.mjs
+++ b/e2e/unit/vite-extract-main-run.test.mjs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+
+// The extractor only does anything when it is the entry module, and it decides
+// that by comparing import.meta.url against argv[1]. Node canonicalizes the
+// entry, so import.meta.url is symlink-free while argv[1] is whatever the
+// caller typed. Any symlink in that path -- /var on macOS, a build system
+// pointing the cache somewhere linked -- makes the two disagree.
+//
+// Getting it wrong is silent by construction: the body is skipped, nothing is
+// written to stdout, and the process exits 0, which the caller cannot tell
+// apart from a config that genuinely had nothing in it.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { asset } from "./harness.mjs";
+
+// argv[2] names a config that does not exist, so the run fails immediately --
+// what is under test is whether it runs at all, not what it extracts.
+function runVia(dir) {
+  return execFileSync(
+    process.execPath,
+    [join(dir, "vite-extract.mjs"), join(dir, "no-such.config.mjs"), dir],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+}
+
+test("the extractor runs when its path reaches it through a symlink", () => {
+  const base = mkdtempSync(join(tmpdir(), "oj-vite-extract-"));
+  try {
+    const real = join(base, "real");
+    mkdirSync(real);
+    copyFileSync(asset("vite-extract.mjs"), join(real, "vite-extract.mjs"));
+    symlinkSync(real, join(base, "link"), "dir");
+
+    // Through the real path it writes "{}" on a failed load; through the
+    // symlink it has to do the same rather than exit silently.
+    assert.equal(runVia(real), "{}");
+    assert.equal(runVia(join(base, "link")), "{}");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## The bug

`vite-extract.mjs` guards its entire body with:

```js
const isMainRun = import.meta.url === pathToFileURL(process.argv[1] || "").href;
if (isMainRun) try { … }
```

Node canonicalises the entry module, so `import.meta.url` is symlink-free. `argv[1]`
is whatever the caller passed. **Any symlink in that path makes the two disagree** —
and on macOS every path under `/var` arrives as `/private/var`, so it is not an
exotic case.

When they disagree the script does nothing, writes nothing, and exits 0.

## Reproduction

Two commands, on any platform:

```console
$ mkdir -p /tmp/x/real && ln -s /tmp/x/real /tmp/x/link
$ cp crates/oj_server/src/assets/vite-extract.mjs /tmp/x/real/

$ node /tmp/x/real/vite-extract.mjs /nonexistent.mjs /tmp
oj: could not extract vite.config values: Error [ERR_MODULE_NOT_FOUND] …    # runs

$ node /tmp/x/link/vite-extract.mjs /nonexistent.mjs /tmp
$                                                                          # exit 0, nothing
```

## Why it matters in practice

`extract_vite_values` builds the script path from `cache_root(root)`. Today
`root` has already been canonicalised by `build_app`, so the paths happen to
agree and nobody notices. They stop agreeing as soon as the cache root comes
from anywhere else — which is exactly what happens with `OJ_CACHE_DIR`
(#120), or for anyone pointing oj at a path that goes through a symlink.

What I actually saw: `server.fs.allow` and `resolve.alias` silently stopped
being applied on macOS only. `/@fs` answered 403 and a first-party bare
specifier resolved nowhere, with no error anywhere — because a skipped body and
an empty config are the same thing to the caller. It took four rounds of
bisecting CI to find.

## The fix

Compare realpaths, falling back to the resolved path when a component does not
exist so a missing entry is still a mismatch rather than a throw.

## Tests

`e2e/unit/vite-extract-main-run.test.mjs` runs the extractor through both a real
directory and a symlink to it and requires the same output from each. Fails on
`main`, passes here. Full `e2e/unit` suite: 125 pass.

## Related

#121 makes this class of failure audible — it reports when an extraction
produced no values instead of returning an all-`None` config. That patch is what
found this one, and the two are independent: this fixes the cause, #121 makes
the next one like it visible in a single log line.