### PR TITLE
experimental: Cloudflare workerd SSR dev (behind OJ_CF_WORKERD)

### DIFF
--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -42,6 +42,12 @@ process.on("unhandledRejection", (e) => {
 // of aborting the load, keeping the editor middleware (dev-server bridge) alive.
 const ojStartMode = initial.ojStartMode === true;
 
+// Experimental: run Cloudflare (@cloudflare/vite-plugin) SSR in workerd via the
+// plugin's dev integration. Off by default; when off, plugin-host behaves as if
+// none of the workerd shims exist (the plugin's configureServer skips as before,
+// no Miniflare boots). See issue #122.
+const cfWorkerd = ojStartMode && process.env.OJ_CF_WORKERD === "1";
+
 const _ojTTY = process.stderr.isTTY && !process.env.NO_COLOR;
 const OJ = _ojTTY ? "\x1b[48;2;255;255;255m\x1b[1;38;2;42;51;212m oj \x1b[0m" : "oj";
 
@@ -216,7 +222,7 @@ function withResolvedDefaults(config) {
         reportCompressedSize: true,
         chunkSizeWarningLimit: 500,
       },
-      server: { headers: {} },
+      server: cfWorkerd ? { headers: {} } : {},
       define: {},
       resolve: {},
       optimizeDeps: {},
@@ -569,13 +575,32 @@ let middlewarePort = null;
 async function setupConfigureServer() {
   const stack = [];
   const middlewares = {
-    stack,
     use(a, b) {
       if (typeof a === "function") stack.push({ path: null, fn: a });
       else stack.push({ path: a, fn: b });
     },
   };
   const noop = () => {};
+  let cfHandleInvoke = null;
+  if (cfWorkerd) {
+    const ojBase = `http://127.0.0.1:${resolvedConfig.server?.port ?? 5199}`;
+    const { createInvokeHandler } = await import("./start/ssr-fetch-module.mjs");
+    cfHandleInvoke = createInvokeHandler({
+      resolveId: async (url, importer) => {
+        const q = new URLSearchParams({ spec: url, importer: importer || "", noExternal: "1" });
+        const rr = await fetch(`${ojBase}/@ssr-resolve?${q}`);
+        if (!rr.ok) return null;
+        const j = await rr.json();
+        return j.external ? { id: j.spec || url, external: true, type: "module" } : { id: j.id, file: j.id };
+      },
+      load: async (id) => {
+        const mr = await fetch(`${ojBase}/@ssr-module?${new URLSearchParams({ id, runner: "1" })}`);
+        if (!mr.ok) throw new Error(`fetchModule ${id}: ${mr.status}`);
+        return await mr.text();
+      },
+      transform: (code) => code,
+    });
+  }
   const makeHot = () => ({
     on(e, cb) { wsApi.on(e, cb); },
     off(e, cb) { wsApi.off(e, cb); },
@@ -583,18 +608,17 @@ async function setupConfigureServer() {
     listen: noop,
     close: noop,
     setInvokeHandler: noop,
-    async handleInvoke() {
-      return { error: { name: "Error", message: "oj: handleInvoke not yet wired" } };
-    },
+    handleInvoke: cfHandleInvoke ?? (async () => ({ error: { name: "Error", message: "oj: cf workerd disabled" } })),
   });
   const environments = {};
-  for (const name of Object.keys(resolvedConfig.environments ?? {})) {
+  for (const name of cfWorkerd ? Object.keys(resolvedConfig.environments ?? {}) : []) {
     environments[name] = {
       name,
       config: resolvedConfig,
       mode: "dev",
       bundledDev: false,
       hot: makeHot(),
+      pluginContainer: { buildStart: async () => {}, buildEnd: async () => {}, close: async () => {} },
       depsOptimizer: { init: noop, async registerMissingImport() {} },
       initRunner() { return { import: async () => ({}) }; },
       async fetchWorkerExportTypes() { return {}; },
@@ -602,20 +626,24 @@ async function setupConfigureServer() {
   }
   const server = {
     config: resolvedConfig,
-    environments,
     middlewares,
-    httpServer: { on: noop, once: noop, address: () => null },
+    httpServer: null,
     ws: wsApi,
     hot: wsApi,
     watcher: { on: noop, off: noop, add: noop, unwatch: noop, close: noop, emit: () => true, removeAllListeners: noop },
     moduleGraph: { getModuleById: () => null, getModulesByFile: () => null, invalidateModule: noop, onFileChange: noop },
     restart: async () => {},
-    close: async () => {},
     transformRequest: async () => null,
     ssrLoadModule: async () => {
       throw new Error("oj: server.ssrLoadModule is not available in configureServer");
     },
   };
+  if (cfWorkerd) {
+    server.environments = environments;
+    server.httpServer = { on: noop, once: noop, address: () => null };
+    server.close = async () => {};
+    middlewares.stack = stack;
+  }
   const post = [];
   for (const p of plugins) {
     if (typeof p.configureServer !== "function") continue;

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -569,6 +569,7 @@ let middlewarePort = null;
 async function setupConfigureServer() {
   const stack = [];
   const middlewares = {
+    stack,
     use(a, b) {
       if (typeof a === "function") stack.push({ path: null, fn: a });
       else stack.push({ path: a, fn: b });
@@ -578,12 +579,13 @@ async function setupConfigureServer() {
   const server = {
     config: resolvedConfig,
     middlewares,
-    httpServer: null,
+    httpServer: { on: noop, once: noop, address: () => null },
     ws: wsApi,
     hot: wsApi,
     watcher: { on: noop, off: noop, add: noop, unwatch: noop, close: noop, emit: () => true, removeAllListeners: noop },
     moduleGraph: { getModuleById: () => null, getModulesByFile: () => null, invalidateModule: noop, onFileChange: noop },
     restart: async () => {},
+    close: async () => {},
     transformRequest: async () => null,
     ssrLoadModule: async () => {
       throw new Error("oj: server.ssrLoadModule is not available in configureServer");

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -216,7 +216,7 @@ function withResolvedDefaults(config) {
         reportCompressedSize: true,
         chunkSizeWarningLimit: 500,
       },
-      server: {},
+      server: { headers: {} },
       define: {},
       resolve: {},
       optimizeDeps: {},

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -576,8 +576,33 @@ async function setupConfigureServer() {
     },
   };
   const noop = () => {};
+  const makeHot = () => ({
+    on(e, cb) { wsApi.on(e, cb); },
+    off(e, cb) { wsApi.off(e, cb); },
+    send(a, b) { wsApi.send(a, b); },
+    listen: noop,
+    close: noop,
+    setInvokeHandler: noop,
+    async handleInvoke() {
+      return { error: { name: "Error", message: "oj: handleInvoke not yet wired" } };
+    },
+  });
+  const environments = {};
+  for (const name of Object.keys(resolvedConfig.environments ?? {})) {
+    environments[name] = {
+      name,
+      config: resolvedConfig,
+      mode: "dev",
+      bundledDev: false,
+      hot: makeHot(),
+      depsOptimizer: { init: noop, async registerMissingImport() {} },
+      initRunner() { return { import: async () => ({}) }; },
+      async fetchWorkerExportTypes() { return {}; },
+    };
+  }
   const server = {
     config: resolvedConfig,
+    environments,
     middlewares,
     httpServer: { on: noop, once: noop, address: () => null },
     ws: wsApi,

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -792,11 +792,12 @@ async fn ssr_resolve(
     let (Some(importer), Some(spec)) = (q.get("importer"), q.get("spec")) else {
         return (StatusCode::BAD_REQUEST, "importer and spec required").into_response();
     };
+    let no_external = q.get("noExternal").map(|v| v == "1").unwrap_or(false);
     let importer_dir = Path::new(importer).parent().unwrap_or(&state.root);
     match state.ssr_resolver.resolve(importer_dir, spec) {
         Ok(p) => {
             let s = p.to_string_lossy();
-            let body = if s.contains("/node_modules/") {
+            let body = if !no_external && s.contains("/node_modules/") {
                 serde_json::json!({ "external": true, "spec": spec })
             } else {
                 serde_json::json!({ "id": s })

--- a/e2e/ssr-runner-endpoint.mjs
+++ b/e2e/ssr-runner-endpoint.mjs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+// The dev server serves module-runner-transformed code over
+// /@ssr-module?...&runner=1 (the fetch-module backend a Vite module runner
+// calls), while the default (no runner flag) path is unchanged ESM.
+
+import { spawn, execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repo = path.join(here, "..");
+const oj = path.join(repo, "target", "debug", "oj");
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+execSync("cargo build -p oj", { cwd: repo, stdio: "inherit" });
+
+const app = fs.mkdtempSync(path.join(os.tmpdir(), "oj-runner-"));
+fs.mkdirSync(path.join(app, "src"), { recursive: true });
+fs.writeFileSync(path.join(app, "package.json"), JSON.stringify({ name: "runner-app", version: "1.0.0", type: "module" }));
+fs.writeFileSync(path.join(app, "src", "dep.js"), "export const dep = 1;\n");
+fs.writeFileSync(
+  path.join(app, "src", "mod.js"),
+  'import { dep } from "./dep.js";\nexport const val = () => dep + 1;\nexport default val;\n',
+);
+fs.writeFileSync(
+  path.join(app, "index.html"),
+  `<!doctype html><html><body><script type="module" src="/src/mod.js"></script></body></html>`,
+);
+
+const port = 5611;
+const srv = spawn(oj, ["dev", app, "--port", String(port)], { stdio: "ignore" });
+let failed = false;
+try {
+  for (let i = 0; i < 100; i++) { try { if ((await fetch(`http://localhost:${port}/`)).ok) break; } catch {} await sleep(200); }
+  const modId = path.join(app, "src", "mod.js");
+
+  const runner = await (await fetch(`http://localhost:${port}/@ssr-module?id=${encodeURIComponent(modId)}&runner=1`)).text();
+  assert.match(runner, /await __vite_ssr_import__\("\.\/dep\.js", \{"importedNames":\["dep"\]\}\)/, `runner import: ${runner}`);
+  assert.match(runner, /\(0, __vite_ssr_import_0__\.dep\)/, `runner live member: ${runner}`);
+  assert.match(runner, /__vite_ssr_exportName__\("val"/, `runner export: ${runner}`);
+  assert.doesNotMatch(runner, /^import /m, `runner still has an import statement: ${runner}`);
+
+  const plain = await (await fetch(`http://localhost:${port}/@ssr-module?id=${encodeURIComponent(modId)}`)).text();
+  assert.match(plain, /^import \{ dep \} from "\.\/dep\.js";/m, `non-runner should be plain ESM: ${plain}`);
+  assert.doesNotMatch(plain, /__vite_ssr_/, `non-runner must not be runner-transformed: ${plain}`);
+
+  console.log("SSR-RUNNER-ENDPOINT E2E PASSED");
+} catch (err) {
+  failed = true;
+  console.error("SSR-RUNNER-ENDPOINT E2E FAILED:", err.message);
+} finally {
+  srv.kill("SIGKILL");
+  await sleep(300);
+  fs.rmSync(app, { recursive: true, force: true });
+}
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Progress on #122 — running a Cloudflare app's SSR in workerd/Miniflare via `@cloudflare/vite-plugin`, native (no Vite embed). **Gated behind `OJ_CF_WORKERD=1`, off by default.**

## Flag off (default) — verified no-op
`configureServer(vite-plugin-cloudflare:dev)` skips exactly as on `main`; no Miniflare boots; routes serve through oj's Node SSR. Verified on the real app (`/`, `/health`, `/login` → 200) and `start.mjs` e2e is green. All workerd shims (server-shape, `server.environments`, `config.server.headers`) are gated so flag-off is equivalent to main behavior.

## Flag on — where it reaches (items 1–4 of #122)
- `config.server.headers` defaults to `{}` so `new Miniflare()` constructs (the real cause of the old `Unexpected options` error — a `JSON.stringify(undefined)`, not a bad option).
- `server.environments[worker]` shell + `pluginContainer.buildStart` + `httpServer`/`close`/`middlewares.stack` shims → the plugin's `configureServer` completes and workerd/Miniflare boots.
- `handleInvoke` wired to the already-tested `ssr-fetch-module.mjs` responder, backed by two Rust endpoints: `/@ssr-resolve?noExternal=1` (internalizes node_modules for workerd) and `/@ssr-module?...&runner=1` (module-runner-transformed code).

## Not done (items 5–6 — need a live-Miniflare loop)
- `initRunner` — the runner-worker WebSocket handshake (stub, so the in-workerd runner does not yet fetch modules).
- Rerouting SSR document requests through `miniflare.dispatchFetch`.

So with the flag on, workerd boots but routes do not yet render through it.

## Resolve/externalize policy — validated vs Vite 8.2.1 + the plugin, with known gaps
The `FetchResult` shapes (`data:`/builtin→`builtin`, http→`network`, internal→`{code,file,id,url,invalidate}`) and `noExternal` direction match Vite/the CF worker env exactly. Documented limitations for the live-Miniflare work: `node:*` must not be blanket-externalized (nodejs_compat splits workerd-native vs unenv-polyfilled); internalized CJS deps need dep pre-bundling (highest risk); `.wasm` additional-module sentinels; `type:network` won't import in workerd; `bun:` is irrelevant.

## Tests
- `e2e/ssr-runner-endpoint.mjs` — `runner=1` serves runner-transformed code; non-runner is unchanged ESM.
- `ssr-fetch-module.mjs` responder: 11 unit tests (reused by the wiring).
- `start.mjs` (flag-off) green — no regression.
