### PR TITLE
feat(stylex): add native StyleX compiler and pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,6 +918,7 @@ dependencies = [
  "oxc_semantic",
  "oxc_sourcemap",
  "oxc_span",
+ "oxc_str",
  "oxc_syntax",
  "ryu-js",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,6 +905,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "fru"
+version = "0.1.16"
+dependencies = [
+ "blake3",
+ "memchr",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_ast_visit",
+ "oxc_codegen",
+ "oxc_parser",
+ "oxc_semantic",
+ "oxc_sourcemap",
+ "oxc_span",
+ "oxc_syntax",
+ "ryu-js",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,6 +1858,7 @@ dependencies = [
  "rolldown",
  "rolldown_common",
  "rolldown_plugin",
+ "rolldown_sourcemap",
  "rolldown_utils",
  "serde_json",
  "tokio",
@@ -1848,6 +1870,7 @@ name = "oj_cache"
 version = "0.1.16"
 dependencies = [
  "blake3",
+ "fru",
  "proptest",
  "serde",
  "serde_json",
@@ -1858,6 +1881,7 @@ dependencies = [
 name = "oj_compiler"
 version = "0.1.16"
 dependencies = [
+ "fru",
  "glob",
  "memchr",
  "oxc_allocator",
@@ -1943,6 +1967,7 @@ dependencies = [
  "anyhow",
  "axum",
  "blake3",
+ "fru",
  "futures-util",
  "glob",
  "json-strip-comments",
@@ -3824,6 +3849,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "ryu-js"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
 
 [[package]]
 name = "same-file"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/oj_compiler",
+    "crates/stylex",
     "crates/oj_css",
     "crates/oj_env",
     "crates/oj_config",
@@ -26,6 +27,7 @@ oj_css = { version = "0.1.16", path = "crates/oj_css" }
 oj_env = { version = "0.1.16", path = "crates/oj_env" }
 oj_config = { version = "0.1.16", path = "crates/oj_config" }
 oj_server = { version = "0.1.16", path = "crates/oj_server" }
+fru = { version = "0.1.16", path = "crates/stylex" }
 
 oxc_allocator = "0.146.0"
 oxc_parser = "0.146.0"

--- a/crates/oj/Cargo.toml
+++ b/crates/oj/Cargo.toml
@@ -22,6 +22,7 @@ tokio.workspace = true
 rolldown = "1.2.5"
 rolldown_common = "1.2.5"
 rolldown_plugin = "1.2.5"
+rolldown_sourcemap = "1.2.5"
 rolldown_utils = "1.2.5"
 arcstr = "1.2.0"
 serde_json.workspace = true

--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -212,6 +212,9 @@ struct OjCssPlugin {
     /// Source ids of `?worker` / `?worker&url` entries emitted as chunks, so the
     /// document-only build helpers can skip chunks that only a worker loads.
     worker_entries: Arc<Mutex<std::collections::HashSet<String>>>,
+    /// StyleX pass configured: swap the `@stylex;` directive for the build
+    /// sentinel so the assembled sheet can be spliced in after bundling.
+    stylex: bool,
 }
 
 /// The app build settings an inline worker bundle shares with its importer:
@@ -772,6 +775,7 @@ async fn compile_stylesheet(
     resolve: &oj_css::CssResolveConfig,
     path: &str,
     id: &str,
+    stylex: bool,
 ) -> anyhow::Result<oj_css::CssOutput> {
     let cfg = oj_config::OjConfig {
         css: css.clone(),
@@ -781,6 +785,11 @@ async fn compile_stylesheet(
     let is_stylus = oj_server::sidecar::is_stylus(path);
     let mut source =
         std::fs::read_to_string(path).map_err(|e| anyhow::anyhow!("cannot read {path}: {e}"))?;
+    // Mirrors the dev path: `@stylex;` handling precedes the sidecars.
+    let stylex_sentinel = stylex && oj_server::stylex::has_directive(&source);
+    if stylex_sentinel {
+        source = oj_server::stylex::substitute_directive(&source, STYLEX_SENTINEL_COMMENT);
+    }
     // Run the plugin transform chain on the raw CSS source first, so directive
     // transformers (UnoCSS `@apply`/`@unocss-include`, etc.) resolve before oj
     // preprocesses and compiles it.
@@ -834,6 +843,10 @@ async fn compile_stylesheet(
     // way), on the source as transformed so far rather than re-read from disk.
     if tailwind || has_postcss {
         source = expand_css_via_sidecar(root, std::path::Path::new(path), &source)?;
+    }
+    if stylex_sentinel {
+        // lightningcss drops comments; the unknown at-rule survives.
+        source = source.replace(STYLEX_SENTINEL_COMMENT, STYLEX_SENTINEL_AT);
     }
     let css_id = match std::path::Path::new(path).strip_prefix(root) {
         Ok(rel) => format!("/{}", rel.display()),
@@ -1033,6 +1046,7 @@ impl Plugin for OjCssPlugin {
         let host = self.host.clone();
         let css_transform_enabled = Arc::clone(&self.css_transform_enabled);
         let self_has_postcss = self.has_postcss;
+        let stylex = self.stylex;
         let css_cfg = self.css.clone();
         let css_resolve = self.resolve.clone();
         let html_inline = Arc::clone(&self.html_inline);
@@ -1061,6 +1075,7 @@ impl Plugin for OjCssPlugin {
                         &css_resolve,
                         file,
                         &id,
+                        stylex,
                     )
                     .await?;
                     let stem = std::path::Path::new(file)
@@ -1190,6 +1205,7 @@ impl Plugin for OjCssPlugin {
                         &css_resolve,
                         file,
                         &id,
+                        stylex,
                     )
                     .await?;
                     return Ok(Some(rolldown_plugin::HookLoadOutput {
@@ -1252,6 +1268,7 @@ impl Plugin for OjCssPlugin {
                         worker: worker.clone(),
                         resolve: css_resolve.clone(),
                         worker_entries: Arc::clone(&worker_entries),
+                        stylex: false,
                     };
                     let code = bundle_worker_inline(&root, file, worker.as_ref(), nested).await?;
                     let literal = serde_json::Value::String(code).to_string();
@@ -1331,6 +1348,7 @@ impl Plugin for OjCssPlugin {
                 &css_resolve,
                 path,
                 &id,
+                stylex,
             )
             .await?;
             // A CSS module: the class map as default plus named exports per
@@ -1357,6 +1375,110 @@ impl Plugin for OjCssPlugin {
             }))
         }
     }
+}
+
+/// What the `@stylex;` directive becomes while css sidecars run (postcss and
+/// friends keep comments)…
+const STYLEX_SENTINEL_COMMENT: &str = "/*__OJ_STYLEX__*/";
+/// …and what rides through `oj_css::compile_css`: lightningcss drops comments
+/// but prints unknown at-rules verbatim, minified output included.
+const STYLEX_SENTINEL_AT: &str = "@-oj-stylex-sentinel;";
+
+/// The build-path StyleX pass: the string-level `stylex_pass` as a rolldown
+/// transform hook (hooks are string-in/string-out and see raw TSX — rolldown's
+/// builtin oxc lowering runs after them). The dev pipeline instead mutates its
+/// own parsed AST via `stylex_pass_ast`; this seam stays on strings by nature.
+/// Rules accumulate per module; the sheet is assembled once after bundling and
+/// spliced into `collected_css`.
+#[derive(Debug)]
+struct OjStylexPlugin {
+    pass: Arc<oj_server::stylex::StylexPassConfig>,
+    rules: StylexRules,
+}
+
+/// Keyed by module path (mirrors the dev registry's BTreeMap) so the rule feed
+/// into assembly is deterministic under rolldown's parallel module transforms.
+type StylexRules =
+    Arc<Mutex<std::collections::BTreeMap<PathBuf, Vec<oj_server::stylex::StylexRule>>>>;
+
+impl Plugin for OjStylexPlugin {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("oj:stylex")
+    }
+
+    fn register_hook_usage(&self) -> rolldown_plugin::HookUsage {
+        rolldown_plugin::HookUsage::Transform
+    }
+
+    fn transform(
+        &self,
+        _ctx: SharedTransformPluginContext,
+        args: &HookTransformArgs<'_>,
+    ) -> impl std::future::Future<Output = HookTransformReturn> + Send {
+        let id = args.id.to_string();
+        let code = args.code.to_string();
+        let pass = Arc::clone(&self.pass);
+        let rules = Arc::clone(&self.rules);
+        async move {
+            let path_str = id.split(['?', '#']).next().unwrap_or(&id);
+            let path = Path::new(path_str);
+            if !pass.is_candidate(path, &code) {
+                return Ok(None);
+            }
+            let out = oj_compiler::stylex::stylex_pass(path, &code, &pass)
+                .map_err(|e| anyhow::anyhow!("stylex: {e}"))?;
+            if !out.rules.is_empty() {
+                rules.lock().unwrap().insert(path.to_path_buf(), out.rules);
+            }
+            let map = out.map;
+            Ok(out.code.map(|code| rolldown_plugin::HookTransformOutput {
+                code: Some(code),
+                // The splice moves line positions, so reporting no map would
+                // leave rolldown composing against the pre-transform text.
+                map: match map.as_deref().and_then(parse_sourcemap) {
+                    Some(map) => HookTransformOutputMap::Sourcemap(Box::new(map)),
+                    None => HookTransformOutputMap::Null,
+                },
+                ..Default::default()
+            }))
+        }
+    }
+}
+
+/// The splice map arrives as JSON; rolldown wants an owned SourceMap.
+fn parse_sourcemap(json: &str) -> Option<rolldown_sourcemap::SourceMap> {
+    let parsed: rolldown_sourcemap::JSONSourceMap = serde_json::from_str(json).ok()?;
+    rolldown_sourcemap::SourceMap::from_json(parsed).ok()
+}
+
+/// Assemble the collected rules and splice the sheet over every sentinel in
+/// `collected_css`. Returns the sheet when rules exist but no stylesheet
+/// carried the directive, so the caller can emit it standalone.
+fn join_stylex_css(
+    pass: &oj_server::stylex::StylexPassConfig,
+    rules: &StylexRules,
+    collected_css: &Arc<Mutex<Vec<(String, String)>>>,
+) -> anyhow::Result<Option<String>> {
+    let all: Vec<oj_server::stylex::StylexRule> =
+        rules.lock().unwrap().values().flatten().cloned().collect();
+    let mut entries = collected_css.lock().unwrap();
+    let has_sentinel = entries
+        .iter()
+        .any(|(_, css)| css.contains(STYLEX_SENTINEL_AT));
+    if all.is_empty() && !has_sentinel {
+        return Ok(None);
+    }
+    let sheet = oj_server::stylex::assemble_sheet(&all, pass)
+        .map_err(|e| anyhow::anyhow!("stylex assemble error: {e}"))?;
+    if has_sentinel {
+        for (_, css) in entries.iter_mut() {
+            if css.contains(STYLEX_SENTINEL_AT) {
+                *css = css.replace(STYLEX_SENTINEL_AT, &sheet);
+            }
+        }
+        return Ok(None);
+    }
+    Ok((!all.is_empty()).then_some(sheet))
 }
 
 /// Tailwind / PostCSS over `css` (the file's content as processed so far, not
@@ -2125,6 +2247,7 @@ async fn user_plugin_host(
     environments: &serde_json::Value,
     env_name: &str,
     mode: &str,
+    stylex_native: bool,
 ) -> Option<Arc<PluginHost>> {
     let (file, plugins_format, label) = match oj_server::plugins::plugin_source(root)? {
         oj_server::plugins::PluginSource::OjPlugins(p) => {
@@ -2133,13 +2256,18 @@ async fn user_plugin_host(
         }
         oj_server::plugins::PluginSource::ViteConfig(p) => (p, "vite", "vite.config".to_string()),
     };
-    let config = serde_json::json!({
+    let mut config = serde_json::json!({
         "config": { "root": root.display().to_string(), "base": base, "mode": mode, "command": "build", "define": define, "environments": environments },
         "env": { "command": "build", "mode": mode },
         "environment": { "name": env_name, "mode": "build" },
         "pluginsFormat": plugins_format,
-    })
-    .to_string();
+    });
+    if stylex_native {
+        // Same dedupe as dev: the native pass replaces the pilot's Babel Vite
+        // plugin; hosting both would transform stylex modules twice.
+        config["nativePluginNames"] = serde_json::json!(["lovable:stylex-transform"]);
+    }
+    let config = config.to_string();
     match PluginHost::spawn(root, &file, &config).await {
         Ok(host) => {
             println!("oj build ({env_name}): plugins from {label}");
@@ -2293,6 +2421,7 @@ pub async fn build(
     root: PathBuf,
     cli_mode: Option<&str>,
     cli: CliOptions,
+    stylex_config: Option<PathBuf>,
 ) -> anyhow::Result<()> {
     let root = root
         .canonicalize()
@@ -2485,6 +2614,16 @@ pub async fn build(
     let worker_entries: Arc<Mutex<std::collections::HashSet<String>>> =
         Arc::new(Mutex::new(std::collections::HashSet::new()));
     let css_split = css_code_split_of(&config);
+    // Build defaults to prod rules (no debug classnames) unless the config's
+    // `dev` key says otherwise; the dev-server default is NODE_ENV-driven.
+    let stylex_pass = oj_server::stylex::resolve_pass_config(
+        stylex_config.as_deref(),
+        &config,
+        &root,
+        mode != "production",
+    )
+    .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let stylex_rules: StylexRules = Arc::default();
     let plugin_host = user_plugin_host(
         &root,
         &base,
@@ -2492,6 +2631,7 @@ pub async fn build(
         &serde_json::json!(config.environments),
         "client",
         mode,
+        stylex_pass.is_some(),
     )
     .await;
     let plugin_defines = plugin_config_defines(&plugin_host).await;
@@ -2516,6 +2656,16 @@ pub async fn build(
         pairs.extend(plugin_defines);
         pairs
     };
+    if let Some(pass) = &stylex_pass {
+        println!(
+            "oj build: stylex native pass enabled ({} include glob(s))",
+            pass.include.len()
+        );
+        oj_plugins.push(Arc::new(OjStylexPlugin {
+            pass: Arc::new(pass.clone()),
+            rules: Arc::clone(&stylex_rules),
+        }));
+    }
     oj_plugins.push(Arc::new(OjCssPlugin {
         collected: Arc::clone(&collected_css),
         root: root.to_path_buf(),
@@ -2535,6 +2685,7 @@ pub async fn build(
             minify: client_minify,
         })),
         worker_entries: Arc::clone(&worker_entries),
+        stylex: stylex_pass.is_some(),
     }));
     let out_ov = ro_output_overrides(ro_opts);
     // Vite's build import analysis (preload wrapping, polyfill) only applies to
@@ -2752,6 +2903,39 @@ pub async fn build(
         }
     }
 
+    // StyleX joins before either CSS emission path reads `collected_css`: the
+    // assembled sheet replaces the sentinel in place. When rules exist but no
+    // stylesheet carried the directive, the sheet becomes its own entry: a
+    // synthetic `collected_css` member when CSS is combined, a standalone
+    // hashed stylesheet linked from every page when CSS is split (a synthetic
+    // entry would match no chunk's modules and be dropped).
+    let mut stylex_css_link: Option<String> = None;
+    if let Some(pass) = &stylex_pass {
+        if let Some(sheet) = join_stylex_css(pass, &stylex_rules, &collected_css)? {
+            if css_split {
+                fs::create_dir_all(out_dir.join("assets"))?;
+                let hash = content_hash(sheet.as_bytes());
+                let css_name = format!("assets/stylex-{}.css", &hash[..8]);
+                fs::write(out_dir.join(&css_name), &sheet)?;
+                emitted.push((css_name.clone(), sheet.len()));
+                for entry in &mut manifest_entries {
+                    if entry.is_entry {
+                        entry.css.push(css_name.clone());
+                    }
+                }
+                stylex_css_link = Some(format!(
+                    "<link rel=\"stylesheet\" href=\"{}\" />",
+                    with_base(&css_name, &base)
+                ));
+            } else {
+                collected_css
+                    .lock()
+                    .unwrap()
+                    .push((root.join("stylex.css").display().to_string(), sheet));
+            }
+        }
+    }
+
     // Non-split CSS is one combined stylesheet linked from every page.
     let combined_css_name: Option<String> = if !css_split {
         let mut css_entries = collected_css.lock().unwrap().clone();
@@ -2899,6 +3083,7 @@ pub async fn build(
                     &link_css_resolve,
                     &src_str,
                     &src_str,
+                    stylex_pass.is_some(),
                 )
                 .await
                 .with_context(|| format!("stylesheet {href} linked from {}", doc.out_rel))?;
@@ -2958,6 +3143,9 @@ pub async fn build(
             });
         }
 
+        if let Some(link) = &stylex_css_link {
+            rewritten_html = insert_before_head(&rewritten_html, link);
+        }
         if let Some(css_name) = &combined_css_name {
             let link = format!(
                 "<link rel=\"stylesheet\" href=\"{}\" crossorigin />",
@@ -3713,6 +3901,7 @@ pub(crate) async fn build_ssr(
         &serde_json::json!(config.environments),
         "ssr",
         mode,
+        false,
     )
     .await;
     let plugin_defines = plugin_config_defines(&plugin_host).await;
@@ -3771,6 +3960,7 @@ pub(crate) async fn build_ssr(
         html_inline: Arc::new(Mutex::new(std::collections::HashMap::new())),
         worker: None,
         worker_entries: Arc::new(Mutex::new(std::collections::HashSet::new())),
+        stylex: false,
     }));
     let mut bundler = BundlerBuilder::default()
         .with_plugins(oj_plugins)
@@ -3932,6 +4122,7 @@ async fn build_server_fns(root: &Path, out_dir: &Path, mode: &str) -> anyhow::Re
                 html_inline: Arc::new(Mutex::new(std::collections::HashMap::new())),
                 worker: None,
                 worker_entries: Arc::new(Mutex::new(std::collections::HashSet::new())),
+                stylex: false,
             })])
             .with_options(BundlerOptions {
                 input: Some(vec![InputItem {
@@ -4284,6 +4475,7 @@ async fn build_client_entry(
         &serde_json::json!(config.environments),
         "client",
         mode,
+        false,
     )
     .await;
     let plugin_defines = plugin_config_defines(&plugin_host).await;
@@ -4309,6 +4501,7 @@ async fn build_client_entry(
         html_inline: Arc::new(Mutex::new(std::collections::HashMap::new())),
         worker: None,
         worker_entries: Arc::new(Mutex::new(std::collections::HashSet::new())),
+        stylex: false,
     }));
 
     let mut bundler = BundlerBuilder::default()
@@ -4542,6 +4735,7 @@ async fn build_library(
                 html_inline: Arc::new(Mutex::new(std::collections::HashMap::new())),
                 worker: None,
                 worker_entries: Arc::new(Mutex::new(std::collections::HashSet::new())),
+                stylex: false,
             })])
             .with_options(BundlerOptions {
                 input: Some(
@@ -5643,7 +5837,7 @@ mod tests {
             .unwrap();
             fs::write(root.join("shared.js"), r#"export const shared = "ready";"#).unwrap();
 
-            build(root.clone(), Some("production"), CliOptions::default())
+            build(root.clone(), Some("production"), CliOptions::default(), None)
                 .await
                 .expect("synthetic shared-chunk fixture should build");
 
@@ -5776,7 +5970,7 @@ mod tests {
             fs::write(root.join("main.js"), "window.ready = true;").unwrap();
             fs::write(root.join("public/asset.txt"), "public asset").unwrap();
 
-            build(root.clone(), Some("production"), CliOptions::default())
+            build(root.clone(), Some("production"), CliOptions::default(), None)
                 .await
                 .expect("synthetic public-directory fixture should build");
 
@@ -5810,7 +6004,7 @@ mod tests {
         .unwrap();
         fs::write(root.join("server.js"), "export const flag = process.env.SOME_FLAG;\n").unwrap();
 
-        build(root.clone(), Some("production"), CliOptions::default())
+        build(root.clone(), Some("production"), CliOptions::default(), None)
             .await
             .expect("client build");
         let mut client = String::new();
@@ -5869,7 +6063,7 @@ mod tests {
         .unwrap();
         fs::write(root.join("public/manifest.webmanifest"), "{}").unwrap();
 
-        build(root.clone(), Some("production"), CliOptions::default())
+        build(root.clone(), Some("production"), CliOptions::default(), None)
             .await
             .expect("html asset fixture should build");
         let html = fs::read_to_string(root.join("dist/index.html")).unwrap();
@@ -5916,7 +6110,7 @@ mod tests {
             "export default { build: { lib: { entry: 'src/index.ts', name: 'MyLib' } } };",
         )
         .unwrap();
-        build(root.clone(), Some("production"), CliOptions::default())
+        build(root.clone(), Some("production"), CliOptions::default(), None)
             .await
             .expect("vite.config build.lib should build");
         assert!(root.join("dist/my-lib.js").is_file(), "es output named after the unscoped package");
@@ -5936,7 +6130,7 @@ mod tests {
             "export default { build: { lib: { entry: { main: 'src/a.ts', extra: 'src/b.ts' }, cssFileName: 'theme' } } };",
         )
         .unwrap();
-        build(root.clone(), Some("production"), CliOptions::default())
+        build(root.clone(), Some("production"), CliOptions::default(), None)
             .await
             .expect("multi-entry lib should build");
         for f in ["main.mjs", "extra.mjs", "main.js", "extra.js"] {
@@ -5955,7 +6149,7 @@ mod tests {
             "export default { build: { lib: { entry: 'src/index.ts', formats: ['umd'] } } };",
         )
         .unwrap();
-        let err = build(root.clone(), Some("production"), CliOptions::default())
+        let err = build(root.clone(), Some("production"), CliOptions::default(), None)
             .await
             .expect_err("umd needs build.lib.name");
         assert!(err.to_string().contains("build.lib.name"), "{err}");
@@ -5993,7 +6187,7 @@ mod tests {
             r#"<html><body><script type="module" src="/src/main.js"></script></body></html>"#,
         )
         .unwrap();
-        build(root.clone(), Some("production"), CliOptions::default())
+        build(root.clone(), Some("production"), CliOptions::default(), None)
             .await
             .expect("inline worker fixture should build");
         let mut code = String::new();
@@ -6678,4 +6872,100 @@ mod tests {
         assert!(out.contains("var d = 1;"), "classic scripts untouched: {out}");
     }
 
+    #[test]
+    fn stylex_sentinel_at_rule_survives_css_minification() {
+        // The whole reason the directive rides as an at-rule and not as the
+        // sidecar-phase comment: lightningcss drops comments (collapsing the
+        // then-empty layer), but prints unknown at-rules verbatim.
+        let src = format!("@layer stylex {{\n  {STYLEX_SENTINEL_AT}\n}}\nbody{{margin:0}}");
+        let out = oj_css::compile_css("/src/styles.css", &src, true).unwrap();
+        assert_eq!(
+            out.css,
+            format!("@layer stylex{{{STYLEX_SENTINEL_AT}}}body{{margin:0}}")
+        );
+        let commented =
+            format!("@layer stylex {{\n  {STYLEX_SENTINEL_COMMENT}\n}}\nbody{{margin:0}}");
+        let out = oj_css::compile_css("/src/styles.css", &commented, true).unwrap();
+        assert!(
+            !out.css.contains("__OJ_STYLEX__"),
+            "comment unexpectedly survived — the two-stage swap can be dropped: {}",
+            out.css
+        );
+    }
+
+    fn stylex_test_pass() -> oj_server::stylex::StylexPassConfig {
+        oj_server::stylex::StylexPassConfig::new(
+            PathBuf::from("/app"),
+            PathBuf::from("/app"),
+            &["src/**".into()],
+            &[],
+            false,
+            true,
+            None,
+        )
+        .unwrap()
+    }
+
+    fn stylex_rule(class: &str, ltr: &str, priority: f64) -> oj_server::stylex::StylexRule {
+        oj_server::stylex::StylexRule {
+            class_name: class.into(),
+            ltr: ltr.into(),
+            rtl: None,
+            const_key: None,
+            const_val: None,
+            priority,
+        }
+    }
+
+    #[test]
+    fn stylex_join_substitutes_every_sentinel_in_place() {
+        let pass = stylex_test_pass();
+        let rules: StylexRules = Arc::default();
+        rules.lock().unwrap().insert(
+            PathBuf::from("/app/src/a.tsx"),
+            vec![stylex_rule("x1", ".x1{color:red}", 3000.0)],
+        );
+        let collected = Arc::new(Mutex::new(vec![
+            (
+                "/app/src/styles.css".to_string(),
+                format!("@layer stylex{{{STYLEX_SENTINEL_AT}}}"),
+            ),
+            (
+                "/app/src/plain.css".to_string(),
+                "body{margin:0}".to_string(),
+            ),
+        ]));
+        let standalone = join_stylex_css(&pass, &rules, &collected).unwrap();
+        assert!(standalone.is_none(), "sentinel found: no standalone sheet");
+        let entries = collected.lock().unwrap();
+        assert_eq!(
+            entries[0].1,
+            "@layer stylex{\n@layer priority1;\n@layer priority1{\n.x1{color:red}\n}}"
+        );
+        assert_eq!(entries[1].1, "body{margin:0}", "non-sentinel css untouched");
+    }
+
+    #[test]
+    fn stylex_join_returns_a_standalone_sheet_without_a_sentinel() {
+        let pass = stylex_test_pass();
+        let rules: StylexRules = Arc::default();
+        rules.lock().unwrap().insert(
+            PathBuf::from("/app/src/a.tsx"),
+            vec![stylex_rule("x1", ".x1{color:red}", 3000.0)],
+        );
+        let collected = Arc::new(Mutex::new(vec![(
+            "/app/src/plain.css".to_string(),
+            "body{margin:0}".to_string(),
+        )]));
+        let standalone = join_stylex_css(&pass, &rules, &collected).unwrap();
+        assert_eq!(
+            standalone.as_deref(),
+            Some("\n@layer priority1;\n@layer priority1{\n.x1{color:red}\n}")
+        );
+        // No rules and no sentinel: nothing to do.
+        let empty: StylexRules = Arc::default();
+        assert!(join_stylex_css(&pass, &empty, &collected)
+            .unwrap()
+            .is_none());
+    }
 }

--- a/crates/oj/src/main.rs
+++ b/crates/oj/src/main.rs
@@ -38,6 +38,10 @@ enum Command {
         /// Vite's `--mode` for the dev server (default `development`).
         #[arg(long)]
         mode: Option<String>,
+        /// StyleX config as JSON (same schema as the `stylex` config section;
+        /// also OJ_STYLEX_CONFIG=<path>), for apps whose config can't carry it.
+        #[arg(long)]
+        stylex_config: Option<PathBuf>,
         /// Enable the experimental on-disk module cache (also OJ_ENABLE_CACHE=1).
         /// Off by default; warm restarts then re-serve compiled modules from disk.
         #[arg(long)]
@@ -105,6 +109,10 @@ enum Command {
         /// configured environment, so this is accepted as a no-op.
         #[arg(long)]
         app: bool,
+        /// StyleX config as JSON (same schema as the `stylex` config section;
+        /// also OJ_STYLEX_CONFIG=<path>), for apps whose config can't carry it.
+        #[arg(long)]
+        stylex_config: Option<PathBuf>,
     },
     Preview {
         root: Option<PathBuf>,
@@ -148,6 +156,7 @@ async fn run() -> anyhow::Result<()> {
             host,
             config,
             mode,
+            stylex_config,
             enable_cache,
             no_cache,
             lazy,
@@ -171,6 +180,7 @@ async fn run() -> anyhow::Result<()> {
                     bundle,
                     host,
                     config,
+                    stylex_config,
                     enable_cache,
                     no_cache,
                     lazy,
@@ -209,6 +219,7 @@ async fn run() -> anyhow::Result<()> {
             ssr_manifest,
             watch,
             app: _,
+            stylex_config,
         } => {
             let root = root.unwrap_or_else(|| {
                 let playground = PathBuf::from("playground");
@@ -240,6 +251,7 @@ async fn run() -> anyhow::Result<()> {
                         ssr_manifest,
                         watch,
                     },
+                    stylex_config,
                 )
                 .await
             }

--- a/crates/oj/src/ssr_dev.rs
+++ b/crates/oj/src/ssr_dev.rs
@@ -45,6 +45,7 @@ pub async fn ssr_dev(
         bundle: false,
         host,
         config: None,
+        stylex_config: None,
         enable_cache: false,
         no_cache: false,
         lazy: false,

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -88,6 +88,7 @@ pub async fn start_dev(
             bundle: false,
             host,
             config,
+            stylex_config: None,
             enable_cache: false,
             no_cache: false,
             lazy: false,

--- a/crates/oj_cache/Cargo.toml
+++ b/crates/oj_cache/Cargo.toml
@@ -7,6 +7,7 @@ description = "Content-addressed persistent cache for compiled module outputs"
 
 [dependencies]
 blake3.workspace = true
+fru.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 

--- a/crates/oj_cache/src/lib.rs
+++ b/crates/oj_cache/src/lib.rs
@@ -111,6 +111,10 @@ pub struct CachedModule {
     /// context, and these are the `accept` declarations for the module graph.
     #[serde(default)]
     pub hot: Option<HotMeta>,
+    /// StyleX rules extracted from this module, persisted so warm starts can
+    /// rebuild the server-side registry without retransforming.
+    #[serde(default)]
+    pub stylex_rules: Vec<fru::rules::StylexRule>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
@@ -220,6 +224,14 @@ mod tests {
             fs_allow: Vec::new(),
             watch_files: Vec::new(),
             hot: None,
+            stylex_rules: vec![fru::rules::StylexRule {
+                class_name: "xtest".into(),
+                ltr: ".xtest{color:red}".into(),
+                rtl: None,
+                const_key: None,
+                const_val: None,
+                priority: 3000.0,
+            }],
         }
     }
 
@@ -256,6 +268,14 @@ mod tests {
             resalted.key(b"source", "/src/App.tsx", "dev"),
             "env defines salt"
         );
+    }
+
+    #[test]
+    fn entries_without_stylex_rules_still_deserialize() {
+        // Pre-stylex cache entries lack the field; serde(default) keeps them valid.
+        let legacy = r#"{"code":"x","map_data_url":null,"imports":[],"is_boundary":false}"#;
+        let module: CachedModule = serde_json::from_str(legacy).unwrap();
+        assert!(module.stylex_rules.is_empty());
     }
 
     #[test]

--- a/crates/oj_cache/tests/common/mod.rs
+++ b/crates/oj_cache/tests/common/mod.rs
@@ -37,6 +37,7 @@ pub fn module(code: &str) -> CachedModule {
         fs_allow: vec!["/node_modules/react".into()],
         watch_files: vec!["/tailwind.config.ts".into()],
         hot: None,
+        stylex_rules: Vec::new(),
     }
 }
 

--- a/crates/oj_cache/tests/faults.rs
+++ b/crates/oj_cache/tests/faults.rs
@@ -228,6 +228,7 @@ fn an_entry_is_only_ever_published_whole() {
         fs_allow: vec!["/tmp/a b/c".into()],
         watch_files: vec!["\\\\?\\C:\\x".into()],
         hot: None,
+        stylex_rules: Vec::new(),
     };
     f.cache.put(&key, &written);
     assert_eq!(f.cache.get(&key), Some(written));

--- a/crates/oj_cache/tests/properties.rs
+++ b/crates/oj_cache/tests/properties.rs
@@ -32,6 +32,7 @@ fn cached_module() -> impl Strategy<Value = CachedModule> {
                 fs_allow: pairs.iter().map(|(a, _)| a.clone()).collect(),
                 watch_files: pairs.iter().map(|(_, b)| b.clone()).collect(),
                 hot: None,
+                stylex_rules: Vec::new(),
             },
         )
 }

--- a/crates/oj_compiler/Cargo.toml
+++ b/crates/oj_compiler/Cargo.toml
@@ -23,6 +23,7 @@ serde_json.workspace = true
 oxc_codegen.workspace = true
 oxc_sourcemap = "8.0.2"
 thiserror.workspace = true
+fru.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/oj_compiler/src/cjs.rs
+++ b/crates/oj_compiler/src/cjs.rs
@@ -31,6 +31,7 @@ pub fn compile_dep(
             sourcemap: false,
             ssr: false,
             jsx: crate::JsxConfig::default(),
+            stylex: None,
         };
         crate::compile_module(path, source_text, &opts, Some(resolve))
     } else {
@@ -217,6 +218,7 @@ export default (module.exports && module.exports.__esModule) ? module.exports["d
         dynamic_imports: Vec::new(),
         is_refresh_boundary: false,
         hot_accept: None,
+        stylex_rules: Vec::new(),
     })
 }
 

--- a/crates/oj_compiler/src/lib.rs
+++ b/crates/oj_compiler/src/lib.rs
@@ -9,6 +9,7 @@ pub mod interop;
 pub mod ssr;
 pub mod json;
 pub mod pkgbundle;
+pub mod stylex;
 
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
@@ -131,15 +132,16 @@ impl JsxConfig {
 }
 
 #[derive(Debug, Clone)]
-pub struct CompileOptions {
+pub struct CompileOptions<'a> {
     pub dev: bool,
     pub refresh: bool,
     pub sourcemap: bool,
     pub ssr: bool,
     pub jsx: JsxConfig,
+    pub stylex: Option<&'a stylex::StylexPassConfig>,
 }
 
-impl CompileOptions {
+impl<'a> CompileOptions<'a> {
     pub fn dev() -> Self {
         Self {
             dev: true,
@@ -147,6 +149,7 @@ impl CompileOptions {
             sourcemap: true,
             ssr: false,
             jsx: JsxConfig::default(),
+            stylex: None,
         }
     }
 
@@ -157,6 +160,7 @@ impl CompileOptions {
             sourcemap: true,
             ssr: false,
             jsx: JsxConfig::default(),
+            stylex: None,
         }
     }
 }
@@ -171,6 +175,7 @@ pub struct CompileOutput {
     /// `Some` when the module references `import.meta.hot` (it needs a hot
     /// context injected); what its `accept` calls declared.
     pub hot_accept: Option<HotAccept>,
+    pub stylex_rules: Vec<stylex::StylexRule>,
 }
 
 /// The `import.meta.hot.accept(...)` forms a module uses (Vite's
@@ -299,6 +304,12 @@ pub fn compile_module_with_maps(
     let source_type = SourceType::from_path(path)
         .map_err(|_| CompileError::UnsupportedFileType(path.to_path_buf()))?;
 
+    // Cheap StyleX pre-gate (path glob + SIMD scan) before the parse; the pass
+    // itself runs on the parsed AST below.
+    let stylex_cfg = opts
+        .stylex
+        .filter(|cfg| cfg.is_candidate(path, source_text));
+
     let allocator = Allocator::default();
 
     let parsed = Parser::new(&allocator, source_text, source_type).parse();
@@ -315,6 +326,25 @@ pub fn compile_module_with_maps(
         });
     }
     let mut program = parsed.program;
+
+    // StyleX mutates the freshly parsed AST, before semantic/Transformer
+    // lowering (babel-parity position: sx JSX props and TS types still
+    // visible). Synthesized nodes carry replaced-node (or empty) spans, so the
+    // codegen sourcemap below maps the ORIGINAL source — the string seam's
+    // transformed-source map trade is gone. Asymmetry: the build path
+    // (rolldown plugin, oj/src/build.rs) stays on the string-level
+    // `stylex_pass`, string-in/string-out by nature.
+    let stylex_rules = match stylex_cfg {
+        Some(cfg) => {
+            stylex::stylex_pass_ast(&allocator, &mut program, path, source_text, cfg)
+                .map_err(|message| CompileError::Transform {
+                    path: path.to_path_buf(),
+                    message,
+                })?
+                .rules
+        }
+        None => Vec::new(),
+    };
 
     let semantic_ret = SemanticBuilder::new()
         .with_excess_capacity(2.0)
@@ -398,7 +428,8 @@ pub fn compile_module_with_maps(
 
     // Synthesized nodes (glob / dynamic-import-vars) carry generated-string spans
     // with no origin in this module's source; sourcemapping them panics oxc's
-    // builder on out-of-range spans, so skip the map for those modules.
+    // builder on out-of-range spans, so skip the map for those modules. StyleX
+    // nodes are exempt: they carry in-range replaced-node spans or empty spans.
     let codegen_options = CodegenOptions {
         source_map_path: (opts.sourcemap && !synthesized).then(|| path.to_path_buf()),
         ..CodegenOptions::default()
@@ -421,6 +452,7 @@ pub fn compile_module_with_maps(
         dynamic_imports,
         is_refresh_boundary,
         hot_accept,
+        stylex_rules,
     })
 }
 
@@ -1022,6 +1054,7 @@ export const used: A extends B ? number : number = c + d;
                 sourcemap: false,
                 ssr: false,
                 jsx: JsxConfig::default(),
+                stylex: None,
             },
             None,
         )
@@ -1039,6 +1072,134 @@ export const used: A extends B ? number : number = c + d;
         assert!(
             matches!(err, CompileError::UnsupportedFileType(_)),
             "got {err:?}"
+        );
+    }
+
+    fn stylex_cfg() -> stylex::StylexPassConfig {
+        stylex::StylexPassConfig::new(
+            PathBuf::from("/app"),
+            PathBuf::from("/app"),
+            &["src/**".into()],
+            &[],
+            true,
+            false,
+            None,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn stylex_seam_compiles_source_and_attaches_rules() {
+        let cfg = stylex_cfg();
+        let src = "import * as stylex from '@stylexjs/stylex';\n\
+                   const styles = stylex.create({ root: { color: 'red', ':hover': { color: 'blue' } } });\n\
+                   export const attrs = stylex.props(styles.root);\n";
+        let mut opts = CompileOptions::dev();
+        opts.stylex = Some(&cfg);
+        let out = compile_module(Path::new("/app/src/a.ts"), src, &opts, None).unwrap();
+        assert!(!out.code.contains("stylex.create"), "create compiled away");
+        assert!(
+            !out.code.contains("@stylexjs/stylex"),
+            "import removed via DCE"
+        );
+        assert_eq!(out.stylex_rules.len(), 2, "base + hover rule");
+        for rule in &out.stylex_rules {
+            assert!(out.code.contains(&*rule.class_name) || rule.ltr.contains(":hover"));
+        }
+        assert!(
+            out.map_data_url.is_some(),
+            "stylex-modified module keeps a real map"
+        );
+    }
+
+    fn b64_decode(s: &str) -> Vec<u8> {
+        const ALPHABET: &[u8; 64] =
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        let idx = |c: u8| ALPHABET.iter().position(|&a| a == c).unwrap() as u32;
+        let bytes: Vec<u8> = s.bytes().filter(|&c| c != b'=' && c != b'\n').collect();
+        let mut out = Vec::new();
+        for chunk in bytes.chunks(4) {
+            let mut v = 0u32;
+            for (i, &c) in chunk.iter().enumerate() {
+                v |= idx(c) << (18 - 6 * i);
+            }
+            out.push((v >> 16) as u8);
+            if chunk.len() > 2 {
+                out.push((v >> 8) as u8);
+            }
+            if chunk.len() > 3 {
+                out.push(v as u8);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn stylex_seam_sourcemap_maps_the_original_source() {
+        let cfg = stylex_cfg();
+        // `styles` is exported so DCE keeps the compiled create object (an
+        // unexported, fully-inlined one is pruned along with its mapping).
+        let src = "import * as stylex from '@stylexjs/stylex';\n\
+                   export const styles = stylex.create({ root: { color: 'red' } });\n\
+                   export const attrs = stylex.props(styles.root);\n";
+        let mut opts = CompileOptions::dev();
+        opts.stylex = Some(&cfg);
+        let out = compile_module(Path::new("/app/src/a.ts"), src, &opts, None).unwrap();
+        let url = out
+            .map_data_url
+            .expect("stylex-modified module keeps a real map");
+        let json = String::from_utf8(b64_decode(url.rsplit(',').next().unwrap())).unwrap();
+        let map = oxc_sourcemap::SourceMap::from_json_string(&json).unwrap();
+        assert_eq!(
+            map.get_source_content(0),
+            Some(src),
+            "sourcesContent is the ORIGINAL source, not the transformed text"
+        );
+        // The compiled create/props replacements keep mappings into their
+        // source lines (0-based lines 1 and 2).
+        assert!(map.get_tokens().any(|t| t.get_src_line() == 1), "{json}");
+        assert!(map.get_tokens().any(|t| t.get_src_line() == 2), "{json}");
+        let n_lines = src.lines().count() as u32;
+        assert!(
+            map.get_tokens().all(|t| t.get_src_line() < n_lines),
+            "every mapping stays inside the original source"
+        );
+    }
+
+    #[test]
+    fn stylex_seam_skips_unmatched_paths_and_stylex_free_sources() {
+        let cfg = stylex_cfg();
+        let mut opts = CompileOptions::dev();
+        opts.stylex = Some(&cfg);
+        let src = "import * as stylex from '@stylexjs/stylex';\nexport const x = stylex;\n";
+        let outside = compile_module(Path::new("/app/lib/a.ts"), src, &opts, None).unwrap();
+        assert!(outside.stylex_rules.is_empty());
+        assert!(
+            outside.code.contains("@stylexjs/stylex"),
+            "untouched outside the glob"
+        );
+        let plain = compile_module(
+            Path::new("/app/src/b.ts"),
+            "export const y = 1;",
+            &opts,
+            None,
+        )
+        .unwrap();
+        assert!(plain.stylex_rules.is_empty());
+    }
+
+    #[test]
+    fn stylex_authoring_error_surfaces_as_transform_error() {
+        let cfg = stylex_cfg();
+        let mut opts = CompileOptions::dev();
+        opts.stylex = Some(&cfg);
+        let src = "import * as stylex from '@stylexjs/stylex';\n\
+                   const dyn = Math.random();\n\
+                   export const styles = stylex.create({ root: { color: dyn } });\n";
+        let err = compile_module(Path::new("/app/src/a.ts"), src, &opts, None).unwrap_err();
+        assert!(
+            matches!(err, CompileError::Transform { .. }),
+            "stylex errors ride the transform-error path, got {err:?}"
         );
     }
 
@@ -1125,6 +1286,7 @@ export const used: A extends B ? number : number = c + d;
                 sourcemap: false,
                 ssr: false,
                 jsx: JsxConfig::default(),
+                stylex: None,
             },
             None,
         )

--- a/crates/oj_compiler/src/stylex.rs
+++ b/crates/oj_compiler/src/stylex.rs
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: MIT
+// StyleX pass plumbing: gate, config, and the dev/build compile seams.
+
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+use fru::api::{transform_program, transform_source_mapped_in, FileContext};
+use fru::module_resolution::StdFs;
+use fru::options::{CompilerOptions, ResolvedOptions};
+use memchr::memmem::Finder;
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Program;
+use serde_json::json;
+
+pub use fru::rules::StylexRule;
+
+/// Bump when the pass's output semantics change: it is folded into cache keys
+/// so modules persisted by an older pass are never replayed.
+pub const STYLEX_PASS_VERSION: u32 = 2;
+
+static F_STYLEX: LazyLock<Finder<'static>> = LazyLock::new(|| Finder::new("stylex"));
+
+#[derive(Debug, Clone)]
+pub struct StylexPassConfig {
+    /// The app root: the compiler's cwd (pins `$$css` debug-string derivation).
+    pub app_root: PathBuf,
+    /// Base directory the include/exclude globs are relative to, and the
+    /// `unstable_moduleResolution` rootDir for cross-file theme references.
+    pub root_dir: PathBuf,
+    pub include: Vec<glob::Pattern>,
+    pub exclude: Vec<glob::Pattern>,
+    pub dev: bool,
+    pub use_css_layers: bool,
+    pub class_name_prefix: Option<String>,
+    options: ResolvedOptions,
+}
+
+impl StylexPassConfig {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        app_root: PathBuf,
+        root_dir: PathBuf,
+        include: &[String],
+        exclude: &[String],
+        dev: bool,
+        use_css_layers: bool,
+        class_name_prefix: Option<String>,
+    ) -> Result<Self, String> {
+        let compile = |globs: &[String]| -> Result<Vec<glob::Pattern>, String> {
+            globs
+                .iter()
+                .map(|g| {
+                    glob::Pattern::new(g).map_err(|e| format!("invalid stylex glob {g:?}: {e}"))
+                })
+                .collect()
+        };
+        let raw = CompilerOptions {
+            dev: Some(json!(dev)),
+            class_name_prefix: class_name_prefix.as_ref().map(|prefix| json!(prefix)),
+            // Always on: oj's dev graph is unbundled and oxc's TS transform elides
+            // imports the pass leaves unused, so without the compensation imports a
+            // theme/const module would drop out of the graph and its rules with it.
+            treeshake_compensation: Some(json!(true)),
+            unstable_module_resolution: Some(json!({
+                "type": "commonJS",
+                "rootDir": root_dir.to_string_lossy().replace('\\', "/"),
+            })),
+            ..CompilerOptions::default()
+        };
+        let options = raw
+            .resolve()
+            .map_err(|e| format!("invalid stylex options: {e}"))?;
+        Ok(Self {
+            app_root,
+            root_dir,
+            include: compile(include)?,
+            exclude: compile(exclude)?,
+            dev,
+            use_css_layers,
+            class_name_prefix,
+            options,
+        })
+    }
+
+    pub fn matches_path(&self, file: &Path) -> bool {
+        let rel = file.strip_prefix(&self.root_dir).unwrap_or(file);
+        let rel = rel.to_string_lossy().replace('\\', "/");
+        self.include.iter().any(|p| p.matches(&rel))
+            && !self.exclude.iter().any(|p| p.matches(&rel))
+    }
+
+    /// Cheap per-module gate: the path must be included and the source must
+    /// mention "stylex" (SIMD scan) before the pass pays for anything.
+    pub fn is_candidate(&self, file: &Path, source: &str) -> bool {
+        crate::scan(&F_STYLEX, source) && self.matches_path(file)
+    }
+
+    /// Canonical config identity for cache salting (callers hash it).
+    pub fn salt_input(&self) -> String {
+        let globs =
+            |v: &[glob::Pattern]| v.iter().map(|p| p.as_str()).collect::<Vec<_>>().join(",");
+        format!(
+            "stylex-pass-v{STYLEX_PASS_VERSION};appRoot={};root={};include={};exclude={};dev={};layers={};prefix={}",
+            self.app_root.display(),
+            self.root_dir.display(),
+            globs(&self.include),
+            globs(&self.exclude),
+            self.dev,
+            self.use_css_layers,
+            self.class_name_prefix.as_deref().unwrap_or("x"),
+        )
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct StylexPassOutput {
+    /// `Some` = the transform changed the module; feed this to the pipeline.
+    pub code: Option<String>,
+    /// v3 map for `code`; the splice shifts lines, so it must be forwarded.
+    pub map: Option<String>,
+    pub rules: Vec<StylexRule>,
+}
+
+#[derive(Debug, Default)]
+pub struct StylexAstOutput {
+    pub modified: bool,
+    pub rules: Vec<StylexRule>,
+}
+
+/// Dev-path seam: mutates oj's own parsed AST in place — one parse per module.
+/// Synthesized nodes carry the span of the node they replace (or an empty
+/// span), so the pipeline's sourcemap stays valid against the ORIGINAL source.
+/// `program` must be the parse of `source_text`.
+pub fn stylex_pass_ast<'a>(
+    allocator: &'a Allocator,
+    program: &mut Program<'a>,
+    path: &Path,
+    source_text: &str,
+    config: &StylexPassConfig,
+) -> Result<StylexAstOutput, String> {
+    let ctx = FileContext {
+        filename: path,
+        source_text,
+        cwd: &config.app_root,
+    };
+    // ProgramScoping::Rebuild (inside transform_program): Prebuilt would need
+    // a Semantic aliasing the &mut program (unsafe here) to save the ~2-25us
+    // internal SemanticBuilder pass measured on the showcase fixture modules.
+    match transform_program(allocator, program, &ctx, &config.options, &StdFs) {
+        Ok(result) => Ok(StylexAstOutput {
+            modified: result.modified,
+            rules: result.rules,
+        }),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+/// String-level pass: kept for the BUILD path only (the rolldown transform
+/// plugin is string-in/string-out by nature); the dev pipeline mutates its
+/// own AST via `stylex_pass_ast` instead.
+pub fn stylex_pass(
+    path: &Path,
+    source_text: &str,
+    config: &StylexPassConfig,
+) -> Result<StylexPassOutput, String> {
+    let ctx = FileContext {
+        filename: path,
+        source_text,
+        cwd: &config.app_root,
+    };
+    // The splice moves line positions, so the map is not optional here: a
+    // transform that reports none makes rolldown keep the pre-splice mapping.
+    let allocator = oxc_allocator::Allocator::default();
+    match transform_source_mapped_in(&allocator, &ctx, &config.options, &StdFs, true) {
+        Ok(Some(result)) => Ok(StylexPassOutput {
+            map: result.modified.then_some(result.map).flatten(),
+            code: result.modified.then_some(result.code),
+            rules: result.rules,
+        }),
+        Ok(None) => Ok(StylexPassOutput::default()),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxc_parser::Parser;
+
+    fn config(include: &[&str], exclude: &[&str]) -> StylexPassConfig {
+        let s = |v: &[&str]| v.iter().map(|x| x.to_string()).collect::<Vec<_>>();
+        StylexPassConfig::new(
+            PathBuf::from("/app"),
+            PathBuf::from("/app"),
+            &s(include),
+            &s(exclude),
+            true,
+            false,
+            None,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn globs_match_root_relative_paths() {
+        let cfg = config(&["src/**"], &[]);
+        assert!(cfg.matches_path(Path::new("/app/src/main.ts")));
+        assert!(cfg.matches_path(Path::new("/app/src/deep/Button.tsx")));
+        assert!(!cfg.matches_path(Path::new("/app/lib/main.ts")));
+    }
+
+    #[test]
+    fn exclude_wins_over_include() {
+        let cfg = config(&["src/**"], &["src/vendor/**"]);
+        assert!(cfg.matches_path(Path::new("/app/src/a.ts")));
+        assert!(!cfg.matches_path(Path::new("/app/src/vendor/b.ts")));
+    }
+
+    #[test]
+    fn candidate_needs_both_path_and_source_mention() {
+        let cfg = config(&["src/**"], &[]);
+        let file = Path::new("/app/src/main.ts");
+        assert!(cfg.is_candidate(file, "import * as stylex from '@stylexjs/stylex';"));
+        assert!(!cfg.is_candidate(file, "export const x = 1;"));
+        assert!(!cfg.is_candidate(Path::new("/app/lib/x.ts"), "stylex"));
+    }
+
+    #[test]
+    fn invalid_glob_is_a_config_error() {
+        let err = StylexPassConfig::new(
+            PathBuf::from("/app"),
+            PathBuf::from("/app"),
+            &["src/[".into()],
+            &[],
+            true,
+            false,
+            None,
+        );
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn salt_input_changes_with_config_and_is_stable() {
+        let a = config(&["src/**"], &[]).salt_input();
+        let b = config(&["src/**"], &[]).salt_input();
+        let c = config(&["app/**"], &[]).salt_input();
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn salt_input_changes_with_class_name_prefix() {
+        let base = config(&["src/**"], &[]);
+        let prefixed = StylexPassConfig::new(
+            PathBuf::from("/app"),
+            PathBuf::from("/app"),
+            &["src/**".into()],
+            &[],
+            true,
+            false,
+            Some("oj".into()),
+        )
+        .unwrap();
+        assert_ne!(base.salt_input(), prefixed.salt_input());
+    }
+
+    #[test]
+    fn pass_compiles_a_create_call_and_extracts_rules() {
+        let cfg = config(&["**"], &[]);
+        let src = "import * as stylex from '@stylexjs/stylex';\n\
+                   export const styles = stylex.create({ root: { color: 'red' } });\n";
+        let out = stylex_pass(Path::new("/app/src/a.ts"), src, &cfg).unwrap();
+        let code = out.code.expect("create call must modify the module");
+        assert!(!code.contains("stylex.create"), "create must compile away");
+        assert_eq!(out.rules.len(), 1);
+        assert!(out.rules[0].ltr.contains("color:red"));
+        assert!(code.contains(&*out.rules[0].class_name));
+    }
+
+    #[test]
+    fn pass_skips_non_stylex_modules_via_pre_gate() {
+        // Path gate passed, but no import source in the text ("stylex" alone
+        // is not an import source match inside the compiler's pre-gate).
+        let cfg = config(&["**"], &[]);
+        let out = stylex_pass(Path::new("/app/src/a.ts"), "const stylexish = 1;", &cfg).unwrap();
+        assert!(out.code.is_none());
+        assert!(out.rules.is_empty());
+    }
+
+    #[test]
+    fn pass_surfaces_authoring_errors() {
+        let cfg = config(&["**"], &[]);
+        let src = "import * as stylex from '@stylexjs/stylex';\n\
+                   const dyn = Math.random();\n\
+                   export const styles = stylex.create({ root: { color: dyn } });\n";
+        let err = stylex_pass(Path::new("/app/src/a.ts"), src, &cfg).unwrap_err();
+        assert!(!err.is_empty());
+    }
+
+    fn reprint(source: &str, path: &Path) -> String {
+        let allocator = Allocator::default();
+        let parsed = Parser::new(
+            &allocator,
+            source,
+            oxc_span::SourceType::from_path(path).unwrap(),
+        )
+        .parse();
+        assert!(!parsed.panicked, "reprint parse failed");
+        oxc_codegen::Codegen::new().build(&parsed.program).code
+    }
+
+    #[test]
+    fn ast_and_string_seams_agree_on_rules_and_reprint() {
+        let cfg = config(&["**"], &[]);
+        let path = Path::new("/app/src/a.ts");
+        let src = "import * as stylex from '@stylexjs/stylex';\n\
+                   const fade = stylex.keyframes({ from: { opacity: 0 }, to: { opacity: 1 } });\n\
+                   export const styles = stylex.create({\n\
+                     root: { color: 'red', ':hover': { color: 'blue' } },\n\
+                     anim: { animationName: fade },\n\
+                   });\n\
+                   export const attrs = stylex.props(styles.root, styles.anim);\n";
+
+        let string_out = stylex_pass(path, src, &cfg).unwrap();
+        let string_code = string_out.code.expect("string seam must modify");
+
+        let allocator = Allocator::default();
+        let parsed = Parser::new(
+            &allocator,
+            src,
+            oxc_span::SourceType::from_path(path).unwrap(),
+        )
+        .parse();
+        assert!(!parsed.panicked && parsed.diagnostics.is_empty());
+        let mut program = parsed.program;
+        let ast_out = stylex_pass_ast(&allocator, &mut program, path, src, &cfg).unwrap();
+
+        assert!(ast_out.modified);
+        assert_eq!(string_out.rules, ast_out.rules, "identical rules");
+        let ast_code = oxc_codegen::Codegen::new().build(&program).code;
+        assert_eq!(
+            reprint(&string_code, path),
+            ast_code,
+            "reprints byte-equal between the two seams"
+        );
+    }
+
+    #[test]
+    fn ast_pass_skips_stylex_free_modules_without_mutating() {
+        let cfg = config(&["**"], &[]);
+        let path = Path::new("/app/src/plain.ts");
+        let src = "export const stylexish = 1;\n";
+        let allocator = Allocator::default();
+        let parsed = Parser::new(
+            &allocator,
+            src,
+            oxc_span::SourceType::from_path(path).unwrap(),
+        )
+        .parse();
+        let mut program = parsed.program;
+        let out = stylex_pass_ast(&allocator, &mut program, path, src, &cfg).unwrap();
+        assert!(!out.modified);
+        assert!(out.rules.is_empty());
+        let code = oxc_codegen::Codegen::new().build(&program).code;
+        assert_eq!(code, reprint(src, path), "program left untouched");
+    }
+
+    #[test]
+    fn class_name_prefix_changes_generated_classnames() {
+        let src = "import * as stylex from '@stylexjs/stylex';\n\
+                   export const styles = stylex.create({ root: { color: 'red' } });\n";
+        let default_cfg = config(&["**"], &[]);
+        let prefixed = StylexPassConfig::new(
+            PathBuf::from("/app"),
+            PathBuf::from("/app"),
+            &["**".into()],
+            &[],
+            true,
+            false,
+            Some("oj".into()),
+        )
+        .unwrap();
+        let a = stylex_pass(Path::new("/app/src/a.ts"), src, &default_cfg).unwrap();
+        let b = stylex_pass(Path::new("/app/src/a.ts"), src, &prefixed).unwrap();
+        assert!(b.rules[0].class_name.starts_with("oj"));
+        assert_ne!(a.rules[0].class_name, b.rules[0].class_name);
+    }
+}

--- a/crates/oj_config/src/lib.rs
+++ b/crates/oj_config/src/lib.rs
@@ -820,6 +820,15 @@ pub fn load(root: &Path) -> Result<OjConfig, ConfigError> {
     load_with(root, "serve", "development")
 }
 
+/// Standalone `StylexConfig` as JSON, for `--stylex-config` / OJ_STYLEX_CONFIG
+/// (projects whose oj/vite config cannot carry the section).
+pub fn load_stylex_json(path: &Path) -> Result<StylexConfig, ConfigError> {
+    let source = std::fs::read_to_string(path)
+        .map_err(|e| ConfigError::Parse(path.to_path_buf(), e.to_string()))?;
+    serde_json::from_str(&source)
+        .map_err(|e| ConfigError::Schema(path.to_path_buf(), e.to_string()))
+}
+
 pub fn load_with(root: &Path, command: &str, mode: &str) -> Result<OjConfig, ConfigError> {
     let Some(path) = CANDIDATES
         .iter()
@@ -1374,6 +1383,49 @@ mod tests {
             environment_defines(&cfg, "ssr").into_iter().collect();
         assert_eq!(ssr_defines.get("__SSR__").unwrap(), "true");
         assert!(environment_defines(&cfg, "client").is_empty());
+    }
+
+    #[test]
+    fn stylex_section_parses_camel_case_and_defaults() {
+        let json = r#"{"stylex":{
+            "include":["src/**"],
+            "exclude":["src/vendor/**"],
+            "rootDir":"..",
+            "dev":true,
+            "useCssLayers":true,
+            "classNamePrefix":"oj"}}"#;
+        let cfg: OjConfig = serde_json::from_str(json).unwrap();
+        let sx = cfg.stylex.unwrap();
+        assert_eq!(sx.include, vec!["src/**".to_string()]);
+        assert_eq!(sx.exclude, vec!["src/vendor/**".to_string()]);
+        assert_eq!(sx.root_dir.as_deref(), Some(".."));
+        assert_eq!(sx.dev, Some(true));
+        assert_eq!(sx.use_css_layers, Some(true));
+        assert_eq!(sx.class_name_prefix.as_deref(), Some("oj"));
+
+        // Every field is optional: an empty section still enables the pass.
+        let minimal: OjConfig = serde_json::from_str(r#"{"stylex":{}}"#).unwrap();
+        let sx = minimal.stylex.unwrap();
+        assert!(sx.include.is_empty() && sx.exclude.is_empty());
+        assert!(sx.root_dir.is_none() && sx.dev.is_none() && sx.use_css_layers.is_none());
+        assert!(sx.class_name_prefix.is_none());
+        let absent: OjConfig = serde_json::from_str("{}").unwrap();
+        assert!(absent.stylex.is_none());
+    }
+
+    #[test]
+    fn stylex_json_override_reads_the_same_schema() {
+        let dir = std::env::temp_dir().join(format!("oj-stylex-json-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("stylex.json");
+        std::fs::write(&path, r#"{"include":["src/**"],"useCssLayers":true}"#).unwrap();
+        let sx = load_stylex_json(&path).unwrap();
+        assert_eq!(sx.include, vec!["src/**".to_string()]);
+        assert_eq!(sx.use_css_layers, Some(true));
+        assert!(load_stylex_json(&dir.join("missing.json")).is_err());
+        std::fs::write(&path, "not json").unwrap();
+        assert!(load_stylex_json(&path).is_err());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/oj_config/src/schema.rs
+++ b/crates/oj_config/src/schema.rs
@@ -44,6 +44,7 @@ pub struct OjConfig {
     /// Vite's `html` block (`cspNonce`).
     pub html: Option<HtmlConfig>,
     pub legacy: Option<LegacyConfig>,
+    pub stylex: Option<StylexConfig>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -71,6 +72,22 @@ impl From<String> for BoolOrString {
     fn from(s: String) -> Self {
         BoolOrString::Str(s)
     }
+}
+
+/// Native StyleX pass. Presence of the section enables it.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct StylexConfig {
+    /// Root-relative globs selecting the files the pass may transform.
+    pub include: Vec<String>,
+    pub exclude: Vec<String>,
+    /// Base dir for the globs (and debug names later); defaults to the root.
+    pub root_dir: Option<String>,
+    /// Defaults to NODE_ENV != "production".
+    pub dev: Option<bool>,
+    pub use_css_layers: Option<bool>,
+    /// Generated class-name prefix (compiler default: "x").
+    pub class_name_prefix: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/oj_css/src/lib.rs
+++ b/crates/oj_css/src/lib.rs
@@ -2193,4 +2193,5 @@ mod tests {
         // The rebased (dev) path parses the same way.
         assert!(compile_css_rebased("/src/vendor.css", src, false).is_ok());
     }
+
 }

--- a/crates/oj_server/Cargo.toml
+++ b/crates/oj_server/Cargo.toml
@@ -20,6 +20,7 @@ notify.workspace = true
 serde_json.workspace = true
 json-strip-comments = "3.1.2"
 blake3.workspace = true
+fru.workspace = true
 simdutf8.workspace = true
 glob = "0.3.4"
 regex = "1.11"

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -365,6 +365,9 @@ const OJ_NATIVE_PLUGIN_NAMES = new Set([
   "vite:react-swc",
   "vite:react-swc:resolve-runtime",
 ]);
+// Extra names the server reimplements natively for this app (e.g. a JS
+// StyleX plugin when the native stylex pass is enabled).
+for (const name of initial.nativePluginNames ?? []) OJ_NATIVE_PLUGIN_NAMES.add(name);
 
 // Dev-tooling plugins oj cannot host: they drive a full Vite dev server (ws
 // error overlay, file watcher, a worker running tsc/eslint) that oj does not

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -23,6 +23,7 @@ pub mod pkg_bundle;
 pub mod pkg_rolldown;
 pub mod plugins;
 pub mod sidecar;
+pub mod stylex;
 pub mod svgr;
 use oj_graph::{HmrDecision, ModuleGraph};
 use oj_resolver::OjResolver;
@@ -228,6 +229,9 @@ pub struct DevServer {
     pub bundle: bool,
     pub host: Option<String>,
     pub config: Option<PathBuf>,
+    /// StylexConfig-as-JSON override (--stylex-config / OJ_STYLEX_CONFIG);
+    /// takes precedence over the config file's `stylex` section.
+    pub stylex_config: Option<PathBuf>,
     /// Enable the experimental on-disk module cache (off by default).
     pub enable_cache: bool,
     /// Force the on-disk module cache off even if enabled.
@@ -271,6 +275,7 @@ struct ServerState {
     preprocess: tokio::sync::OnceCell<std::sync::Arc<Sidecar>>,
     svelte: tokio::sync::OnceCell<std::sync::Arc<Sidecar>>,
     tailwind_urls: Mutex<std::collections::HashSet<String>>,
+    stylex: Option<Arc<stylex::StylexState>>,
     has_postcss: bool,
     scss_additional_data: Option<String>,
     sass_additional_data: Option<String>,
@@ -527,6 +532,16 @@ impl DevServer {
         let mut env_defines_digest = digest_defines(&defines);
         oj_compiler::set_import_meta_env(defines);
 
+        let stylex_state = resolve_stylex_state(self.stylex_config.as_deref(), &config, &root)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        if let Some(sx) = &stylex_state {
+            println!(
+                "  stylex: native pass enabled ({} include glob(s))",
+                sx.pass.include.len()
+            );
+            sx.seed_fake_rules_from_env(&root);
+        }
+
         let server_cfg = config.server.clone().unwrap_or_default();
         let port = self.port.or(server_cfg.port).unwrap_or(5199);
         let strict_port = oj_config::server_strict_port(&config);
@@ -590,6 +605,11 @@ impl DevServer {
             "pluginsFormat": plugins_format,
             "ojStartMode": is_start,
         });
+        if stylex_state.is_some() {
+            // The native pass replaces the pilot's Babel Vite plugin; hosting
+            // both would transform stylex modules twice.
+            plugin_cfg["nativePluginNames"] = serde_json::json!(["lovable:stylex-transform"]);
+        }
         if let Some(dir) = &ssr_bridge_dir {
             plugin_cfg["ssrBridge"] = serde_json::json!({ "dir": dir.display().to_string() });
         }
@@ -864,6 +884,7 @@ impl DevServer {
             preprocess: tokio::sync::OnceCell::new(),
             svelte: tokio::sync::OnceCell::new(),
             tailwind_urls: Mutex::new(std::collections::HashSet::new()),
+            stylex: stylex_state,
             has_postcss: has_postcss_config(&root),
             scss_additional_data: oj_config::css_additional_data(&config, "scss"),
             sass_additional_data: oj_config::css_additional_data(&config, "sass"),
@@ -1020,6 +1041,7 @@ impl DevServer {
             .route("/@oj/worker.js", get(serve_worker_chunk))
             .route("/@oj/routes.js", get(serve_oj_routes))
             .route("/@oj/server-fn.js", get(|| async { js(SERVER_FN_JS) }))
+            .route("/@oj/stylex.css", get(serve_stylex_css))
             .route(
                 "/@oj/lingui-macro-shim.js",
                 get(|| async { js(LINGUI_MACRO_SHIM_JS) }),
@@ -3218,7 +3240,14 @@ async fn serve_path(
     match tokio::fs::read(&file).await {
         Ok(bytes) if ext == "html" => serve_html(&state, bytes, &url_of(&state.root, &file), &file).await,
         Ok(bytes) if ext == "css" => {
-            let source = String::from_utf8_lossy(&bytes).into_owned();
+            let mut source = String::from_utf8_lossy(&bytes).into_owned();
+            if let Some(sx) = &state.stylex {
+                if stylex::has_directive(&source) {
+                    stylex_flush_dirty(&state).await;
+                    sx.record_css_url(&url_of(&state.root, &file));
+                    source = stylex::substitute_directive(&source, &sx.assembled());
+                }
+            }
             if is_tailwind_css(&source) {
                 let url = url_of(&state.root, &file);
                 return match compile_tailwind(&state, &url, &source).await {
@@ -3408,6 +3437,7 @@ async fn ensure_module(
                     css_exports: Vec::new(),
                     fs_allow: Vec::new(),
                     watch_files: Vec::new(),
+                    stylex_rules: Vec::new(),
                 });
                 register_in_graph(state, url, &module);
                 return Ok((String::new(), module));
@@ -3442,6 +3472,7 @@ async fn ensure_module(
                     css_exports: Vec::new(),
                     fs_allow: Vec::new(),
                     watch_files: Vec::new(),
+                    stylex_rules: Vec::new(),
                 });
                 register_in_graph(state, url, &module);
                 return Ok((String::new(), module));
@@ -3473,6 +3504,7 @@ async fn ensure_module(
                 css_exports: Vec::new(),
                 fs_allow: Vec::new(),
                 watch_files: Vec::new(),
+                stylex_rules: Vec::new(),
             })
         } else {
             Arc::new(CachedModule {
@@ -3486,6 +3518,7 @@ async fn ensure_module(
                 css_exports: Vec::new(),
                 fs_allow: Vec::new(),
                 watch_files: Vec::new(),
+                stylex_rules: Vec::new(),
             })
         };
         register_in_graph(state, url, &module);
@@ -3506,6 +3539,7 @@ async fn ensure_module(
             .map(|(_, _, k)| k.clone());
         if let Some(key) = cached_key {
             if let Some(module) = memory_get(state, url, &key) {
+                stylex_register(state, file, &module);
                 register_in_graph(state, url, &module);
                 return Ok((key, module));
             }
@@ -3550,7 +3584,7 @@ async fn ensure_module(
     } else {
         None
     };
-    let source = match plugin_loaded {
+    let mut source = match plugin_loaded {
         Some(code) => code,
         None => bytes_to_string(
             tokio::fs::read(file)
@@ -3559,6 +3593,21 @@ async fn ensure_module(
         )
         .map_err(|err| format!("read error for {url}: {err}"))?,
     };
+    // `@stylex;` substitution runs before the tailwind/postcss handling so the
+    // sidecars see plain CSS. Such css is generation-dependent: it must never
+    // enter the mtime fast path (the file is unchanged when the sheet changes);
+    // content-keyed caching below stays sound because the sheet is inlined.
+    let mut stylex_css = false;
+    if file.extension().and_then(|e| e.to_str()) == Some("css") {
+        if let Some(sx) = &state.stylex {
+            if stylex::has_directive(&source) {
+                stylex_flush_dirty(state).await;
+                sx.record_css_url(url);
+                source = stylex::substitute_directive(&source, &sx.assembled());
+                stylex_css = true;
+            }
+        }
+    }
     if !state.bundle && source.contains("import.meta.glob") {
         let patterns: Vec<glob::Pattern> = oj_compiler::glob::glob_patterns(&source, file)
             .iter()
@@ -3585,6 +3634,7 @@ async fn ensure_module(
             css_exports: Vec::new(),
             fs_allow: Vec::new(),
             watch_files: Vec::new(),
+            stylex_rules: Vec::new(),
         });
         register_in_graph(state, url, &module);
         return Ok((String::new(), module));
@@ -3612,16 +3662,25 @@ async fn ensure_module(
     } else {
         mode.to_string()
     };
+    // Fold the stylex config + pass identity into the key: rules ride the
+    // cached module, so a config change or pass bump must invalidate.
+    let mode_key = match &state.stylex {
+        Some(sx) => format!("{mode_key}:sx{}", sx.cache_salt),
+        None => mode_key,
+    };
     let key = state.cache.key(source.as_bytes(), url, &mode_key);
     if let Some((mtime, size)) = stamp {
-        state
-            .mtime_keys
-            .lock()
-            .unwrap()
-            .insert(url.to_string(), (mtime, size, key.clone()));
+        if !stylex_css {
+            state
+                .mtime_keys
+                .lock()
+                .unwrap()
+                .insert(url.to_string(), (mtime, size, key.clone()));
+        }
     }
 
     if let Some(module) = memory_get(state, url, &key) {
+        stylex_register(state, file, &module);
         register_in_graph(state, url, &module);
         return Ok((key, module));
     }
@@ -3633,6 +3692,7 @@ async fn ensure_module(
     let _guard = lock.lock().await;
 
     if let Some(module) = memory_get(state, url, &key) {
+        stylex_register(state, file, &module);
         register_in_graph(state, url, &module);
         return Ok((key, module));
     }
@@ -3647,12 +3707,17 @@ async fn ensure_module(
     // those. Modules whose imports are all real files (svgr on disk, plain
     // source, deps) keep the fast persistent cache (Vite has no cross-restart
     // transform cache at all; this preserves oj's where it is sound).
-    if let Some(module) = state.persistent_cache.then(|| state.cache.get(&key)).flatten() {
+    if let Some(module) = state
+        .persistent_cache
+        .then(|| state.cache.get(&key))
+        .flatten()
+    {
         let module = Arc::new(module);
         let needs_retransform = state.plugins_have_transform
             && !is_dep_early
             && imports_a_plugin_virtual(&module.imports, &state.root, &state.dir_cache);
         if !needs_retransform {
+            stylex_register(state, file, &module);
             memory_put(state, url, &key, &module);
             register_in_graph(state, url, &module);
             replay_module_parsed(state, file, &key, is_dep_early, is_server).await;
@@ -3673,6 +3738,7 @@ async fn ensure_module(
             css_exports: Vec::new(),
             fs_allow: Vec::new(),
             watch_files: Vec::new(),
+            stylex_rules: Vec::new(),
         });
         if state.persistent_cache {
             let _ = state
@@ -3817,6 +3883,7 @@ async fn ensure_module(
             css_exports: Vec::new(),
             fs_allow: Vec::new(),
             watch_files: Vec::new(),
+            stylex_rules: Vec::new(),
         });
         register_in_graph(state, url, &module);
         return Ok((String::new(), module));
@@ -3847,6 +3914,7 @@ async fn ensure_module(
         file.to_path_buf()
     };
     let url_owned = url.to_string();
+    let stylex_pass = state.stylex.as_ref().map(|sx| sx.pass.clone());
     let sass_data = sass_additional_data_for(state, &url_owned);
     let sass_load_paths = sass_load_paths_for(state, &url_owned);
     let css_resolve = state.css_resolve.clone();
@@ -3888,6 +3956,7 @@ async fn ensure_module(
                 css_exports: Vec::new(),
                 fs_allow: Vec::new(),
                 watch_files: Vec::new(),
+                stylex_rules: Vec::new(),
             });
         }
         if is_css {
@@ -3928,6 +3997,7 @@ async fn ensure_module(
                 css_exports: output.exports.unwrap_or_default(),
                 fs_allow: Vec::new(),
                 watch_files: Vec::new(),
+                stylex_rules: Vec::new(),
             });
         }
         // The first relative import nothing on disk satisfies. Vite's import
@@ -4032,6 +4102,7 @@ async fn ensure_module(
                 map_data_url: None,
                 fs_allow: fs_allow_from(&factory.imports),
                 watch_files: Vec::new(),
+                stylex_rules: Vec::new(),
                 imports: factory.imports,
                 require_map: factory.require_map,
                 css_exports: Vec::new(),
@@ -4106,11 +4177,13 @@ async fn ensure_module(
                         sourcemap: true,
                         ssr: false,
                         jsx: oj_compiler::JsxConfig::default(),
+                        stylex: None,
                     }
                 } else {
                     oj_compiler::CompileOptions::dev()
                 };
                 opts.jsx = jsx_config;
+                opts.stylex = stylex_pass.as_ref();
                 oj_compiler::compile_module_with_maps(
                     &file_owned,
                     interopped.as_deref().unwrap_or(&source),
@@ -4133,6 +4206,7 @@ async fn ensure_module(
                 map_data_url: output.map_data_url,
                 fs_allow: fs_allow_from(&output.imports),
                 watch_files: Vec::new(),
+                stylex_rules: output.stylex_rules,
                 imports: output.imports,
                 kind: if is_svelte {
                     "svelte".into()
@@ -4173,6 +4247,7 @@ async fn ensure_module(
             .cache_writes
             .try_send((key.clone(), Arc::clone(&module)));
     }
+    stylex_register(state, file, &module);
     memory_put(state, url, &key, &module);
     register_in_graph(state, url, &module);
     state
@@ -4314,6 +4389,11 @@ fn module_weight(module: &CachedModule) -> usize {
         + strs(&module.watch_files)
         + pairs(&module.require_map)
         + pairs(&module.css_exports)
+        + module
+            .stylex_rules
+            .iter()
+            .map(|r| r.class_name.len() + r.ltr.len() + r.rtl.as_ref().map_or(0, |s| s.len()) + 64)
+            .sum::<usize>()
 }
 
 fn memory_cache_budget() -> usize {
@@ -4491,6 +4571,55 @@ async fn serve_css_wrapper(state: &Arc<ServerState>, file: &Path, url: &str) -> 
             (header::CACHE_CONTROL, "no-cache"),
         ],
         body,
+    )
+        .into_response()
+}
+
+fn resolve_stylex_state(
+    override_path: Option<&Path>,
+    config: &oj_config::OjConfig,
+    root: &Path,
+) -> Result<Option<Arc<stylex::StylexState>>, String> {
+    let default_dev = std::env::var("NODE_ENV").as_deref() != Ok("production");
+    Ok(
+        stylex::resolve_pass_config(override_path, config, root, default_dev)?
+            .map(|pass| Arc::new(stylex::StylexState::new(pass))),
+    )
+}
+
+/// Feed a compile-pipeline module's rules into the registry; runs on fresh
+/// compiles and on every cache-hit path, so warm starts rebuild the registry.
+fn stylex_register(state: &ServerState, file: &Path, module: &CachedModule) {
+    if let Some(sx) = &state.stylex {
+        sx.register(file, &module.stylex_rules);
+    }
+}
+
+/// Re-ensure watcher-dirtied stylex modules so the registry is current before
+/// a sheet is assembled, regardless of which client fetch lands first.
+async fn stylex_flush_dirty(state: &Arc<ServerState>) {
+    let Some(sx) = &state.stylex else { return };
+    for path in sx.take_dirty() {
+        if path.exists() {
+            let url = url_of(&state.root, &path);
+            let _ = Box::pin(ensure_module(state, &path, &url)).await;
+        } else {
+            sx.remove(&path);
+        }
+    }
+}
+
+async fn serve_stylex_css(State(state): State<Arc<ServerState>>) -> Response {
+    let Some(sx) = &state.stylex else {
+        return (StatusCode::NOT_FOUND, "oj: stylex is not enabled").into_response();
+    };
+    stylex_flush_dirty(&state).await;
+    (
+        [
+            (header::CONTENT_TYPE, "text/css"),
+            (header::CACHE_CONTROL, "no-cache"),
+        ],
+        sx.assembled(),
     )
         .into_response()
 }
@@ -5815,7 +5944,7 @@ async fn serve_oj_routes(State(state): State<Arc<ServerState>>) -> Response {
     }
 }
 
-fn dev_compile_opts(state: &ServerState) -> oj_compiler::CompileOptions {
+fn dev_compile_opts(state: &ServerState) -> oj_compiler::CompileOptions<'static> {
     let mut opts = oj_compiler::CompileOptions::dev();
     opts.jsx = state.jsx.clone();
     opts
@@ -7599,6 +7728,40 @@ async fn decide(
         let file = state.root.join(importer.trim_start_matches('/'));
         if !paths.contains(&file) {
             paths.push(file);
+        }
+    }
+
+    if let Some(sx) = &state.stylex {
+        let mut gated = false;
+        for path in &paths {
+            if path.components().any(|c| {
+                let c = c.as_os_str();
+                c == "node_modules" || c == ".oj-cache" || c == "dist"
+            }) {
+                continue;
+            }
+            let compilable = path
+                .extension()
+                .and_then(|e| e.to_str())
+                .is_some_and(|e| COMPILABLE.contains(&e));
+            if !compilable || !sx.pass.matches_path(path) {
+                continue;
+            }
+            if path.exists() {
+                sx.mark_dirty(path);
+            } else {
+                sx.remove(path);
+            }
+            gated = true;
+        }
+        if gated {
+            // Mirror the tailwind repush: the client refetches each sheet, and
+            // the serving paths flush dirty modules before assembling.
+            let timestamp = now_millis() as u64;
+            for url in sx.css_urls() {
+                updates.push(update_entry("css-update", &url, timestamp));
+            }
+            updates.push(update_entry("css-update", "/@oj/stylex.css", timestamp));
         }
     }
 

--- a/crates/oj_server/src/stylex.rs
+++ b/crates/oj_server/src/stylex.rs
@@ -1,0 +1,443 @@
+// SPDX-License-Identifier: MIT
+// StyleX serving: the per-module rule registry and sheet assembly.
+
+use std::collections::{BTreeMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use fru::assemble::{AssembleConfig, LayersConfig};
+
+pub use oj_compiler::stylex::{StylexPassConfig, StylexRule};
+
+/// The dev-server side of the StyleX pass: the pass config, the cache salt,
+/// and the per-module rule registry the served stylesheet is assembled from.
+pub struct StylexState {
+    pub pass: StylexPassConfig,
+    /// blake3 of the config identity + pass version, folded into cache keys so
+    /// a config or pass bump invalidates persisted modules.
+    pub cache_salt: String,
+    assemble_cfg: AssembleConfig,
+    registry: Mutex<StylexRegistry>,
+}
+
+#[derive(Default)]
+struct StylexRegistry {
+    /// BTreeMap: file-path order pins a deterministic rule feed into assembly
+    /// regardless of request order (matches the compiler's RuleRegistry).
+    rules: BTreeMap<PathBuf, Vec<StylexRule>>,
+    /// Served css URLs whose source contained the `@stylex;` directive; each
+    /// gets a css-update repush when any stylex-gated module changes.
+    css_urls: HashSet<String>,
+    /// Watcher-marked modules, re-ensured lazily before the next assembly.
+    dirty: HashSet<PathBuf>,
+    generation: u64,
+    assembled: Option<(u64, String)>,
+}
+
+fn assemble_config(pass: &StylexPassConfig) -> AssembleConfig {
+    AssembleConfig {
+        use_layers: if pass.use_css_layers {
+            LayersConfig::On {
+                before: Vec::new(),
+                after: Vec::new(),
+                prefix: None,
+            }
+        } else {
+            LayersConfig::Off
+        },
+        ..AssembleConfig::default()
+    }
+}
+
+/// One-shot assembly for the build path (the dev server memoizes via
+/// `StylexState::assembled` instead).
+pub fn assemble_sheet(rules: &[StylexRule], pass: &StylexPassConfig) -> Result<String, String> {
+    fru::assemble::assemble(rules, &assemble_config(pass)).map_err(|e| e.to_string())
+}
+
+/// Shared `stylex` config resolution for dev and build: `--stylex-config` /
+/// OJ_STYLEX_CONFIG override the config file's `stylex` section.
+/// The zero-config default: enabled iff package.json depends on
+/// @stylexjs/stylex, over the whole project except node_modules.
+fn auto_config(root: &Path) -> Option<oj_config::StylexConfig> {
+    let manifest = std::fs::read_to_string(root.join("package.json")).ok()?;
+    let manifest: serde_json::Value = serde_json::from_str(&manifest).ok()?;
+    let has_dep = ["dependencies", "devDependencies"].iter().any(|key| {
+        manifest
+            .get(key)
+            .and_then(|deps| deps.get("@stylexjs/stylex"))
+            .is_some()
+    });
+    if !has_dep {
+        return None;
+    }
+    println!("  stylex: auto-enabled (@stylexjs/stylex dependency detected)");
+    Some(oj_config::StylexConfig {
+        include: vec!["**".to_string()],
+        exclude: vec!["node_modules/**".to_string()],
+        ..oj_config::StylexConfig::default()
+    })
+}
+
+pub fn resolve_pass_config(
+    override_path: Option<&Path>,
+    config: &oj_config::OjConfig,
+    root: &Path,
+    default_dev: bool,
+) -> Result<Option<StylexPassConfig>, String> {
+    let env_path = std::env::var("OJ_STYLEX_CONFIG")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from);
+    let schema = match override_path.map(Path::to_path_buf).or(env_path) {
+        Some(path) => {
+            let path = if path.is_absolute() {
+                path
+            } else {
+                root.join(path)
+            };
+            Some(oj_config::load_stylex_json(&path).map_err(|e| e.to_string())?)
+        }
+        None => config.stylex.clone(),
+    };
+    let schema = match schema {
+        Some(schema) => schema,
+        // Auto pickup: a project that depends on @stylexjs/stylex gets the
+        // pass with defaults; a `stylex` config section overrides everything.
+        None => match auto_config(root) {
+            Some(schema) => schema,
+            None => return Ok(None),
+        },
+    };
+    let root_dir = match &schema.root_dir {
+        Some(dir) => {
+            let dir = PathBuf::from(dir);
+            if dir.is_absolute() {
+                dir
+            } else {
+                root.join(dir)
+            }
+        }
+        None => root.to_path_buf(),
+    };
+    let pass = StylexPassConfig::new(
+        root.to_path_buf(),
+        root_dir,
+        &schema.include,
+        &schema.exclude,
+        schema.dev.unwrap_or(default_dev),
+        schema.use_css_layers.unwrap_or(false),
+        schema.class_name_prefix.clone(),
+    )?;
+    Ok(Some(pass))
+}
+
+impl StylexState {
+    pub fn new(pass: StylexPassConfig) -> Self {
+        let cache_salt = blake3::hash(pass.salt_input().as_bytes())
+            .to_hex()
+            .to_string();
+        let assemble_cfg = assemble_config(&pass);
+        Self {
+            pass,
+            cache_salt,
+            assemble_cfg,
+            registry: Mutex::new(StylexRegistry::default()),
+        }
+    }
+
+    /// Idempotent: bumps the generation (dropping the memoized sheet) only
+    /// when this module's rules actually changed.
+    pub fn register(&self, file: &Path, rules: &[StylexRule]) {
+        let mut reg = self.registry.lock().unwrap();
+        reg.dirty.remove(file);
+        let changed = match reg.rules.get(file) {
+            Some(prev) => prev.as_slice() != rules,
+            None => !rules.is_empty(),
+        };
+        if !changed {
+            return;
+        }
+        if rules.is_empty() {
+            reg.rules.remove(file);
+        } else {
+            reg.rules.insert(file.to_path_buf(), rules.to_vec());
+        }
+        reg.generation += 1;
+        reg.assembled = None;
+    }
+
+    pub fn remove(&self, file: &Path) {
+        let mut reg = self.registry.lock().unwrap();
+        reg.dirty.remove(file);
+        if reg.rules.remove(file).is_some() {
+            reg.generation += 1;
+            reg.assembled = None;
+        }
+    }
+
+    pub fn mark_dirty(&self, file: &Path) {
+        self.registry
+            .lock()
+            .unwrap()
+            .dirty
+            .insert(file.to_path_buf());
+    }
+
+    pub fn take_dirty(&self) -> Vec<PathBuf> {
+        self.registry.lock().unwrap().dirty.drain().collect()
+    }
+
+    pub fn record_css_url(&self, url: &str) {
+        self.registry
+            .lock()
+            .unwrap()
+            .css_urls
+            .insert(url.to_string());
+    }
+
+    pub fn has_css_url(&self, url: &str) -> bool {
+        self.registry.lock().unwrap().css_urls.contains(url)
+    }
+
+    pub fn css_urls(&self) -> Vec<String> {
+        let mut urls: Vec<String> = self
+            .registry
+            .lock()
+            .unwrap()
+            .css_urls
+            .iter()
+            .cloned()
+            .collect();
+        urls.sort();
+        urls
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.registry.lock().unwrap().generation
+    }
+
+    /// The full assembled sheet, memoized per registry generation.
+    pub fn assembled(&self) -> String {
+        let mut reg = self.registry.lock().unwrap();
+        if let Some((generation, css)) = &reg.assembled {
+            if *generation == reg.generation {
+                return css.clone();
+            }
+        }
+        let all: Vec<StylexRule> = reg.rules.values().flatten().cloned().collect();
+        // An assemble error (circular defineConsts reference) is an authoring
+        // error; keep serving a sheet so the page stays usable.
+        let css = match fru::assemble::assemble(&all, &self.assemble_cfg) {
+            Ok(css) => css,
+            Err(e) => {
+                eprintln!("oj: stylex assemble error: {e}");
+                format!("/* oj: stylex assemble error: {e} */")
+            }
+        };
+        reg.assembled = Some((reg.generation, css.clone()));
+        css
+    }
+
+    /// TEMPORARY smoke seam: OJ_STYLEX_FAKE_RULES (a JSON StylexRule array)
+    /// seeds the registry at boot so serving is testable before the real pass.
+    pub fn seed_fake_rules_from_env(&self, root: &Path) {
+        let Ok(json) = std::env::var("OJ_STYLEX_FAKE_RULES") else {
+            return;
+        };
+        match serde_json::from_str::<Vec<StylexRule>>(&json) {
+            Ok(rules) => {
+                println!(
+                    "  stylex: seeded {} fake rule(s) from OJ_STYLEX_FAKE_RULES",
+                    rules.len()
+                );
+                self.register(&root.join("__oj_stylex_fake__"), &rules);
+            }
+            Err(e) => eprintln!("oj: OJ_STYLEX_FAKE_RULES is not a StylexRule array: {e}"),
+        }
+    }
+}
+
+pub fn has_directive(source: &str) -> bool {
+    source.contains("@stylex;")
+}
+
+/// Replace every `@stylex;` at-rule (the postcss-plugin convention) with the
+/// assembled sheet; the caller checks `has_directive` first.
+pub fn substitute_directive(source: &str, sheet: &str) -> String {
+    source.replace("@stylex;", sheet)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rule(class: &str, ltr: &str, priority: f64) -> StylexRule {
+        StylexRule {
+            class_name: class.into(),
+            ltr: ltr.into(),
+            rtl: None,
+            const_key: None,
+            const_val: None,
+            priority,
+        }
+    }
+
+    fn state_with(use_css_layers: bool) -> StylexState {
+        StylexState::new(
+            StylexPassConfig::new(
+                PathBuf::from("/app"),
+                PathBuf::from("/app"),
+                &["src/**".into()],
+                &[],
+                true,
+                use_css_layers,
+                None,
+            )
+            .unwrap(),
+        )
+    }
+
+    fn state() -> StylexState {
+        state_with(false)
+    }
+
+    #[test]
+    fn register_is_idempotent_and_generation_tracks_change() {
+        let sx = state();
+        let a = Path::new("/app/src/a.tsx");
+        assert_eq!(sx.generation(), 0);
+        sx.register(a, &[rule("x1", ".x1{color:red}", 3000.0)]);
+        assert_eq!(sx.generation(), 1);
+        sx.register(a, &[rule("x1", ".x1{color:red}", 3000.0)]);
+        assert_eq!(sx.generation(), 1, "same rules must not bump");
+        sx.register(a, &[rule("x2", ".x2{color:blue}", 3000.0)]);
+        assert_eq!(sx.generation(), 2);
+        sx.register(a, &[]);
+        assert_eq!(sx.generation(), 3, "losing all rules is a change");
+        sx.register(Path::new("/app/src/b.tsx"), &[]);
+        assert_eq!(sx.generation(), 3, "empty on an unknown module is a no-op");
+    }
+
+    #[test]
+    fn assembly_sorts_by_priority_dedupes_and_polyfills_specificity() {
+        let sx = state();
+        sx.register(
+            Path::new("/app/src/a.tsx"),
+            &[
+                rule("x2", ".x2{margin:0}", 1000.0),
+                rule("x1", ".x1{color:red}", 3000.0),
+            ],
+        );
+        sx.register(
+            Path::new("/app/src/b.tsx"),
+            &[rule("x1", ".x1{color:red}", 3000.0)],
+        );
+        // Layers off: the second priority band gets the :not(#\#) polyfill.
+        assert_eq!(sx.assembled(), ".x2{margin:0}\n.x1:not(#\\#){color:red}");
+    }
+
+    #[test]
+    fn assembly_with_layers_emits_layer_header_and_blocks() {
+        let sx = state_with(true);
+        sx.register(
+            Path::new("/app/src/a.tsx"),
+            &[rule("x1", ".x1{color:red}", 3000.0)],
+        );
+        assert_eq!(
+            sx.assembled(),
+            "\n@layer priority1;\n@layer priority1{\n.x1{color:red}\n}"
+        );
+    }
+
+    #[test]
+    fn assembly_substitutes_define_consts() {
+        let sx = state();
+        let const_rule = StylexRule {
+            class_name: "xconsthash".into(),
+            ltr: String::new().into(),
+            rtl: None,
+            const_key: Some("--spacing".into()),
+            const_val: Some(serde_json::json!("8px")),
+            priority: 0.0,
+        };
+        sx.register(Path::new("/app/src/tokens.stylex.ts"), &[const_rule]);
+        sx.register(
+            Path::new("/app/src/a.tsx"),
+            &[rule("x1", ".x1{padding:var(--xconsthash)}", 3000.0)],
+        );
+        assert_eq!(sx.assembled(), ".x1{padding:8px}");
+    }
+
+    #[test]
+    fn assembly_is_memoized_per_generation() {
+        let sx = state();
+        sx.register(
+            Path::new("/app/src/a.tsx"),
+            &[rule("x1", ".x1{color:red}", 0.0)],
+        );
+        let first = sx.assembled();
+        assert_eq!(sx.assembled(), first);
+        sx.remove(Path::new("/app/src/a.tsx"));
+        assert_eq!(sx.assembled(), "");
+    }
+
+    #[test]
+    fn cache_salt_differs_across_configs() {
+        let a = state().cache_salt;
+        let b = StylexState::new(
+            StylexPassConfig::new(
+                PathBuf::from("/app"),
+                PathBuf::from("/app"),
+                &["app/**".into()],
+                &[],
+                true,
+                false,
+                None,
+            )
+            .unwrap(),
+        )
+        .cache_salt;
+        let c = StylexState::new(
+            StylexPassConfig::new(
+                PathBuf::from("/app"),
+                PathBuf::from("/app"),
+                &["src/**".into()],
+                &[],
+                true,
+                false,
+                Some("oj".into()),
+            )
+            .unwrap(),
+        )
+        .cache_salt;
+        assert_ne!(a, b);
+        assert_ne!(a, c, "classNamePrefix must invalidate the cache");
+        assert_eq!(a.len(), 64);
+    }
+
+    #[test]
+    fn directive_substitution_replaces_the_at_rule_in_place() {
+        let src = "@layer stylex { @stylex; }\nbody { margin: 0 }\n";
+        assert!(has_directive(src));
+        let out = substitute_directive(src, ".x1{color:red}\n");
+        assert_eq!(
+            out,
+            "@layer stylex { .x1{color:red}\n }\nbody { margin: 0 }\n"
+        );
+        // "@stylexjs" in an import path is not the directive.
+        assert!(!has_directive("@import \"@stylexjs/open-props\";"));
+    }
+
+    #[test]
+    fn dirty_set_drains_and_forgets_removed_modules() {
+        let sx = state();
+        let a = PathBuf::from("/app/src/a.tsx");
+        sx.mark_dirty(&a);
+        assert_eq!(sx.take_dirty(), vec![a.clone()]);
+        assert!(sx.take_dirty().is_empty());
+        sx.mark_dirty(&a);
+        sx.register(&a, &[rule("x1", ".x1{}", 0.0)]);
+        assert!(sx.take_dirty().is_empty(), "register clears dirty");
+    }
+}

--- a/crates/oj_server/src/stylex.rs
+++ b/crates/oj_server/src/stylex.rs
@@ -358,7 +358,7 @@ mod tests {
             ltr: String::new().into(),
             rtl: None,
             const_key: Some("--spacing".into()),
-            const_val: Some(serde_json::json!("8px")),
+            const_val: Some(Box::new(serde_json::json!("8px"))),
             priority: 0.0,
         };
         sx.register(Path::new("/app/src/tokens.stylex.ts"), &[const_rule]);

--- a/crates/stylex/Cargo.toml
+++ b/crates/stylex/Cargo.toml
@@ -14,6 +14,7 @@ oxc_ast_visit = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
 oxc_syntax = { workspace = true }
+oxc_str = "0.146.0"
 oxc_codegen = { workspace = true }
 oxc_sourcemap = "8.1.2"
 memchr = { workspace = true }

--- a/crates/stylex/Cargo.toml
+++ b/crates/stylex/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "fru"
+version = "0.1.16"
+edition = "2024"
+rust-version = "1.95"
+license = "MIT"
+description = "Clean-room StyleX compiler, byte-identical to @stylexjs/babel-plugin 0.19.0"
+
+[dependencies]
+oxc_allocator = { workspace = true }
+oxc_parser = { workspace = true }
+oxc_ast = { workspace = true }
+oxc_ast_visit = { workspace = true }
+oxc_semantic = { workspace = true }
+oxc_span = { workspace = true }
+oxc_syntax = { workspace = true }
+oxc_codegen = { workspace = true }
+oxc_sourcemap = "8.1.2"
+memchr = { workspace = true }
+blake3 = { workspace = true }
+serde = { version = "1", features = ["derive", "rc"] }
+# preserve_order: JS object key order is semantic (alias last-wins); the default
+# alphabetizing Map silently reorders keys through every JSON bridge.
+serde_json = { version = "1", features = ["preserve_order", "raw_value"] }
+thiserror = "2"
+ryu-js = "1"

--- a/crates/stylex/src/api.rs
+++ b/crates/stylex/src/api.rs
@@ -11,9 +11,9 @@ use oxc_span::SourceType;
 
 use crate::errors::StylexError;
 use crate::eval::value::JsObjectMap;
-use crate::imports::scan_imports;
+use crate::imports::{ATOMS_SOURCE, ImportTable, scan_imports};
 use crate::module_resolution::{FsProvider, THEME_FILE_EXTENSION};
-use crate::options::ResolvedOptions;
+use crate::options::{ImportSource, ResolvedOptions};
 use crate::rules::StylexRule;
 use crate::state::CompileState;
 use crate::transform::ast_backend::apply_plan;
@@ -37,32 +37,54 @@ pub struct SourceCompileResult {
     pub create_objects: Vec<(Option<String>, std::sync::Arc<JsObjectMap>)>,
 }
 
-pub fn might_contain_stylex(source: &str, options: &ResolvedOptions) -> bool {
-    options
-        .import_sources
-        .iter()
-        .map(crate::options::ImportSource::from_specifier)
-        .any(|needle| memmem::find(source.as_bytes(), needle.as_bytes()).is_some())
-        // Atoms compile off a hardcoded source no importSources setting covers.
-        || memmem::find(source.as_bytes(), crate::imports::ATOMS_SOURCE.as_bytes()).is_some()
-        // The sx prop compiles with no stylex import in the file at all, so
-        // it needs the same needle `is_dormant` already carries.
-        || options
-            .sx_prop_name
-            .as_deref()
-            .is_some_and(|sx| memmem::find(source.as_bytes(), sx.as_bytes()).is_some())
-        // A rewritable import source must carry the hardcoded `.stylex`
-        // suffix, so the literal is a sound pre-gate for that pass too.
-        || (options.rewrite_aliases
-            && memmem::find(source.as_bytes(), THEME_FILE_EXTENSION.as_bytes()).is_some())
-        || has_string_escapes(source)
+/// What [`transform_source_in_with_map`] renders into `SourceCompileResult::map`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MapMode {
+    Off,
+    /// Mappings and `sources` only; the consumer supplies `sourcesContent`.
+    Mappings,
+    WithContent,
 }
 
-// A `\u`/`\x` escape can cook into an import-source match the raw needles
-// miss (`"@stylexjs/stylex"`); parse and decide post-parse.
-fn has_string_escapes(source: &str) -> bool {
-    memmem::find(source.as_bytes(), b"\\u").is_some()
-        || memmem::find(source.as_bytes(), b"\\x").is_some()
+pub fn might_contain_stylex(source: &str, options: &ResolvedOptions) -> bool {
+    pre_gate(source, options).is_some()
+}
+
+/// `None` = the file cannot reference any stylex import source; `Some(sx)`
+/// carries whether the sx-prop needle hit, sparing the dormancy check a rescan.
+fn pre_gate(source: &str, options: &ResolvedOptions) -> Option<bool> {
+    let bytes = source.as_bytes();
+    // The sx prop compiles with no stylex import in the file at all.
+    if options
+        .sx_prop_name
+        .as_deref()
+        .is_some_and(|sx| memmem::find(bytes, sx.as_bytes()).is_some())
+    {
+        return Some(true);
+    }
+    // Atoms compile off a hardcoded source no importSources setting covers; a
+    // rewritable import source must carry the hardcoded `.stylex` suffix.
+    let needles = || {
+        options
+            .import_sources
+            .iter()
+            .map(ImportSource::from_specifier)
+            .chain(std::iter::once(ATOMS_SOURCE))
+            .chain(options.rewrite_aliases.then_some(THEME_FILE_EXTENSION))
+    };
+    // A needle containing another (or repeating an earlier one) can only hit
+    // where that one hits: the default set collapses to "stylex" alone.
+    let hit = needles().enumerate().any(|(i, needle)| {
+        let redundant = needles().enumerate().any(|(j, other)| {
+            (other.len() < needle.len() && needle.contains(other)) || (j < i && other == needle)
+        });
+        !redundant && memmem::find(bytes, needle.as_bytes()).is_some()
+    });
+    // A `\u`/`\x` escape can cook into an import-source match the raw needles
+    // miss (`"@stylexjs/stylex"`); parse and decide post-parse.
+    let escapes =
+        || memchr::memchr_iter(b'\\', bytes).any(|i| matches!(bytes.get(i + 1), Some(b'u' | b'x')));
+    (hit || escapes()).then_some(false)
 }
 
 /// `None` = pre-gate skip (the file cannot reference any stylex import source).
@@ -95,15 +117,32 @@ pub fn transform_source_mapped_in(
     fs: &dyn FsProvider,
     want_map: bool,
 ) -> Result<Option<SourceCompileResult>, StylexError> {
-    if !might_contain_stylex(ctx.source_text, options) {
+    let mode = if want_map {
+        MapMode::WithContent
+    } else {
+        MapMode::Off
+    };
+    transform_source_in_with_map(allocator, ctx, options, fs, mode)
+}
+
+/// [`transform_source_mapped_in`] with the map's content policy chosen by the caller.
+pub fn transform_source_in_with_map(
+    allocator: &Allocator,
+    ctx: &FileContext<'_>,
+    options: &ResolvedOptions,
+    fs: &dyn FsProvider,
+    map_mode: MapMode,
+) -> Result<Option<SourceCompileResult>, StylexError> {
+    let want_map = map_mode != MapMode::Off;
+    let Some(sx_hit) = pre_gate(ctx.source_text, options) else {
         return Ok(None);
-    }
+    };
     let filename = ctx.filename.to_string_lossy().replace('\\', "/");
     let program = {
         let _t = crate::timings::start(crate::timings::Stage::Parse);
         parse_program(allocator, ctx.source_text, &filename)?
     };
-    if is_dormant(&program, ctx.source_text, options)? {
+    let Some(imports) = scan_unless_dormant(&program, sx_hit, options)? else {
         return Ok(Some(SourceCompileResult {
             code: ctx.source_text.to_string(),
             map: None,
@@ -111,14 +150,15 @@ pub fn transform_source_mapped_in(
             modified: false,
             create_objects: Vec::new(),
         }));
-    }
+    };
     let filename_for_map = want_map.then(|| filename.clone());
-    let mut state = CompileState::build(
+    let mut state = CompileState::build_with_imports(
         &program,
         options,
         Some(filename),
         ctx.cwd.to_string_lossy().replace('\\', "/"),
-    )?;
+        imports,
+    );
     let out = {
         let _t = crate::timings::start(crate::timings::Stage::Transform);
         transform_module(&program, ctx.source_text, &mut state, fs, false, want_map)?
@@ -127,7 +167,7 @@ pub fn transform_source_mapped_in(
         render_sourcemap(
             m,
             filename_for_map.as_deref().unwrap_or_default(),
-            ctx.source_text,
+            (map_mode == MapMode::WithContent).then_some(ctx.source_text),
         )
     });
     Ok(Some(SourceCompileResult {
@@ -181,34 +221,38 @@ pub fn transform_program<'a>(
     options: &ResolvedOptions,
     fs: &dyn FsProvider,
 ) -> Result<CompileResult, StylexError> {
-    if !might_contain_stylex(ctx.source_text, options) {
+    let Some(sx_hit) = pre_gate(ctx.source_text, options) else {
         return Ok(CompileResult {
             modified: false,
             rules: Vec::new(),
             create_objects: Vec::new(),
         });
-    }
-    if is_dormant(program, ctx.source_text, options)? {
+    };
+    let Some(imports) = scan_unless_dormant(program, sx_hit, options)? else {
         return Ok(CompileResult {
             modified: false,
             rules: Vec::new(),
             create_objects: Vec::new(),
         });
-    }
+    };
     let filename = ctx.filename.to_string_lossy().replace('\\', "/");
     let cwd = ctx.cwd.to_string_lossy().replace('\\', "/");
     // Read-only analysis at a shorter reborrow (the AST is covariant over
     // the arena lifetime) yields an owned plan; the mutation follows.
     let (plan, modified, rules, create_objects) = {
         let program_ref: &Program<'_> = &*program;
-        let mut state = CompileState::build(program_ref, options, Some(filename), cwd)?;
+        let mut state =
+            CompileState::build_with_imports(program_ref, options, Some(filename), cwd, imports);
         let out = {
             let _t = crate::timings::start(crate::timings::Stage::Transform);
             transform_module(program_ref, ctx.source_text, &mut state, fs, true, false)?
         };
         (out.plan, out.modified, state.rules, out.create_objects)
     };
-    apply_plan(allocator, program, &plan)?;
+    {
+        let _t = crate::timings::start(crate::timings::Stage::ApplyPlan);
+        apply_plan(allocator, program, plan)?;
+    }
     Ok(CompileResult {
         modified,
         rules,
@@ -230,40 +274,42 @@ pub fn transform_program_with_dep_log<'a>(
     Ok((result, recorder.into_log()))
 }
 
-// Dormant needs no stylex binding AND no possible sx prop: that transform
-// fires with no import at all and synthesizes one.
-fn is_dormant(
+// Dormant (`None`): no stylex binding, no possible sx prop (it compiles with no
+// import at all), and no `rewriteAliases` (rewrites imports with no binding).
+fn scan_unless_dormant(
     program: &Program<'_>,
-    source: &str,
+    sx_hit: bool,
     options: &ResolvedOptions,
-) -> Result<bool, StylexError> {
-    // `rewriteAliases` runs in Program.exit over every import declaration, with
-    // no stylex binding required anywhere in the file.
-    if options.rewrite_aliases {
-        return Ok(false);
-    }
-    if let Some(sx_prop) = &options.sx_prop_name
-        && memmem::find(source.as_bytes(), sx_prop.as_bytes()).is_some()
-    {
-        return Ok(false);
-    }
+) -> Result<Option<ImportTable>, StylexError> {
     let _t = crate::timings::start(crate::timings::Stage::ImportScan);
-    Ok(scan_imports(program, options)?.is_dormant())
+    let imports = scan_imports(program, options)?;
+    Ok((options.rewrite_aliases || sx_hit || !imports.is_dormant()).then_some(imports))
 }
 
-/// Serializes splice positions as a v3 sourcemap with the original inlined.
+/// Serializes splice positions as a v3 sourcemap, inlining the original when
+/// `source_text` is given.
 fn render_sourcemap(
     map: &crate::transform::js_out::SpliceMap,
     filename: &str,
-    source_text: &str,
+    source_text: Option<&str>,
 ) -> String {
-    let mut builder = oxc_sourcemap::SourceMapBuilder::default();
-    let src_id = builder.set_source_and_content(filename, source_text);
-    builder.set_file(filename);
-    for &(dst_line, dst_col, src_line, src_col) in &map.tokens {
-        builder.add_token(dst_line, dst_col, src_line, src_col, Some(src_id), None);
-    }
-    builder.into_sourcemap().to_json_string()
+    let tokens: Vec<oxc_sourcemap::Token> = map
+        .tokens
+        .iter()
+        .map(|&(dst_line, dst_col, src_line, src_col)| {
+            oxc_sourcemap::Token::new(dst_line, dst_col, src_line, src_col, Some(0), None)
+        })
+        .collect();
+    oxc_sourcemap::SourceMap::new(
+        Some(filename.into()),
+        Vec::new(),
+        None,
+        vec![filename.into()],
+        vec![source_text.map(Into::into)],
+        tokens.into_boxed_slice(),
+        None,
+    )
+    .to_json_string()
 }
 
 // The oracle parses every file with the typescript+jsx plugins regardless of
@@ -284,4 +330,54 @@ pub fn parse_program<'a>(
         .map(|d| d.message.to_string())
         .unwrap_or_else(|| "unknown parse error".to_string());
     Err(StylexError::parse_error(&detail))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn options(json: serde_json::Value) -> ResolvedOptions {
+        crate::options::CompilerOptions::from_json(&json)
+            .unwrap()
+            .resolve()
+            .unwrap()
+    }
+
+    #[test]
+    fn pre_gate_admits_every_needle_and_reports_sx() {
+        let opts = ResolvedOptions::default();
+        assert_eq!(pre_gate("export const x = 1;\n", &opts), None);
+        for (source, sx) in [
+            ("import * as s from '@stylexjs/stylex';", false),
+            ("import s from 'stylex';", false),
+            ("import { color } from '@stylexjs/atoms';", false),
+            ("const t = './tokens.stylex';", false),
+            ("<div sx={x} />", true),
+            ("const tsx = 1;", true),
+            ("const s = '\\u0040stylexjs/stylex';", false),
+            ("const s = '\\x40';", false),
+        ] {
+            assert_eq!(pre_gate(source, &opts), Some(sx), "{source}");
+        }
+    }
+
+    #[test]
+    fn pre_gate_keeps_non_default_needles_and_honours_sx_off() {
+        let opts = options(serde_json::json!({
+            "importSources": ["foo-bar", { "from": "my-stylex-lib", "as": "css" }],
+            "sxPropName": false,
+        }));
+        assert_eq!(
+            pre_gate("import { css } from 'foo-bar';", &opts),
+            Some(false)
+        );
+        assert_eq!(
+            pre_gate("import { css } from 'my-stylex-lib';", &opts),
+            Some(false)
+        );
+        assert_eq!(pre_gate("<div sx={x} />", &opts), None);
+        let custom_sx = options(serde_json::json!({ "sxPropName": "css" }));
+        assert_eq!(pre_gate("<div css={x} />", &custom_sx), Some(true));
+        assert_eq!(pre_gate("<div sx={x} />", &custom_sx), None);
+    }
 }

--- a/crates/stylex/src/api.rs
+++ b/crates/stylex/src/api.rs
@@ -1,0 +1,287 @@
+//! Public transform surface (design-core.md §3): the memchr pre-gate, the
+//! splice compile (CLI/harness/rolldown), and the AST compile (oj dev path).
+
+use std::path::Path;
+
+use memchr::memmem;
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Program;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+
+use crate::errors::StylexError;
+use crate::eval::value::JsObjectMap;
+use crate::imports::scan_imports;
+use crate::module_resolution::{FsProvider, THEME_FILE_EXTENSION};
+use crate::options::ResolvedOptions;
+use crate::rules::StylexRule;
+use crate::state::CompileState;
+use crate::transform::ast_backend::apply_plan;
+use crate::transform::visitor::transform_module;
+
+pub struct FileContext<'s> {
+    /// Absolute path the source pretends to live at.
+    pub filename: &'s Path,
+    pub source_text: &'s str,
+    /// process.cwd() equivalent; pins `$$css` debug-string derivation.
+    pub cwd: &'s Path,
+}
+
+#[derive(Debug)]
+pub struct SourceCompileResult {
+    pub code: String,
+    pub map: Option<String>,
+    pub rules: Vec<StylexRule>,
+    pub modified: bool,
+    /// (var name, compiled namespaces) per create call, pre-DCE, in order.
+    pub create_objects: Vec<(Option<String>, std::sync::Arc<JsObjectMap>)>,
+}
+
+pub fn might_contain_stylex(source: &str, options: &ResolvedOptions) -> bool {
+    options
+        .import_sources
+        .iter()
+        .map(crate::options::ImportSource::from_specifier)
+        .any(|needle| memmem::find(source.as_bytes(), needle.as_bytes()).is_some())
+        // Atoms compile off a hardcoded source no importSources setting covers.
+        || memmem::find(source.as_bytes(), crate::imports::ATOMS_SOURCE.as_bytes()).is_some()
+        // The sx prop compiles with no stylex import in the file at all, so
+        // it needs the same needle `is_dormant` already carries.
+        || options
+            .sx_prop_name
+            .as_deref()
+            .is_some_and(|sx| memmem::find(source.as_bytes(), sx.as_bytes()).is_some())
+        // A rewritable import source must carry the hardcoded `.stylex`
+        // suffix, so the literal is a sound pre-gate for that pass too.
+        || (options.rewrite_aliases
+            && memmem::find(source.as_bytes(), THEME_FILE_EXTENSION.as_bytes()).is_some())
+        || has_string_escapes(source)
+}
+
+// A `\u`/`\x` escape can cook into an import-source match the raw needles
+// miss (`"@stylexjs/stylex"`); parse and decide post-parse.
+fn has_string_escapes(source: &str) -> bool {
+    memmem::find(source.as_bytes(), b"\\u").is_some()
+        || memmem::find(source.as_bytes(), b"\\x").is_some()
+}
+
+/// `None` = pre-gate skip (the file cannot reference any stylex import source).
+pub fn transform_source(
+    ctx: &FileContext<'_>,
+    options: &ResolvedOptions,
+    fs: &dyn FsProvider,
+) -> Result<Option<SourceCompileResult>, StylexError> {
+    let allocator = Allocator::default();
+    transform_source_in(&allocator, ctx, options, fs)
+}
+
+/// [`transform_source`] parsing into the caller's arena (reusable across jobs
+/// via `reset()` — nothing in the result borrows it).
+pub fn transform_source_in(
+    allocator: &Allocator,
+    ctx: &FileContext<'_>,
+    options: &ResolvedOptions,
+    fs: &dyn FsProvider,
+) -> Result<Option<SourceCompileResult>, StylexError> {
+    transform_source_mapped_in(allocator, ctx, options, fs, false)
+}
+
+/// [`transform_source_in`] that also builds a v3 sourcemap; emitted text is
+/// byte-identical either way, so the map stays opt-in.
+pub fn transform_source_mapped_in(
+    allocator: &Allocator,
+    ctx: &FileContext<'_>,
+    options: &ResolvedOptions,
+    fs: &dyn FsProvider,
+    want_map: bool,
+) -> Result<Option<SourceCompileResult>, StylexError> {
+    if !might_contain_stylex(ctx.source_text, options) {
+        return Ok(None);
+    }
+    let filename = ctx.filename.to_string_lossy().replace('\\', "/");
+    let program = {
+        let _t = crate::timings::start(crate::timings::Stage::Parse);
+        parse_program(allocator, ctx.source_text, &filename)?
+    };
+    if is_dormant(&program, ctx.source_text, options)? {
+        return Ok(Some(SourceCompileResult {
+            code: ctx.source_text.to_string(),
+            map: None,
+            rules: Vec::new(),
+            modified: false,
+            create_objects: Vec::new(),
+        }));
+    }
+    let filename_for_map = want_map.then(|| filename.clone());
+    let mut state = CompileState::build(
+        &program,
+        options,
+        Some(filename),
+        ctx.cwd.to_string_lossy().replace('\\', "/"),
+    )?;
+    let out = {
+        let _t = crate::timings::start(crate::timings::Stage::Transform);
+        transform_module(&program, ctx.source_text, &mut state, fs, false, want_map)?
+    };
+    let map = out.splice_map.as_ref().map(|m| {
+        render_sourcemap(
+            m,
+            filename_for_map.as_deref().unwrap_or_default(),
+            ctx.source_text,
+        )
+    });
+    Ok(Some(SourceCompileResult {
+        code: out.code,
+        map,
+        rules: state.rules,
+        modified: out.modified,
+        create_objects: out.create_objects,
+    }))
+}
+
+/// [`transform_source`] that also returns the fs-dependency log the cache
+/// needs (crate::cache); recording costs one package.json read per hit dir.
+pub fn transform_source_with_dep_log(
+    ctx: &FileContext<'_>,
+    options: &ResolvedOptions,
+    fs: &dyn FsProvider,
+) -> Result<(Option<SourceCompileResult>, crate::cache::DepLog), StylexError> {
+    let allocator = Allocator::default();
+    transform_source_with_dep_log_in(&allocator, ctx, options, fs)
+}
+
+/// [`transform_source_with_dep_log`] in the caller's arena (see
+/// [`transform_source_in`]).
+pub fn transform_source_with_dep_log_in(
+    allocator: &Allocator,
+    ctx: &FileContext<'_>,
+    options: &ResolvedOptions,
+    fs: &dyn FsProvider,
+) -> Result<(Option<SourceCompileResult>, crate::cache::DepLog), StylexError> {
+    let recorder = crate::cache::RecordingFs::new(fs, ctx.cwd);
+    let result = transform_source_in(allocator, ctx, options, &recorder)?;
+    Ok((result, recorder.into_log()))
+}
+
+/// AST-backend result: rules plus whether the caller's program was mutated.
+#[derive(Debug)]
+pub struct CompileResult {
+    pub modified: bool,
+    pub rules: Vec<StylexRule>,
+    /// (var name, compiled namespaces) per create call, pre-DCE, in order.
+    pub create_objects: Vec<(Option<String>, std::sync::Arc<JsObjectMap>)>,
+}
+
+/// oj dev path: mutates the caller's AST in place; the program must be the
+/// parse of `ctx.source_text` (synthesized-node spans point into it).
+pub fn transform_program<'a>(
+    allocator: &'a Allocator,
+    program: &mut Program<'a>,
+    ctx: &FileContext<'_>,
+    options: &ResolvedOptions,
+    fs: &dyn FsProvider,
+) -> Result<CompileResult, StylexError> {
+    if !might_contain_stylex(ctx.source_text, options) {
+        return Ok(CompileResult {
+            modified: false,
+            rules: Vec::new(),
+            create_objects: Vec::new(),
+        });
+    }
+    if is_dormant(program, ctx.source_text, options)? {
+        return Ok(CompileResult {
+            modified: false,
+            rules: Vec::new(),
+            create_objects: Vec::new(),
+        });
+    }
+    let filename = ctx.filename.to_string_lossy().replace('\\', "/");
+    let cwd = ctx.cwd.to_string_lossy().replace('\\', "/");
+    // Read-only analysis at a shorter reborrow (the AST is covariant over
+    // the arena lifetime) yields an owned plan; the mutation follows.
+    let (plan, modified, rules, create_objects) = {
+        let program_ref: &Program<'_> = &*program;
+        let mut state = CompileState::build(program_ref, options, Some(filename), cwd)?;
+        let out = {
+            let _t = crate::timings::start(crate::timings::Stage::Transform);
+            transform_module(program_ref, ctx.source_text, &mut state, fs, true, false)?
+        };
+        (out.plan, out.modified, state.rules, out.create_objects)
+    };
+    apply_plan(allocator, program, &plan)?;
+    Ok(CompileResult {
+        modified,
+        rules,
+        create_objects,
+    })
+}
+
+/// [`transform_program`] with the cache's fs-dependency log, mirroring
+/// [`transform_source_with_dep_log`].
+pub fn transform_program_with_dep_log<'a>(
+    allocator: &'a Allocator,
+    program: &mut Program<'a>,
+    ctx: &FileContext<'_>,
+    options: &ResolvedOptions,
+    fs: &dyn FsProvider,
+) -> Result<(CompileResult, crate::cache::DepLog), StylexError> {
+    let recorder = crate::cache::RecordingFs::new(fs, ctx.cwd);
+    let result = transform_program(allocator, program, ctx, options, &recorder)?;
+    Ok((result, recorder.into_log()))
+}
+
+// Dormant needs no stylex binding AND no possible sx prop: that transform
+// fires with no import at all and synthesizes one.
+fn is_dormant(
+    program: &Program<'_>,
+    source: &str,
+    options: &ResolvedOptions,
+) -> Result<bool, StylexError> {
+    // `rewriteAliases` runs in Program.exit over every import declaration, with
+    // no stylex binding required anywhere in the file.
+    if options.rewrite_aliases {
+        return Ok(false);
+    }
+    if let Some(sx_prop) = &options.sx_prop_name
+        && memmem::find(source.as_bytes(), sx_prop.as_bytes()).is_some()
+    {
+        return Ok(false);
+    }
+    let _t = crate::timings::start(crate::timings::Stage::ImportScan);
+    Ok(scan_imports(program, options)?.is_dormant())
+}
+
+/// Serializes splice positions as a v3 sourcemap with the original inlined.
+fn render_sourcemap(
+    map: &crate::transform::js_out::SpliceMap,
+    filename: &str,
+    source_text: &str,
+) -> String {
+    let mut builder = oxc_sourcemap::SourceMapBuilder::default();
+    let src_id = builder.set_source_and_content(filename, source_text);
+    builder.set_file(filename);
+    for &(dst_line, dst_col, src_line, src_col) in &map.tokens {
+        builder.add_token(dst_line, dst_col, src_line, src_col, Some(src_id), None);
+    }
+    builder.into_sourcemap().to_json_string()
+}
+
+// The oracle parses every file with the typescript+jsx plugins regardless of
+// extension (`input.js` with `f<T>(0)` is a generic call, not comparisons).
+pub fn parse_program<'a>(
+    allocator: &'a Allocator,
+    source: &'a str,
+    _filename: &str,
+) -> Result<Program<'a>, StylexError> {
+    let ret = Parser::new(allocator, source, SourceType::tsx()).parse();
+    if !ret.panicked && !ret.diagnostics.has_errors() {
+        return Ok(ret.program);
+    }
+    let detail = ret
+        .diagnostics
+        .errors()
+        .next()
+        .map(|d| d.message.to_string())
+        .unwrap_or_else(|| "unknown parse error".to_string());
+    Err(StylexError::parse_error(&detail))
+}

--- a/crates/stylex/src/assemble.rs
+++ b/crates/stylex/src/assemble.rs
@@ -3,8 +3,8 @@
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::hash::BuildHasherDefault;
-use std::sync::Arc;
+use std::hash::{BuildHasher, BuildHasherDefault};
+use std::sync::{Arc, Weak};
 
 use crate::fxhash::{FxHashMap, FxHashSet};
 use crate::jsrt::{ASCII_LOCALE_KEYS, locale_key, utf16_cmp};
@@ -1066,7 +1066,7 @@ struct PreparedRule {
 }
 
 struct FilePrep {
-    rules: Vec<PreparedRule>,
+    rules: PreparedRules,
     const_decls: Vec<(String, ConstVal)>,
     // safe = every sort key verified and every priority finite: the exact
     // preconditions under which sorted-by-key order equals the stable sort.
@@ -1074,9 +1074,86 @@ struct FilePrep {
     logical_float: bool,
 }
 
-fn prepare_file(rules: &[StylexRule], legacy: bool, consts: &[PreparedConst]) -> FilePrep {
+struct SharedPreparedRule {
+    source: StylexRule,
+    prepared: PreparedRule,
+}
+
+enum PreparedRules {
+    Inline(Vec<PreparedRule>),
+    Shared(Vec<Arc<SharedPreparedRule>>),
+}
+
+impl PreparedRules {
+    fn len(&self) -> usize {
+        match self {
+            Self::Inline(rules) => rules.len(),
+            Self::Shared(rules) => rules.len(),
+        }
+    }
+}
+
+impl std::ops::Index<usize> for PreparedRules {
+    type Output = PreparedRule;
+
+    fn index(&self, i: usize) -> &Self::Output {
+        match self {
+            Self::Inline(rules) => &rules[i],
+            Self::Shared(rules) => &rules[i].prepared,
+        }
+    }
+}
+
+type PreparedPool = HashMap<u64, Vec<Weak<SharedPreparedRule>>, BuildHasherDefault<IdentityHasher>>;
+
+fn prefer_shared_preparation(files: &BTreeMap<String, Vec<StylexRule>>) -> bool {
+    let mut seen = FxHashSet::default();
+    let mut total = 0;
+    let hasher = crate::fxhash::FxBuildHasher::default();
+    for rule in files.values().flatten().filter(|r| !is_const_rule(r)) {
+        total += 1;
+        seen.insert(hasher.hash_one((
+            &rule.class_name,
+            &rule.ltr,
+            &rule.rtl,
+            rule.priority.to_bits(),
+        )));
+    }
+    total >= 256 && seen.len() * 2 <= total
+}
+
+fn prepare_rule(r: &StylexRule, legacy: bool, consts: &[PreparedConst]) -> PreparedRule {
+    let ltr = substitute_consts(&r.ltr, consts)
+        .map(Arc::from)
+        .unwrap_or_else(|| r.ltr.clone());
+    let rtl = r.rtl.as_ref().map(|t| {
+        substitute_consts(t, consts)
+            .map(Arc::from)
+            .unwrap_or_else(|| t.clone())
+    });
+    PreparedRule {
+        class_name: r.class_name.clone(),
+        class_hash: class_hash64(&r.class_name),
+        priority: r.priority,
+        key: RuleKey::for_rule(r, legacy),
+        plain_split: plain_split(&ltr, rtl.as_deref()),
+        ltr,
+        rtl,
+    }
+}
+
+fn prepare_file(
+    rules: &[StylexRule],
+    legacy: bool,
+    consts: &[PreparedConst],
+    pool: &mut Option<PreparedPool>,
+) -> FilePrep {
     let mut prep = FilePrep {
-        rules: Vec::with_capacity(rules.len()),
+        rules: if pool.is_some() {
+            PreparedRules::Shared(Vec::with_capacity(rules.len()))
+        } else {
+            PreparedRules::Inline(Vec::with_capacity(rules.len()))
+        },
         const_decls: Vec::new(),
         safe: true,
         logical_float: false,
@@ -1087,25 +1164,31 @@ fn prepare_file(rules: &[StylexRule], legacy: bool, consts: &[PreparedConst]) ->
             continue;
         }
         prep.logical_float |= rule_has_logical_float(r);
-        let key = RuleKey::for_rule(r, legacy);
-        prep.safe &= r.priority.is_finite() && key.verified();
-        let ltr = substitute_consts(&r.ltr, consts)
-            .map(Arc::from)
-            .unwrap_or_else(|| r.ltr.clone());
-        let rtl = r.rtl.as_ref().map(|t| {
-            substitute_consts(t, consts)
-                .map(Arc::from)
-                .unwrap_or_else(|| t.clone())
-        });
-        prep.rules.push(PreparedRule {
-            class_name: r.class_name.clone(),
-            class_hash: class_hash64(&r.class_name),
-            priority: r.priority,
-            key,
-            plain_split: plain_split(&ltr, rtl.as_deref()),
-            ltr,
-            rtl,
-        });
+        match &mut prep.rules {
+            PreparedRules::Inline(rules) => rules.push(prepare_rule(r, legacy, consts)),
+            PreparedRules::Shared(rules) => {
+                let bucket = pool
+                    .as_mut()
+                    .expect("shared preparation pool")
+                    .entry(class_hash64(&r.class_name))
+                    .or_default();
+                let shared = bucket
+                    .iter()
+                    .filter_map(Weak::upgrade)
+                    .find(|p| p.source == *r)
+                    .unwrap_or_else(|| {
+                        let shared = Arc::new(SharedPreparedRule {
+                            source: r.clone(),
+                            prepared: prepare_rule(r, legacy, consts),
+                        });
+                        bucket.push(Arc::downgrade(&shared));
+                        shared
+                    });
+                rules.push(shared);
+            }
+        }
+        let prepared = &prep.rules[prep.rules.len() - 1];
+        prep.safe &= prepared.priority.is_finite() && prepared.key.verified();
     }
     prep
 }
@@ -1136,6 +1219,7 @@ struct IncrState {
     prepared_consts: Vec<PreparedConst>,
     paths: Vec<String>,
     files: Vec<FilePrep>,
+    pool: Option<PreparedPool>,
     sorted: Vec<(u32, u32)>,
 }
 
@@ -1202,7 +1286,11 @@ impl RuleRegistry {
         {
             return result.clone();
         }
-        let result = match self.try_incremental(cfg) {
+        let prepared = self.try_incremental(cfg).or_else(|| {
+            self.rebuild_incr_state(cfg);
+            self.try_incremental(cfg)
+        });
+        let result = match prepared {
             Some(css) => {
                 // Debug cross-check: the incremental path must match one-shot output.
                 #[cfg(debug_assertions)]
@@ -1216,11 +1304,7 @@ impl RuleRegistry {
                 }
                 Ok(css)
             }
-            None => {
-                let result = assemble(&self.all_rules(), cfg);
-                self.rebuild_incr_state(cfg);
-                result
-            }
+            None => assemble(&self.all_rules(), cfg),
         };
         self.cache = Some((self.generation, cfg.clone(), result.clone()));
         result
@@ -1256,6 +1340,7 @@ impl RuleRegistry {
                 files.get(path)?,
                 state.cfg.use_legacy_classnames_sort,
                 &state.prepared_consts,
+                &mut state.pool,
             );
             if !prep.safe {
                 return None;
@@ -1266,6 +1351,17 @@ impl RuleRegistry {
                 .collect();
             fresh.sort_unstable_by(|&a, &b| entry_cmp(&state.files, a, b));
             state.sorted = merge_sorted(&state.files, &state.sorted, rank, fresh);
+        }
+        if let Some(pool) = &mut state.pool {
+            let mut unique = 0;
+            pool.retain(|_, bucket| {
+                bucket.retain(|rule| rule.strong_count() != 0);
+                unique += bucket.len();
+                !bucket.is_empty()
+            });
+            if unique * 2 > state.sorted.len() {
+                return None;
+            }
         }
 
         if files.values().all(|rules| rules.is_empty()) {
@@ -1288,8 +1384,14 @@ impl RuleRegistry {
         let prepared_consts = prepare_consts(&consts);
         let mut paths = Vec::with_capacity(self.files.len());
         let mut fps = Vec::with_capacity(self.files.len());
+        let mut pool = prefer_shared_preparation(&self.files).then(PreparedPool::default);
         for (path, rules) in &self.files {
-            let prep = prepare_file(rules, cfg.use_legacy_classnames_sort, &prepared_consts);
+            let prep = prepare_file(
+                rules,
+                cfg.use_legacy_classnames_sort,
+                &prepared_consts,
+                &mut pool,
+            );
             if !prep.safe {
                 return;
             }
@@ -1313,6 +1415,7 @@ impl RuleRegistry {
             prepared_consts,
             paths,
             files: fps,
+            pool,
             sorted,
         });
     }
@@ -1447,4 +1550,36 @@ fn render(state: &IncrState) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod preparation_tests {
+    use super::*;
+
+    #[test]
+    fn edits_that_remove_repetition_switch_back_to_inline_storage() {
+        let rule = |i: usize| StylexRule {
+            class_name: format!("x{i}").into(),
+            ltr: format!(".x{i}{{width:{i}px}}").into(),
+            rtl: None,
+            const_key: None,
+            const_val: None,
+            priority: 3000.0,
+        };
+        let mut registry = RuleRegistry::new();
+        let cfg = AssembleConfig::default();
+        for i in 0..64 {
+            registry.set_file_rules(&format!("{i:03}.ts"), vec![rule(0); 8]);
+        }
+        registry.emit(&cfg).unwrap();
+        assert!(registry.incr[0].pool.is_some());
+        for i in 0..64 {
+            registry.set_file_rules(
+                &format!("{i:03}.ts"),
+                (1 + i * 8..1 + (i + 1) * 8).map(rule).collect(),
+            );
+            assert_eq!(registry.emit(&cfg), assemble(&registry.all_rules(), &cfg));
+        }
+        assert!(registry.incr[0].pool.is_none());
+    }
 }

--- a/crates/stylex/src/assemble.rs
+++ b/crates/stylex/src/assemble.rs
@@ -1,11 +1,15 @@
 // parity: stylex-0.19.0 packages/@stylexjs/babel-plugin/src/index.js processStylexRules
 
 use std::cmp::Ordering;
+use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::hash::BuildHasherDefault;
+use std::sync::Arc;
 
-use crate::jsrt::{locale_key, utf16_cmp};
+use crate::fxhash::{FxHashMap, FxHashSet};
+use crate::jsrt::{ASCII_LOCALE_KEYS, locale_key, utf16_cmp};
 use crate::rules::StylexRule;
+use crate::timings::{self, Stage};
 
 const LOGICAL_FLOAT_START_VAR: &str = "--stylex-logical-start";
 const LOGICAL_FLOAT_END_VAR: &str = "--stylex-logical-end";
@@ -246,11 +250,11 @@ fn collect_resolved_consts(
 }
 
 fn rule_has_logical_float(r: &StylexRule) -> bool {
-    r.ltr.contains(LOGICAL_FLOAT_START_VAR)
-        || r.ltr.contains(LOGICAL_FLOAT_END_VAR)
-        || r.rtl.as_deref().is_some_and(|t| {
-            t.contains(LOGICAL_FLOAT_START_VAR) || t.contains(LOGICAL_FLOAT_END_VAR)
-        })
+    fn has(text: &str) -> bool {
+        text.contains("--stylex-logical-")
+            && (text.contains(LOGICAL_FLOAT_START_VAR) || text.contains(LOGICAL_FLOAT_END_VAR))
+    }
+    has(&r.ltr) || r.rtl.as_deref().is_some_and(has)
 }
 
 fn logical_float_block(has_logical_float: bool) -> String {
@@ -320,6 +324,21 @@ fn rule_chunk(ltr: &str, rtl: Option<&str>, index: usize, cfg: &AssembleConfig) 
     }
 }
 
+// The common shape (no rtl, no theme pair) is pushed as slices; the rest takes
+// rule_chunk. `", ."` is a literal every theme-pair match contains.
+fn push_chunk(out: &mut String, ltr: &str, rtl: Option<&str>, index: usize, cfg: &AssembleConfig) {
+    if rtl.is_some() || ltr.contains(", .") {
+        out.push_str(&rule_chunk(ltr, rtl, index, cfg));
+        return;
+    }
+    let use_layers_on = matches!(cfg.use_layers, LayersConfig::On { .. });
+    if use_layers_on || cfg.legacy_disable_layers || index == 0 {
+        out.push_str(ltr);
+    } else {
+        push_specificity_level(out, ltr, index);
+    }
+}
+
 fn compare_rules(
     a: &StylexRule,
     b: &StylexRule,
@@ -353,211 +372,311 @@ fn assemble_impl(
         return Ok(String::new());
     }
 
-    let non_const: Vec<&StylexRule> = rules.iter().filter(|r| !is_const_rule(r)).collect();
+    let consts_timer = timings::start(Stage::AssembleConsts);
     let consts =
         collect_resolved_consts(rules.iter().filter(|r| is_const_rule(r)).map(const_decl))?;
     let prepared_consts = prepare_consts(&consts);
+    let non_const: Vec<&StylexRule> = rules.iter().filter(|r| !is_const_rule(r)).collect();
+    drop(consts_timer);
 
-    let mut sorted: Vec<StylexRule> = match custom_cmp {
+    let sorted: Vec<&StylexRule> = match custom_cmp {
         Some(cmp) => {
-            let mut cloned: Vec<StylexRule> = non_const.iter().map(|r| (*r).clone()).collect();
-            cloned.sort_by(|a, b| compare_rules(a, b, cfg, cmp));
-            cloned
+            let _t = timings::start(Stage::AssembleSort);
+            let mut refs = non_const;
+            refs.sort_by(|a, b| compare_rules(a, b, cfg, cmp));
+            refs
         }
-        None => keyed_sorted_clone(&non_const, cfg.use_legacy_classnames_sort),
+        None => keyed_order(non_const, cfg.use_legacy_classnames_sort),
     };
 
     // Logical-float detection reads the pre-substitution rule text.
-    let has_logical_float = non_const.iter().any(|r| rule_has_logical_float(r));
-    let logical_float_vars = logical_float_block(has_logical_float);
+    let logical_float_vars = logical_float_block(sorted.iter().any(|r| rule_has_logical_float(r)));
 
-    for rule in &mut sorted {
-        if let Some(ltr) = substitute_consts(&rule.ltr, &prepared_consts) {
-            rule.ltr = ltr.into();
-        }
-        if let Some(rtl) = &rule.rtl
-            && let Some(rtl_text) = substitute_consts(rtl, &prepared_consts)
-        {
-            rule.rtl = Some(rtl_text.into());
-        }
-    }
+    let subst_timer = timings::start(Stage::AssembleSubst);
+    let substituted: Vec<(Option<String>, Option<String>)> = if prepared_consts.is_empty() {
+        Vec::new()
+    } else {
+        sorted
+            .iter()
+            .map(|r| {
+                (
+                    substitute_consts(&r.ltr, &prepared_consts),
+                    r.rtl
+                        .as_deref()
+                        .and_then(|t| substitute_consts(t, &prepared_consts)),
+                )
+            })
+            .collect()
+    };
+    drop(subst_timer);
+    let text_of = |i: usize| -> (&str, Option<&str>) {
+        let rule = sorted[i];
+        let (ltr, rtl) = match substituted.get(i) {
+            Some((ltr, rtl)) => (ltr.as_deref(), rtl.as_deref()),
+            None => (None, None),
+        };
+        (ltr.unwrap_or(&rule.ltr), rtl.or(rule.rtl.as_deref()))
+    };
 
+    let _render_timer = timings::start(Stage::AssembleRender);
     // Consecutive runs of floor(priority/1000); input is priority-sorted so runs
     // are the priority bands.
-    let mut groups: Vec<Vec<StylexRule>> = Vec::new();
+    let mut bands: Vec<(usize, usize)> = Vec::new();
     let mut last_level = -1.0f64;
-    for rule in sorted {
+    for (i, rule) in sorted.iter().enumerate() {
         let level = (rule.priority / 1000.0).floor();
-        match groups.last_mut() {
-            Some(last) if level == last_level => last.push(rule),
+        match bands.last_mut() {
+            Some(band) if level == last_level => band.1 = i + 1,
             _ => {
                 last_level = level;
-                groups.push(vec![rule]);
+                bands.push((i, i + 1));
             }
         }
     }
 
     let (use_layers_on, _, _, layer_prefix) = layer_parts(cfg);
     let header = if use_layers_on {
-        layers_header(cfg, groups.len())
+        layers_header(cfg, bands.len())
     } else {
         String::new()
     };
 
-    let mut group_blocks: Vec<String> = Vec::with_capacity(groups.len());
-    for (index, group) in groups.iter().enumerate() {
-        let pri = group[0].priority;
+    let text_bytes: usize = sorted
+        .iter()
+        .map(|r| r.ltr.len() + r.rtl.as_ref().map_or(0, |t| t.len() + 40) + 1)
+        .sum();
+    let mut out = String::with_capacity(
+        logical_float_vars.len() + header.len() + text_bytes + 32 * bands.len(),
+    );
+    out.push_str(&logical_float_vars);
+    out.push_str(&header);
 
+    let mut slots: Vec<usize> = Vec::new();
+    let mut slot_of: FxHashMap<&str, usize> = FxHashMap::default();
+    for (index, &(start, end)) in bands.iter().enumerate() {
         // Last-wins dedupe by className, first-occurrence order (JS Map semantics).
-        let mut order: Vec<&str> = Vec::with_capacity(group.len());
-        let mut latest: HashMap<&str, &StylexRule> = HashMap::with_capacity(group.len());
-        for rule in group {
-            if latest.insert(&rule.class_name, rule).is_none() {
-                order.push(&rule.class_name);
+        slots.clear();
+        slot_of.clear();
+        for (offset, rule) in sorted[start..end].iter().enumerate() {
+            let i = start + offset;
+            match slot_of.entry(&rule.class_name) {
+                Entry::Vacant(vacant) => {
+                    vacant.insert(slots.len());
+                    slots.push(i);
+                }
+                Entry::Occupied(occupied) => slots[*occupied.get()] = i,
             }
         }
 
-        let mut chunks: Vec<String> = Vec::with_capacity(order.len());
-        for class_name in order {
-            let rule = latest[class_name];
-            // Empty rtl is falsy upstream and behaves exactly like absent.
-            let rtl = rule.rtl.as_deref().filter(|s| !s.is_empty());
-            chunks.push(rule_chunk(&rule.ltr, rtl, index, cfg));
+        if index > 0 {
+            out.push('\n');
         }
-        let collected = chunks.join("\n");
-        group_blocks.push(if use_layers_on && pri > 0.0 {
-            format!(
-                "@layer {}{{\n{}\n}}",
-                layer_name(layer_prefix, index),
-                collected
-            )
-        } else {
-            collected
-        });
+        let wrap = use_layers_on && sorted[start].priority > 0.0;
+        if wrap {
+            out.push_str("@layer ");
+            out.push_str(&layer_name(layer_prefix, index));
+            out.push_str("{\n");
+        }
+        for (j, &i) in slots.iter().enumerate() {
+            if j > 0 {
+                out.push('\n');
+            }
+            let (ltr, rtl) = text_of(i);
+            // Empty rtl is falsy upstream and behaves exactly like absent.
+            push_chunk(&mut out, ltr, rtl.filter(|s| !s.is_empty()), index, cfg);
+        }
+        if wrap {
+            out.push_str("\n}");
+        }
     }
-
-    Ok(format!(
-        "{logical_float_vars}{header}{}",
-        group_blocks.join("\n")
-    ))
+    Ok(out)
 }
 
-// localeCompare levels of one string, laid out [primary n][secondary n]
-// [tertiary n]; Fallback marks a char outside the pinned collation alphabet.
-enum CollKey {
-    Verified { n: usize, buf: Vec<u8> },
+// localeCompare levels of one string laid out [primary n][secondary n][tertiary n];
+// the declaration slice is its last `decl` chars, so that key is each level's suffix.
+enum RuleKey {
+    Verified { n: usize, decl: usize, buf: Vec<u8> },
+    DeclOnly { decl: usize, buf: Vec<u8> },
     Fallback,
 }
 
-impl CollKey {
-    fn derive(s: &str) -> CollKey {
+type Segments<'a> = [&'a [u8]; 3];
+
+fn cmp_segments(a: Segments<'_>, b: Segments<'_>) -> Ordering {
+    a[0].cmp(b[0])
+        .then_with(|| a[1].cmp(b[1]))
+        .then_with(|| a[2].cmp(b[2]))
+}
+
+impl RuleKey {
+    fn for_rule(r: &StylexRule, legacy: bool) -> RuleKey {
+        if legacy {
+            RuleKey::derive(&r.class_name, 0)
+        } else {
+            RuleKey::derive(&r.ltr, decl_slice(&r.ltr).len())
+        }
+    }
+
+    fn derive(s: &str, decl_bytes: usize) -> RuleKey {
+        let decl_start = s.len() - decl_bytes;
+        if s.is_ascii() {
+            let n = s.len();
+            let mut buf = vec![0u8; 3 * n];
+            for (i, &b) in s.as_bytes().iter().enumerate() {
+                match ASCII_LOCALE_KEYS[usize::from(b)] {
+                    Some((p, sec, ter)) => {
+                        buf[i] = p;
+                        buf[n + i] = sec;
+                        buf[2 * n + i] = ter;
+                    }
+                    None => return RuleKey::decl_only(s, decl_start, i),
+                }
+            }
+            return RuleKey::Verified {
+                n,
+                decl: decl_bytes,
+                buf,
+            };
+        }
         let n = s.chars().count();
         let mut buf = vec![0u8; 3 * n];
-        for (i, c) in s.chars().enumerate() {
+        for (i, (at, c)) in s.char_indices().enumerate() {
             match locale_key(c) {
                 Ok((p, sec, ter)) => {
                     buf[i] = p;
                     buf[n + i] = sec;
                     buf[2 * n + i] = ter;
                 }
-                Err(_) => return CollKey::Fallback,
+                Err(_) => return RuleKey::decl_only(s, decl_start, at),
             }
         }
-        CollKey::Verified { n, buf }
+        RuleKey::Verified {
+            n,
+            decl: s[decl_start..].chars().count(),
+            buf,
+        }
+    }
+
+    // An unverified char at byte `at`; only a fully verified declaration suffix
+    // after it keeps a key.
+    fn decl_only(s: &str, decl_start: usize, at: usize) -> RuleKey {
+        if at >= decl_start || decl_start == s.len() {
+            return RuleKey::Fallback;
+        }
+        match RuleKey::derive(&s[decl_start..], s.len() - decl_start) {
+            RuleKey::Verified { n, buf, .. } => RuleKey::DeclOnly { decl: n, buf },
+            _ => RuleKey::Fallback,
+        }
     }
 
     fn verified(&self) -> bool {
-        matches!(self, CollKey::Verified { .. })
+        matches!(self, RuleKey::Verified { .. })
+    }
+
+    fn decl_segments(&self) -> Option<Segments<'_>> {
+        match self {
+            RuleKey::Verified { n, decl, buf } => Some([
+                &buf[n - decl..*n],
+                &buf[2 * n - decl..2 * n],
+                &buf[3 * n - decl..],
+            ]),
+            RuleKey::DeclOnly { decl, buf } => {
+                Some([&buf[..*decl], &buf[*decl..2 * decl], &buf[2 * decl..]])
+            }
+            RuleKey::Fallback => None,
+        }
+    }
+
+    fn full_segments(&self) -> Option<Segments<'_>> {
+        match self {
+            RuleKey::Verified { n, buf, .. } => Some([&buf[..*n], &buf[*n..2 * n], &buf[2 * n..]]),
+            _ => None,
+        }
     }
 
     // Equal primary sequences imply equal char counts, so the secondary and
     // tertiary segment comparisons are always aligned.
-    fn cmp_verified(&self, other: &CollKey) -> Ordering {
+    fn cmp_verified(&self, other: &RuleKey) -> Ordering {
         match (self, other) {
-            (CollKey::Verified { n: na, buf: ba }, CollKey::Verified { n: nb, buf: bb }) => ba
-                [..*na]
-                .cmp(&bb[..*nb])
+            (
+                RuleKey::Verified {
+                    n: na,
+                    decl: da,
+                    buf: ba,
+                },
+                RuleKey::Verified {
+                    n: nb,
+                    decl: db,
+                    buf: bb,
+                },
+            ) => ba[na - da..*na]
+                .cmp(&bb[nb - db..*nb])
+                .then_with(|| ba[2 * na - da..2 * na].cmp(&bb[2 * nb - db..2 * nb]))
+                .then_with(|| ba[3 * na - da..].cmp(&bb[3 * nb - db..]))
+                .then_with(|| ba[..*na].cmp(&bb[..*nb]))
                 .then_with(|| ba[*na..2 * na].cmp(&bb[*nb..2 * nb]))
                 .then_with(|| ba[2 * na..].cmp(&bb[2 * nb..])),
             _ => unreachable!("cmp_verified on a fallback collation key"),
         }
     }
 
-    // default_locale_cmp semantics: either side unverified → UTF-16 order.
-    fn cmp_or<'x>(
+    // default_locale_cmp semantics per step: either side unverified → UTF-16 order.
+    fn cmp_with_fallback(
         &self,
-        other: &CollKey,
-        fallback: impl FnOnce() -> (&'x str, &'x str),
+        other: &RuleKey,
+        a: &StylexRule,
+        b: &StylexRule,
+        legacy: bool,
     ) -> Ordering {
-        if self.verified() && other.verified() {
-            self.cmp_verified(other)
-        } else {
-            let (a, b) = fallback();
-            utf16_cmp(a, b)
-        }
-    }
-}
-
-enum SortKeys {
-    Legacy(CollKey),
-    Standard { decl: CollKey, ltr: CollKey },
-}
-
-impl SortKeys {
-    fn for_rule(r: &StylexRule, legacy: bool) -> SortKeys {
         if legacy {
-            SortKeys::Legacy(CollKey::derive(&r.class_name))
-        } else {
-            SortKeys::Standard {
-                decl: CollKey::derive(decl_slice(&r.ltr)),
-                ltr: CollKey::derive(&r.ltr),
-            }
+            return match (self.full_segments(), other.full_segments()) {
+                (Some(ka), Some(kb)) => cmp_segments(ka, kb),
+                _ => utf16_cmp(&a.class_name, &b.class_name),
+            };
         }
-    }
-
-    fn verified(&self) -> bool {
-        match self {
-            SortKeys::Legacy(k) => k.verified(),
-            SortKeys::Standard { decl, ltr } => decl.verified() && ltr.verified(),
+        let decl = match (self.decl_segments(), other.decl_segments()) {
+            (Some(ka), Some(kb)) => cmp_segments(ka, kb),
+            _ => utf16_cmp(decl_slice(&a.ltr), decl_slice(&b.ltr)),
+        };
+        if decl != Ordering::Equal {
+            return decl;
         }
-    }
-
-    fn cmp_with_fallback(&self, other: &SortKeys, a: &StylexRule, b: &StylexRule) -> Ordering {
-        match (self, other) {
-            (SortKeys::Legacy(ka), SortKeys::Legacy(kb)) => {
-                ka.cmp_or(kb, || (&a.class_name, &b.class_name))
-            }
-            (
-                SortKeys::Standard { decl: da, ltr: la },
-                SortKeys::Standard { decl: db, ltr: lb },
-            ) => match da.cmp_or(db, || (decl_slice(&a.ltr), decl_slice(&b.ltr))) {
-                Ordering::Equal => la.cmp_or(lb, || (&a.ltr, &b.ltr)),
-                other => other,
-            },
-            _ => unreachable!("mixed sort key kinds"),
-        }
-    }
-
-    fn cmp_verified(&self, other: &SortKeys) -> Ordering {
-        match (self, other) {
-            (SortKeys::Legacy(ka), SortKeys::Legacy(kb)) => ka.cmp_verified(kb),
-            (
-                SortKeys::Standard { decl: da, ltr: la },
-                SortKeys::Standard { decl: db, ltr: lb },
-            ) => da.cmp_verified(db).then_with(|| la.cmp_verified(lb)),
-            _ => unreachable!("mixed sort key kinds"),
+        match (self.full_segments(), other.full_segments()) {
+            (Some(ka), Some(kb)) => cmp_segments(ka, kb),
+            _ => utf16_cmp(&a.ltr, &b.ltr),
         }
     }
 }
 
-// Collation keys derived once per rule instead of once per comparison; the
-// stable sort and the per-pair fallback keep comparator semantics identical.
-fn keyed_sorted_clone(non_const: &[&StylexRule], legacy: bool) -> Vec<StylexRule> {
-    let mut entries: Vec<(SortKeys, &StylexRule)> = non_const
+// Keys derived once per rule; the stable index sort and the per-pair fallback
+// keep comparator semantics identical.
+fn keyed_order(non_const: Vec<&StylexRule>, legacy: bool) -> Vec<&StylexRule> {
+    let dedupe_timer = timings::start(Stage::AssembleDedupe);
+    let mut unique = dedupe_keep_first(&non_const);
+    drop(dedupe_timer);
+    let keys_timer = timings::start(Stage::AssembleKeys);
+    let mut keys: Vec<RuleKey> = unique
         .iter()
-        .map(|r| (SortKeys::for_rule(r, legacy), *r))
+        .map(|r| RuleKey::for_rule(r, legacy))
         .collect();
-    entries.sort_by(|(ka, a), (kb, b)| {
+    // Dropping duplicates is order-neutral only under a consistent total order
+    // (verified keys, finite priorities); otherwise sort the full input as before.
+    if keys
+        .iter()
+        .zip(&unique)
+        .any(|(k, r)| !k.verified() || !r.priority.is_finite())
+    {
+        unique = non_const;
+        keys = unique
+            .iter()
+            .map(|r| RuleKey::for_rule(r, legacy))
+            .collect();
+    }
+    drop(keys_timer);
+    let _sort_timer = timings::start(Stage::AssembleSort);
+    let mut order: Vec<u32> = (0..unique.len() as u32).collect();
+    order.sort_by(|&ia, &ib| {
+        let (a, b) = (unique[ia as usize], unique[ib as usize]);
         let diff = a.priority - b.priority;
         if diff != 0.0 {
             return if diff < 0.0 {
@@ -566,9 +685,40 @@ fn keyed_sorted_clone(non_const: &[&StylexRule], legacy: bool) -> Vec<StylexRule
                 Ordering::Greater
             };
         }
-        ka.cmp_with_fallback(kb, a, b)
+        keys[ia as usize].cmp_with_fallback(&keys[ib as usize], a, b, legacy)
     });
-    entries.into_iter().map(|(_, r)| r.clone()).collect()
+    order.into_iter().map(|i| unique[i as usize]).collect()
+}
+
+// Keep-first is output-neutral (copies sort Equal, adjacent); a class with two
+// distinct texts keeps every copy, since a copy between them decides last-wins.
+fn dedupe_keep_first<'a>(rules: &[&'a StylexRule]) -> Vec<&'a StylexRule> {
+    let mut seen: FxHashSet<(&str, &str, Option<&str>, u64)> = FxHashSet::default();
+    let first: Vec<bool> = rules
+        .iter()
+        .map(|r| {
+            seen.insert((
+                &r.class_name,
+                &r.ltr,
+                r.rtl.as_deref(),
+                r.priority.to_bits(),
+            ))
+        })
+        .collect();
+    if seen.len() == rules.len() {
+        return rules.to_vec();
+    }
+    let mut texts: FxHashMap<&str, u32> = FxHashMap::default();
+    for (r, _) in rules.iter().zip(&first).filter(|(_, fresh)| **fresh) {
+        *texts.entry(&r.class_name).or_default() += 1;
+    }
+    let single_text_classes = texts.len() == seen.len();
+    rules
+        .iter()
+        .zip(first)
+        .filter(|(r, fresh)| *fresh || (!single_text_classes && texts[&*r.class_name] > 1))
+        .map(|(r, _)| *r)
+        .collect()
 }
 
 // rule.slice(rule.lastIndexOf('{')): lastIndexOf misses → -1 → JS slice(-1) is
@@ -676,6 +826,9 @@ fn prepare_consts(consts: &[(String, ConstVal)]) -> Vec<PreparedConst> {
 /// `None` when no const reference matched: callers keep sharing the rule's
 /// Arc'd text instead of materializing an identical String.
 fn substitute_consts(text: &str, consts: &[PreparedConst]) -> Option<String> {
+    if consts.is_empty() {
+        return None;
+    }
     let mut out: Option<String> = None;
     let mut has_ref = text.contains("var(--");
     for c in consts {
@@ -761,11 +914,21 @@ fn js_replace_all(s: &str, needle: &str, replacement: &str) -> String {
 // :not(#\#) polyfill; inserted before the first '::' when present, else before
 // the last '{'; @keyframes exempt (only @keyframes — @property etc. are not).
 fn add_specificity_level(selector: &str, index: usize) -> String {
+    let mut out = String::with_capacity(selector.len() + 9 * index);
+    push_specificity_level(&mut out, selector, index);
+    out
+}
+
+fn push_specificity_level(out: &mut String, selector: &str, index: usize) {
     if selector.starts_with("@keyframes") {
-        return selector.to_string();
+        out.push_str(selector);
+        return;
     }
-    let pseudo = ":not(#\\#)".repeat(index);
-    let split_at = match selector.find("::") {
+    push_split(out, selector, specificity_split(selector), index);
+}
+
+fn specificity_split(selector: &str) -> usize {
+    match selector.find("::") {
         Some(i) => i,
         None => match selector.rfind('{') {
             Some(i) => i,
@@ -773,13 +936,24 @@ fn add_specificity_level(selector: &str, index: usize) -> String {
             // final character.
             None => selector.char_indices().last().map(|(i, _)| i).unwrap_or(0),
         },
-    };
-    format!(
-        "{}{}{}",
-        &selector[..split_at],
-        pseudo,
-        &selector[split_at..]
-    )
+    }
+}
+
+fn push_split(out: &mut String, selector: &str, split_at: usize, index: usize) {
+    out.push_str(&selector[..split_at]);
+    for _ in 0..index {
+        out.push_str(":not(#\\#)");
+    }
+    out.push_str(&selector[split_at..]);
+}
+
+// Split point of a rule that renders as plain slices (no rtl, no theme pair,
+// not @keyframes); None routes the rule through push_chunk.
+fn plain_split(ltr: &str, rtl: Option<&str>) -> Option<usize> {
+    if rtl.is_some_and(|t| !t.is_empty()) || ltr.contains(", .") || ltr.starts_with("@keyframes") {
+        return None;
+    }
+    Some(specificity_split(ltr))
 }
 
 fn add_ancestor_selector(selector: &str, ancestor_selector: &str) -> String {
@@ -881,15 +1055,14 @@ impl std::hash::Hasher for IdentityHasher {
 }
 
 struct PreparedRule {
-    class_name: std::sync::Arc<str>,
+    class_name: Arc<str>,
     class_hash: u64,
     priority: f64,
-    keys: SortKeys,
-    // ltr/rtl carry the const substitutions; chunk memoizes the emitted text
-    // per group index.
-    ltr: String,
-    rtl: Option<String>,
-    chunk: Option<(usize, String)>,
+    key: RuleKey,
+    // ltr/rtl carry the const substitutions; unchanged text shares the rule's Arc.
+    ltr: Arc<str>,
+    rtl: Option<Arc<str>>,
+    plain_split: Option<usize>,
 }
 
 struct FilePrep {
@@ -914,21 +1087,24 @@ fn prepare_file(rules: &[StylexRule], legacy: bool, consts: &[PreparedConst]) ->
             continue;
         }
         prep.logical_float |= rule_has_logical_float(r);
-        let keys = SortKeys::for_rule(r, legacy);
-        prep.safe &= r.priority.is_finite() && keys.verified();
-        let ltr = substitute_consts(&r.ltr, consts).unwrap_or_else(|| r.ltr.to_string());
-        let rtl = r
-            .rtl
-            .as_ref()
-            .map(|t| substitute_consts(t, consts).unwrap_or_else(|| t.to_string()));
+        let key = RuleKey::for_rule(r, legacy);
+        prep.safe &= r.priority.is_finite() && key.verified();
+        let ltr = substitute_consts(&r.ltr, consts)
+            .map(Arc::from)
+            .unwrap_or_else(|| r.ltr.clone());
+        let rtl = r.rtl.as_ref().map(|t| {
+            substitute_consts(t, consts)
+                .map(Arc::from)
+                .unwrap_or_else(|| t.clone())
+        });
         prep.rules.push(PreparedRule {
             class_name: r.class_name.clone(),
             class_hash: class_hash64(&r.class_name),
             priority: r.priority,
-            keys,
+            key,
+            plain_split: plain_split(&ltr, rtl.as_deref()),
             ltr,
             rtl,
-            chunk: None,
         });
     }
     prep
@@ -947,7 +1123,7 @@ fn entry_cmp(files: &[FilePrep], a: (u32, u32), b: (u32, u32)) -> Ordering {
             Ordering::Greater
         };
     }
-    pa.keys.cmp_verified(&pb.keys).then_with(|| a.cmp(&b))
+    pa.key.cmp_verified(&pb.key).then_with(|| a.cmp(&b))
 }
 
 // Per-config incremental state: prepared rules, resolved consts, and the
@@ -1168,7 +1344,7 @@ fn merge_sorted(
 // collision costs a heap allocation.
 type SlotMap = HashMap<u64, (u32, Vec<u32>), BuildHasherDefault<IdentityHasher>>;
 
-fn render(state: &mut IncrState) -> String {
+fn render(state: &IncrState) -> String {
     let IncrState {
         cfg, files, sorted, ..
     } = state;
@@ -1254,13 +1430,17 @@ fn render(state: &mut IncrState) -> String {
             if j > 0 {
                 out.push('\n');
             }
-            let p = &mut files[rank as usize].rules[seq as usize];
-            if !matches!(&p.chunk, Some((i, _)) if *i == index) {
-                let rtl = p.rtl.as_deref().filter(|s| !s.is_empty());
-                let chunk = rule_chunk(&p.ltr, rtl, index, cfg);
-                p.chunk = Some((index, chunk));
+            let p = &files[rank as usize].rules[seq as usize];
+            match p.plain_split {
+                Some(_) if use_layers_on || cfg.legacy_disable_layers || index == 0 => {
+                    out.push_str(&p.ltr);
+                }
+                Some(split) => push_split(&mut out, &p.ltr, split, index),
+                None => {
+                    let rtl = p.rtl.as_deref().filter(|s| !s.is_empty());
+                    push_chunk(&mut out, &p.ltr, rtl, index, cfg);
+                }
             }
-            out.push_str(&p.chunk.as_ref().expect("chunk just memoized").1);
         }
         if wrap {
             out.push_str("\n}");

--- a/crates/stylex/src/assemble.rs
+++ b/crates/stylex/src/assemble.rs
@@ -1,0 +1,1270 @@
+// parity: stylex-0.19.0 packages/@stylexjs/babel-plugin/src/index.js processStylexRules
+
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::hash::BuildHasherDefault;
+
+use crate::jsrt::{locale_key, utf16_cmp};
+use crate::rules::StylexRule;
+
+const LOGICAL_FLOAT_START_VAR: &str = "--stylex-logical-start";
+const LOGICAL_FLOAT_END_VAR: &str = "--stylex-logical-end";
+
+pub type Comparator = fn(&str, &str) -> Ordering;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LayersConfig {
+    Off,
+    On {
+        before: Vec<String>,
+        after: Vec<String>,
+        prefix: Option<String>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AssembleConfig {
+    pub use_layers: LayersConfig,
+    pub use_legacy_classnames_sort: bool,
+    pub legacy_disable_layers: bool,
+    pub enable_ltr_rtl_comments: bool,
+}
+
+impl Default for AssembleConfig {
+    fn default() -> Self {
+        AssembleConfig {
+            use_layers: LayersConfig::Off,
+            use_legacy_classnames_sort: false,
+            legacy_disable_layers: false,
+            enable_ltr_rtl_comments: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum AssembleError {
+    // Message text mirrors the upstream throw byte for byte.
+    #[error("circular reference detected for constant {0}")]
+    CircularConst(String),
+    #[error("unsupported processStylexRules config: {0}")]
+    Unsupported(String),
+    #[error("invalid processStylexRules config: {0}")]
+    InvalidConfig(String),
+}
+
+impl AssembleConfig {
+    // Mirrors the upstream raw-config parse: `boolean` is shorthand for `{useLayers}`,
+    // `useLayers !== false` turns layers on, falsy prefix means no prefix.
+    pub fn from_json(v: &serde_json::Value) -> Result<Self, AssembleError> {
+        use serde_json::Value;
+        let obj = match v {
+            Value::Bool(b) => {
+                return Ok(AssembleConfig {
+                    use_layers: if *b {
+                        LayersConfig::on_empty()
+                    } else {
+                        LayersConfig::Off
+                    },
+                    ..AssembleConfig::default()
+                });
+            }
+            Value::Null => return Ok(AssembleConfig::default()),
+            Value::Object(o) => o,
+            other => {
+                return Err(AssembleError::InvalidConfig(format!(
+                    "expected boolean or object, got {other}"
+                )));
+            }
+        };
+        let use_layers = match obj.get("useLayers") {
+            None | Some(Value::Null) | Some(Value::Bool(false)) => LayersConfig::Off,
+            Some(Value::Bool(true)) => LayersConfig::on_empty(),
+            Some(Value::Object(l)) => {
+                let list = |key: &str| -> Result<Vec<String>, AssembleError> {
+                    match l.get(key) {
+                        None | Some(Value::Null) => Ok(vec![]),
+                        Some(Value::Array(a)) => a
+                            .iter()
+                            .map(|s| {
+                                s.as_str().map(str::to_string).ok_or_else(|| {
+                                    AssembleError::InvalidConfig(format!(
+                                        "useLayers.{key} entries must be strings"
+                                    ))
+                                })
+                            })
+                            .collect(),
+                        Some(other) => Err(AssembleError::InvalidConfig(format!(
+                            "useLayers.{key} must be an array, got {other}"
+                        ))),
+                    }
+                };
+                let prefix = match l.get("prefix") {
+                    None | Some(Value::Null) => None,
+                    Some(Value::String(s)) => Some(s.clone()),
+                    Some(other) => {
+                        return Err(AssembleError::InvalidConfig(format!(
+                            "useLayers.prefix must be a string, got {other}"
+                        )));
+                    }
+                };
+                LayersConfig::On {
+                    before: list("before")?,
+                    after: list("after")?,
+                    prefix,
+                }
+            }
+            Some(other) => {
+                return Err(AssembleError::InvalidConfig(format!(
+                    "useLayers must be boolean or object, got {other}"
+                )));
+            }
+        };
+        Ok(AssembleConfig {
+            use_layers,
+            use_legacy_classnames_sort: obj.get("useLegacyClassnamesSort").is_some_and(js_truthy),
+            legacy_disable_layers: obj.get("legacyDisableLayers").is_some_and(js_truthy),
+            enable_ltr_rtl_comments: obj.get("enableLTRRTLComments").is_some_and(js_truthy),
+        })
+    }
+}
+
+impl LayersConfig {
+    fn on_empty() -> Self {
+        LayersConfig::On {
+            before: vec![],
+            after: vec![],
+            prefix: None,
+        }
+    }
+}
+
+fn js_truthy(v: &serde_json::Value) -> bool {
+    use serde_json::Value;
+    match v {
+        Value::Null => false,
+        Value::Bool(b) => *b,
+        Value::Number(n) => n.as_f64().is_some_and(|f| f != 0.0 && !f.is_nan()),
+        Value::String(s) => !s.is_empty(),
+        Value::Array(_) | Value::Object(_) => true,
+    }
+}
+
+// JS string|number const value; `Other` covers metadata that upstream would
+// stringify via String().
+#[derive(Clone, Debug, PartialEq)]
+enum ConstVal {
+    Str(String),
+    Num(f64),
+    Other(serde_json::Value),
+}
+
+impl ConstVal {
+    fn from_json(v: &serde_json::Value) -> ConstVal {
+        match v {
+            serde_json::Value::String(s) => ConstVal::Str(s.clone()),
+            serde_json::Value::Number(n) => ConstVal::Num(n.as_f64().unwrap_or(f64::NAN)),
+            other => match crate::rules::non_finite_from_tag(other) {
+                Some(x) => ConstVal::Num(x),
+                None => ConstVal::Other(other.clone()),
+            },
+        }
+    }
+
+    fn to_js_string(&self) -> String {
+        match self {
+            ConstVal::Str(s) => s.clone(),
+            ConstVal::Num(n) => crate::jsrt::js_number_to_string(*n),
+            ConstVal::Other(v) => js_string_of_value(v),
+        }
+    }
+}
+
+fn js_string_of_value(v: &serde_json::Value) -> String {
+    use serde_json::Value;
+    match v {
+        Value::Null => "null".to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => crate::jsrt::js_number_to_string(n.as_f64().unwrap_or(f64::NAN)),
+        Value::String(s) => s.clone(),
+        // Array.prototype.toString: elements joined by ',', null → ''.
+        Value::Array(a) => a
+            .iter()
+            .map(|e| {
+                if e.is_null() {
+                    String::new()
+                } else {
+                    js_string_of_value(e)
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(","),
+        Value::Object(_) => "[object Object]".to_string(),
+    }
+}
+
+pub fn assemble(rules: &[StylexRule], cfg: &AssembleConfig) -> Result<String, AssembleError> {
+    assemble_impl(rules, cfg, None)
+}
+
+pub fn assemble_with_comparator(
+    rules: &[StylexRule],
+    cfg: &AssembleConfig,
+    cmp: Comparator,
+) -> Result<String, AssembleError> {
+    assemble_impl(rules, cfg, Some(cmp))
+}
+
+fn is_const_rule(r: &StylexRule) -> bool {
+    r.const_key.is_some() && matches!(&r.const_val, Some(v) if !v.is_null())
+}
+
+fn const_decl(r: &StylexRule) -> (String, ConstVal) {
+    (
+        format!("var(--{})", r.class_name),
+        ConstVal::from_json(r.const_val.as_ref().unwrap()),
+    )
+}
+
+// Insertion-ordered "var(--keyhash)" → value map; duplicate keys keep their
+// slot, value last-wins (JS Map.set). Each value is then resolved in place.
+fn collect_resolved_consts(
+    decls: impl Iterator<Item = (String, ConstVal)>,
+) -> Result<Vec<(String, ConstVal)>, AssembleError> {
+    let mut consts: Vec<(String, ConstVal)> = Vec::new();
+    for (key, val) in decls {
+        match consts.iter_mut().find(|(k, _)| *k == key) {
+            Some(slot) => slot.1 = val,
+            None => consts.push((key, val)),
+        }
+    }
+    for i in 0..consts.len() {
+        let value = consts[i].1.clone();
+        let resolved = resolve_constant(&value, &consts, &mut Vec::new())?;
+        consts[i].1 = resolved;
+    }
+    Ok(consts)
+}
+
+fn rule_has_logical_float(r: &StylexRule) -> bool {
+    r.ltr.contains(LOGICAL_FLOAT_START_VAR)
+        || r.ltr.contains(LOGICAL_FLOAT_END_VAR)
+        || r.rtl.as_deref().is_some_and(|t| {
+            t.contains(LOGICAL_FLOAT_START_VAR) || t.contains(LOGICAL_FLOAT_END_VAR)
+        })
+}
+
+fn logical_float_block(has_logical_float: bool) -> String {
+    if has_logical_float {
+        format!(
+            ":root, [dir=\"ltr\"] {{\n  {LOGICAL_FLOAT_START_VAR}: left;\n  \
+             {LOGICAL_FLOAT_END_VAR}: right;\n}}\n[dir=\"rtl\"] {{\n  \
+             {LOGICAL_FLOAT_START_VAR}: right;\n  {LOGICAL_FLOAT_END_VAR}: left;\n}}\n"
+        )
+    } else {
+        String::new()
+    }
+}
+
+fn layer_parts(cfg: &AssembleConfig) -> (bool, &[String], &[String], &str) {
+    match &cfg.use_layers {
+        LayersConfig::On {
+            before,
+            after,
+            prefix,
+        } => (true, before, after, prefix.as_deref().unwrap_or("")),
+        LayersConfig::Off => (false, &[], &[], ""),
+    }
+}
+
+fn layer_name(prefix: &str, index: usize) -> String {
+    if prefix.is_empty() {
+        format!("priority{}", index + 1)
+    } else {
+        format!("{prefix}.priority{}", index + 1)
+    }
+}
+
+fn layers_header(cfg: &AssembleConfig, group_count: usize) -> String {
+    let (_, before, after, prefix) = layer_parts(cfg);
+    let names: Vec<String> = before
+        .iter()
+        .cloned()
+        .chain((0..group_count).map(|i| layer_name(prefix, i)))
+        .chain(after.iter().cloned())
+        .collect();
+    format!("\n@layer {};\n", names.join(", "))
+}
+
+// One deduped class's output: the ltr line, or the ltr/rtl pair joined by the
+// same '\n' the group join would use.
+fn rule_chunk(ltr: &str, rtl: Option<&str>, index: usize, cfg: &AssembleConfig) -> String {
+    let use_layers_on = matches!(cfg.use_layers, LayersConfig::On { .. });
+    let mut ltr = ltr.to_string();
+    let mut rtl = rtl.map(str::to_string);
+    if !use_layers_on && !cfg.legacy_disable_layers {
+        ltr = add_specificity_level(&ltr, index);
+        rtl = rtl.map(|r| add_specificity_level(&r, index));
+    }
+    ltr = double_theme_classes(&ltr);
+    rtl = rtl.map(|r| double_theme_classes(&r));
+    match rtl {
+        Some(rtl) if cfg.enable_ltr_rtl_comments => {
+            format!("/* @ltr begin */{ltr}/* @ltr end */\n/* @rtl begin */{rtl}/* @rtl end */")
+        }
+        Some(rtl) => format!(
+            "{}\n{}",
+            add_ancestor_selector(&ltr, "html:not([dir='rtl'])"),
+            add_ancestor_selector(&rtl, "html[dir='rtl']")
+        ),
+        None => ltr,
+    }
+}
+
+fn compare_rules(
+    a: &StylexRule,
+    b: &StylexRule,
+    cfg: &AssembleConfig,
+    cmp: Comparator,
+) -> Ordering {
+    let diff = a.priority - b.priority;
+    if diff != 0.0 {
+        return if diff < 0.0 {
+            Ordering::Less
+        } else {
+            Ordering::Greater
+        };
+    }
+    if cfg.use_legacy_classnames_sort {
+        cmp(&a.class_name, &b.class_name)
+    } else {
+        match cmp(decl_slice(&a.ltr), decl_slice(&b.ltr)) {
+            Ordering::Equal => cmp(&a.ltr, &b.ltr),
+            other => other,
+        }
+    }
+}
+
+fn assemble_impl(
+    rules: &[StylexRule],
+    cfg: &AssembleConfig,
+    custom_cmp: Option<Comparator>,
+) -> Result<String, AssembleError> {
+    if rules.is_empty() {
+        return Ok(String::new());
+    }
+
+    let non_const: Vec<&StylexRule> = rules.iter().filter(|r| !is_const_rule(r)).collect();
+    let consts =
+        collect_resolved_consts(rules.iter().filter(|r| is_const_rule(r)).map(const_decl))?;
+    let prepared_consts = prepare_consts(&consts);
+
+    let mut sorted: Vec<StylexRule> = match custom_cmp {
+        Some(cmp) => {
+            let mut cloned: Vec<StylexRule> = non_const.iter().map(|r| (*r).clone()).collect();
+            cloned.sort_by(|a, b| compare_rules(a, b, cfg, cmp));
+            cloned
+        }
+        None => keyed_sorted_clone(&non_const, cfg.use_legacy_classnames_sort),
+    };
+
+    // Logical-float detection reads the pre-substitution rule text.
+    let has_logical_float = non_const.iter().any(|r| rule_has_logical_float(r));
+    let logical_float_vars = logical_float_block(has_logical_float);
+
+    for rule in &mut sorted {
+        if let Some(ltr) = substitute_consts(&rule.ltr, &prepared_consts) {
+            rule.ltr = ltr.into();
+        }
+        if let Some(rtl) = &rule.rtl
+            && let Some(rtl_text) = substitute_consts(rtl, &prepared_consts)
+        {
+            rule.rtl = Some(rtl_text.into());
+        }
+    }
+
+    // Consecutive runs of floor(priority/1000); input is priority-sorted so runs
+    // are the priority bands.
+    let mut groups: Vec<Vec<StylexRule>> = Vec::new();
+    let mut last_level = -1.0f64;
+    for rule in sorted {
+        let level = (rule.priority / 1000.0).floor();
+        match groups.last_mut() {
+            Some(last) if level == last_level => last.push(rule),
+            _ => {
+                last_level = level;
+                groups.push(vec![rule]);
+            }
+        }
+    }
+
+    let (use_layers_on, _, _, layer_prefix) = layer_parts(cfg);
+    let header = if use_layers_on {
+        layers_header(cfg, groups.len())
+    } else {
+        String::new()
+    };
+
+    let mut group_blocks: Vec<String> = Vec::with_capacity(groups.len());
+    for (index, group) in groups.iter().enumerate() {
+        let pri = group[0].priority;
+
+        // Last-wins dedupe by className, first-occurrence order (JS Map semantics).
+        let mut order: Vec<&str> = Vec::with_capacity(group.len());
+        let mut latest: HashMap<&str, &StylexRule> = HashMap::with_capacity(group.len());
+        for rule in group {
+            if latest.insert(&rule.class_name, rule).is_none() {
+                order.push(&rule.class_name);
+            }
+        }
+
+        let mut chunks: Vec<String> = Vec::with_capacity(order.len());
+        for class_name in order {
+            let rule = latest[class_name];
+            // Empty rtl is falsy upstream and behaves exactly like absent.
+            let rtl = rule.rtl.as_deref().filter(|s| !s.is_empty());
+            chunks.push(rule_chunk(&rule.ltr, rtl, index, cfg));
+        }
+        let collected = chunks.join("\n");
+        group_blocks.push(if use_layers_on && pri > 0.0 {
+            format!(
+                "@layer {}{{\n{}\n}}",
+                layer_name(layer_prefix, index),
+                collected
+            )
+        } else {
+            collected
+        });
+    }
+
+    Ok(format!(
+        "{logical_float_vars}{header}{}",
+        group_blocks.join("\n")
+    ))
+}
+
+// localeCompare levels of one string, laid out [primary n][secondary n]
+// [tertiary n]; Fallback marks a char outside the pinned collation alphabet.
+enum CollKey {
+    Verified { n: usize, buf: Vec<u8> },
+    Fallback,
+}
+
+impl CollKey {
+    fn derive(s: &str) -> CollKey {
+        let n = s.chars().count();
+        let mut buf = vec![0u8; 3 * n];
+        for (i, c) in s.chars().enumerate() {
+            match locale_key(c) {
+                Ok((p, sec, ter)) => {
+                    buf[i] = p;
+                    buf[n + i] = sec;
+                    buf[2 * n + i] = ter;
+                }
+                Err(_) => return CollKey::Fallback,
+            }
+        }
+        CollKey::Verified { n, buf }
+    }
+
+    fn verified(&self) -> bool {
+        matches!(self, CollKey::Verified { .. })
+    }
+
+    // Equal primary sequences imply equal char counts, so the secondary and
+    // tertiary segment comparisons are always aligned.
+    fn cmp_verified(&self, other: &CollKey) -> Ordering {
+        match (self, other) {
+            (CollKey::Verified { n: na, buf: ba }, CollKey::Verified { n: nb, buf: bb }) => ba
+                [..*na]
+                .cmp(&bb[..*nb])
+                .then_with(|| ba[*na..2 * na].cmp(&bb[*nb..2 * nb]))
+                .then_with(|| ba[2 * na..].cmp(&bb[2 * nb..])),
+            _ => unreachable!("cmp_verified on a fallback collation key"),
+        }
+    }
+
+    // default_locale_cmp semantics: either side unverified → UTF-16 order.
+    fn cmp_or<'x>(
+        &self,
+        other: &CollKey,
+        fallback: impl FnOnce() -> (&'x str, &'x str),
+    ) -> Ordering {
+        if self.verified() && other.verified() {
+            self.cmp_verified(other)
+        } else {
+            let (a, b) = fallback();
+            utf16_cmp(a, b)
+        }
+    }
+}
+
+enum SortKeys {
+    Legacy(CollKey),
+    Standard { decl: CollKey, ltr: CollKey },
+}
+
+impl SortKeys {
+    fn for_rule(r: &StylexRule, legacy: bool) -> SortKeys {
+        if legacy {
+            SortKeys::Legacy(CollKey::derive(&r.class_name))
+        } else {
+            SortKeys::Standard {
+                decl: CollKey::derive(decl_slice(&r.ltr)),
+                ltr: CollKey::derive(&r.ltr),
+            }
+        }
+    }
+
+    fn verified(&self) -> bool {
+        match self {
+            SortKeys::Legacy(k) => k.verified(),
+            SortKeys::Standard { decl, ltr } => decl.verified() && ltr.verified(),
+        }
+    }
+
+    fn cmp_with_fallback(&self, other: &SortKeys, a: &StylexRule, b: &StylexRule) -> Ordering {
+        match (self, other) {
+            (SortKeys::Legacy(ka), SortKeys::Legacy(kb)) => {
+                ka.cmp_or(kb, || (&a.class_name, &b.class_name))
+            }
+            (
+                SortKeys::Standard { decl: da, ltr: la },
+                SortKeys::Standard { decl: db, ltr: lb },
+            ) => match da.cmp_or(db, || (decl_slice(&a.ltr), decl_slice(&b.ltr))) {
+                Ordering::Equal => la.cmp_or(lb, || (&a.ltr, &b.ltr)),
+                other => other,
+            },
+            _ => unreachable!("mixed sort key kinds"),
+        }
+    }
+
+    fn cmp_verified(&self, other: &SortKeys) -> Ordering {
+        match (self, other) {
+            (SortKeys::Legacy(ka), SortKeys::Legacy(kb)) => ka.cmp_verified(kb),
+            (
+                SortKeys::Standard { decl: da, ltr: la },
+                SortKeys::Standard { decl: db, ltr: lb },
+            ) => da.cmp_verified(db).then_with(|| la.cmp_verified(lb)),
+            _ => unreachable!("mixed sort key kinds"),
+        }
+    }
+}
+
+// Collation keys derived once per rule instead of once per comparison; the
+// stable sort and the per-pair fallback keep comparator semantics identical.
+fn keyed_sorted_clone(non_const: &[&StylexRule], legacy: bool) -> Vec<StylexRule> {
+    let mut entries: Vec<(SortKeys, &StylexRule)> = non_const
+        .iter()
+        .map(|r| (SortKeys::for_rule(r, legacy), *r))
+        .collect();
+    entries.sort_by(|(ka, a), (kb, b)| {
+        let diff = a.priority - b.priority;
+        if diff != 0.0 {
+            return if diff < 0.0 {
+                Ordering::Less
+            } else {
+                Ordering::Greater
+            };
+        }
+        ka.cmp_with_fallback(kb, a, b)
+    });
+    entries.into_iter().map(|(_, r)| r.clone()).collect()
+}
+
+// rule.slice(rule.lastIndexOf('{')): lastIndexOf misses → -1 → JS slice(-1) is
+// the final character.
+fn decl_slice(rule: &str) -> &str {
+    match rule.rfind('{') {
+        Some(i) => &rule[i..],
+        None => rule
+            .char_indices()
+            .last()
+            .map(|(i, _)| &rule[i..])
+            .unwrap_or(""),
+    }
+}
+
+fn resolve_constant(
+    value: &ConstVal,
+    consts: &[(String, ConstVal)],
+    visited: &mut Vec<String>,
+) -> Result<ConstVal, AssembleError> {
+    let ConstVal::Str(s) = value else {
+        return Ok(value.clone());
+    };
+    let mut result = s.clone();
+    let mut scan_from = 0usize;
+    while let Some((start, end)) = find_var_ref(&result, scan_from) {
+        let ref_name = result[start + 4..end - 1].to_string();
+        if visited.contains(&ref_name) {
+            return Err(AssembleError::CircularConst(ref_name));
+        }
+        let ref_key = format!("var({ref_name})");
+        let Some((_, ref_val)) = consts.iter().find(|(k, _)| *k == ref_key) else {
+            scan_from = end;
+            continue;
+        };
+        visited.push(ref_name.clone());
+        let replacement = resolve_constant(&ref_val.clone(), consts, visited)?;
+        let needle = result[start..end].to_string();
+        result = js_replace_first(&result, &needle, &replacement.to_js_string());
+        visited.retain(|v| *v != ref_name);
+        scan_from = 0;
+    }
+    Ok(ConstVal::Str(result))
+}
+
+// Scanner for /var\((--[A-Za-z0-9_-]+)\)/ from a byte offset; returns the byte
+// span of the whole match.
+fn find_var_ref(s: &str, from: usize) -> Option<(usize, usize)> {
+    let bytes = s.as_bytes();
+    let mut pos = from;
+    loop {
+        let off = s.get(pos..)?.find("var(--")?;
+        let start = pos + off;
+        let mut j = start + 6;
+        while j < bytes.len() && is_var_ident_byte(bytes[j]) {
+            j += 1;
+        }
+        if j > start + 6 && j < bytes.len() && bytes[j] == b')' {
+            return Some((start, j + 1));
+        }
+        pos = start + 1;
+    }
+}
+
+fn is_var_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b == b'-'
+}
+
+// The per-const strings substitution needs, derived once per assemble instead
+// of once per rule × const.
+struct PreparedConst {
+    var_ref: String,
+    replacement: String,
+    key_rewrite: Option<(String, String)>,
+}
+
+fn prepare_consts(consts: &[(String, ConstVal)]) -> Vec<PreparedConst> {
+    consts
+        .iter()
+        .map(|(var_ref, const_val)| {
+            let replacement = const_val.to_js_string();
+            // A const resolving to var(...) also rewrites `--constName:` declaration
+            // keys so the target variable stays overridable. Trims are ES TrimString.
+            let key_rewrite =
+                (replacement.starts_with("var(") && replacement.ends_with(')')).then(|| {
+                    let inside = crate::jsrt::js_trim(&replacement[4..replacement.len() - 1]);
+                    let target_name = match inside.find(',') {
+                        Some(ci) => crate::jsrt::js_trim(&inside[..ci]),
+                        None => inside,
+                    };
+                    let const_name = &var_ref[4..var_ref.len() - 1];
+                    (format!("{const_name}:"), format!("{target_name}:"))
+                });
+            PreparedConst {
+                var_ref: var_ref.clone(),
+                replacement,
+                key_rewrite,
+            }
+        })
+        .collect()
+}
+
+// The contains gates only skip js_replace_all calls that would be identity
+// copies; a hit re-probes for var(-- because replacements can add/remove refs.
+/// `None` when no const reference matched: callers keep sharing the rule's
+/// Arc'd text instead of materializing an identical String.
+fn substitute_consts(text: &str, consts: &[PreparedConst]) -> Option<String> {
+    let mut out: Option<String> = None;
+    let mut has_ref = text.contains("var(--");
+    for c in consts {
+        let cur = out.as_deref().unwrap_or(text);
+        if has_ref && cur.contains(c.var_ref.as_str()) {
+            let next = js_replace_all(cur, &c.var_ref, &c.replacement);
+            has_ref = next.contains("var(--");
+            out = Some(next);
+        }
+        let cur = out.as_deref().unwrap_or(text);
+        if let Some((needle, target)) = &c.key_rewrite
+            && cur.contains(needle.as_str())
+        {
+            let next = js_replace_all(cur, needle, target);
+            has_ref = next.contains("var(--");
+            out = Some(next);
+        }
+    }
+    out
+}
+
+// JS GetSubstitution for string-pattern replace/replaceAll: only $$, $&, $`, $'
+// are active (no capture groups exist).
+fn js_substitution(out: &mut Vec<u8>, full: &str, pos: usize, matched: &str, replacement: &str) {
+    let rep = replacement.as_bytes();
+    let mut i = 0;
+    while i < rep.len() {
+        if rep[i] == b'$' && i + 1 < rep.len() {
+            match rep[i + 1] {
+                b'$' => {
+                    out.push(b'$');
+                    i += 2;
+                    continue;
+                }
+                b'&' => {
+                    out.extend_from_slice(matched.as_bytes());
+                    i += 2;
+                    continue;
+                }
+                b'`' => {
+                    out.extend_from_slice(&full.as_bytes()[..pos]);
+                    i += 2;
+                    continue;
+                }
+                b'\'' => {
+                    out.extend_from_slice(&full.as_bytes()[pos + matched.len()..]);
+                    i += 2;
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        out.push(rep[i]);
+        i += 1;
+    }
+}
+
+fn js_replace_first(s: &str, needle: &str, replacement: &str) -> String {
+    let Some(pos) = s.find(needle) else {
+        return s.to_string();
+    };
+    let mut out = Vec::with_capacity(s.len());
+    out.extend_from_slice(&s.as_bytes()[..pos]);
+    js_substitution(&mut out, s, pos, needle, replacement);
+    out.extend_from_slice(&s.as_bytes()[pos + needle.len()..]);
+    String::from_utf8(out).expect("byte-splices preserve UTF-8")
+}
+
+fn js_replace_all(s: &str, needle: &str, replacement: &str) -> String {
+    debug_assert!(!needle.is_empty());
+    let mut out = Vec::with_capacity(s.len());
+    let mut pos = 0;
+    while let Some(off) = s[pos..].find(needle) {
+        let at = pos + off;
+        out.extend_from_slice(&s.as_bytes()[pos..at]);
+        js_substitution(&mut out, s, at, needle, replacement);
+        pos = at + needle.len();
+    }
+    out.extend_from_slice(&s.as_bytes()[pos..]);
+    String::from_utf8(out).expect("byte-splices preserve UTF-8")
+}
+
+// :not(#\#) polyfill; inserted before the first '::' when present, else before
+// the last '{'; @keyframes exempt (only @keyframes — @property etc. are not).
+fn add_specificity_level(selector: &str, index: usize) -> String {
+    if selector.starts_with("@keyframes") {
+        return selector.to_string();
+    }
+    let pseudo = ":not(#\\#)".repeat(index);
+    let split_at = match selector.find("::") {
+        Some(i) => i,
+        None => match selector.rfind('{') {
+            Some(i) => i,
+            // lastIndexOf miss → -1 → JS slice(0,-1) / slice(-1) split before the
+            // final character.
+            None => selector.char_indices().last().map(|(i, _)| i).unwrap_or(0),
+        },
+    };
+    format!(
+        "{}{}{}",
+        &selector[..split_at],
+        pseudo,
+        &selector[split_at..]
+    )
+}
+
+fn add_ancestor_selector(selector: &str, ancestor_selector: &str) -> String {
+    if selector.starts_with("@keyframes") {
+        return selector.to_string();
+    }
+    if !selector.starts_with('@') {
+        return format!("{ancestor_selector} {selector}");
+    }
+    let last_at_rule = selector.rfind('@').unwrap_or(0);
+    match selector[last_at_rule..].find('{') {
+        Some(off) => {
+            let bracket = last_at_rule + off;
+            format!(
+                "{}{} {}",
+                &selector[..bracket + 1],
+                ancestor_selector,
+                &selector[bracket + 1..]
+            )
+        }
+        // indexOf miss → -1 → slice(0,0) prefix and the whole string as rest.
+        None => format!("{ancestor_selector} {selector}"),
+    }
+}
+
+// /\.([a-zA-Z0-9]+), \.([a-zA-Z0-9]+):root/g → '.$1.$1, .$1.$1:root' — the
+// second class is intentionally overwritten by the first, as upstream does.
+fn double_theme_classes(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(s.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'.'
+            && let Some((end, class_end)) = match_theme_pair(bytes, i)
+        {
+            let class = &s[i + 1..class_end];
+            out.extend_from_slice(format!(".{class}.{class}, .{class}.{class}:root").as_bytes());
+            i = end;
+            continue;
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8(out).expect("ASCII-anchored splices preserve UTF-8")
+}
+
+fn match_theme_pair(bytes: &[u8], start: usize) -> Option<(usize, usize)> {
+    let mut j = start + 1;
+    while j < bytes.len() && bytes[j].is_ascii_alphanumeric() {
+        j += 1;
+    }
+    if j == start + 1 {
+        return None;
+    }
+    let class_end = j;
+    if !bytes[j..].starts_with(b", .") {
+        return None;
+    }
+    j += 3;
+    let second_start = j;
+    while j < bytes.len() && bytes[j].is_ascii_alphanumeric() {
+        j += 1;
+    }
+    if j == second_start || !bytes[j..].starts_with(b":root") {
+        return None;
+    }
+    Some((j + 5, class_end))
+}
+
+// The one comparator shared with pseudo sorting (jsrt::default_locale_cmp);
+// re-exported so existing callers keep their import path.
+pub use crate::jsrt::default_locale_cmp;
+
+fn class_hash64(s: &str) -> u64 {
+    let mut h = 0xcbf29ce484222325u64;
+    for b in s.bytes() {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    h
+}
+
+// Hash values are precomputed 64-bit class hashes; pass them through verbatim.
+#[derive(Default)]
+struct IdentityHasher(u64);
+
+impl std::hash::Hasher for IdentityHasher {
+    fn finish(&self) -> u64 {
+        self.0
+    }
+    fn write(&mut self, bytes: &[u8]) {
+        for &b in bytes {
+            self.0 = (self.0 << 8) | u64::from(b);
+        }
+    }
+    fn write_u64(&mut self, x: u64) {
+        self.0 = x;
+    }
+}
+
+struct PreparedRule {
+    class_name: std::sync::Arc<str>,
+    class_hash: u64,
+    priority: f64,
+    keys: SortKeys,
+    // ltr/rtl carry the const substitutions; chunk memoizes the emitted text
+    // per group index.
+    ltr: String,
+    rtl: Option<String>,
+    chunk: Option<(usize, String)>,
+}
+
+struct FilePrep {
+    rules: Vec<PreparedRule>,
+    const_decls: Vec<(String, ConstVal)>,
+    // safe = every sort key verified and every priority finite: the exact
+    // preconditions under which sorted-by-key order equals the stable sort.
+    safe: bool,
+    logical_float: bool,
+}
+
+fn prepare_file(rules: &[StylexRule], legacy: bool, consts: &[PreparedConst]) -> FilePrep {
+    let mut prep = FilePrep {
+        rules: Vec::with_capacity(rules.len()),
+        const_decls: Vec::new(),
+        safe: true,
+        logical_float: false,
+    };
+    for r in rules {
+        if is_const_rule(r) {
+            prep.const_decls.push(const_decl(r));
+            continue;
+        }
+        prep.logical_float |= rule_has_logical_float(r);
+        let keys = SortKeys::for_rule(r, legacy);
+        prep.safe &= r.priority.is_finite() && keys.verified();
+        let ltr = substitute_consts(&r.ltr, consts).unwrap_or_else(|| r.ltr.to_string());
+        let rtl = r
+            .rtl
+            .as_ref()
+            .map(|t| substitute_consts(t, consts).unwrap_or_else(|| t.to_string()));
+        prep.rules.push(PreparedRule {
+            class_name: r.class_name.clone(),
+            class_hash: class_hash64(&r.class_name),
+            priority: r.priority,
+            keys,
+            ltr,
+            rtl,
+            chunk: None,
+        });
+    }
+    prep
+}
+
+// Strict total order = comparator order + the (file, seq) input position; with
+// safe files this reproduces the one-shot stable sort exactly.
+fn entry_cmp(files: &[FilePrep], a: (u32, u32), b: (u32, u32)) -> Ordering {
+    let pa = &files[a.0 as usize].rules[a.1 as usize];
+    let pb = &files[b.0 as usize].rules[b.1 as usize];
+    let diff = pa.priority - pb.priority;
+    if diff != 0.0 {
+        return if diff < 0.0 {
+            Ordering::Less
+        } else {
+            Ordering::Greater
+        };
+    }
+    pa.keys.cmp_verified(&pb.keys).then_with(|| a.cmp(&b))
+}
+
+// Per-config incremental state: prepared rules, resolved consts, and the
+// maintained global sort order that make a single-file swap re-emit O(rules).
+struct IncrState {
+    cfg: AssembleConfig,
+    dirty: BTreeSet<String>,
+    structural: bool,
+    consts: Vec<(String, ConstVal)>,
+    prepared_consts: Vec<PreparedConst>,
+    paths: Vec<String>,
+    files: Vec<FilePrep>,
+    sorted: Vec<(u32, u32)>,
+}
+
+const MAX_INCR_STATES: usize = 4;
+
+// Incremental assembly for the HMR path (design-core.md §7): file-keyed rule
+// sets, canonical emission order = BTreeMap file order, memoized full assemble.
+#[derive(Default)]
+pub struct RuleRegistry {
+    files: BTreeMap<String, Vec<StylexRule>>,
+    generation: u64,
+    cache: Option<(u64, AssembleConfig, Result<String, AssembleError>)>,
+    incr: Vec<IncrState>,
+}
+
+impl RuleRegistry {
+    pub fn new() -> Self {
+        RuleRegistry::default()
+    }
+
+    pub fn set_file_rules(&mut self, file: &str, rules: Vec<StylexRule>) {
+        if self.files.get(file).is_some_and(|old| *old == rules) {
+            return;
+        }
+        let existed = self.files.insert(file.to_string(), rules).is_some();
+        for state in &mut self.incr {
+            if existed {
+                state.dirty.insert(file.to_string());
+            } else {
+                state.structural = true;
+            }
+        }
+        self.generation += 1;
+    }
+
+    pub fn remove_file(&mut self, file: &str) -> bool {
+        let removed = self.files.remove(file).is_some();
+        if removed {
+            for state in &mut self.incr {
+                state.structural = true;
+            }
+            self.generation += 1;
+        }
+        removed
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub fn file_count(&self) -> usize {
+        self.files.len()
+    }
+
+    // The one-shot-equivalent rule list: files in path order, rules in file order.
+    pub fn all_rules(&self) -> Vec<StylexRule> {
+        self.files.values().flatten().cloned().collect()
+    }
+
+    pub fn emit(&mut self, cfg: &AssembleConfig) -> Result<String, AssembleError> {
+        if let Some((generation, cached_cfg, result)) = &self.cache
+            && *generation == self.generation
+            && cached_cfg == cfg
+        {
+            return result.clone();
+        }
+        let result = match self.try_incremental(cfg) {
+            Some(css) => {
+                // Debug cross-check: the incremental path must match one-shot output.
+                #[cfg(debug_assertions)]
+                {
+                    let full = assemble(&self.all_rules(), cfg);
+                    debug_assert_eq!(
+                        full.as_deref(),
+                        Ok(css.as_str()),
+                        "incremental emit diverged from one-shot assemble"
+                    );
+                }
+                Ok(css)
+            }
+            None => {
+                let result = assemble(&self.all_rules(), cfg);
+                self.rebuild_incr_state(cfg);
+                result
+            }
+        };
+        self.cache = Some((self.generation, cfg.clone(), result.clone()));
+        result
+    }
+
+    // The fast path: re-prepare only the swapped files and splice them into the
+    // cached sort order. None = fall back to the one-shot path.
+    fn try_incremental(&mut self, cfg: &AssembleConfig) -> Option<String> {
+        let Self { files, incr, .. } = self;
+        let state = incr.iter_mut().find(|s| s.cfg == *cfg)?;
+        if state.structural {
+            return None;
+        }
+
+        let mut raw_consts: Vec<(String, ConstVal)> = Vec::new();
+        for (rank, path) in state.paths.iter().enumerate() {
+            if state.dirty.contains(path) {
+                let rules = files.get(path)?;
+                raw_consts.extend(rules.iter().filter(|r| is_const_rule(r)).map(const_decl));
+            } else {
+                raw_consts.extend(state.files[rank].const_decls.iter().cloned());
+            }
+        }
+        let resolved = collect_resolved_consts(raw_consts.into_iter()).ok()?;
+        if resolved != state.consts {
+            return None;
+        }
+
+        let dirty: Vec<String> = std::mem::take(&mut state.dirty).into_iter().collect();
+        for path in &dirty {
+            let rank = state.paths.binary_search(path).ok()? as u32;
+            let prep = prepare_file(
+                files.get(path)?,
+                state.cfg.use_legacy_classnames_sort,
+                &state.prepared_consts,
+            );
+            if !prep.safe {
+                return None;
+            }
+            state.files[rank as usize] = prep;
+            let mut fresh: Vec<(u32, u32)> = (0..state.files[rank as usize].rules.len())
+                .map(|seq| (rank, seq as u32))
+                .collect();
+            fresh.sort_unstable_by(|&a, &b| entry_cmp(&state.files, a, b));
+            state.sorted = merge_sorted(&state.files, &state.sorted, rank, fresh);
+        }
+
+        if files.values().all(|rules| rules.is_empty()) {
+            return Some(String::new());
+        }
+        Some(render(state))
+    }
+
+    // Full rebuild of the per-config state; drops it instead when the rule set
+    // is outside the safe preconditions (or consts fail to resolve).
+    fn rebuild_incr_state(&mut self, cfg: &AssembleConfig) {
+        self.incr.retain(|s| s.cfg != *cfg);
+        let raw = self
+            .files
+            .values()
+            .flat_map(|rules| rules.iter().filter(|r| is_const_rule(r)).map(const_decl));
+        let Ok(consts) = collect_resolved_consts(raw) else {
+            return;
+        };
+        let prepared_consts = prepare_consts(&consts);
+        let mut paths = Vec::with_capacity(self.files.len());
+        let mut fps = Vec::with_capacity(self.files.len());
+        for (path, rules) in &self.files {
+            let prep = prepare_file(rules, cfg.use_legacy_classnames_sort, &prepared_consts);
+            if !prep.safe {
+                return;
+            }
+            paths.push(path.clone());
+            fps.push(prep);
+        }
+        let mut sorted: Vec<(u32, u32)> = fps
+            .iter()
+            .enumerate()
+            .flat_map(|(rank, f)| (0..f.rules.len()).map(move |seq| (rank as u32, seq as u32)))
+            .collect();
+        sorted.sort_unstable_by(|&a, &b| entry_cmp(&fps, a, b));
+        if self.incr.len() >= MAX_INCR_STATES {
+            self.incr.remove(0);
+        }
+        self.incr.push(IncrState {
+            cfg: cfg.clone(),
+            dirty: BTreeSet::new(),
+            structural: false,
+            consts,
+            prepared_consts,
+            paths,
+            files: fps,
+            sorted,
+        });
+    }
+}
+
+// old minus `rank`'s stale entries, merged with that file's fresh pre-sorted
+// entries by binary-searched insertion points (strict entry_cmp total order).
+fn merge_sorted(
+    files: &[FilePrep],
+    old: &[(u32, u32)],
+    rank: u32,
+    fresh: Vec<(u32, u32)>,
+) -> Vec<(u32, u32)> {
+    let kept: Vec<(u32, u32)> = old.iter().copied().filter(|e| e.0 != rank).collect();
+    let mut merged = Vec::with_capacity(kept.len() + fresh.len());
+    let mut prev = 0usize;
+    for &candidate in &fresh {
+        let at = prev
+            + kept[prev..].partition_point(|&e| entry_cmp(files, e, candidate) == Ordering::Less);
+        merged.extend_from_slice(&kept[prev..at]);
+        merged.push(candidate);
+        prev = at;
+    }
+    merged.extend_from_slice(&kept[prev..]);
+    merged
+}
+
+// First slot inline: an empty Vec never allocates, so only a real 64-bit hash
+// collision costs a heap allocation.
+type SlotMap = HashMap<u64, (u32, Vec<u32>), BuildHasherDefault<IdentityHasher>>;
+
+fn render(state: &mut IncrState) -> String {
+    let IncrState {
+        cfg, files, sorted, ..
+    } = state;
+
+    struct GroupMeta {
+        first_priority: f64,
+        emit: Vec<(u32, u32)>,
+    }
+    let mut groups: Vec<GroupMeta> = Vec::new();
+    let mut slots: Vec<(u32, u32)> = Vec::new();
+    let mut slot_map: SlotMap = SlotMap::default();
+    let mut last_band = 0.0f64;
+    let mut first_priority = 0.0f64;
+    let mut open = false;
+    for &(rank, seq) in sorted.iter() {
+        let p = &files[rank as usize].rules[seq as usize];
+        let band = (p.priority / 1000.0).floor();
+        if !open || band != last_band {
+            if open {
+                groups.push(GroupMeta {
+                    first_priority,
+                    emit: std::mem::take(&mut slots),
+                });
+            }
+            slot_map.clear();
+            open = true;
+            last_band = band;
+            first_priority = p.priority;
+        }
+        // JS Map semantics: a repeated class keeps its first slot, latest value wins.
+        match slot_map.entry(p.class_hash) {
+            std::collections::hash_map::Entry::Vacant(vacant) => {
+                vacant.insert((slots.len() as u32, Vec::new()));
+                slots.push((rank, seq));
+            }
+            std::collections::hash_map::Entry::Occupied(mut occupied) => {
+                let same_class = |&si: &u32| {
+                    let (er, es) = slots[si as usize];
+                    files[er as usize].rules[es as usize].class_name == p.class_name
+                };
+                let (first, rest) = occupied.get_mut();
+                let existing = std::iter::once(*first).find(|si| same_class(si));
+                let existing = existing.or_else(|| rest.iter().copied().find(|si| same_class(si)));
+                match existing {
+                    Some(si) => slots[si as usize] = (rank, seq),
+                    None => {
+                        rest.push(slots.len() as u32);
+                        slots.push((rank, seq));
+                    }
+                }
+            }
+        }
+    }
+    if open {
+        groups.push(GroupMeta {
+            first_priority,
+            emit: slots,
+        });
+    }
+
+    let (use_layers_on, _, _, layer_prefix) = layer_parts(cfg);
+    let header = if use_layers_on {
+        layers_header(cfg, groups.len())
+    } else {
+        String::new()
+    };
+    let logical = logical_float_block(files.iter().any(|f| f.logical_float));
+
+    let mut out = String::with_capacity(logical.len() + header.len() + 64 * sorted.len().min(8192));
+    out.push_str(&logical);
+    out.push_str(&header);
+    for (index, group) in groups.iter().enumerate() {
+        if index > 0 {
+            out.push('\n');
+        }
+        let wrap = use_layers_on && group.first_priority > 0.0;
+        if wrap {
+            out.push_str("@layer ");
+            out.push_str(&layer_name(layer_prefix, index));
+            out.push_str("{\n");
+        }
+        for (j, &(rank, seq)) in group.emit.iter().enumerate() {
+            if j > 0 {
+                out.push('\n');
+            }
+            let p = &mut files[rank as usize].rules[seq as usize];
+            if !matches!(&p.chunk, Some((i, _)) if *i == index) {
+                let rtl = p.rtl.as_deref().filter(|s| !s.is_empty());
+                let chunk = rule_chunk(&p.ltr, rtl, index, cfg);
+                p.chunk = Some((index, chunk));
+            }
+            out.push_str(&p.chunk.as_ref().expect("chunk just memoized").1);
+        }
+        if wrap {
+            out.push_str("\n}");
+        }
+    }
+    out
+}

--- a/crates/stylex/src/cache.rs
+++ b/crates/stylex/src/cache.rs
@@ -1,0 +1,957 @@
+//! Local content-addressed compile cache (docs/design-cache.md): entries pair
+//! the result with an fs-observation log, replayed to validate every hit.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::{Deserialize, Serialize};
+
+use crate::api::{
+    FileContext, SourceCompileResult, might_contain_stylex, transform_source_with_dep_log_in,
+};
+use crate::errors::StylexError;
+use crate::eval::value::{EvalValue, JsObjectMap};
+use crate::module_resolution::{FsProvider, ResolveConfig, path_relative};
+use crate::options::ResolvedOptions;
+use crate::rules::StylexRule;
+
+// v2: options key material moved to the precomputed ResolvedOptions::cache_repr.
+pub const CACHE_SCHEMA_VERSION: u32 = 2;
+
+/// Bump on any behavior-affecting compiler change (the STYLEX_PASS_VERSION
+/// pattern): the crate version alone does not move per commit.
+pub const STYLEX_PASS_VERSION: &str = "0.19.0-rs.2";
+
+pub fn compiler_fingerprint() -> &'static str {
+    static FINGERPRINT: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    FINGERPRINT.get_or_init(|| {
+        format!(
+            "{}+{STYLEX_PASS_VERSION}+schema{CACHE_SCHEMA_VERSION}",
+            env!("CARGO_PKG_VERSION")
+        )
+    })
+}
+
+// ------------------------------------------------------------ dep recording
+
+/// One fs observation made during a compile, with its full outcome.
+#[derive(Clone, Debug, PartialEq)]
+pub enum DepEvent {
+    NearestPackage {
+        from: PathBuf,
+        found: Option<(String, PathBuf)>,
+        /// blake3 of the found package.json bytes: any edit there is a miss.
+        package_json_hash: Option<String>,
+    },
+    ResolveImport {
+        specifier: String,
+        importer: PathBuf,
+        resolved: Option<PathBuf>,
+    },
+    Exists {
+        path: PathBuf,
+        found: bool,
+    },
+    /// The `fs.existsSync` probe of the alias branches (directories count).
+    ExistsAny {
+        path: PathBuf,
+        found: bool,
+    },
+}
+
+/// Every fs observation of one compile, with the root the paths anchor to.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct DepLog {
+    /// Canonicalized compile root (`ctx.cwd`); in-root paths serialize relative.
+    pub root: PathBuf,
+    /// The root as the caller spelled it (macOS tempdirs alias /var → /private/var).
+    pub raw_root: PathBuf,
+    pub events: Vec<DepEvent>,
+}
+
+/// [`FsProvider`] wrapper logging every call + outcome for cache validation.
+pub struct RecordingFs<'a> {
+    inner: &'a dyn FsProvider,
+    root: PathBuf,
+    raw_root: PathBuf,
+    events: Mutex<Vec<DepEvent>>,
+}
+
+impl<'a> RecordingFs<'a> {
+    pub fn new(inner: &'a dyn FsProvider, root: &Path) -> Self {
+        let canonical = inner.canonicalize_root(root);
+        Self {
+            inner,
+            root: canonical,
+            raw_root: root.to_path_buf(),
+            events: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn into_log(self) -> DepLog {
+        DepLog {
+            root: self.root,
+            raw_root: self.raw_root,
+            events: self
+                .events
+                .into_inner()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        }
+    }
+
+    fn record(&self, event: DepEvent) {
+        let mut events = self
+            .events
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !events.contains(&event) {
+            events.push(event);
+        }
+    }
+}
+
+impl FsProvider for RecordingFs<'_> {
+    fn nearest_package(&self, from: &Path) -> Option<(String, PathBuf)> {
+        let found = self.inner.nearest_package(from);
+        let package_json_hash = found
+            .as_ref()
+            .and_then(|(_, dir)| self.inner.hash_file(&dir.join("package.json")));
+        self.record(DepEvent::NearestPackage {
+            from: from.to_path_buf(),
+            found: found.clone(),
+            package_json_hash,
+        });
+        found
+    }
+
+    fn resolve_import(
+        &self,
+        specifier: &str,
+        importer: &Path,
+        config: ResolveConfig<'_>,
+    ) -> Option<PathBuf> {
+        let resolved = self.inner.resolve_import(specifier, importer, config);
+        self.record(DepEvent::ResolveImport {
+            specifier: specifier.to_string(),
+            importer: importer.to_path_buf(),
+            resolved: resolved.clone(),
+        });
+        resolved
+    }
+
+    fn exists(&self, p: &Path) -> bool {
+        let found = self.inner.exists(p);
+        self.record(DepEvent::Exists {
+            path: p.to_path_buf(),
+            found,
+        });
+        found
+    }
+
+    fn exists_any(&self, p: &Path) -> bool {
+        let found = self.inner.exists_any(p);
+        self.record(DepEvent::ExistsAny {
+            path: p.to_path_buf(),
+            found,
+        });
+        found
+    }
+
+    fn hash_file(&self, p: &Path) -> Option<String> {
+        self.inner.hash_file(p)
+    }
+}
+
+// --------------------------------------------------------------------- key
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct CacheKey([u8; 32]);
+
+impl CacheKey {
+    pub fn hex(&self) -> String {
+        blake3::Hash::from(self.0).to_hex().to_string()
+    }
+}
+
+/// `filename_key` must be the compile path relative to `ctx.cwd` (see
+/// [`filename_key`]) so entries are shareable across worktrees.
+pub fn cache_key(source: &str, filename_key: &str, options: &ResolvedOptions) -> CacheKey {
+    cache_key_with_fingerprint(source, filename_key, options, compiler_fingerprint())
+}
+
+pub fn cache_key_with_fingerprint(
+    source: &str,
+    filename_key: &str,
+    options: &ResolvedOptions,
+    fingerprint: &str,
+) -> CacheKey {
+    // The precomputed Debug capture keys every ResolvedOptions field, present
+    // and future — no per-field listing to drift out of sync with options.rs.
+    let mut hasher = blake3::Hasher::new();
+    for field in [source, filename_key, &options.cache_repr, fingerprint] {
+        hasher.update(&(field.len() as u64).to_le_bytes());
+        hasher.update(field.as_bytes());
+    }
+    CacheKey(*hasher.finalize().as_bytes())
+}
+
+pub fn filename_key(cwd: &Path, filename: &Path) -> String {
+    path_relative(cwd, filename)
+}
+
+// ------------------------------------------------------------- wire format
+
+#[derive(Serialize, Deserialize)]
+struct EntryWire {
+    schema: u32,
+    fingerprint: String,
+    root: String,
+    deps: Vec<DepEventWire>,
+    result: ResultWire,
+}
+
+/// In-root paths serialize root-relative so a hit can revalidate from any
+/// worktree; an absolute path pins the entry to its recorded root.
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
+#[serde(tag = "t")]
+enum PathWire {
+    #[serde(rename = "r")]
+    Rel { p: String },
+    #[serde(rename = "a")]
+    Abs { p: String },
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "t")]
+enum DepEventWire {
+    #[serde(rename = "pkg")]
+    NearestPackage {
+        from: PathWire,
+        found: Option<(String, PathWire)>,
+        hash: Option<String>,
+    },
+    #[serde(rename = "imp")]
+    ResolveImport {
+        specifier: String,
+        importer: PathWire,
+        resolved: Option<PathWire>,
+    },
+    #[serde(rename = "ex")]
+    Exists { path: PathWire, found: bool },
+    #[serde(rename = "exa")]
+    ExistsAny { path: PathWire, found: bool },
+}
+
+#[derive(Serialize, Deserialize)]
+struct ResultWire {
+    code: String,
+    map: Option<String>,
+    rules: Vec<StylexRule>,
+    modified: bool,
+    create_objects: Vec<(Option<String>, ObjWire)>,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
+struct ObjWire {
+    entries: Vec<(String, ValueWire)>,
+    css_type: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
+#[serde(tag = "t")]
+enum ValueWire {
+    Null,
+    Undef,
+    Bool {
+        v: bool,
+    },
+    /// f64 bits — exact for NaN payloads, -0.0, and infinities.
+    Num {
+        bits: u64,
+    },
+    Str {
+        v: String,
+    },
+    Arr {
+        v: Vec<ValueWire>,
+    },
+    Obj {
+        v: ObjWire,
+    },
+}
+
+fn encode_value(value: &EvalValue) -> ValueWire {
+    match value {
+        EvalValue::Null => ValueWire::Null,
+        EvalValue::Undefined => ValueWire::Undef,
+        EvalValue::Bool(b) => ValueWire::Bool { v: *b },
+        EvalValue::Num(n) => ValueWire::Num { bits: n.to_bits() },
+        EvalValue::Str(s) => ValueWire::Str { v: s.clone() },
+        EvalValue::Arr(items) => ValueWire::Arr {
+            v: items.iter().map(encode_value).collect(),
+        },
+        EvalValue::Obj(map) => ValueWire::Obj {
+            v: encode_object(map),
+        },
+    }
+}
+
+fn decode_value(wire: ValueWire) -> EvalValue {
+    match wire {
+        ValueWire::Null => EvalValue::Null,
+        ValueWire::Undef => EvalValue::Undefined,
+        ValueWire::Bool { v } => EvalValue::Bool(v),
+        ValueWire::Num { bits } => EvalValue::Num(f64::from_bits(bits)),
+        ValueWire::Str { v } => EvalValue::Str(v),
+        ValueWire::Arr { v } => EvalValue::Arr(v.into_iter().map(decode_value).collect()),
+        ValueWire::Obj { v } => EvalValue::Obj(Arc::new(decode_object(v))),
+    }
+}
+
+fn encode_object(map: &JsObjectMap) -> ObjWire {
+    ObjWire {
+        entries: map
+            .entries()
+            .map(|(k, v)| (k.to_string(), encode_value(v)))
+            .collect(),
+        css_type: map.css_type().map(str::to_string),
+    }
+}
+
+fn decode_object(wire: ObjWire) -> JsObjectMap {
+    let mut map = JsObjectMap::new();
+    for (k, v) in wire.entries {
+        map.insert(k, decode_value(v));
+    }
+    if let Some(syntax) = wire.css_type {
+        map.set_css_type(syntax);
+    }
+    map
+}
+
+fn encode_result(result: &SourceCompileResult) -> ResultWire {
+    ResultWire {
+        code: result.code.clone(),
+        map: result.map.clone(),
+        rules: result.rules.clone(),
+        modified: result.modified,
+        create_objects: result
+            .create_objects
+            .iter()
+            .map(|(name, obj)| (name.clone(), encode_object(obj)))
+            .collect(),
+    }
+}
+
+fn decode_result(wire: ResultWire) -> SourceCompileResult {
+    SourceCompileResult {
+        code: wire.code,
+        map: wire.map,
+        rules: wire.rules,
+        modified: wire.modified,
+        create_objects: wire
+            .create_objects
+            .into_iter()
+            .map(|(name, obj)| (name, Arc::new(decode_object(obj))))
+            .collect(),
+    }
+}
+
+fn to_wire_path(log: &DepLog, p: &Path) -> PathWire {
+    for root in [&log.root, &log.raw_root] {
+        if let Ok(rel) = p.strip_prefix(root) {
+            return PathWire::Rel {
+                p: rel.to_string_lossy().replace('\\', "/"),
+            };
+        }
+    }
+    PathWire::Abs {
+        p: p.to_string_lossy().into_owned(),
+    }
+}
+
+fn to_wire_event(log: &DepLog, event: &DepEvent) -> DepEventWire {
+    match event {
+        DepEvent::NearestPackage {
+            from,
+            found,
+            package_json_hash,
+        } => DepEventWire::NearestPackage {
+            from: to_wire_path(log, from),
+            found: found
+                .as_ref()
+                .map(|(name, dir)| (name.clone(), to_wire_path(log, dir))),
+            hash: package_json_hash.clone(),
+        },
+        DepEvent::ResolveImport {
+            specifier,
+            importer,
+            resolved,
+        } => DepEventWire::ResolveImport {
+            specifier: specifier.clone(),
+            importer: to_wire_path(log, importer),
+            resolved: resolved.as_ref().map(|p| to_wire_path(log, p)),
+        },
+        DepEvent::Exists { path, found } => DepEventWire::Exists {
+            path: to_wire_path(log, path),
+            found: *found,
+        },
+        DepEvent::ExistsAny { path, found } => DepEventWire::ExistsAny {
+            path: to_wire_path(log, path),
+            found: *found,
+        },
+    }
+}
+
+// ---------------------------------------------------------- hit validation
+
+struct Anchor {
+    current_root: PathBuf,
+    same_root: bool,
+}
+
+/// `None` on an absolute path under a different root: such entries are
+/// root-pinned because relative derivations cannot reconstruct them.
+fn from_wire_path(anchor: &Anchor, wire: &PathWire) -> Option<PathBuf> {
+    match wire {
+        PathWire::Rel { p } => Some(anchor.current_root.join(p)),
+        PathWire::Abs { p } if anchor.same_root => Some(PathBuf::from(p)),
+        PathWire::Abs { .. } => None,
+    }
+}
+
+fn deps_valid(
+    entry: &EntryWire,
+    current_root: &Path,
+    fs: &dyn FsProvider,
+    config: ResolveConfig<'_>,
+) -> bool {
+    let canonical = fs.canonicalize_root(current_root);
+    let anchor = Anchor {
+        same_root: canonical == Path::new(&entry.root),
+        current_root: canonical,
+    };
+    entry
+        .deps
+        .iter()
+        .all(|dep| dep_valid(dep, &anchor, fs, config))
+}
+
+fn dep_valid(
+    dep: &DepEventWire,
+    anchor: &Anchor,
+    fs: &dyn FsProvider,
+    config: ResolveConfig<'_>,
+) -> bool {
+    match dep {
+        DepEventWire::NearestPackage { from, found, hash } => {
+            let Some(from) = from_wire_path(anchor, from) else {
+                return false;
+            };
+            let expected = match found {
+                None => None,
+                Some((name, dir)) => match from_wire_path(anchor, dir) {
+                    Some(dir) => Some((name.clone(), dir)),
+                    None => return false,
+                },
+            };
+            if fs.nearest_package(&from) != expected {
+                return false;
+            }
+            let recomputed = expected
+                .as_ref()
+                .and_then(|(_, dir)| fs.hash_file(&dir.join("package.json")));
+            recomputed == *hash
+        }
+        DepEventWire::ResolveImport {
+            specifier,
+            importer,
+            resolved,
+        } => {
+            let Some(importer) = from_wire_path(anchor, importer) else {
+                return false;
+            };
+            let expected = match resolved {
+                None => None,
+                Some(p) => match from_wire_path(anchor, p) {
+                    Some(p) => Some(p),
+                    None => return false,
+                },
+            };
+            fs.resolve_import(specifier, &importer, config) == expected
+        }
+        DepEventWire::Exists { path, found } => {
+            let Some(path) = from_wire_path(anchor, path) else {
+                return false;
+            };
+            fs.exists(&path) == *found
+        }
+        DepEventWire::ExistsAny { path, found } => {
+            let Some(path) = from_wire_path(anchor, path) else {
+                return false;
+            };
+            fs.exists_any(&path) == *found
+        }
+    }
+}
+
+// ------------------------------------------------------------------- store
+
+const DEFAULT_MAX_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
+/// One file per key under `dir`; atomic tmp+rename writes, lock-free.
+pub struct CacheStore {
+    dir: PathBuf,
+    max_bytes: u64,
+    written_since_gc: AtomicU64,
+}
+
+impl CacheStore {
+    pub fn new(dir: &Path) -> std::io::Result<Self> {
+        Self::with_max_bytes(dir, DEFAULT_MAX_BYTES)
+    }
+
+    pub fn with_max_bytes(dir: &Path, max_bytes: u64) -> std::io::Result<Self> {
+        std::fs::create_dir_all(dir)?;
+        Ok(Self {
+            dir: dir.to_path_buf(),
+            max_bytes,
+            written_since_gc: AtomicU64::new(0),
+        })
+    }
+
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    fn entry_path(&self, key: &CacheKey) -> PathBuf {
+        self.dir.join(key.hex())
+    }
+
+    /// A hit only when the entry parses, matches the compiler fingerprint,
+    /// and every logged fs observation replays identically against `fs`.
+    pub fn get_validated(
+        &self,
+        key: &CacheKey,
+        current_root: &Path,
+        fs: &dyn FsProvider,
+        config: ResolveConfig<'_>,
+    ) -> Option<SourceCompileResult> {
+        let path = self.entry_path(key);
+        let bytes = {
+            let _t = crate::timings::start(crate::timings::Stage::CacheRead);
+            std::fs::read(&path).ok()?
+        };
+        let entry = {
+            let _t = crate::timings::start(crate::timings::Stage::CacheParse);
+            serde_json::from_slice::<EntryWire>(&bytes)
+        };
+        let Ok(entry) = entry else {
+            let _ = std::fs::remove_file(&path);
+            return None;
+        };
+        if entry.schema != CACHE_SCHEMA_VERSION || entry.fingerprint != compiler_fingerprint() {
+            return None;
+        }
+        {
+            let _t = crate::timings::start(crate::timings::Stage::CacheReplay);
+            if !deps_valid(&entry, current_root, fs, config) {
+                return None;
+            }
+        }
+        let _t = crate::timings::start(crate::timings::Stage::CacheDecode);
+        Some(decode_result(entry.result))
+    }
+
+    pub fn put(
+        &self,
+        key: &CacheKey,
+        result: &SourceCompileResult,
+        deps: &DepLog,
+    ) -> std::io::Result<()> {
+        let entry = EntryWire {
+            schema: CACHE_SCHEMA_VERSION,
+            fingerprint: compiler_fingerprint().to_string(),
+            root: deps.root.to_string_lossy().into_owned(),
+            deps: deps.events.iter().map(|e| to_wire_event(deps, e)).collect(),
+            result: encode_result(result),
+        };
+        let bytes = serde_json::to_vec(&entry).map_err(std::io::Error::other)?;
+        static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+        let tmp = self.dir.join(format!(
+            ".tmp-{}-{}",
+            std::process::id(),
+            TMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::write(&tmp, &bytes)?;
+        std::fs::rename(&tmp, self.entry_path(key))?;
+        let written = self
+            .written_since_gc
+            .fetch_add(bytes.len() as u64, Ordering::Relaxed)
+            + bytes.len() as u64;
+        if written > self.max_bytes / 8 {
+            self.written_since_gc.store(0, Ordering::Relaxed);
+            self.gc()?;
+        }
+        Ok(())
+    }
+
+    /// Deletes oldest entries beyond the byte cap (and stale tmp files);
+    /// returns bytes freed. GC only causes misses, never wrong output.
+    pub fn gc(&self) -> std::io::Result<u64> {
+        let mut entries: Vec<(PathBuf, u64, std::time::SystemTime)> = Vec::new();
+        let mut total: u64 = 0;
+        for dirent in std::fs::read_dir(&self.dir)? {
+            let dirent = dirent?;
+            let path = dirent.path();
+            let Ok(meta) = dirent.metadata() else {
+                continue;
+            };
+            let modified = meta.modified().unwrap_or(std::time::UNIX_EPOCH);
+            let name = dirent.file_name();
+            let is_tmp = name.to_string_lossy().starts_with(".tmp-");
+            if is_tmp {
+                let stale = modified
+                    .elapsed()
+                    .is_ok_and(|age| age > std::time::Duration::from_secs(3600));
+                if stale {
+                    let _ = std::fs::remove_file(&path);
+                }
+                continue;
+            }
+            total += meta.len();
+            entries.push((path, meta.len(), modified));
+        }
+        if total <= self.max_bytes {
+            return Ok(0);
+        }
+        entries.sort_by(|a, b| (a.2, &a.0).cmp(&(b.2, &b.0)));
+        let mut freed = 0;
+        for (path, len, _) in entries {
+            if total - freed <= self.max_bytes {
+                break;
+            }
+            if std::fs::remove_file(&path).is_ok() {
+                freed += len;
+            }
+        }
+        Ok(freed)
+    }
+}
+
+// ------------------------------------------------------------- verify mode
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct VerifyMismatch {
+    pub field: &'static str,
+    pub cached: String,
+    pub fresh: String,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum CacheStatus {
+    Hit,
+    Miss,
+    /// The pre-gate skipped the file; nothing to cache.
+    Gated,
+    /// Verify mode found a stale/corrupt hit; the fresh result was returned
+    /// and the entry repaired.
+    Poisoned(VerifyMismatch),
+}
+
+fn snippet(text: &str) -> String {
+    let mut s: String = text.chars().take(160).collect();
+    if s.len() < text.len() {
+        s.push('…');
+    }
+    s
+}
+
+/// Byte-exact comparison via the lossless wire encoding of each field.
+pub fn compare_results(
+    cached: &SourceCompileResult,
+    fresh: &SourceCompileResult,
+) -> Result<(), VerifyMismatch> {
+    let mismatch = |field, cached: &str, fresh: &str| VerifyMismatch {
+        field,
+        cached: snippet(cached),
+        fresh: snippet(fresh),
+    };
+    if cached.code != fresh.code {
+        return Err(mismatch("code", &cached.code, &fresh.code));
+    }
+    if cached.map != fresh.map {
+        return Err(mismatch(
+            "map",
+            &format!("{:?}", cached.map),
+            &format!("{:?}", fresh.map),
+        ));
+    }
+    if cached.modified != fresh.modified {
+        return Err(mismatch(
+            "modified",
+            &cached.modified.to_string(),
+            &fresh.modified.to_string(),
+        ));
+    }
+    if cached.rules != fresh.rules {
+        return Err(mismatch(
+            "rules",
+            &format!("{:?}", cached.rules),
+            &format!("{:?}", fresh.rules),
+        ));
+    }
+    let encode = |result: &SourceCompileResult| {
+        serde_json::to_string(
+            &result
+                .create_objects
+                .iter()
+                .map(|(name, obj)| (name.clone(), encode_object(obj)))
+                .collect::<Vec<_>>(),
+        )
+        .unwrap_or_default()
+    };
+    let (cached_objs, fresh_objs) = (encode(cached), encode(fresh));
+    if cached_objs != fresh_objs {
+        return Err(mismatch("create_objects", &cached_objs, &fresh_objs));
+    }
+    Ok(())
+}
+
+/// Cache-fronted [`crate::api::transform_source`]. With `verify` it compiles
+/// even on a hit, byte-compares, and repairs + reports a poisoned entry.
+pub fn compile_through_cache(
+    store: &CacheStore,
+    ctx: &FileContext<'_>,
+    options: &ResolvedOptions,
+    fs: &dyn FsProvider,
+    verify: bool,
+) -> Result<(Option<SourceCompileResult>, CacheStatus), StylexError> {
+    let allocator = oxc_allocator::Allocator::default();
+    compile_through_cache_in(&allocator, store, ctx, options, fs, verify)
+}
+
+/// [`compile_through_cache`] compiling misses into the caller's arena (see
+/// [`crate::api::transform_source_in`]); at most one compile lands per call.
+pub fn compile_through_cache_in(
+    allocator: &oxc_allocator::Allocator,
+    store: &CacheStore,
+    ctx: &FileContext<'_>,
+    options: &ResolvedOptions,
+    fs: &dyn FsProvider,
+    verify: bool,
+) -> Result<(Option<SourceCompileResult>, CacheStatus), StylexError> {
+    if !might_contain_stylex(ctx.source_text, options) {
+        return Ok((None, CacheStatus::Gated));
+    }
+    let key = cache_key(
+        ctx.source_text,
+        &filename_key(ctx.cwd, ctx.filename),
+        options,
+    );
+    // The key hashes every ResolvedOptions field, so an entry under it was
+    // recorded with this resolver config; replaying under it is sound.
+    let hit = store.get_validated(&key, ctx.cwd, fs, ResolveConfig::of(options));
+    if let Some(hit) = hit {
+        if !verify {
+            return Ok((Some(hit), CacheStatus::Hit));
+        }
+        let (fresh, log) = transform_source_with_dep_log_in(allocator, ctx, options, fs)?;
+        // The gate is pure on (source, options): an entry under this key
+        // proves the gate passed, so fresh is always Some here.
+        let Some(fresh) = fresh else {
+            return Ok((None, CacheStatus::Gated));
+        };
+        return Ok(match compare_results(&hit, &fresh) {
+            Ok(()) => (Some(fresh), CacheStatus::Hit),
+            Err(report) => {
+                let _ = store.put(&key, &fresh, &log);
+                (Some(fresh), CacheStatus::Poisoned(report))
+            }
+        });
+    }
+    let (fresh, log) = transform_source_with_dep_log_in(allocator, ctx, options, fs)?;
+    let Some(fresh) = fresh else {
+        return Ok((None, CacheStatus::Gated));
+    };
+    // A failed entry write must never fail the compile.
+    let _ = store.put(&key, &fresh, &log);
+    Ok((Some(fresh), CacheStatus::Miss))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::options::CompilerOptions;
+
+    fn options(json: serde_json::Value) -> ResolvedOptions {
+        CompilerOptions::from_json(&json)
+            .expect("options parse")
+            .resolve()
+            .expect("options resolve")
+    }
+
+    #[test]
+    fn key_is_sensitive_to_every_dimension() {
+        let base_opts = options(serde_json::json!({}));
+        let base = cache_key("src", "a/input.ts", &base_opts);
+        assert_eq!(base, cache_key("src", "a/input.ts", &base_opts));
+        assert_ne!(base, cache_key("src2", "a/input.ts", &base_opts));
+        assert_ne!(base, cache_key("src", "a/other.ts", &base_opts));
+        assert_ne!(
+            base,
+            cache_key(
+                "src",
+                "a/input.ts",
+                &options(serde_json::json!({"dev": true}))
+            )
+        );
+        assert_ne!(
+            base,
+            cache_key(
+                "src",
+                "a/input.ts",
+                &options(serde_json::json!({"classNamePrefix": "y"}))
+            )
+        );
+        assert_ne!(
+            base,
+            cache_key(
+                "src",
+                "a/input.ts",
+                &options(serde_json::json!({"env": {"k": "red"}}))
+            )
+        );
+        assert_ne!(
+            cache_key(
+                "src",
+                "a/input.ts",
+                &options(serde_json::json!({"env": {"k": "red"}}))
+            ),
+            cache_key(
+                "src",
+                "a/input.ts",
+                &options(serde_json::json!({"env": {"k": "blue"}}))
+            )
+        );
+        assert_ne!(
+            base,
+            cache_key_with_fingerprint("src", "a/input.ts", &base_opts, "other-version")
+        );
+        // Length-prefixed fields: shifting bytes across a boundary re-keys.
+        assert_ne!(
+            cache_key("ab", "c", &base_opts),
+            cache_key("a", "bc", &base_opts)
+        );
+    }
+
+    #[test]
+    fn value_wire_roundtrip_is_lossless() {
+        let mut inner = JsObjectMap::new();
+        inner.insert("width", EvalValue::Str("1px".into()));
+        inner.set_css_type("<length>".to_string());
+        let mut obj = JsObjectMap::new();
+        obj.insert("2", EvalValue::Num(-0.0));
+        obj.insert("b", EvalValue::Num(f64::NAN));
+        obj.insert("0", EvalValue::Num(f64::NEG_INFINITY));
+        obj.insert("a", EvalValue::Undefined);
+        obj.insert(
+            "arr",
+            EvalValue::Arr(vec![EvalValue::Null, EvalValue::Obj(inner.into())]),
+        );
+        let value = EvalValue::Obj(obj.into());
+        let wire = encode_value(&value);
+        let rewire = encode_value(&decode_value(wire.clone()));
+        assert!(wire == rewire, "round-trip drifted");
+        if let EvalValue::Obj(map) = decode_value(wire) {
+            assert_eq!(
+                map.keys().collect::<Vec<_>>(),
+                vec!["0", "2", "b", "a", "arr"]
+            );
+        } else {
+            panic!("expected object");
+        }
+    }
+
+    #[test]
+    fn puts_are_atomic_under_concurrent_writers() {
+        let dir = std::env::temp_dir().join(format!("stylex-cache-atomic-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let store = CacheStore::new(&dir).expect("store");
+        let opts = options(serde_json::json!({}));
+        let key = cache_key("const a = 1;", "input.ts", &opts);
+        let result = SourceCompileResult {
+            code: "X".repeat(4096),
+            map: None,
+            rules: Vec::new(),
+            modified: false,
+            create_objects: Vec::new(),
+        };
+        let deps = DepLog::default();
+        std::thread::scope(|scope| {
+            for _ in 0..8 {
+                scope.spawn(|| {
+                    for _ in 0..50 {
+                        store.put(&key, &result, &deps).expect("put");
+                        if let Some(read) = store.get_validated(
+                            &key,
+                            Path::new("/nonexistent"),
+                            &NoFs,
+                            ResolveConfig::default(),
+                        ) {
+                            assert_eq!(read.code, result.code, "torn read");
+                        }
+                    }
+                });
+            }
+        });
+        let read = store
+            .get_validated(
+                &key,
+                Path::new("/nonexistent"),
+                &NoFs,
+                ResolveConfig::default(),
+            )
+            .expect("entry after writers");
+        assert_eq!(read.code, result.code);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn gc_deletes_oldest_beyond_cap() {
+        let dir = std::env::temp_dir().join(format!("stylex-cache-gc-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let store = CacheStore::with_max_bytes(&dir, 1).expect("store");
+        let opts = options(serde_json::json!({}));
+        let result = SourceCompileResult {
+            code: "y".repeat(512),
+            map: None,
+            rules: Vec::new(),
+            modified: false,
+            create_objects: Vec::new(),
+        };
+        for i in 0..4 {
+            let key = cache_key(&format!("src{i}"), "input.ts", &opts);
+            store.put(&key, &result, &DepLog::default()).expect("put");
+        }
+        let remaining = std::fs::read_dir(&dir).expect("dir").count();
+        assert!(remaining <= 1, "cap not enforced: {remaining} entries left");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Empty-log validation needs an FsProvider; no call should ever land.
+    struct NoFs;
+    impl FsProvider for NoFs {
+        fn nearest_package(&self, _: &Path) -> Option<(String, PathBuf)> {
+            unreachable!("empty dep log must not touch the fs")
+        }
+        fn resolve_import(&self, _: &str, _: &Path, _: ResolveConfig<'_>) -> Option<PathBuf> {
+            unreachable!("empty dep log must not touch the fs")
+        }
+        fn exists(&self, _: &Path) -> bool {
+            unreachable!("empty dep log must not touch the fs")
+        }
+    }
+}

--- a/crates/stylex/src/errors.rs
+++ b/crates/stylex/src/errors.rs
@@ -1,0 +1,496 @@
+use thiserror::Error;
+
+// Upstream-mirrored codes carry the exact user-facing message text of
+// @stylexjs/babel-plugin@0.19; the Unsupported*/Unknown/Invalid codes are ours.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ErrorCode {
+    IllegalArgumentLength,
+    NonStaticValue,
+    NonStyleObject,
+    IllegalNamespaceValue,
+    IllegalPropValue,
+    IllegalPropArrayValue,
+    NoObjectSpreads,
+    InvalidMediaQuerySyntax,
+    CyclicConstReference,
+    CyclicDefineVarsReference,
+    UnclosedFunction,
+    UnclosedString,
+    BannedShorthand,
+    UnsupportedOption,
+    UnsupportedApi,
+    UnknownOption,
+    InvalidOptionValue,
+    DuplicateConditional,
+    InvalidPseudoOrAtRule,
+    NonContiguousVars,
+    ShorthandFallback,
+    InvalidListStyleValue,
+    EmptyValue,
+    NonObjectKeyframe,
+    UnboundCallValue,
+    NonExportNamedDeclaration,
+    CannotGenerateHash,
+    InvalidWhenSelector,
+    UpstreamTypeError,
+    ParseError,
+    PositionTryInvalidProperty,
+    ViewTransitionClassInvalidProperty,
+    NestedKeySeparator,
+    NestedThemeInvalidVars,
+    InvalidDefineVarsValue,
+    ArrayInDefineVars,
+    MissingDefaultValue,
+    UnknownDefineVarsReference,
+    InvalidDefineVarsFunctionValue,
+    ThemeWithoutVarGroup,
+    OnlyNamedParameters,
+    AstBackend,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("{message}")]
+pub struct StylexError {
+    pub code: ErrorCode,
+    pub message: String,
+}
+
+impl StylexError {
+    pub fn new(code: ErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+
+    // parity: babel-plugin src/shared/messages.js illegalArgumentLength
+    pub fn illegal_argument_length(fn_name: &str, arg_length: usize) -> Self {
+        let plural = if arg_length == 1 { "" } else { "s" };
+        Self::new(
+            ErrorCode::IllegalArgumentLength,
+            format!("{fn_name}() should have {arg_length} argument{plural}."),
+        )
+    }
+
+    // parity: babel-plugin src/shared/messages.js nonStaticValue
+    pub fn non_static_value(fn_name: &str) -> Self {
+        Self::new(
+            ErrorCode::NonStaticValue,
+            format!("Only static values are allowed inside of a {fn_name}() call."),
+        )
+    }
+
+    // parity: babel-plugin src/shared/messages.js nonStyleObject
+    pub fn non_style_object(fn_name: &str) -> Self {
+        Self::new(
+            ErrorCode::NonStyleObject,
+            format!("{fn_name}() can only accept an object."),
+        )
+    }
+
+    pub fn illegal_namespace_value() -> Self {
+        Self::new(
+            ErrorCode::IllegalNamespaceValue,
+            "A StyleX namespace must be an object.",
+        )
+    }
+
+    pub fn illegal_prop_value() -> Self {
+        Self::new(
+            ErrorCode::IllegalPropValue,
+            "A style value can only contain an array, string or number.",
+        )
+    }
+
+    pub fn illegal_prop_array_value() -> Self {
+        Self::new(
+            ErrorCode::IllegalPropArrayValue,
+            "A style array value can only contain strings or numbers.",
+        )
+    }
+
+    pub fn no_object_spreads() -> Self {
+        Self::new(
+            ErrorCode::NoObjectSpreads,
+            "Object spreads are not allowed in create() calls.",
+        )
+    }
+
+    pub fn invalid_media_query_syntax() -> Self {
+        Self::new(
+            ErrorCode::InvalidMediaQuerySyntax,
+            "Invalid media query syntax.",
+        )
+    }
+
+    // parity: babel-plugin src/index.js:572 (const resolution)
+    pub fn cyclic_const_reference(const_ref: &str) -> Self {
+        Self::new(
+            ErrorCode::CyclicConstReference,
+            format!("circular reference detected for constant {const_ref}"),
+        )
+    }
+
+    // parity: babel-plugin src/shared/messages.js cyclicDefineVarsReference
+    pub fn cyclic_define_vars_reference(cycle: &str) -> Self {
+        Self::new(
+            ErrorCode::CyclicDefineVarsReference,
+            format!("Cyclic same-group references in defineVars() are not allowed: {cycle}."),
+        )
+    }
+
+    pub fn unclosed_function() -> Self {
+        Self::new(
+            ErrorCode::UnclosedFunction,
+            "Rule contains an unclosed function",
+        )
+    }
+
+    pub fn unclosed_string() -> Self {
+        Self::new(
+            ErrorCode::UnclosedString,
+            "Rule contains an unclosed string",
+        )
+    }
+
+    /// `None` when `property` is not a banned shorthand under property-specificity.
+    pub fn banned_shorthand(property: &str) -> Option<Self> {
+        banned_shorthand_message(property).map(|m| Self::new(ErrorCode::BannedShorthand, m))
+    }
+
+    pub fn unsupported_option(description: &str) -> Self {
+        Self::new(
+            ErrorCode::UnsupportedOption,
+            format!(
+                "Unsupported option `{description}`: a deliberate v1 gap of the Rust StyleX compiler. See crates/stylex/docs."
+            ),
+        )
+    }
+
+    pub fn unsupported_api(api: &str) -> Self {
+        Self::new(
+            ErrorCode::UnsupportedApi,
+            format!(
+                "Unsupported API `{api}`: a deliberate v1 gap of the Rust StyleX compiler. See crates/stylex/docs."
+            ),
+        )
+    }
+
+    /// Loud-over-lossy doctrine: upstream emits the corrupt lone surrogate;
+    /// this compiler refuses (documented rust-rejects-more divergence).
+    pub fn lone_surrogate(context: &str) -> Self {
+        Self::new(
+            ErrorCode::UnsupportedApi,
+            format!(
+                "Unsupported API `{context} producing a lone UTF-16 surrogate`: a deliberate v1 gap of the Rust StyleX compiler. See crates/stylex/docs."
+            ),
+        )
+    }
+
+    pub fn only_named_parameters() -> Self {
+        Self::new(
+            ErrorCode::OnlyNamedParameters,
+            "Only named parameters are allowed in Dynamic Style functions. Destructuring, spreading or default values are not allowed.",
+        )
+    }
+
+    pub fn unknown_option(key: &str) -> Self {
+        Self::new(
+            ErrorCode::UnknownOption,
+            format!(
+                "Unknown option `{key}`: not a recognized @stylexjs/babel-plugin option. See crates/stylex/docs."
+            ),
+        )
+    }
+
+    pub fn duplicate_conditional() -> Self {
+        Self::new(
+            ErrorCode::DuplicateConditional,
+            "The same pseudo selector or at-rule cannot be used more than once.",
+        )
+    }
+
+    pub fn invalid_pseudo_or_at_rule() -> Self {
+        Self::new(
+            ErrorCode::InvalidPseudoOrAtRule,
+            "Invalid pseudo or at-rule.",
+        )
+    }
+
+    pub fn non_contiguous_vars() -> Self {
+        Self::new(
+            ErrorCode::NonContiguousVars,
+            "All variables passed to firstThatWorks() must be contiguous.",
+        )
+    }
+
+    // parity: babel-plugin src/shared/preprocess-rules/index.js:50
+    pub fn shorthand_fallback() -> Self {
+        Self::new(
+            ErrorCode::ShorthandFallback,
+            "Cannot use fallbacks for shorthands. Use the expansion instead.",
+        )
+    }
+
+    // parity: legacy-expand-shorthands.js listStyle; `text` is already
+    // JSON-quoted by the caller (the two spellings differ by a quote pair).
+    pub fn invalid_list_style(text: &str) -> Self {
+        Self::new(
+            ErrorCode::InvalidListStyleValue,
+            format!("invalid \"listStyle\" value of {text}"),
+        )
+    }
+
+    // Upstream crashes with a TypeError here; structured stand-in (W2 divergence).
+    pub fn empty_value() -> Self {
+        Self::new(ErrorCode::EmptyValue, "Cannot normalize an empty value")
+    }
+
+    pub fn non_object_keyframe() -> Self {
+        Self::new(
+            ErrorCode::NonObjectKeyframe,
+            "Every frame within a keyframes() call must be an object.",
+        )
+    }
+
+    // parity: babel-plugin src/shared/messages.js unboundCallValue
+    pub fn unbound_call_value(fn_name: &str) -> Self {
+        Self::new(
+            ErrorCode::UnboundCallValue,
+            format!("{fn_name}() calls must be bound to a bare variable."),
+        )
+    }
+
+    // parity: babel-plugin src/shared/messages.js nonExportNamedDeclaration
+    pub fn non_export_named_declaration(fn_name: &str) -> Self {
+        Self::new(
+            ErrorCode::NonExportNamedDeclaration,
+            format!("The return value of {fn_name}() must be bound to a named export."),
+        )
+    }
+
+    // parity: babel-plugin src/shared/messages.js cannotGenerateHash
+    pub fn cannot_generate_hash(fn_name: &str) -> Self {
+        Self::new(
+            ErrorCode::CannotGenerateHash,
+            format!(
+                "Unable to generate hash for {fn_name}(). Check that the file has a valid extension and that unstable_moduleResolution is configured."
+            ),
+        )
+    }
+
+    /// The exact `message` comes from when.js validatePseudoSelector.
+    pub fn invalid_when_selector(message: &str) -> Self {
+        Self::new(ErrorCode::InvalidWhenSelector, message)
+    }
+
+    pub fn parse_error(detail: &str) -> Self {
+        Self::new(
+            ErrorCode::ParseError,
+            format!("Failed to parse the source file: {detail}"),
+        )
+    }
+
+    // parity: babel-plugin src/shared/messages.js POSITION_TRY_INVALID_PROPERTY
+    pub fn position_try_invalid_property() -> Self {
+        Self::new(
+            ErrorCode::PositionTryInvalidProperty,
+            "Invalid property in `positionTry()` call. It may only contain, positionAnchor, positionArea, inset properties (top, left, insetInline etc.), margin properties, size properties (height, inlineSize, etc.), and self-alignment properties (alignSelf, justifySelf, placeSelf)",
+        )
+    }
+
+    // parity: babel-plugin src/shared/messages.js VIEW_TRANSITION_CLASS_INVALID_PROPERTY
+    pub fn view_transition_class_invalid_property() -> Self {
+        Self::new(
+            ErrorCode::ViewTransitionClassInvalidProperty,
+            "Invalid property in `viewTransitionClass()` call. It may only contain group, imagePair, old, and new properties",
+        )
+    }
+
+    // parity: babel-plugin src/shared/stylex-nested-utils.js flattenImpl key check
+    pub fn nested_key_contains_separator(key: &str) -> Self {
+        Self::new(
+            ErrorCode::NestedKeySeparator,
+            format!(
+                "Key \"{key}\" must not contain the \".\" character. Use nested objects instead of dots in key names. See: https://www.designtokens.org/tr/drafts/format/#character-restrictions"
+            ),
+        )
+    }
+
+    // parity: visitors/stylex-create-theme-nested.js __varGroupHash__ check
+    pub fn nested_theme_invalid_vars() -> Self {
+        Self::new(
+            ErrorCode::NestedThemeInvalidVars,
+            "Can only override variables theme created with unstable_defineVarsNested().",
+        )
+    }
+
+    // parity: shared/stylex-vars-utils.js + visitors/stylex-define-vars.js
+    pub fn invalid_define_vars_value() -> Self {
+        Self::new(
+            ErrorCode::InvalidDefineVarsValue,
+            "Invalid value in defineVars",
+        )
+    }
+
+    // parity: same plain-Error text in defineVars and createTheme collection.
+    pub fn array_in_define_vars() -> Self {
+        Self::new(
+            ErrorCode::ArrayInDefineVars,
+            "Array is not supported in defineVars",
+        )
+    }
+
+    /// `key` is present everywhere except getDefaultValue's keyless variant.
+    pub fn missing_default_value(key: Option<&str>) -> Self {
+        let message = match key {
+            Some(key) => format!("Default value is not defined for {key} variable."),
+            None => "Default value is not defined for variable.".to_string(),
+        };
+        Self::new(ErrorCode::MissingDefaultValue, message)
+    }
+
+    // parity: babel-plugin src/shared/messages.js unknownDefineVarsReference
+    pub fn unknown_define_vars_reference(key: &str, dependency: &str) -> Self {
+        Self::new(
+            ErrorCode::UnknownDefineVarsReference,
+            format!(
+                "Unknown same-group reference \"{dependency}\" found while resolving \"{key}\" in defineVars()."
+            ),
+        )
+    }
+
+    // parity: babel-plugin src/shared/messages.js invalidDefineVarsFunctionValue
+    pub fn invalid_define_vars_function_value() -> Self {
+        Self::new(
+            ErrorCode::InvalidDefineVarsFunctionValue,
+            "Function values in defineVars() must be zero-argument and return a static value supported by defineVars().",
+        )
+    }
+
+    // parity: visitors/stylex-create-theme.js + shared/stylex-create-theme.js
+    pub fn theme_without_var_group() -> Self {
+        Self::new(
+            ErrorCode::ThemeWithoutVarGroup,
+            "Can only override variables theme created with defineVars().",
+        )
+    }
+
+    // Upstream crashes with "Cannot convert undefined or null to object";
+    // structured stand-in, same compile-fails outcome (W3 divergence).
+    pub fn upstream_type_crash(context: &str) -> Self {
+        Self::new(
+            ErrorCode::UpstreamTypeError,
+            format!(
+                "Upstream crashes with a TypeError on {context}; the Rust compiler rejects it instead."
+            ),
+        )
+    }
+}
+
+// parity: babel-plugin src/shared/preprocess-rules/property-specificity.js
+// (throwing shorthands plus the aliases that point at them).
+pub fn banned_shorthand_message(property: &str) -> Option<&'static str> {
+    Some(match property {
+        "all" => "all is not supported",
+        "animation" => "animation is not supported",
+        "background" => {
+            "background is not supported. Use background-color, border-image etc. instead."
+        }
+        "border" => {
+            "border is not supported. Use border-width, border-style and border-color instead."
+        }
+        "borderInline" | "borderHorizontal" => {
+            "borderInline is not supported. Use borderInlineWidth, borderInlineStyle and borderInlineColor instead."
+        }
+        "borderBlock" | "borderVertical" => {
+            "borderBlock is not supported. Use borderBlockWidth, borderBlockStyle and borderBlockColor instead."
+        }
+        "borderTop" | "borderBlockStart" => {
+            "borderTop is not supported. Use borderTopWidth, borderTopStyle and borderTopColor instead."
+        }
+        "borderInlineEnd" | "borderEnd" => {
+            "borderInlineEnd is not supported. Use borderInlineEndWidth, borderInlineEndStyle and borderInlineEndColor instead."
+        }
+        "borderRight" => {
+            "borderRight is not supported. Use borderRightWidth, borderRightStyle and borderRightColor instead."
+        }
+        "borderBottom" | "borderBlockEnd" => {
+            "borderBottom is not supported. Use borderBottomWidth, borderBottomStyle and borderBottomColor instead."
+        }
+        "borderInlineStart" | "borderStart" => {
+            "borderInlineStart is not supported. Use borderInlineStartWidth, borderInlineStartStyle and borderInlineStartColor instead."
+        }
+        "borderLeft" => {
+            "`borderLeft` is not supported. You could use `borderLeftWidth`, `borderLeftStyle` and `borderLeftColor`, but it is preferable to use `borderInlineStartWidth`, `borderInlineStartStyle` and `borderInlineStartColor`."
+        }
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_text_matches_upstream() {
+        assert_eq!(
+            StylexError::illegal_argument_length("create", 1).message,
+            "create() should have 1 argument."
+        );
+        assert_eq!(
+            StylexError::illegal_argument_length("keyframes", 2).message,
+            "keyframes() should have 2 arguments."
+        );
+        assert_eq!(
+            StylexError::non_static_value("create").message,
+            "Only static values are allowed inside of a create() call."
+        );
+        assert_eq!(
+            StylexError::non_style_object("create").message,
+            "create() can only accept an object."
+        );
+        assert_eq!(
+            StylexError::cyclic_const_reference("colors.bg").message,
+            "circular reference detected for constant colors.bg"
+        );
+        assert_eq!(
+            StylexError::cyclic_define_vars_reference("a -> b -> a").message,
+            "Cyclic same-group references in defineVars() are not allowed: a -> b -> a."
+        );
+    }
+
+    #[test]
+    fn banned_shorthand_table() {
+        assert_eq!(
+            banned_shorthand_message("border").unwrap(),
+            "border is not supported. Use border-width, border-style and border-color instead."
+        );
+        // Aliases throw with the message of the shorthand they point at.
+        assert_eq!(
+            banned_shorthand_message("borderHorizontal"),
+            banned_shorthand_message("borderInline")
+        );
+        assert_eq!(
+            banned_shorthand_message("borderBlockStart"),
+            banned_shorthand_message("borderTop")
+        );
+        assert!(
+            banned_shorthand_message("borderLeft")
+                .unwrap()
+                .starts_with("`borderLeft`")
+        );
+        assert_eq!(banned_shorthand_message("marginTop"), None);
+        let err = StylexError::banned_shorthand("all").unwrap();
+        assert_eq!(err.code, ErrorCode::BannedShorthand);
+        assert_eq!(err.message, "all is not supported");
+    }
+
+    #[test]
+    fn display_is_the_message() {
+        let e = StylexError::unknown_option("fooBar");
+        assert_eq!(e.to_string(), e.message);
+        assert!(e.message.contains("fooBar"));
+    }
+}

--- a/crates/stylex/src/eval/cross_file.rs
+++ b/crates/stylex/src/eval/cross_file.rs
@@ -1,6 +1,8 @@
 //! `.stylex` theme-file import proxies: hash-only, no file contents are read.
 // parity: evaluate-path.js createVarGroupProxy/resolveVarGroupKey/:595-654
 
+use std::rc::Rc;
+
 use crate::hash::hash;
 use crate::module_resolution::gen_file_based_identifier;
 use crate::options::ResolvedOptions;
@@ -37,15 +39,28 @@ pub fn unsupported_operator(op: &str) -> String {
 
 /// Stand-in for the upstream JS Proxy over a theme-file export: every member
 /// access resolves to a `var(--…)` string derived from hashes alone.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct VarGroupProxy {
+    group: Rc<VarGroup>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct VarGroup {
     /// Canonical theme-file name (`pkg:relPath` form).
-    pub file_name: String,
-    pub export_name: String,
-    pub var_group_hash: String,
+    file_name: String,
+    export_name: String,
+    var_group_hash: String,
     class_name_prefix: String,
     debug_class_names: bool,
 }
+
+impl PartialEq for VarGroupProxy {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.group, &other.group) || self.group == other.group
+    }
+}
+
+impl Eq for VarGroupProxy {}
 
 impl VarGroupProxy {
     pub fn new(file_name: String, export_name: String, options: &ResolvedOptions) -> Self {
@@ -55,12 +70,18 @@ impl VarGroupProxy {
             hash(&gen_file_based_identifier(&file_name, &export_name, None))
         );
         VarGroupProxy {
-            file_name,
-            export_name,
-            var_group_hash,
-            class_name_prefix: options.class_name_prefix.clone(),
-            debug_class_names: options.debug && options.enable_debug_class_names,
+            group: Rc::new(VarGroup {
+                file_name,
+                export_name,
+                var_group_hash,
+                class_name_prefix: options.class_name_prefix.clone(),
+                debug_class_names: options.debug && options.enable_debug_class_names,
+            }),
         }
+    }
+
+    pub fn var_group_hash(&self) -> &str {
+        &self.group.var_group_hash
     }
 
     // parity: evaluate-path.js resolveVarGroupKey.
@@ -68,12 +89,13 @@ impl VarGroupProxy {
         if key.starts_with("--") {
             return format!("var({key})");
         }
+        let group = &*self.group;
         let hashed = hash(&gen_file_based_identifier(
-            &self.file_name,
-            &self.export_name,
+            &group.file_name,
+            &group.export_name,
             Some(key),
         ));
-        let var_name = if self.debug_class_names {
+        let var_name = if group.debug_class_names {
             let mut safe: String = key
                 .chars()
                 .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
@@ -81,9 +103,9 @@ impl VarGroupProxy {
             if key.starts_with(|c: char| c.is_ascii_digit()) {
                 safe.insert(0, '_');
             }
-            format!("{safe}-{}{hashed}", self.class_name_prefix)
+            format!("{safe}-{}{hashed}", group.class_name_prefix)
         } else {
-            format!("{}{hashed}", self.class_name_prefix)
+            format!("{}{hashed}", group.class_name_prefix)
         };
         format!("var(--{var_name})")
     }
@@ -106,7 +128,7 @@ mod tests {
         // Pinned live against @stylexjs/babel-plugin 0.19.0 (probe 2026-08-27).
         let options = ResolvedOptions::default();
         let p = proxy(&options);
-        assert_eq!(p.var_group_hash, "x73pkp7");
+        assert_eq!(p.var_group_hash(), "x73pkp7");
         assert_eq!(p.resolve_key("accent"), "var(--x8fssgy)");
         assert_eq!(p.resolve_key("--raw"), "var(--raw)");
     }

--- a/crates/stylex/src/eval/cross_file.rs
+++ b/crates/stylex/src/eval/cross_file.rs
@@ -1,0 +1,126 @@
+//! `.stylex` theme-file import proxies: hash-only, no file contents are read.
+// parity: evaluate-path.js createVarGroupProxy/resolveVarGroupKey/:595-654
+
+use crate::hash::hash;
+use crate::module_resolution::gen_file_based_identifier;
+use crate::options::ResolvedOptions;
+
+// parity: evaluation-errors.js — exact user-facing texts (first line is what
+// pins compare after babel's code-frame formatting).
+pub const IMPORT_PATH_RESOLUTION_ERROR: &str = "Could not resolve the path to the imported file.\nPlease ensure that the theme file has a .stylex.js or .stylex.ts extension and follows the\nrules for defining variables:\n\nhttps://stylexjs.com/docs/learn/theming/defining-variables/#rules-when-defining-variables\n";
+
+pub const IMPORT_FILE_EVAL_ERROR: &str = "There was an error when attempting to evaluate the imported file.\nPlease ensure that the imported file is self-contained and does not rely on dynamic behavior.\n";
+
+pub const NON_CONSTANT: &str = "Referenced value is not a constant.\n\n";
+
+pub const USED_BEFORE_DECLARATION: &str = "Referenced value is used before declaration.\n\n";
+
+pub const UNINITIALIZED_CONST: &str = "Referenced constant is not initialized.\n\n";
+
+pub const UNDEFINED_CONST: &str = "Referenced constant is not defined.";
+
+pub const PATH_WITHOUT_NODE: &str =
+    "Unexpected error:\nCould not resolve the code being evaluated.\n";
+
+pub const UNEXPECTED_MEMBER_LOOKUP: &str =
+    "Unexpected error:\nCould not determine the property being accessed.\n";
+
+pub const OBJECT_METHOD: &str = "Unsupported object method.\n\n";
+
+pub fn unsupported_expression(node_type: &str) -> String {
+    format!("Unsupported expression: {node_type}\n\n")
+}
+
+pub fn unsupported_operator(op: &str) -> String {
+    format!("Unsupported operator: {op}\n\n")
+}
+
+/// Stand-in for the upstream JS Proxy over a theme-file export: every member
+/// access resolves to a `var(--…)` string derived from hashes alone.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VarGroupProxy {
+    /// Canonical theme-file name (`pkg:relPath` form).
+    pub file_name: String,
+    pub export_name: String,
+    pub var_group_hash: String,
+    class_name_prefix: String,
+    debug_class_names: bool,
+}
+
+impl VarGroupProxy {
+    pub fn new(file_name: String, export_name: String, options: &ResolvedOptions) -> Self {
+        let var_group_hash = format!(
+            "{}{}",
+            options.class_name_prefix,
+            hash(&gen_file_based_identifier(&file_name, &export_name, None))
+        );
+        VarGroupProxy {
+            file_name,
+            export_name,
+            var_group_hash,
+            class_name_prefix: options.class_name_prefix.clone(),
+            debug_class_names: options.debug && options.enable_debug_class_names,
+        }
+    }
+
+    // parity: evaluate-path.js resolveVarGroupKey.
+    pub fn resolve_key(&self, key: &str) -> String {
+        if key.starts_with("--") {
+            return format!("var({key})");
+        }
+        let hashed = hash(&gen_file_based_identifier(
+            &self.file_name,
+            &self.export_name,
+            Some(key),
+        ));
+        let var_name = if self.debug_class_names {
+            let mut safe: String = key
+                .chars()
+                .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+                .collect();
+            if key.starts_with(|c: char| c.is_ascii_digit()) {
+                safe.insert(0, '_');
+            }
+            format!("{safe}-{}{hashed}", self.class_name_prefix)
+        } else {
+            format!("{}{hashed}", self.class_name_prefix)
+        };
+        format!("var(--{var_name})")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn proxy(options: &ResolvedOptions) -> VarGroupProxy {
+        VarGroupProxy::new(
+            "probe-pkg:src/tokens.stylex.ts".to_string(),
+            "colors".to_string(),
+            options,
+        )
+    }
+
+    #[test]
+    fn oracle_pinned_hashes() {
+        // Pinned live against @stylexjs/babel-plugin 0.19.0 (probe 2026-08-27).
+        let options = ResolvedOptions::default();
+        let p = proxy(&options);
+        assert_eq!(p.var_group_hash, "x73pkp7");
+        assert_eq!(p.resolve_key("accent"), "var(--x8fssgy)");
+        assert_eq!(p.resolve_key("--raw"), "var(--raw)");
+    }
+
+    #[test]
+    fn debug_class_names_var_safe_keys() {
+        let options = crate::options::CompilerOptions::from_json(
+            &serde_json::json!({ "debug": true, "enableDebugClassNames": true }),
+        )
+        .unwrap()
+        .resolve()
+        .unwrap();
+        let p = proxy(&options);
+        assert_eq!(p.resolve_key("2fast"), "var(--_2fast-x1xncp22)");
+        assert_eq!(p.resolve_key("weird key!"), "var(--weird_key_-x1ixwx2f)");
+    }
+}

--- a/crates/stylex/src/eval/functions.rs
+++ b/crates/stylex/src/eval/functions.rs
@@ -1,0 +1,595 @@
+//! Injected-callable seam between the evaluator and the emit-API modules.
+// parity: stylex-create.js:140-206 FunctionConfig wiring
+
+use std::sync::Arc;
+
+use crate::errors::StylexError;
+use crate::eval::value::EvalValue;
+use crate::state::CompileState;
+
+/// The compile-time callables `stylex.create` evaluation may dispatch to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum StylexCallable {
+    FirstThatWorks,
+    Keyframes,
+    PositionTry,
+    DefaultMarker,
+    WhenAncestor,
+    WhenDescendant,
+    WhenSiblingBefore,
+    WhenSiblingAfter,
+    WhenAnySibling,
+    /// `types.<name>(…)` for defineVars contexts (integrator-wired).
+    Types(String),
+    /// `unstable_conditional(x)` — the upstream identity fn for typing.
+    Conditional,
+}
+
+pub const WHEN_MEMBERS: [(&str, StylexCallable); 5] = [
+    ("ancestor", StylexCallable::WhenAncestor),
+    ("descendant", StylexCallable::WhenDescendant),
+    ("siblingBefore", StylexCallable::WhenSiblingBefore),
+    ("siblingAfter", StylexCallable::WhenSiblingAfter),
+    ("anySibling", StylexCallable::WhenAnySibling),
+];
+
+/// The seam the emit-API slice plugs its real semantics into; `state` lets
+/// keyframes/positionTry record their injectable rules.
+pub trait EvalCallables {
+    fn call(
+        &self,
+        callee: &StylexCallable,
+        args: &[EvalValue],
+        state: &mut CompileState<'_>,
+    ) -> Result<EvalValue, StylexError>;
+}
+
+/// Placeholder while the emit-API modules are mid-flight: every dispatch is a
+/// structured unsupported_api error naming the callable.
+pub struct StubCallables;
+
+impl EvalCallables for StubCallables {
+    fn call(
+        &self,
+        callee: &StylexCallable,
+        _args: &[EvalValue],
+        _state: &mut CompileState<'_>,
+    ) -> Result<EvalValue, StylexError> {
+        let name = match callee {
+            StylexCallable::FirstThatWorks => "firstThatWorks",
+            StylexCallable::Keyframes => "keyframes",
+            StylexCallable::PositionTry => "positionTry",
+            StylexCallable::DefaultMarker => "defaultMarker",
+            StylexCallable::WhenAncestor => "when.ancestor",
+            StylexCallable::WhenDescendant => "when.descendant",
+            StylexCallable::WhenSiblingBefore => "when.siblingBefore",
+            StylexCallable::WhenSiblingAfter => "when.siblingAfter",
+            StylexCallable::WhenAnySibling => "when.anySibling",
+            StylexCallable::Types(_) => "types.*",
+            StylexCallable::Conditional => "unstable_conditional",
+        };
+        Err(StylexError::unsupported_api(name))
+    }
+}
+
+// ---- theming (defineVars / createTheme) evaluator support ------------------
+
+use oxc_ast::ast::{
+    Argument, ArrayExpressionElement, CallExpression, Expression, ObjectPropertyKind, PropertyKind,
+    UnaryOperator,
+};
+use oxc_span::GetSpan;
+
+use crate::eval::cross_file::VarGroupProxy;
+use crate::eval::{
+    Callable, EvalOutcome, Evaluator, FunctionRegistry, JsObj, JsValue, RegistryEntry,
+    collect_member_chain, from_eval_value, is_invalid_method, is_valid_callee, js_to_string,
+    truthy, unwrap_parens,
+};
+use crate::imports::{ImportTable, StylexNamedImport};
+use crate::shared::types::TYPES_MEMBERS;
+
+fn types_object() -> JsValue {
+    let mut obj = JsObj::default();
+    for name in TYPES_MEMBERS {
+        obj.insert(
+            name.to_string(),
+            JsValue::Callable(Callable::Stylex(StylexCallable::Types(name.to_string()))),
+        );
+    }
+    JsValue::object(obj)
+}
+
+/// FunctionConfig of visitors/stylex-define-vars.js and the second argument of
+/// visitors/stylex-create-theme.js: keyframes, positionTry, types, env.
+pub fn vars_registry(imports: &ImportTable, env: &EvalValue) -> FunctionRegistry {
+    let mut registry = FunctionRegistry::default();
+    for (local, binding) in &imports.named {
+        let entry = match binding {
+            StylexNamedImport::Keyframes => RegistryEntry::Callable(StylexCallable::Keyframes),
+            StylexNamedImport::PositionTry => RegistryEntry::Callable(StylexCallable::PositionTry),
+            StylexNamedImport::Types => RegistryEntry::Value(types_object()),
+            StylexNamedImport::Env => RegistryEntry::Value(from_eval_value(env)),
+            StylexNamedImport::Conditional => RegistryEntry::Callable(StylexCallable::Conditional),
+            _ => continue,
+        };
+        registry.identifiers.insert(local.clone(), entry);
+    }
+    for namespace in &imports.stylex_namespaces {
+        let mut obj = JsObj::default();
+        obj.insert("types".to_string(), types_object());
+        obj.insert("env".to_string(), from_eval_value(env));
+        registry.identifiers.insert(
+            namespace.clone(),
+            RegistryEntry::Value(JsValue::object(obj)),
+        );
+        for (name, callable) in [
+            ("keyframes", StylexCallable::Keyframes),
+            ("positionTry", StylexCallable::PositionTry),
+            ("unstable_conditional", StylexCallable::Conditional),
+        ] {
+            registry
+                .member_callables
+                .insert((namespace.clone(), name.to_string()), callable);
+        }
+    }
+    registry
+}
+
+/// Mirrors `identifiers[varId.name] = selfReferenceProxy` (set after the first
+/// evaluation, visible to function leaves invoked during normalization).
+pub fn register_self_reference(
+    ev: &mut Evaluator<'_, '_>,
+    export_name: &str,
+    proxy: VarGroupProxy,
+) {
+    ev.registry.identifiers.insert(
+        export_name.to_string(),
+        RegistryEntry::Value(JsValue::proxy(proxy)),
+    );
+}
+
+/// Body and param count of an evaluated expression-body arrow (`Callable::Arrow`).
+pub fn arrow_info<'a>(ev: &Evaluator<'a, '_>, key: u32) -> Option<(&'a Expression<'a>, usize)> {
+    ev.arrow_bodies
+        .get(&key)
+        .map(|(body, params)| (*body, params.len()))
+}
+
+/// The self-reference proxy's `onAccess` stand-in: walks a function body in
+/// evaluation order (lazy conditionals, last-only sequences, eager logicals).
+pub struct DepTracker<'p> {
+    self_proxy: &'p VarGroupProxy,
+    pub deps: Vec<String>,
+    depth: u32,
+}
+
+impl<'p> DepTracker<'p> {
+    pub fn new(self_proxy: &'p VarGroupProxy) -> Self {
+        DepTracker {
+            self_proxy,
+            deps: Vec::new(),
+            depth: 0,
+        }
+    }
+
+    fn record(&mut self, key: String) {
+        if !self.deps.iter().any(|d| d == &key) {
+            self.deps.push(key);
+        }
+    }
+
+    // The proxy's __IS_PROXY/toString/__varGroupHash__ traps bypass onAccess.
+    fn record_access(&mut self, key: &str) {
+        if !matches!(key, "__IS_PROXY" | "__varGroupHash__" | "toString") {
+            self.record(key.to_string());
+        }
+    }
+
+    fn is_self(&self, value: &JsValue) -> bool {
+        matches!(value, JsValue::Proxy(p) if p.as_ref() == self.self_proxy)
+    }
+
+    fn eval_value<'a>(
+        &mut self,
+        ev: &mut Evaluator<'a, '_>,
+        expr: &'a Expression<'a>,
+    ) -> Option<JsValue> {
+        match ev.eval(expr) {
+            Ok(EvalOutcome::Value(v)) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// `None` halts the walk: the real evaluation deopts or errors right there.
+    pub fn walk<'a>(&mut self, ev: &mut Evaluator<'a, '_>, expr: &'a Expression<'a>) -> Option<()> {
+        self.depth += 1;
+        let result = if self.depth > 128 {
+            None
+        } else {
+            self.walk_inner(ev, expr)
+        };
+        self.depth -= 1;
+        result
+    }
+
+    fn walk_inner<'a>(
+        &mut self,
+        ev: &mut Evaluator<'a, '_>,
+        expr: &'a Expression<'a>,
+    ) -> Option<()> {
+        match expr {
+            Expression::ParenthesizedExpression(e) => self.walk(ev, &e.expression),
+            Expression::TSAsExpression(e) => self.walk(ev, &e.expression),
+            Expression::TSSatisfiesExpression(e) => self.walk(ev, &e.expression),
+            Expression::ArrowFunctionExpression(_) => Some(()),
+            Expression::SequenceExpression(seq) => match seq.expressions.last() {
+                Some(last) => self.walk(ev, last),
+                None => None,
+            },
+            Expression::StringLiteral(_)
+            | Expression::NumericLiteral(_)
+            | Expression::BooleanLiteral(_)
+            | Expression::NullLiteral(_) => Some(()),
+            Expression::TemplateLiteral(tpl) => {
+                for expr in &tpl.expressions {
+                    self.walk(ev, expr)?;
+                }
+                Some(())
+            }
+            Expression::ConditionalExpression(cond) => {
+                self.walk(ev, &cond.test)?;
+                let test = self.eval_value(ev, &cond.test)?;
+                if truthy(&test) {
+                    self.walk(ev, &cond.consequent)
+                } else {
+                    self.walk(ev, &cond.alternate)
+                }
+            }
+            Expression::StaticMemberExpression(_) | Expression::ComputedMemberExpression(_) => {
+                self.walk_member(ev, expr)
+            }
+            Expression::Identifier(id) => {
+                let name = id.name.as_str();
+                if ev.registry.identifiers.contains_key(name) {
+                    return Some(());
+                }
+                let Some(symbol) = ev.state.symbol_of(id) else {
+                    return match name {
+                        "undefined" | "Infinity" | "NaN" => Some(()),
+                        _ => None,
+                    };
+                };
+                let info = ev.state.binding_info(symbol);
+                if matches!(
+                    info.decl,
+                    crate::state::BindingDecl::NamedImport
+                        | crate::state::BindingDecl::DefaultImport
+                        | crate::state::BindingDecl::NamespaceImport
+                ) {
+                    return Some(());
+                }
+                if ev.state.is_non_constant(symbol)
+                    || ev.state.is_mutated(symbol)
+                    || id.span.start < info.span.end
+                {
+                    return None;
+                }
+                if ev.state.binding_override(symbol).is_some() {
+                    return Some(());
+                }
+                match info.decl {
+                    crate::state::BindingDecl::Declarator(declarator)
+                        if declarator.id.get_binding_identifier().is_some() =>
+                    {
+                        match &declarator.init {
+                            Some(init) => self.walk(ev, init),
+                            None => None,
+                        }
+                    }
+                    _ => None,
+                }
+            }
+            Expression::UnaryExpression(unary) => match unary.operator {
+                UnaryOperator::Void => Some(()),
+                UnaryOperator::Delete => None,
+                UnaryOperator::Typeof
+                    if matches!(
+                        unary.argument,
+                        Expression::FunctionExpression(_)
+                            | Expression::ArrowFunctionExpression(_)
+                            | Expression::ClassExpression(_)
+                    ) =>
+                {
+                    Some(())
+                }
+                _ => self.walk(ev, &unary.argument),
+            },
+            Expression::ArrayExpression(array) => {
+                for element in &array.elements {
+                    match element {
+                        ArrayExpressionElement::Elision(_)
+                        | ArrayExpressionElement::SpreadElement(_) => return None,
+                        _ => self.walk(ev, element.to_expression())?,
+                    }
+                }
+                Some(())
+            }
+            Expression::ObjectExpression(object) => {
+                for property in &object.properties {
+                    match property {
+                        ObjectPropertyKind::SpreadProperty(spread) => {
+                            self.walk(ev, &spread.argument)?;
+                        }
+                        ObjectPropertyKind::ObjectProperty(prop) => {
+                            if prop.method || prop.kind != PropertyKind::Init {
+                                return None;
+                            }
+                            if prop.computed {
+                                let key_expr = prop.key.as_expression()?;
+                                self.walk(ev, key_expr)?;
+                                let key_value = self.eval_value(ev, key_expr)?;
+                                js_to_string(&key_value)?;
+                            }
+                            self.walk(ev, &prop.value)?;
+                        }
+                    }
+                }
+                Some(())
+            }
+            Expression::LogicalExpression(logical) => {
+                // parity: both operands evaluate eagerly upstream.
+                self.walk(ev, &logical.left)?;
+                self.walk(ev, &logical.right)
+            }
+            Expression::BinaryExpression(binary) => {
+                self.walk(ev, &binary.left)?;
+                self.walk(ev, &binary.right)
+            }
+            Expression::CallExpression(call) => self.walk_call(ev, call),
+            _ => None,
+        }
+    }
+
+    fn walk_member<'a>(
+        &mut self,
+        ev: &mut Evaluator<'a, '_>,
+        expr: &'a Expression<'a>,
+    ) -> Option<()> {
+        if let Some((base, parts)) = collect_member_chain(expr)
+            && parts.len() >= 2
+        {
+            self.walk(ev, base)?;
+            let base_value = self.eval_value(ev, base)?;
+            if self.is_self(&base_value) {
+                self.record(parts.join("."));
+                return Some(());
+            }
+            let mut current = base_value;
+            for (i, key) in parts.iter().enumerate() {
+                current = match ev.member_lookup(&current, key, expr.span()) {
+                    Ok(EvalOutcome::Value(v)) => v,
+                    _ => return None,
+                };
+                if self.is_self(&current) && i + 1 < parts.len() {
+                    self.record(parts[i + 1..].join("."));
+                    return Some(());
+                }
+            }
+            return Some(());
+        }
+        let (object_expr, key) = match expr {
+            Expression::StaticMemberExpression(member) => {
+                (&member.object, member.property.name.to_string())
+            }
+            Expression::ComputedMemberExpression(member) => {
+                self.walk(ev, &member.expression)?;
+                let key_value = self.eval_value(ev, &member.expression)?;
+                (&member.object, js_to_string(&key_value)?)
+            }
+            _ => return None,
+        };
+        self.walk(ev, object_expr)?;
+        let object = self.eval_value(ev, object_expr)?;
+        if self.is_self(&object) {
+            self.record_access(&key);
+        }
+        Some(())
+    }
+
+    fn walk_args_only<'a>(
+        &mut self,
+        ev: &mut Evaluator<'a, '_>,
+        call: &'a CallExpression<'a>,
+    ) -> Option<()> {
+        for argument in &call.arguments {
+            match argument {
+                Argument::SpreadElement(_) => return None,
+                _ => self.walk(ev, argument.to_expression())?,
+            }
+        }
+        Some(())
+    }
+
+    fn walk_arrow_call<'a>(
+        &mut self,
+        ev: &mut Evaluator<'a, '_>,
+        key: u32,
+        call: &'a CallExpression<'a>,
+    ) -> Option<()> {
+        let (body, params) = ev.arrow_bodies.get(&key).map(|(b, p)| (*b, p.clone()))?;
+        let mut args = Vec::with_capacity(call.arguments.len());
+        for argument in &call.arguments {
+            match argument {
+                Argument::SpreadElement(_) => return None,
+                _ => {
+                    let expr = argument.to_expression();
+                    self.walk(ev, expr)?;
+                    args.push(self.eval_value(ev, expr)?);
+                }
+            }
+        }
+        let mut saved: Vec<(String, Option<RegistryEntry>)> = Vec::with_capacity(params.len());
+        for (i, name) in params.iter().enumerate() {
+            let value = args.get(i).cloned().unwrap_or(JsValue::Undefined);
+            let previous = ev
+                .registry
+                .identifiers
+                .insert(name.clone(), RegistryEntry::Value(value));
+            saved.push((name.clone(), previous));
+        }
+        let result = self.walk(ev, body);
+        for (name, previous) in saved.into_iter().rev() {
+            match previous {
+                Some(entry) => {
+                    ev.registry.identifiers.insert(name, entry);
+                }
+                None => {
+                    ev.registry.identifiers.remove(&name);
+                }
+            }
+        }
+        result
+    }
+
+    fn walk_call<'a>(
+        &mut self,
+        ev: &mut Evaluator<'a, '_>,
+        call: &'a CallExpression<'a>,
+    ) -> Option<()> {
+        if call.optional {
+            return None;
+        }
+        let callee = unwrap_parens(&call.callee);
+        if let Expression::Identifier(id) = callee {
+            let name = id.name.as_str();
+            if let Some(entry) = ev.registry.identifiers.get(name) {
+                return match entry {
+                    RegistryEntry::Callable(_) => self.walk_args_only(ev, call),
+                    RegistryEntry::Value(_) => None,
+                };
+            }
+            if ev.state.symbol_of(id).is_none() && is_valid_callee(name) {
+                return match name {
+                    "Math" => None,
+                    _ => self.walk_args_only(ev, call),
+                };
+            }
+            self.walk(ev, callee)?;
+            return match self.eval_value(ev, callee)? {
+                JsValue::Callable(Callable::Stylex(_)) => self.walk_args_only(ev, call),
+                JsValue::Callable(Callable::Arrow(key)) => self.walk_arrow_call(ev, key, call),
+                _ => None,
+            };
+        }
+        if let Some(member) = callee.as_member_expression() {
+            let property =
+                member
+                    .static_property_name()
+                    .map(str::to_string)
+                    .or_else(|| match member {
+                        oxc_ast::ast::MemberExpression::ComputedMemberExpression(m) => {
+                            match &m.expression {
+                                Expression::StringLiteral(lit) => Some(lit.value.to_string()),
+                                _ => None,
+                            }
+                        }
+                        _ => None,
+                    });
+            let property = property?;
+            if let Expression::Identifier(object) = member.object() {
+                let object_name = object.name.as_str();
+                let is_member_callable = ev
+                    .registry
+                    .member_callables
+                    .contains_key(&(object_name.to_string(), property.clone()));
+                if !is_member_callable
+                    && is_valid_callee(object_name)
+                    && !is_invalid_method(&property)
+                {
+                    return match crate::eval::methods::lookup_global_static(object_name, &property)
+                    {
+                        crate::eval::methods::StaticMember::Fn(_) => self.walk_args_only(ev, call),
+                        crate::eval::methods::StaticMember::Unknown => None,
+                        _ => None,
+                    };
+                }
+                if is_member_callable {
+                    return self.walk_args_only(ev, call);
+                }
+            }
+            self.walk(ev, member.object())?;
+            let object_value = self.eval_value(ev, member.object())?;
+            if matches!(&object_value, JsValue::Proxy(_)) && property == "toString" {
+                return self.walk_args_only(ev, call);
+            }
+            if let JsValue::Obj(obj) = &object_value
+                && let Some(JsValue::Callable(callable)) = obj.get(&property)
+            {
+                match callable.clone() {
+                    Callable::Stylex(_) => return self.walk_args_only(ev, call),
+                    Callable::Arrow(key) => return self.walk_arrow_call(ev, key, call),
+                    Callable::Opaque => {}
+                }
+            }
+            return None;
+        }
+        None
+    }
+}
+
+/// The vars-context keyframes closure skips visitor validation upstream;
+/// Object.entries shapes strings/arrays/primitives into frame objects instead.
+pub fn coerce_vars_keyframes_frames(frames: &EvalValue) -> Result<EvalValue, StylexError> {
+    fn entries_object(value: &EvalValue) -> Option<crate::eval::value::JsObjectMap> {
+        let mut out = crate::eval::value::JsObjectMap::new();
+        match value {
+            EvalValue::Str(s) => {
+                for (i, unit) in s.encode_utf16().enumerate() {
+                    out.insert(
+                        i.to_string(),
+                        EvalValue::Str(String::from_utf16_lossy(&[unit])),
+                    );
+                }
+            }
+            EvalValue::Arr(items) => {
+                for (i, v) in items.iter().enumerate() {
+                    out.insert(i.to_string(), v.clone());
+                }
+            }
+            EvalValue::Num(_) | EvalValue::Bool(_) => {}
+            _ => return None,
+        }
+        Some(out)
+    }
+    let frame_entries: Vec<(String, EvalValue)> = match frames {
+        EvalValue::Obj(map) => map
+            .entries()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect(),
+        EvalValue::Null | EvalValue::Undefined => {
+            return Err(StylexError::upstream_type_crash(
+                "a nullish keyframes() argument in a defineVars/createTheme context",
+            ));
+        }
+        other => entries_object(other)
+            .expect("non-object frames are strings, arrays or primitives here")
+            .entries()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect(),
+    };
+    let mut out = crate::eval::value::JsObjectMap::new();
+    for (key, frame) in frame_entries {
+        let coerced = match &frame {
+            EvalValue::Obj(_) | EvalValue::Null => frame,
+            // Object.entries(undefined) crashes exactly like a null frame does.
+            EvalValue::Undefined => EvalValue::Null,
+            other => EvalValue::Obj(Arc::new(
+                entries_object(other).expect("frame values here are strings/arrays/primitives"),
+            )),
+        };
+        out.insert(key, coerced);
+    }
+    Ok(EvalValue::Obj(Arc::new(out)))
+}

--- a/crates/stylex/src/eval/functions.rs
+++ b/crates/stylex/src/eval/functions.rs
@@ -129,9 +129,7 @@ pub fn vars_registry(imports: &ImportTable, env: &EvalValue) -> FunctionRegistry
             ("positionTry", StylexCallable::PositionTry),
             ("unstable_conditional", StylexCallable::Conditional),
         ] {
-            registry
-                .member_callables
-                .insert((namespace.clone(), name.to_string()), callable);
+            registry.add_member_callable(namespace, name, callable);
         }
     }
     registry
@@ -144,7 +142,7 @@ pub fn register_self_reference(
     export_name: &str,
     proxy: VarGroupProxy,
 ) {
-    ev.registry.identifiers.insert(
+    ev.registry.to_mut().identifiers.insert(
         export_name.to_string(),
         RegistryEntry::Value(JsValue::proxy(proxy)),
     );
@@ -435,18 +433,20 @@ impl<'p> DepTracker<'p> {
             let value = args.get(i).cloned().unwrap_or(JsValue::Undefined);
             let previous = ev
                 .registry
+                .to_mut()
                 .identifiers
                 .insert(name.clone(), RegistryEntry::Value(value));
             saved.push((name.clone(), previous));
         }
         let result = self.walk(ev, body);
+        let identifiers = &mut ev.registry.to_mut().identifiers;
         for (name, previous) in saved.into_iter().rev() {
             match previous {
                 Some(entry) => {
-                    ev.registry.identifiers.insert(name, entry);
+                    identifiers.insert(name, entry);
                 }
                 None => {
-                    ev.registry.identifiers.remove(&name);
+                    identifiers.remove(&name);
                 }
             }
         }
@@ -502,8 +502,8 @@ impl<'p> DepTracker<'p> {
                 let object_name = object.name.as_str();
                 let is_member_callable = ev
                     .registry
-                    .member_callables
-                    .contains_key(&(object_name.to_string(), property.clone()));
+                    .member_callable(object_name, &property)
+                    .is_some();
                 if !is_member_callable
                     && is_valid_callee(object_name)
                     && !is_invalid_method(&property)

--- a/crates/stylex/src/eval/methods.rs
+++ b/crates/stylex/src/eval/methods.rs
@@ -1,0 +1,1579 @@
+//! The VALID_CALLEES global surface and prototype-method dispatch.
+// parity: evaluate-path.js:945-1053, transcribed for every reachable method.
+
+use std::rc::Rc;
+
+use crate::errors::{ErrorCode, StylexError};
+use crate::eval::value::array_index;
+use crate::eval::{JsObj, JsValue, is_nullish, js_to_number, js_to_string, truthy};
+use crate::jsrt::{js_number_to_string, js_slice_utf16_checked, js_to_fixed, js_trim, utf16_cmp};
+
+pub(crate) const VALID_CALLEES: [&str; 5] = ["String", "Number", "Math", "Object", "Array"];
+pub(crate) const INVALID_METHODS: [&str; 7] = [
+    "random",
+    "assign",
+    "defineProperties",
+    "defineProperty",
+    "freeze",
+    "seal",
+    "splice",
+];
+
+pub(crate) fn is_valid_callee(name: &str) -> bool {
+    VALID_CALLEES.contains(&name)
+}
+
+pub(crate) fn is_invalid_method(name: &str) -> bool {
+    INVALID_METHODS.contains(&name)
+}
+
+/// What `global[object][property]` holds upstream.
+pub(crate) enum StaticMember {
+    /// A function we implement: called with evaluated args.
+    Fn(&'static str),
+    /// A data property: upstream throws `func.apply is not a function`.
+    NonCallable,
+    /// Callable upstream but not modelled: structured loud error.
+    Unsupported,
+    /// Absent upstream: falls through to the value-callee branch.
+    Unknown,
+}
+
+fn func_apply_error() -> StylexError {
+    StylexError::new(ErrorCode::NonStaticValue, "func.apply is not a function")
+}
+
+fn unsupported_global(name: &str) -> StylexError {
+    StylexError::unsupported_api(&format!("compile-time call to {name}"))
+}
+
+const MATH_FNS: [&str; 34] = [
+    "abs", "acos", "acosh", "asin", "asinh", "atan", "atan2", "atanh", "cbrt", "ceil", "clz32",
+    "cos", "cosh", "exp", "expm1", "floor", "fround", "hypot", "imul", "log", "log1p", "log2",
+    "log10", "max", "min", "pow", "round", "sign", "sin", "sinh", "sqrt", "tan", "tanh", "trunc",
+];
+const MATH_CONSTS: [&str; 8] = [
+    "E", "LN10", "LN2", "LOG10E", "LOG2E", "PI", "SQRT1_2", "SQRT2",
+];
+
+pub(crate) fn lookup_global_static(object: &str, property: &str) -> StaticMember {
+    match object {
+        "Math" => {
+            if MATH_FNS.contains(&property) {
+                StaticMember::Fn(property_static("Math", property))
+            } else if MATH_CONSTS.contains(&property) {
+                StaticMember::NonCallable
+            } else if property == "f16round" || property == "sumPrecise" {
+                StaticMember::Unsupported
+            } else {
+                StaticMember::Unknown
+            }
+        }
+        "Object" => match property {
+            "keys"
+            | "values"
+            | "entries"
+            | "fromEntries"
+            | "is"
+            | "hasOwn"
+            | "getOwnPropertyNames"
+            | "getOwnPropertySymbols"
+            | "isExtensible"
+            | "isFrozen"
+            | "isSealed" => StaticMember::Fn(property_static("Object", property)),
+            "create"
+            | "getOwnPropertyDescriptor"
+            | "getOwnPropertyDescriptors"
+            | "getPrototypeOf"
+            | "groupBy"
+            | "preventExtensions"
+            | "setPrototypeOf" => StaticMember::Unsupported,
+            "length" | "name" | "prototype" => StaticMember::NonCallable,
+            _ => StaticMember::Unknown,
+        },
+        "Array" => match property {
+            "isArray" | "of" | "from" => StaticMember::Fn(property_static("Array", property)),
+            "fromAsync" => StaticMember::Unsupported,
+            "length" | "name" | "prototype" => StaticMember::NonCallable,
+            _ => StaticMember::Unknown,
+        },
+        "String" => match property {
+            "fromCharCode" | "fromCodePoint" => {
+                StaticMember::Fn(property_static("String", property))
+            }
+            "raw" => StaticMember::Unsupported,
+            "length" | "name" | "prototype" => StaticMember::NonCallable,
+            _ => StaticMember::Unknown,
+        },
+        "Number" => match property {
+            "isFinite" | "isInteger" | "isNaN" | "isSafeInteger" | "parseFloat" | "parseInt" => {
+                StaticMember::Fn(property_static("Number", property))
+            }
+            "EPSILON" | "MAX_SAFE_INTEGER" | "MAX_VALUE" | "MIN_SAFE_INTEGER" | "MIN_VALUE"
+            | "NaN" | "NEGATIVE_INFINITY" | "POSITIVE_INFINITY" | "length" | "name"
+            | "prototype" => StaticMember::NonCallable,
+            _ => StaticMember::Unknown,
+        },
+        _ => StaticMember::Unknown,
+    }
+}
+
+// Canonical "&'static str" for the (object, property) pair so `Fn` can carry it.
+fn property_static(object: &'static str, property: &str) -> &'static str {
+    let joined: &[(&str, &[&str])] = &[
+        ("Math", &MATH_FNS),
+        (
+            "Object",
+            &[
+                "keys",
+                "values",
+                "entries",
+                "fromEntries",
+                "is",
+                "hasOwn",
+                "getOwnPropertyNames",
+                "getOwnPropertySymbols",
+                "isExtensible",
+                "isFrozen",
+                "isSealed",
+            ],
+        ),
+        ("Array", &["isArray", "of", "from"]),
+        ("String", &["fromCharCode", "fromCodePoint"]),
+        (
+            "Number",
+            &[
+                "isFinite",
+                "isInteger",
+                "isNaN",
+                "isSafeInteger",
+                "parseFloat",
+                "parseInt",
+            ],
+        ),
+    ];
+    joined
+        .iter()
+        .find(|(o, _)| *o == object)
+        .and_then(|(_, list)| list.iter().find(|p| **p == property))
+        .copied()
+        .expect("property listed in the matching table")
+}
+
+/// The arrow-closure hook: methods with callbacks call back into the evaluator.
+pub(crate) trait ArrowCaller {
+    fn call_arrow(&mut self, key: u32, args: Vec<JsValue>) -> Result<JsValue, StylexError>;
+}
+
+fn call_callback(
+    ev: &mut dyn ArrowCaller,
+    callback: &JsValue,
+    args: Vec<JsValue>,
+    method: &str,
+) -> Result<JsValue, StylexError> {
+    match callback {
+        JsValue::Callable(crate::eval::Callable::Arrow(key)) => ev.call_arrow(*key, args),
+        JsValue::Callable(_) => Err(unsupported_global(&format!(
+            "a non-arrow callback in {method}()"
+        ))),
+        _ => Err(StylexError::new(
+            ErrorCode::NonStaticValue,
+            format!(
+                "{} is not a function",
+                js_to_string(callback).unwrap_or_default()
+            ),
+        )),
+    }
+}
+
+fn lone_surrogate_slice(context: &'static str) -> StylexError {
+    StylexError::lone_surrogate(context)
+}
+
+fn utf16_len(s: &str) -> usize {
+    s.encode_utf16().count()
+}
+
+// ES ToIntegerOrInfinity.
+fn to_integer_or_infinity(n: f64) -> f64 {
+    if n.is_nan() { 0.0 } else { n.trunc() }
+}
+
+fn relative_index(n: f64, len: usize) -> isize {
+    let len = len as f64;
+    let k = to_integer_or_infinity(n);
+    let clamped = if k < 0.0 {
+        (len + k).max(0.0)
+    } else {
+        k.min(len)
+    };
+    clamped as isize
+}
+
+fn arg(args: &[JsValue], i: usize) -> JsValue {
+    args.get(i).cloned().unwrap_or(JsValue::Undefined)
+}
+
+fn num_arg(args: &[JsValue], i: usize) -> f64 {
+    js_to_number(&arg(args, i))
+}
+
+fn str_arg(args: &[JsValue], i: usize, method: &str) -> Result<String, StylexError> {
+    js_to_string(&arg(args, i))
+        .ok_or_else(|| unsupported_global(&format!("a function argument to {method}()")))
+}
+
+// parity: ES SameValue.
+fn same_value(a: &JsValue, b: &JsValue) -> bool {
+    match (a, b) {
+        (JsValue::Num(x), JsValue::Num(y)) => {
+            if x.is_nan() && y.is_nan() {
+                true
+            } else {
+                x == y && x.is_sign_positive() == y.is_sign_positive()
+            }
+        }
+        _ => crate::eval::js_strict_eq(a, b),
+    }
+}
+
+/// ES-ordered own enumerable string keys (index keys ascending, then insertion).
+fn es_own_keys(obj: &JsObj) -> Vec<String> {
+    let mut index_keys: Vec<(u32, &str)> = Vec::new();
+    let mut named: Vec<&str> = Vec::new();
+    for (key, _) in obj.entries() {
+        match array_index(key) {
+            Some(n) => index_keys.push((n, key)),
+            None => named.push(key),
+        }
+    }
+    index_keys.sort_by_key(|(n, _)| *n);
+    index_keys
+        .into_iter()
+        .map(|(_, k)| k.to_string())
+        .chain(named.into_iter().map(str::to_string))
+        .collect()
+}
+
+fn keyable(value: &JsValue, method: &str) -> Result<Option<KeySource>, StylexError> {
+    Ok(match value {
+        JsValue::Null | JsValue::Undefined => {
+            return Err(StylexError::new(
+                ErrorCode::NonStaticValue,
+                "Cannot convert undefined or null to object",
+            ));
+        }
+        JsValue::Obj(obj) => Some(KeySource::Obj(Rc::clone(obj))),
+        JsValue::Arr(items) => Some(KeySource::Arr(items.len())),
+        JsValue::Str(s) => Some(KeySource::Str(utf16_len(s))),
+        JsValue::Num(_) | JsValue::Bool(_) | JsValue::Proxy(_) => None,
+        JsValue::Callable(_) => {
+            return Err(unsupported_global(&format!("{method} of a function")));
+        }
+    })
+}
+
+enum KeySource {
+    Obj(Rc<JsObj>),
+    Arr(usize),
+    Str(usize),
+}
+
+fn own_keys_of(value: &JsValue, method: &str) -> Result<Vec<String>, StylexError> {
+    Ok(match keyable(value, method)? {
+        None => Vec::new(),
+        Some(KeySource::Obj(obj)) => es_own_keys(&obj),
+        Some(KeySource::Arr(len)) | Some(KeySource::Str(len)) => {
+            (0..len).map(|i| i.to_string()).collect()
+        }
+    })
+}
+
+fn own_value_of(value: &JsValue, key: &str) -> Result<JsValue, StylexError> {
+    Ok(match value {
+        JsValue::Obj(obj) => obj.get(key).cloned().unwrap_or(JsValue::Undefined),
+        JsValue::Arr(items) => array_index(key)
+            .and_then(|i| items.get(i as usize))
+            .cloned()
+            .unwrap_or(JsValue::Undefined),
+        JsValue::Str(s) => match array_index(key) {
+            Some(i) if (i as usize) < utf16_len(s) => JsValue::Str(
+                js_slice_utf16_checked(s, i as usize, i as isize + 1)
+                    .map_err(|_| lone_surrogate_slice("string indexing"))?,
+            ),
+            _ => JsValue::Undefined,
+        },
+        _ => JsValue::Undefined,
+    })
+}
+
+pub(crate) fn call_global_static(
+    ev: &mut dyn ArrowCaller,
+    object: &str,
+    method: &'static str,
+    args: &[JsValue],
+) -> Result<JsValue, StylexError> {
+    match object {
+        "Math" => call_math(method, args),
+        "Object" => call_object_static(method, args),
+        "Array" => call_array_static(ev, method, args),
+        "String" => call_string_static(method, args),
+        "Number" => call_number_static(method, args),
+        _ => Err(unsupported_global(object)),
+    }
+}
+
+fn call_math(method: &str, args: &[JsValue]) -> Result<JsValue, StylexError> {
+    let nums: Vec<f64> = args.iter().map(js_to_number).collect();
+    let x = nums.first().copied().unwrap_or(f64::NAN);
+    let y = nums.get(1).copied().unwrap_or(f64::NAN);
+    let result = match method {
+        // parity: JS Math.min/max — any NaN operand wins (Rust min/max drop it).
+        "min" => nums.iter().copied().fold(f64::INFINITY, |a, b| {
+            if a.is_nan() || b.is_nan() {
+                f64::NAN
+            } else {
+                a.min(b)
+            }
+        }),
+        "max" => nums.iter().copied().fold(f64::NEG_INFINITY, |a, b| {
+            if a.is_nan() || b.is_nan() {
+                f64::NAN
+            } else {
+                a.max(b)
+            }
+        }),
+        "abs" => x.abs(),
+        "acos" => x.acos(),
+        "acosh" => x.acosh(),
+        "asin" => x.asin(),
+        "asinh" => x.asinh(),
+        "atan" => x.atan(),
+        "atan2" => x.atan2(y),
+        "atanh" => x.atanh(),
+        "cbrt" => x.cbrt(),
+        "ceil" => x.ceil(),
+        "clz32" => f64::from(crate::eval::to_uint32(x).leading_zeros()),
+        "cos" => x.cos(),
+        "cosh" => x.cosh(),
+        "exp" => x.exp(),
+        "expm1" => x.exp_m1(),
+        "floor" => x.floor(),
+        "fround" => x as f32 as f64,
+        "hypot" => nums.iter().copied().fold(0.0f64, f64::hypot),
+        "imul" => f64::from(crate::eval::to_int32(x).wrapping_mul(crate::eval::to_int32(y))),
+        "log" => x.ln(),
+        "log1p" => x.ln_1p(),
+        "log2" => x.log2(),
+        "log10" => x.log10(),
+        "pow" => crate::eval::js_pow(x, y),
+        "round" => crate::jsrt::js_math_round(x),
+        "sign" => {
+            if x.is_nan() || x == 0.0 {
+                x
+            } else if x > 0.0 {
+                1.0
+            } else {
+                -1.0
+            }
+        }
+        "sin" => x.sin(),
+        "sinh" => x.sinh(),
+        "sqrt" => x.sqrt(),
+        "tan" => x.tan(),
+        "tanh" => x.tanh(),
+        "trunc" => x.trunc(),
+        _ => return Err(unsupported_global(&format!("Math.{method}"))),
+    };
+    Ok(JsValue::Num(result))
+}
+
+fn call_object_static(method: &str, args: &[JsValue]) -> Result<JsValue, StylexError> {
+    let target = arg(args, 0);
+    match method {
+        "keys" => Ok(JsValue::array(
+            own_keys_of(&target, "Object.keys")?
+                .into_iter()
+                .map(JsValue::Str)
+                .collect(),
+        )),
+        "values" => {
+            let keys = own_keys_of(&target, "Object.values")?;
+            let values = keys
+                .iter()
+                .map(|k| own_value_of(&target, k))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(JsValue::array(values))
+        }
+        "entries" => {
+            let keys = own_keys_of(&target, "Object.entries")?;
+            let entries = keys
+                .into_iter()
+                .map(|k| {
+                    let value = own_value_of(&target, &k)?;
+                    Ok(JsValue::array(vec![JsValue::Str(k), value]))
+                })
+                .collect::<Result<Vec<_>, StylexError>>()?;
+            Ok(JsValue::array(entries))
+        }
+        "fromEntries" => {
+            let JsValue::Arr(entries) = &target else {
+                return Err(unsupported_global(
+                    "Object.fromEntries of a non-array iterable",
+                ));
+            };
+            let mut obj = JsObj::default();
+            for entry in entries.iter() {
+                let JsValue::Arr(pair) = entry else {
+                    return Err(unsupported_global(
+                        "Object.fromEntries of non-array entries",
+                    ));
+                };
+                let key = js_to_string(&pair.first().cloned().unwrap_or(JsValue::Undefined))
+                    .ok_or_else(|| unsupported_global("a function key in Object.fromEntries"))?;
+                obj.insert(key, pair.get(1).cloned().unwrap_or(JsValue::Undefined));
+            }
+            Ok(JsValue::object(obj))
+        }
+        "is" => Ok(JsValue::Bool(same_value(&target, &arg(args, 1)))),
+        "hasOwn" => {
+            let key = js_to_string(&arg(args, 1))
+                .ok_or_else(|| unsupported_global("a function key in Object.hasOwn"))?;
+            let has = match keyable(&target, "Object.hasOwn")? {
+                None => false,
+                Some(KeySource::Obj(obj)) => obj.get(&key).is_some(),
+                Some(KeySource::Arr(len)) | Some(KeySource::Str(len)) => {
+                    key == "length" || array_index(&key).is_some_and(|i| (i as usize) < len)
+                }
+            };
+            Ok(JsValue::Bool(has))
+        }
+        "getOwnPropertyNames" => {
+            let mut keys = own_keys_of(&target, "Object.getOwnPropertyNames")?;
+            if matches!(target, JsValue::Arr(_) | JsValue::Str(_)) {
+                keys.push("length".to_string());
+            }
+            Ok(JsValue::array(keys.into_iter().map(JsValue::Str).collect()))
+        }
+        "getOwnPropertySymbols" => match target {
+            JsValue::Null | JsValue::Undefined => Err(StylexError::new(
+                ErrorCode::NonStaticValue,
+                "Cannot convert undefined or null to object",
+            )),
+            _ => Ok(JsValue::array(Vec::new())),
+        },
+        "isExtensible" => Ok(JsValue::Bool(matches!(
+            target,
+            JsValue::Obj(_) | JsValue::Arr(_) | JsValue::Proxy(_) | JsValue::Callable(_)
+        ))),
+        "isFrozen" | "isSealed" => Ok(JsValue::Bool(!matches!(
+            target,
+            JsValue::Obj(_) | JsValue::Arr(_) | JsValue::Proxy(_) | JsValue::Callable(_)
+        ))),
+        _ => Err(unsupported_global(&format!("Object.{method}"))),
+    }
+}
+
+fn call_array_static(
+    ev: &mut dyn ArrowCaller,
+    method: &str,
+    args: &[JsValue],
+) -> Result<JsValue, StylexError> {
+    match method {
+        "isArray" => Ok(JsValue::Bool(matches!(arg(args, 0), JsValue::Arr(_)))),
+        "of" => Ok(JsValue::array(args.to_vec())),
+        "from" => {
+            let source = arg(args, 0);
+            let items: Vec<JsValue> = match &source {
+                JsValue::Str(s) => s.chars().map(|c| JsValue::Str(c.to_string())).collect(),
+                JsValue::Arr(items) => items.as_ref().clone(),
+                JsValue::Obj(obj) => {
+                    let len =
+                        js_to_number(&obj.get("length").cloned().unwrap_or(JsValue::Undefined));
+                    let len = to_integer_or_infinity(len).max(0.0);
+                    if !(0.0..=65535.0).contains(&len) {
+                        return Err(unsupported_global("Array.from of a huge array-like"));
+                    }
+                    (0..len as usize)
+                        .map(|i| {
+                            obj.get(&i.to_string())
+                                .cloned()
+                                .unwrap_or(JsValue::Undefined)
+                        })
+                        .collect()
+                }
+                JsValue::Num(_) | JsValue::Bool(_) => Vec::new(),
+                _ => return Err(unsupported_global("Array.from of this source")),
+            };
+            let mapper = arg(args, 1);
+            if matches!(mapper, JsValue::Undefined) {
+                return Ok(JsValue::array(items));
+            }
+            let mut out = Vec::with_capacity(items.len());
+            for (i, item) in items.into_iter().enumerate() {
+                out.push(call_callback(
+                    ev,
+                    &mapper,
+                    vec![item, JsValue::Num(i as f64)],
+                    "Array.from",
+                )?);
+            }
+            Ok(JsValue::array(out))
+        }
+        _ => Err(unsupported_global(&format!("Array.{method}"))),
+    }
+}
+
+// ES ToUint16.
+fn to_uint16(n: f64) -> u16 {
+    (crate::eval::to_uint32(n) & 0xFFFF) as u16
+}
+
+fn utf16_units_to_string(units: &[u16], context: &'static str) -> Result<String, StylexError> {
+    String::from_utf16(units).map_err(|_| lone_surrogate_slice(context))
+}
+
+fn call_string_static(method: &str, args: &[JsValue]) -> Result<JsValue, StylexError> {
+    match method {
+        "fromCharCode" => {
+            let units: Vec<u16> = args.iter().map(|a| to_uint16(js_to_number(a))).collect();
+            Ok(JsValue::Str(utf16_units_to_string(
+                &units,
+                "String.fromCharCode",
+            )?))
+        }
+        "fromCodePoint" => {
+            let mut out = String::new();
+            for value in args {
+                let n = js_to_number(value);
+                if n.fract() != 0.0 || !(0.0..=1_114_111.0).contains(&n) {
+                    return Err(StylexError::new(
+                        ErrorCode::NonStaticValue,
+                        format!("Invalid code point {}", js_number_to_string(n)),
+                    ));
+                }
+                let code = n as u32;
+                match char::from_u32(code) {
+                    Some(c) => out.push(c),
+                    None => return Err(lone_surrogate_slice("String.fromCodePoint")),
+                }
+            }
+            Ok(JsValue::Str(out))
+        }
+        _ => Err(unsupported_global(&format!("String.{method}"))),
+    }
+}
+
+fn call_number_static(method: &str, args: &[JsValue]) -> Result<JsValue, StylexError> {
+    let value = arg(args, 0);
+    match method {
+        "isFinite" => Ok(JsValue::Bool(
+            matches!(value, JsValue::Num(n) if n.is_finite()),
+        )),
+        "isNaN" => Ok(JsValue::Bool(
+            matches!(value, JsValue::Num(n) if n.is_nan()),
+        )),
+        "isInteger" => Ok(JsValue::Bool(
+            matches!(value, JsValue::Num(n) if n.is_finite() && n.fract() == 0.0),
+        )),
+        "isSafeInteger" => Ok(JsValue::Bool(
+            matches!(value, JsValue::Num(n) if n.is_finite() && n.fract() == 0.0 && n.abs() <= 9_007_199_254_740_991.0),
+        )),
+        "parseInt" => {
+            let input = js_to_string(&value)
+                .ok_or_else(|| unsupported_global("a function argument to parseInt()"))?;
+            Ok(JsValue::Num(js_parse_int(&input, num_arg(args, 1))))
+        }
+        "parseFloat" => {
+            let input = js_to_string(&value)
+                .ok_or_else(|| unsupported_global("a function argument to parseFloat()"))?;
+            Ok(JsValue::Num(js_parse_float(&input)))
+        }
+        _ => Err(unsupported_global(&format!("Number.{method}"))),
+    }
+}
+
+// parity: ES parseInt (trim, sign, radix with 0x handling, maximal prefix).
+pub(crate) fn js_parse_int(input: &str, radix: f64) -> f64 {
+    let s = js_trim(input);
+    let (sign, s) = match s.strip_prefix('-') {
+        Some(rest) => (-1.0, rest),
+        None => (1.0, s.strip_prefix('+').unwrap_or(s)),
+    };
+    let mut radix = crate::eval::to_int32(radix);
+    let mut s = s;
+    if radix == 16 || radix == 0 {
+        if let Some(rest) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+            s = rest;
+            radix = 16;
+        } else if radix == 0 {
+            radix = 10;
+        }
+    }
+    if !(2..=36).contains(&radix) {
+        return f64::NAN;
+    }
+    let digits: Vec<u32> = s
+        .chars()
+        .map_while(|c| c.to_digit(36).filter(|d| *d < radix as u32))
+        .collect();
+    if digits.is_empty() {
+        return f64::NAN;
+    }
+    let mut out = 0.0f64;
+    for d in digits {
+        out = out * f64::from(radix) + f64::from(d);
+    }
+    sign * out
+}
+
+// parity: ES parseFloat (maximal StrDecimalLiteral prefix).
+pub(crate) fn js_parse_float(input: &str) -> f64 {
+    let s = js_trim(input);
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    if i < bytes.len() && (bytes[i] == b'+' || bytes[i] == b'-') {
+        i += 1;
+    }
+    if s[i..].starts_with("Infinity") {
+        return if bytes.first() == Some(&b'-') {
+            f64::NEG_INFINITY
+        } else {
+            f64::INFINITY
+        };
+    }
+    let digits_start = i;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+    }
+    if i < bytes.len() && bytes[i] == b'.' {
+        i += 1;
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+    }
+    if i == digits_start || (i == digits_start + 1 && bytes[digits_start] == b'.') {
+        return f64::NAN;
+    }
+    let mantissa_end = i;
+    if i < bytes.len() && (bytes[i] == b'e' || bytes[i] == b'E') {
+        let mut j = i + 1;
+        if j < bytes.len() && (bytes[j] == b'+' || bytes[j] == b'-') {
+            j += 1;
+        }
+        let exp_digits = j;
+        while j < bytes.len() && bytes[j].is_ascii_digit() {
+            j += 1;
+        }
+        if j > exp_digits {
+            i = j;
+        }
+    }
+    let _ = mantissa_end;
+    s[..i].parse::<f64>().unwrap_or(f64::NAN)
+}
+
+/// Prototype-method dispatch for evaluated receivers (the `func == null`
+/// fallback in evaluate-path.js, where real JS methods run).
+pub(crate) enum ProtoLookup {
+    Fn(&'static str),
+    Unsupported(&'static str),
+    NotFound,
+}
+
+const STR_METHODS: [&str; 26] = [
+    "at",
+    "charAt",
+    "charCodeAt",
+    "codePointAt",
+    "concat",
+    "endsWith",
+    "includes",
+    "indexOf",
+    "lastIndexOf",
+    "padEnd",
+    "padStart",
+    "repeat",
+    "replace",
+    "replaceAll",
+    "slice",
+    "split",
+    "startsWith",
+    "substr",
+    "substring",
+    "toLowerCase",
+    "toString",
+    "toUpperCase",
+    "trim",
+    "trimEnd",
+    "trimStart",
+    "valueOf",
+];
+const STR_UNSUPPORTED: [&str; 22] = [
+    "anchor",
+    "big",
+    "blink",
+    "bold",
+    "fixed",
+    "fontcolor",
+    "fontsize",
+    "isWellFormed",
+    "italics",
+    "link",
+    "localeCompare",
+    "match",
+    "matchAll",
+    "normalize",
+    "search",
+    "small",
+    "strike",
+    "sub",
+    "sup",
+    "toLocaleLowerCase",
+    "toLocaleUpperCase",
+    "toWellFormed",
+];
+
+const ARR_METHODS: [&str; 25] = [
+    "at",
+    "concat",
+    "every",
+    "filter",
+    "find",
+    "findIndex",
+    "findLast",
+    "findLastIndex",
+    "flat",
+    "flatMap",
+    "forEach",
+    "includes",
+    "indexOf",
+    "join",
+    "lastIndexOf",
+    "map",
+    "reduce",
+    "reduceRight",
+    "reverse",
+    "slice",
+    "some",
+    "sort",
+    "toReversed",
+    "toSorted",
+    "toString",
+];
+const ARR_UNSUPPORTED: [&str; 13] = [
+    "copyWithin",
+    "entries",
+    "fill",
+    "keys",
+    "pop",
+    "push",
+    "shift",
+    "splice",
+    "toLocaleString",
+    "toSpliced",
+    "unshift",
+    "values",
+    "with",
+];
+
+pub(crate) const NUM_METHODS: [&str; 3] = ["toFixed", "toString", "valueOf"];
+pub(crate) const NUM_UNSUPPORTED: [&str; 3] = ["toExponential", "toLocaleString", "toPrecision"];
+
+const OBJ_METHODS: [&str; 6] = [
+    "hasOwnProperty",
+    "isPrototypeOf",
+    "propertyIsEnumerable",
+    "toLocaleString",
+    "toString",
+    "valueOf",
+];
+const OBJ_UNSUPPORTED: [&str; 4] = [
+    "__defineGetter__",
+    "__defineSetter__",
+    "__lookupGetter__",
+    "__lookupSetter__",
+];
+
+fn find_static(table: &'static [&'static str], name: &str) -> Option<&'static str> {
+    table.iter().find(|m| **m == name).copied()
+}
+
+pub(crate) fn lookup_proto_method(receiver: &JsValue, name: &str) -> ProtoLookup {
+    let (methods, unsupported): (&'static [&'static str], &'static [&'static str]) = match receiver
+    {
+        JsValue::Str(_) => (&STR_METHODS, &STR_UNSUPPORTED),
+        JsValue::Arr(_) => (&ARR_METHODS, &ARR_UNSUPPORTED),
+        JsValue::Num(_) => (&NUM_METHODS, &NUM_UNSUPPORTED),
+        JsValue::Bool(_) => (&["toString", "valueOf"][..], &[][..]),
+        JsValue::Obj(_) => (&OBJ_METHODS, &OBJ_UNSUPPORTED),
+        _ => (&[][..], &[][..]),
+    };
+    if let Some(found) = find_static(methods, name) {
+        ProtoLookup::Fn(found)
+    } else if let Some(found) = find_static(unsupported, name) {
+        ProtoLookup::Unsupported(found)
+    } else {
+        ProtoLookup::NotFound
+    }
+}
+
+pub(crate) fn call_proto_method(
+    ev: &mut dyn ArrowCaller,
+    receiver: &JsValue,
+    method: &'static str,
+    args: &[JsValue],
+) -> Result<JsValue, StylexError> {
+    match receiver {
+        JsValue::Str(s) => call_string_method(s, method, args),
+        JsValue::Arr(items) => call_array_method(ev, receiver, items, method, args),
+        JsValue::Num(n) => call_number_method(*n, method, args),
+        JsValue::Bool(b) => match method {
+            "toString" => Ok(JsValue::Str(b.to_string())),
+            "valueOf" => Ok(JsValue::Bool(*b)),
+            _ => Err(unsupported_global(method)),
+        },
+        JsValue::Obj(obj) => call_object_method(receiver, obj, method, args),
+        _ => Err(unsupported_global(method)),
+    }
+}
+
+fn checked_slice(
+    s: &str,
+    start: isize,
+    end: isize,
+    context: &'static str,
+) -> Result<String, StylexError> {
+    let start = start.max(0) as usize;
+    js_slice_utf16_checked(s, start, end).map_err(|_| lone_surrogate_slice(context))
+}
+
+fn call_string_method(
+    s: &str,
+    method: &'static str,
+    args: &[JsValue],
+) -> Result<JsValue, StylexError> {
+    let len = utf16_len(s) as isize;
+    let units = || s.encode_utf16().collect::<Vec<u16>>();
+    match method {
+        "toString" | "valueOf" => Ok(JsValue::Str(s.to_string())),
+        "toUpperCase" => Ok(JsValue::Str(s.to_uppercase())),
+        "toLowerCase" => Ok(JsValue::Str(s.to_lowercase())),
+        "trim" => Ok(JsValue::Str(js_trim(s).to_string())),
+        "trimStart" => Ok(JsValue::Str(
+            s.trim_start_matches(crate::jsrt::is_js_whitespace)
+                .to_string(),
+        )),
+        "trimEnd" => Ok(JsValue::Str(
+            s.trim_end_matches(crate::jsrt::is_js_whitespace)
+                .to_string(),
+        )),
+        "charAt" => {
+            let i = to_integer_or_infinity(num_arg(args, 0));
+            if i < 0.0 || i >= len as f64 {
+                return Ok(JsValue::Str(String::new()));
+            }
+            Ok(JsValue::Str(checked_slice(
+                s,
+                i as isize,
+                i as isize + 1,
+                "String.prototype.charAt",
+            )?))
+        }
+        "at" => {
+            let mut i = to_integer_or_infinity(num_arg(args, 0));
+            if i < 0.0 {
+                i += len as f64;
+            }
+            if i < 0.0 || i >= len as f64 {
+                return Ok(JsValue::Undefined);
+            }
+            Ok(JsValue::Str(checked_slice(
+                s,
+                i as isize,
+                i as isize + 1,
+                "String.prototype.at",
+            )?))
+        }
+        "charCodeAt" => {
+            let i = to_integer_or_infinity(num_arg(args, 0));
+            if i < 0.0 || i >= len as f64 {
+                return Ok(JsValue::Num(f64::NAN));
+            }
+            Ok(JsValue::Num(f64::from(units()[i as usize])))
+        }
+        "codePointAt" => {
+            let i = to_integer_or_infinity(num_arg(args, 0));
+            if i < 0.0 || i >= len as f64 {
+                return Ok(JsValue::Undefined);
+            }
+            let us = units();
+            let first = us[i as usize];
+            let code = if (0xD800..=0xDBFF).contains(&first)
+                && let Some(second) = us.get(i as usize + 1)
+                && (0xDC00..=0xDFFF).contains(second)
+            {
+                0x10000 + (u32::from(first) - 0xD800) * 0x400 + (u32::from(*second) - 0xDC00)
+            } else {
+                u32::from(first)
+            };
+            Ok(JsValue::Num(f64::from(code)))
+        }
+        "indexOf" | "lastIndexOf" | "includes" | "startsWith" | "endsWith" => {
+            let needle = str_arg(args, 0, method)?;
+            let position = args.get(1).map(js_to_number);
+            string_search(s, &needle, position, method)
+        }
+        "slice" => {
+            let start = relative_index(num_arg(args, 0), len as usize);
+            let end = match args.get(1) {
+                None | Some(JsValue::Undefined) => len,
+                Some(v) => relative_index(js_to_number(v), len as usize),
+            };
+            if start >= end {
+                return Ok(JsValue::Str(String::new()));
+            }
+            Ok(JsValue::Str(checked_slice(
+                s,
+                start,
+                end,
+                "String.prototype.slice",
+            )?))
+        }
+        "substring" => {
+            let a = to_integer_or_infinity(num_arg(args, 0)).clamp(0.0, len as f64) as isize;
+            let b = match args.get(1) {
+                None | Some(JsValue::Undefined) => len,
+                Some(v) => to_integer_or_infinity(js_to_number(v)).clamp(0.0, len as f64) as isize,
+            };
+            let (start, end) = if a <= b { (a, b) } else { (b, a) };
+            Ok(JsValue::Str(checked_slice(
+                s,
+                start,
+                end,
+                "String.prototype.substring",
+            )?))
+        }
+        "substr" => {
+            let mut start = to_integer_or_infinity(num_arg(args, 0)) as isize;
+            if start < 0 {
+                start = (len + start).max(0);
+            }
+            let count = match args.get(1) {
+                None | Some(JsValue::Undefined) => len - start,
+                Some(v) => to_integer_or_infinity(js_to_number(v)) as isize,
+            };
+            // parity: JS adds as floats, so Infinity clamps instead of wrapping.
+            let end = start.saturating_add(count.max(0)).min(len);
+            if start >= end {
+                return Ok(JsValue::Str(String::new()));
+            }
+            Ok(JsValue::Str(checked_slice(
+                s,
+                start,
+                end,
+                "String.prototype.substr",
+            )?))
+        }
+        "concat" => {
+            let mut out = s.to_string();
+            for value in args {
+                out.push_str(&js_to_string(value).ok_or_else(|| {
+                    unsupported_global("a function argument to String.prototype.concat()")
+                })?);
+            }
+            Ok(JsValue::Str(out))
+        }
+        "repeat" => {
+            let n = to_integer_or_infinity(num_arg(args, 0));
+            if n < 0.0 || n.is_infinite() {
+                return Err(StylexError::new(
+                    ErrorCode::NonStaticValue,
+                    format!(
+                        "Invalid count value: {}",
+                        js_number_to_string(num_arg(args, 0))
+                    ),
+                ));
+            }
+            if n * len as f64 > 65535.0 {
+                return Err(unsupported_global("String.prototype.repeat beyond 64KiB"));
+            }
+            Ok(JsValue::Str(s.repeat(n as usize)))
+        }
+        "padStart" | "padEnd" => {
+            let target = to_integer_or_infinity(num_arg(args, 0));
+            let filler = match args.get(1) {
+                None | Some(JsValue::Undefined) => " ".to_string(),
+                Some(v) => js_to_string(v).ok_or_else(|| {
+                    unsupported_global("a function argument to String.prototype.pad()")
+                })?,
+            };
+            if target > 65535.0 {
+                return Err(unsupported_global("String.prototype.pad beyond 64KiB"));
+            }
+            if target <= len as f64 || filler.is_empty() {
+                return Ok(JsValue::Str(s.to_string()));
+            }
+            let missing = target as usize - len as usize;
+            let filler_units: Vec<u16> = filler.encode_utf16().collect();
+            let pad_units: Vec<u16> = filler_units.iter().copied().cycle().take(missing).collect();
+            let pad = utf16_units_to_string(&pad_units, "String.prototype.pad")?;
+            Ok(JsValue::Str(if method == "padStart" {
+                format!("{pad}{s}")
+            } else {
+                format!("{s}{pad}")
+            }))
+        }
+        "split" => {
+            let limit = match args.get(1) {
+                None | Some(JsValue::Undefined) => u32::MAX,
+                Some(v) => crate::eval::to_uint32(js_to_number(v)),
+            };
+            let separator = match args.first() {
+                None | Some(JsValue::Undefined) => {
+                    if limit == 0 {
+                        return Ok(JsValue::array(Vec::new()));
+                    }
+                    return Ok(JsValue::array(vec![JsValue::Str(s.to_string())]));
+                }
+                Some(v) => js_to_string(v).ok_or_else(|| {
+                    unsupported_global("a function separator in String.prototype.split()")
+                })?,
+            };
+            let mut parts: Vec<JsValue> = Vec::new();
+            if separator.is_empty() {
+                let us = units();
+                for i in 0..us.len().min(limit as usize) {
+                    parts.push(JsValue::Str(checked_slice(
+                        s,
+                        i as isize,
+                        i as isize + 1,
+                        "String.prototype.split",
+                    )?));
+                }
+            } else {
+                for piece in s.split(&separator) {
+                    if parts.len() >= limit as usize {
+                        break;
+                    }
+                    parts.push(JsValue::Str(piece.to_string()));
+                }
+            }
+            Ok(JsValue::array(parts))
+        }
+        "replace" | "replaceAll" => Err(unsupported_global("String.prototype.replace")),
+        _ => Err(unsupported_global(method)),
+    }
+}
+
+fn string_search(
+    s: &str,
+    needle: &str,
+    position: Option<f64>,
+    method: &str,
+) -> Result<JsValue, StylexError> {
+    let hay: Vec<u16> = s.encode_utf16().collect();
+    let pat: Vec<u16> = needle.encode_utf16().collect();
+    let len = hay.len();
+    let find_from = |from: usize| -> Option<usize> {
+        if pat.is_empty() {
+            return Some(from.min(len));
+        }
+        if pat.len() > len {
+            return None;
+        }
+        (from..=len.saturating_sub(pat.len())).find(|&i| hay[i..i + pat.len()] == pat[..])
+    };
+    match method {
+        "indexOf" => {
+            let from = position
+                .map_or(0.0, to_integer_or_infinity)
+                .clamp(0.0, len as f64) as usize;
+            Ok(JsValue::Num(find_from(from).map_or(-1.0, |i| i as f64)))
+        }
+        "includes" => {
+            let from = position
+                .map_or(0.0, to_integer_or_infinity)
+                .clamp(0.0, len as f64) as usize;
+            Ok(JsValue::Bool(find_from(from).is_some()))
+        }
+        "lastIndexOf" => {
+            let from = match position {
+                None => len as f64,
+                Some(p) => {
+                    let p = to_integer_or_infinity(p);
+                    if p.is_nan() { len as f64 } else { p }
+                }
+            }
+            .clamp(0.0, len as f64) as usize;
+            if pat.is_empty() {
+                return Ok(JsValue::Num(from.min(len) as f64));
+            }
+            let mut best: f64 = -1.0;
+            let mut i = 0usize;
+            while let Some(found) = find_from(i) {
+                if found > from {
+                    break;
+                }
+                best = found as f64;
+                i = found + 1;
+            }
+            Ok(JsValue::Num(best))
+        }
+        "startsWith" => {
+            let from = position
+                .map_or(0.0, to_integer_or_infinity)
+                .clamp(0.0, len as f64) as usize;
+            Ok(JsValue::Bool(
+                from + pat.len() <= len && hay[from..from + pat.len()] == pat[..],
+            ))
+        }
+        "endsWith" => {
+            let end = match position {
+                None => len,
+                Some(p) => to_integer_or_infinity(p).clamp(0.0, len as f64) as usize,
+            };
+            Ok(JsValue::Bool(
+                pat.len() <= end && hay[end - pat.len()..end] == pat[..],
+            ))
+        }
+        _ => Err(unsupported_global(method)),
+    }
+}
+
+fn element_string(value: &JsValue, method: &str) -> Result<String, StylexError> {
+    if is_nullish(value) {
+        return Ok(String::new());
+    }
+    js_to_string(value)
+        .ok_or_else(|| unsupported_global(&format!("a function element in {method}()")))
+}
+
+fn call_array_method(
+    ev: &mut dyn ArrowCaller,
+    receiver: &JsValue,
+    items: &Rc<Vec<JsValue>>,
+    method: &'static str,
+    args: &[JsValue],
+) -> Result<JsValue, StylexError> {
+    let len = items.len();
+    let callback_args =
+        |item: &JsValue, i: usize| vec![item.clone(), JsValue::Num(i as f64), receiver.clone()];
+    match method {
+        "toString" | "join" => {
+            let separator = match (method, args.first()) {
+                ("join", Some(JsValue::Undefined)) | ("join", None) | ("toString", _) => {
+                    ",".to_string()
+                }
+                ("join", Some(v)) => js_to_string(v).ok_or_else(|| {
+                    unsupported_global("a function separator in Array.prototype.join()")
+                })?,
+                _ => ",".to_string(),
+            };
+            let parts = items
+                .iter()
+                .map(|item| element_string(item, "Array.prototype.join"))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(JsValue::Str(parts.join(&separator)))
+        }
+        "at" => {
+            let mut i = to_integer_or_infinity(num_arg(args, 0));
+            if i < 0.0 {
+                i += len as f64;
+            }
+            if i < 0.0 || i >= len as f64 {
+                return Ok(JsValue::Undefined);
+            }
+            Ok(items[i as usize].clone())
+        }
+        "includes" => Ok(JsValue::Bool(
+            items
+                .iter()
+                .any(|item| same_value_zero(item, &arg(args, 0))),
+        )),
+        "indexOf" => Ok(JsValue::Num(
+            items
+                .iter()
+                .position(|item| crate::eval::js_strict_eq(item, &arg(args, 0)))
+                .map_or(-1.0, |i| i as f64),
+        )),
+        "lastIndexOf" => Ok(JsValue::Num(
+            items
+                .iter()
+                .rposition(|item| crate::eval::js_strict_eq(item, &arg(args, 0)))
+                .map_or(-1.0, |i| i as f64),
+        )),
+        "slice" => {
+            let start = relative_index(num_arg(args, 0), len);
+            let end = match args.get(1) {
+                None | Some(JsValue::Undefined) => len as isize,
+                Some(v) => relative_index(js_to_number(v), len),
+            };
+            if start >= end {
+                return Ok(JsValue::array(Vec::new()));
+            }
+            Ok(JsValue::array(items[start as usize..end as usize].to_vec()))
+        }
+        "concat" => {
+            let mut out = items.as_ref().clone();
+            for value in args {
+                match value {
+                    JsValue::Arr(more) => out.extend(more.iter().cloned()),
+                    other => out.push(other.clone()),
+                }
+            }
+            Ok(JsValue::array(out))
+        }
+        "flat" => {
+            let depth = match args.first() {
+                None | Some(JsValue::Undefined) => 1.0,
+                Some(v) => to_integer_or_infinity(js_to_number(v)),
+            };
+            let mut out = Vec::new();
+            flatten_into(&mut out, items, depth);
+            Ok(JsValue::array(out))
+        }
+        "reverse" | "toReversed" => Ok(JsValue::array(
+            items.iter().rev().cloned().collect::<Vec<_>>(),
+        )),
+        "sort" | "toSorted" => {
+            let comparator = arg(args, 0);
+            let mut sorted: Vec<JsValue> = items.as_ref().clone();
+            // ES SortCompare: undefined elements sort last, before holes.
+            let mut error: Option<StylexError> = None;
+            if matches!(comparator, JsValue::Undefined) {
+                let mut keyed: Vec<(Option<String>, JsValue)> = Vec::with_capacity(sorted.len());
+                for item in sorted {
+                    let key = if matches!(item, JsValue::Undefined) {
+                        None
+                    } else {
+                        match js_to_string(&item) {
+                            Some(k) => Some(k),
+                            None => {
+                                return Err(unsupported_global(
+                                    "a function element in Array.prototype.sort()",
+                                ));
+                            }
+                        }
+                    };
+                    keyed.push((key, item));
+                }
+                keyed.sort_by(|(a, _), (b, _)| match (a, b) {
+                    (None, None) => std::cmp::Ordering::Equal,
+                    (None, Some(_)) => std::cmp::Ordering::Greater,
+                    (Some(_), None) => std::cmp::Ordering::Less,
+                    (Some(a), Some(b)) => utf16_cmp(a, b),
+                });
+                sorted = keyed.into_iter().map(|(_, v)| v).collect();
+            } else {
+                sorted.sort_by(|a, b| {
+                    if error.is_some() {
+                        return std::cmp::Ordering::Equal;
+                    }
+                    if matches!(a, JsValue::Undefined) || matches!(b, JsValue::Undefined) {
+                        return match (
+                            matches!(a, JsValue::Undefined),
+                            matches!(b, JsValue::Undefined),
+                        ) {
+                            (true, true) => std::cmp::Ordering::Equal,
+                            (true, false) => std::cmp::Ordering::Greater,
+                            (false, true) => std::cmp::Ordering::Less,
+                            _ => unreachable!(),
+                        };
+                    }
+                    match call_callback(
+                        ev,
+                        &comparator,
+                        vec![a.clone(), b.clone()],
+                        "Array.prototype.sort",
+                    ) {
+                        Ok(v) => {
+                            let n = js_to_number(&v);
+                            if n < 0.0 {
+                                std::cmp::Ordering::Less
+                            } else if n > 0.0 {
+                                std::cmp::Ordering::Greater
+                            } else {
+                                std::cmp::Ordering::Equal
+                            }
+                        }
+                        Err(e) => {
+                            error = Some(e);
+                            std::cmp::Ordering::Equal
+                        }
+                    }
+                });
+                if let Some(e) = error {
+                    return Err(e);
+                }
+            }
+            Ok(JsValue::array(sorted))
+        }
+        "map" | "flatMap" => {
+            let callback = arg(args, 0);
+            let mut out = Vec::with_capacity(len);
+            for (i, item) in items.iter().enumerate() {
+                let mapped =
+                    call_callback(ev, &callback, callback_args(item, i), "Array.prototype.map")?;
+                if method == "flatMap" {
+                    match mapped {
+                        JsValue::Arr(inner) => out.extend(inner.iter().cloned()),
+                        other => out.push(other),
+                    }
+                } else {
+                    out.push(mapped);
+                }
+            }
+            Ok(JsValue::array(out))
+        }
+        "filter" => {
+            let callback = arg(args, 0);
+            let mut out = Vec::new();
+            for (i, item) in items.iter().enumerate() {
+                if truthy(&call_callback(
+                    ev,
+                    &callback,
+                    callback_args(item, i),
+                    "Array.prototype.filter",
+                )?) {
+                    out.push(item.clone());
+                }
+            }
+            Ok(JsValue::array(out))
+        }
+        "forEach" => {
+            let callback = arg(args, 0);
+            for (i, item) in items.iter().enumerate() {
+                call_callback(
+                    ev,
+                    &callback,
+                    callback_args(item, i),
+                    "Array.prototype.forEach",
+                )?;
+            }
+            Ok(JsValue::Undefined)
+        }
+        "some" | "every" => {
+            let callback = arg(args, 0);
+            for (i, item) in items.iter().enumerate() {
+                let passed = truthy(&call_callback(
+                    ev,
+                    &callback,
+                    callback_args(item, i),
+                    "Array.prototype.some",
+                )?);
+                if method == "some" && passed {
+                    return Ok(JsValue::Bool(true));
+                }
+                if method == "every" && !passed {
+                    return Ok(JsValue::Bool(false));
+                }
+            }
+            Ok(JsValue::Bool(method == "every"))
+        }
+        "find" | "findIndex" | "findLast" | "findLastIndex" => {
+            let callback = arg(args, 0);
+            let indices: Vec<usize> = if method.contains("Last") {
+                (0..len).rev().collect()
+            } else {
+                (0..len).collect()
+            };
+            for i in indices {
+                let item = &items[i];
+                if truthy(&call_callback(
+                    ev,
+                    &callback,
+                    callback_args(item, i),
+                    "Array.prototype.find",
+                )?) {
+                    return Ok(if method.ends_with("Index") {
+                        JsValue::Num(i as f64)
+                    } else {
+                        item.clone()
+                    });
+                }
+            }
+            Ok(if method.ends_with("Index") {
+                JsValue::Num(-1.0)
+            } else {
+                JsValue::Undefined
+            })
+        }
+        "reduce" | "reduceRight" => {
+            let callback = arg(args, 0);
+            let mut order: Vec<usize> = (0..len).collect();
+            if method == "reduceRight" {
+                order.reverse();
+            }
+            let mut iter = order.into_iter();
+            let mut acc = match args.get(1) {
+                Some(initial) => initial.clone(),
+                None => match iter.next() {
+                    Some(i) => items[i].clone(),
+                    None => {
+                        return Err(StylexError::new(
+                            ErrorCode::NonStaticValue,
+                            "Reduce of empty array with no initial value",
+                        ));
+                    }
+                },
+            };
+            for i in iter {
+                acc = call_callback(
+                    ev,
+                    &callback,
+                    vec![
+                        acc,
+                        items[i].clone(),
+                        JsValue::Num(i as f64),
+                        receiver.clone(),
+                    ],
+                    "Array.prototype.reduce",
+                )?;
+            }
+            Ok(acc)
+        }
+        _ => Err(unsupported_global(method)),
+    }
+}
+
+// ES SameValueZero (Array.prototype.includes).
+fn same_value_zero(a: &JsValue, b: &JsValue) -> bool {
+    match (a, b) {
+        (JsValue::Num(x), JsValue::Num(y)) => (x.is_nan() && y.is_nan()) || x == y,
+        _ => crate::eval::js_strict_eq(a, b),
+    }
+}
+
+fn flatten_into(out: &mut Vec<JsValue>, items: &[JsValue], depth: f64) {
+    for item in items {
+        match item {
+            JsValue::Arr(inner) if depth >= 1.0 => flatten_into(out, inner, depth - 1.0),
+            other => out.push(other.clone()),
+        }
+    }
+}
+
+fn call_number_method(
+    n: f64,
+    method: &'static str,
+    args: &[JsValue],
+) -> Result<JsValue, StylexError> {
+    match method {
+        "valueOf" => Ok(JsValue::Num(n)),
+        "toString" => {
+            let radix = match args.first() {
+                None | Some(JsValue::Undefined) => 10.0,
+                Some(v) => to_integer_or_infinity(js_to_number(v)),
+            };
+            if radix == 10.0 {
+                return Ok(JsValue::Str(js_number_to_string(n)));
+            }
+            if !(2.0..=36.0).contains(&radix) {
+                return Err(StylexError::new(
+                    ErrorCode::NonStaticValue,
+                    "toString() radix must be between 2 and 36",
+                ));
+            }
+            if !n.is_finite() {
+                return Ok(JsValue::Str(js_number_to_string(n)));
+            }
+            if n.fract() != 0.0 || n.abs() >= 9_007_199_254_740_992.0 {
+                return Err(unsupported_global(
+                    "Number.prototype.toString with a non-integral radix argument",
+                ));
+            }
+            let radix = radix as u32;
+            let negative = n < 0.0;
+            let mut magnitude = n.abs() as u64;
+            let mut digits = Vec::new();
+            loop {
+                let digit = (magnitude % u64::from(radix)) as u32;
+                digits.push(char::from_digit(digit, radix).expect("digit < radix"));
+                magnitude /= u64::from(radix);
+                if magnitude == 0 {
+                    break;
+                }
+            }
+            if negative {
+                digits.push('-');
+            }
+            Ok(JsValue::Str(digits.into_iter().rev().collect()))
+        }
+        "toFixed" => {
+            let digits = to_integer_or_infinity(num_arg(args, 0));
+            if !(0.0..=100.0).contains(&digits) {
+                return Err(StylexError::new(
+                    ErrorCode::NonStaticValue,
+                    "toFixed() digits argument must be between 0 and 100",
+                ));
+            }
+            Ok(JsValue::Str(js_to_fixed(n, digits as usize)))
+        }
+        _ => Err(unsupported_global(method)),
+    }
+}
+
+fn call_object_method(
+    receiver: &JsValue,
+    obj: &Rc<JsObj>,
+    method: &'static str,
+    args: &[JsValue],
+) -> Result<JsValue, StylexError> {
+    match method {
+        "toString" | "toLocaleString" => Ok(JsValue::Str("[object Object]".to_string())),
+        "valueOf" => Ok(receiver.clone()),
+        "hasOwnProperty" | "propertyIsEnumerable" => {
+            let key = js_to_string(&arg(args, 0)).ok_or_else(|| {
+                unsupported_global("a function key in Object.prototype.hasOwnProperty()")
+            })?;
+            Ok(JsValue::Bool(obj.get(&key).is_some()))
+        }
+        "isPrototypeOf" => Ok(JsValue::Bool(false)),
+        _ => Err(unsupported_global(method)),
+    }
+}
+
+/// The global identifier-callee surface (`String(x)`, `Array(…)`, …).
+pub(crate) fn call_global_identifier(
+    name: &str,
+    args: &[JsValue],
+) -> Result<Option<JsValue>, StylexError> {
+    match name {
+        // parity: global.Math is not callable — the TypeError escapes.
+        "Math" => Err(func_apply_error()),
+        "String" => Ok(match args.first() {
+            None => Some(JsValue::Str(String::new())),
+            Some(v) => js_to_string(v).map(JsValue::Str),
+        }),
+        "Number" => Ok(Some(JsValue::Num(args.first().map_or(0.0, js_to_number)))),
+        "Array" => {
+            if args.len() == 1
+                && let JsValue::Num(n) = args[0]
+            {
+                if n.fract() != 0.0 || !(0.0..=4_294_967_295.0).contains(&n) {
+                    return Err(StylexError::new(
+                        ErrorCode::NonStaticValue,
+                        "Invalid array length",
+                    ));
+                }
+                if n > 65535.0 {
+                    return Err(unsupported_global("Array() beyond 65535 elements"));
+                }
+                // Holes approximated as undefined (visible only via own-keys).
+                return Ok(Some(JsValue::array(vec![JsValue::Undefined; n as usize])));
+            }
+            Ok(Some(JsValue::array(args.to_vec())))
+        }
+        "Object" => match args.first() {
+            None | Some(JsValue::Null | JsValue::Undefined) => {
+                Ok(Some(JsValue::object(JsObj::default())))
+            }
+            Some(v @ (JsValue::Obj(_) | JsValue::Arr(_) | JsValue::Proxy(_))) => {
+                Ok(Some(v.clone()))
+            }
+            Some(_) => Err(unsupported_global("Object() wrapper objects")),
+        },
+        _ => Ok(None),
+    }
+}

--- a/crates/stylex/src/eval/mod.rs
+++ b/crates/stylex/src/eval/mod.rs
@@ -1,0 +1,2132 @@
+//! Compile-time partial evaluator over the oxc AST, default-deny past the
+//! verified surface. parity: evaluate-path.js + parse-stylex-create-arg.js
+
+pub mod cross_file;
+pub mod functions;
+pub mod methods;
+pub mod value;
+
+use std::collections::BTreeMap;
+
+use crate::fxhash::FxHashMap;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use oxc_ast::ast::{
+    Argument, ArrayExpressionElement, BinaryExpression, CallExpression, ChainElement, Expression,
+    IdentifierReference, LogicalExpression, ObjectExpression, ObjectPropertyKind, PropertyKey,
+    PropertyKind, TemplateLiteral, UnaryExpression,
+};
+use oxc_span::{GetSpan, Span};
+use oxc_syntax::operator::{BinaryOperator, LogicalOperator, UnaryOperator};
+use oxc_syntax::symbol::SymbolId;
+
+use crate::errors::{ErrorCode, StylexError};
+use crate::eval::cross_file as errs;
+use crate::eval::cross_file::VarGroupProxy;
+use crate::eval::functions::{EvalCallables, StylexCallable, WHEN_MEMBERS};
+use crate::eval::methods::ArrowCaller;
+use crate::eval::value::{EvalValue, JsObjectMap, array_index};
+use crate::imports::{ImportTable, ImportedSymbol, StylexNamedImport};
+use crate::jsrt::{js_number_to_string, js_slice_utf16, js_slice_utf16_checked, utf16_cmp};
+use crate::module_resolution::FsProvider;
+use crate::shared::dynamic::{DynamicFn, inline_style_for_leaf};
+use crate::state::{BindingDecl, CompileState};
+
+/// Evaluator-local value model; `Rc` containers keep JS allocation identity
+/// through clones (`x === x` via the node cache), like real objects upstream.
+#[derive(Debug, Clone)]
+pub enum JsValue {
+    Null,
+    Undefined,
+    Bool(bool),
+    Num(f64),
+    Str(String),
+    Arr(Rc<Vec<JsValue>>),
+    Obj(Rc<JsObj>),
+    Proxy(Rc<VarGroupProxy>),
+    Callable(Callable),
+}
+
+impl JsValue {
+    pub fn array(items: Vec<JsValue>) -> Self {
+        JsValue::Arr(Rc::new(items))
+    }
+
+    pub fn object(obj: JsObj) -> Self {
+        JsValue::Obj(Rc::new(obj))
+    }
+
+    pub fn proxy(proxy: VarGroupProxy) -> Self {
+        JsValue::Proxy(Rc::new(proxy))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Callable {
+    Stylex(StylexCallable),
+    /// A local expression-body arrow, callable at compile time; the key is
+    /// its span start in the evaluator's arrow-body table.
+    Arrow(u32),
+    /// Function values calls never dispatch to.
+    Opaque,
+}
+
+/// Insertion-ordered object; ES OwnPropertyKeys ordering is restored when the
+/// value converts to `JsObjectMap`, which every observable path goes through.
+#[derive(Debug, Clone, Default)]
+pub struct JsObj {
+    entries: Vec<(String, JsValue)>,
+    /// Lazy key→position table so wide objects avoid quadratic scans.
+    // Boxed to keep the usually-None field one word in every JsObj.
+    #[allow(clippy::box_collection)]
+    index: Option<Box<FxHashMap<String, usize>>>,
+    /// CSSType `instanceof` brand (the syntax): out-of-band like a prototype —
+    /// spreads copy entries only, aliases share the allocation.
+    css_type: Option<String>,
+}
+
+impl JsObj {
+    pub fn get(&self, key: &str) -> Option<&JsValue> {
+        if let Some(index) = &self.index {
+            index.get(key).map(|&i| &self.entries[i].1)
+        } else {
+            self.entries.iter().find(|(k, _)| k == key).map(|(_, v)| v)
+        }
+    }
+
+    pub fn insert(&mut self, key: String, value: JsValue) {
+        if self.index.is_none() && self.entries.len() >= value::NAMED_INDEX_THRESHOLD {
+            self.index = Some(Box::new(
+                self.entries
+                    .iter()
+                    .enumerate()
+                    .map(|(i, (k, _))| (k.clone(), i))
+                    .collect(),
+            ));
+        }
+        if let Some(index) = &mut self.index {
+            match index.entry(key) {
+                std::collections::hash_map::Entry::Occupied(e) => {
+                    self.entries[*e.get()].1 = value;
+                }
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    self.entries.push((e.key().clone(), value));
+                    e.insert(self.entries.len() - 1);
+                }
+            }
+        } else if let Some(entry) = self.entries.iter_mut().find(|(k, _)| *k == key) {
+            entry.1 = value;
+        } else {
+            self.entries.push((key, value));
+        }
+    }
+
+    pub fn entries(&self) -> impl Iterator<Item = (&str, &JsValue)> {
+        self.entries.iter().map(|(k, v)| (k.as_str(), v))
+    }
+
+    pub fn css_type(&self) -> Option<&str> {
+        self.css_type.as_deref()
+    }
+
+    pub fn set_css_type(&mut self, syntax: String) {
+        self.css_type = Some(syntax);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Deopt {
+    pub reason: String,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub enum EvalOutcome {
+    Value(JsValue),
+    /// Upstream deopt: hard error in create/defineVars contexts, bail-to-runtime
+    /// marker in props()/stylex() merge contexts.
+    NonStatic(Deopt),
+}
+
+pub type EvalResult = Result<EvalOutcome, StylexError>;
+
+/// Proxies convert to empty objects (the upstream JS Proxy has no own keys);
+/// functions to `undefined` (downstream validation rejects both identically).
+pub fn to_eval_value(value: &JsValue) -> EvalValue {
+    match value {
+        JsValue::Null => EvalValue::Null,
+        JsValue::Undefined | JsValue::Callable(_) => EvalValue::Undefined,
+        JsValue::Bool(b) => EvalValue::Bool(*b),
+        JsValue::Num(n) => EvalValue::Num(*n),
+        JsValue::Str(s) => EvalValue::Str(s.clone()),
+        JsValue::Arr(items) => EvalValue::Arr(items.iter().map(to_eval_value).collect()),
+        JsValue::Obj(obj) => {
+            let mut map = JsObjectMap::new();
+            for (k, v) in obj.entries() {
+                map.insert(k.to_string(), to_eval_value(v));
+            }
+            if let Some(syntax) = obj.css_type() {
+                map.set_css_type(syntax.to_string());
+            }
+            EvalValue::Obj(Arc::new(map))
+        }
+        JsValue::Proxy(_) => EvalValue::Obj(JsObjectMap::new().into()),
+    }
+}
+
+pub fn from_eval_value(value: &EvalValue) -> JsValue {
+    match value {
+        EvalValue::Null => JsValue::Null,
+        EvalValue::Undefined => JsValue::Undefined,
+        EvalValue::Bool(b) => JsValue::Bool(*b),
+        EvalValue::Num(n) => JsValue::Num(*n),
+        EvalValue::Str(s) => JsValue::Str(s.clone()),
+        EvalValue::Arr(items) => JsValue::array(items.iter().map(from_eval_value).collect()),
+        EvalValue::Obj(map) => {
+            let mut obj = JsObj::default();
+            for (k, v) in map.entries() {
+                obj.insert(k.to_string(), from_eval_value(v));
+            }
+            if let Some(syntax) = map.css_type() {
+                obj.set_css_type(syntax.to_string());
+            }
+            JsValue::object(obj)
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum RegistryEntry {
+    Callable(StylexCallable),
+    Value(JsValue),
+}
+
+/// Outcome of the babel-`resolve()` walk over declarator inits.
+enum Resolved<'a> {
+    Override(EvalValue),
+    Expr(&'a Expression<'a>),
+    Identifier(&'a IdentifierReference<'a>),
+    /// Declarator without an initializer (babel: null init path).
+    NullInit,
+    /// A non-init declaration node, named as babel would report it.
+    DeclNode(&'static str, Span),
+}
+
+impl Resolved<'_> {
+    fn span(&self) -> Option<Span> {
+        match self {
+            Resolved::Expr(expr) => Some(expr.span()),
+            Resolved::Identifier(id) => Some(id.span),
+            Resolved::DeclNode(_, span) => Some(*span),
+            Resolved::Override(_) | Resolved::NullInit => None,
+        }
+    }
+}
+
+/// The `FunctionConfig` equivalent the visitor hands the evaluator.
+// parity: stylex-create.js:171-206 + state-manager.js applyStylexEnv
+#[derive(Debug, Clone, Default)]
+pub struct FunctionRegistry {
+    identifiers: BTreeMap<String, RegistryEntry>,
+    member_callables: BTreeMap<(String, String), StylexCallable>,
+}
+
+fn when_object() -> JsValue {
+    let mut obj = JsObj::default();
+    for (name, callable) in WHEN_MEMBERS {
+        obj.insert(
+            name.to_string(),
+            JsValue::Callable(Callable::Stylex(callable)),
+        );
+    }
+    JsValue::object(obj)
+}
+
+impl FunctionRegistry {
+    /// FunctionConfig of visitors/stylex-keyframes.js: firstThatWorks + env only.
+    pub fn for_keyframes(imports: &ImportTable, env: &EvalValue) -> Self {
+        let mut registry = Self::restricted_base(imports, env);
+        for (local, binding) in &imports.named {
+            if *binding == StylexNamedImport::FirstThatWorks {
+                registry.identifiers.insert(
+                    local.clone(),
+                    RegistryEntry::Callable(StylexCallable::FirstThatWorks),
+                );
+            }
+        }
+        for namespace in &imports.stylex_namespaces {
+            registry.member_callables.insert(
+                (namespace.clone(), "firstThatWorks".to_string()),
+                StylexCallable::FirstThatWorks,
+            );
+        }
+        registry
+    }
+
+    /// FunctionConfig of visitors/stylex-props.js: defaultMarker + env only.
+    pub fn for_props(imports: &ImportTable, env: &EvalValue) -> Self {
+        let mut registry = Self::restricted_base(imports, env);
+        for (local, binding) in &imports.named {
+            if *binding == StylexNamedImport::DefaultMarker {
+                registry.identifiers.insert(
+                    local.clone(),
+                    RegistryEntry::Callable(StylexCallable::DefaultMarker),
+                );
+            }
+        }
+        for namespace in &imports.stylex_namespaces {
+            registry.member_callables.insert(
+                (namespace.clone(), "defaultMarker".to_string()),
+                StylexCallable::DefaultMarker,
+            );
+        }
+        registry
+    }
+
+    /// FunctionConfig of visitors/stylex-define-consts.js: env only.
+    pub fn for_consts(imports: &ImportTable, env: &EvalValue) -> Self {
+        Self::restricted_base(imports, env)
+    }
+
+    /// FunctionConfig of visitors/stylex-view-transition-class.js:
+    /// firstThatWorks + keyframes + env.
+    pub fn for_view_transition(imports: &ImportTable, env: &EvalValue) -> Self {
+        let mut registry = Self::for_keyframes(imports, env);
+        for (local, binding) in &imports.named {
+            if *binding == StylexNamedImport::Keyframes {
+                registry.identifiers.insert(
+                    local.clone(),
+                    RegistryEntry::Callable(StylexCallable::Keyframes),
+                );
+            }
+        }
+        for namespace in &imports.stylex_namespaces {
+            registry.member_callables.insert(
+                (namespace.clone(), "keyframes".to_string()),
+                StylexCallable::Keyframes,
+            );
+        }
+        registry
+    }
+
+    fn restricted_base(imports: &ImportTable, env: &EvalValue) -> Self {
+        let mut registry = FunctionRegistry::default();
+        for (local, binding) in &imports.named {
+            if *binding == StylexNamedImport::Env {
+                registry
+                    .identifiers
+                    .insert(local.clone(), RegistryEntry::Value(from_eval_value(env)));
+            }
+        }
+        for namespace in &imports.stylex_namespaces {
+            let mut obj = JsObj::default();
+            obj.insert("env".to_string(), from_eval_value(env));
+            registry.identifiers.insert(
+                namespace.clone(),
+                RegistryEntry::Value(JsValue::object(obj)),
+            );
+        }
+        registry
+    }
+
+    pub fn for_create(imports: &ImportTable, env: &EvalValue) -> Self {
+        let mut registry = FunctionRegistry::default();
+        for (local, binding) in &imports.named {
+            let entry = match binding {
+                StylexNamedImport::FirstThatWorks => {
+                    RegistryEntry::Callable(StylexCallable::FirstThatWorks)
+                }
+                StylexNamedImport::Keyframes => RegistryEntry::Callable(StylexCallable::Keyframes),
+                StylexNamedImport::PositionTry => {
+                    RegistryEntry::Callable(StylexCallable::PositionTry)
+                }
+                StylexNamedImport::DefaultMarker => {
+                    RegistryEntry::Callable(StylexCallable::DefaultMarker)
+                }
+                StylexNamedImport::When => RegistryEntry::Value(when_object()),
+                StylexNamedImport::Env => RegistryEntry::Value(from_eval_value(env)),
+                _ => continue,
+            };
+            registry.identifiers.insert(local.clone(), entry);
+        }
+        for namespace in &imports.stylex_namespaces {
+            let mut obj = JsObj::default();
+            obj.insert("when".to_string(), when_object());
+            obj.insert("env".to_string(), from_eval_value(env));
+            registry.identifiers.insert(
+                namespace.clone(),
+                RegistryEntry::Value(JsValue::object(obj)),
+            );
+            for (name, callable) in [
+                ("firstThatWorks", StylexCallable::FirstThatWorks),
+                ("keyframes", StylexCallable::Keyframes),
+                ("positionTry", StylexCallable::PositionTry),
+                ("defaultMarker", StylexCallable::DefaultMarker),
+            ] {
+                registry
+                    .member_callables
+                    .insert((namespace.clone(), name.to_string()), callable);
+            }
+        }
+        registry
+    }
+}
+
+pub struct Evaluator<'a, 'env> {
+    pub state: &'env mut CompileState<'a>,
+    pub fs: &'env dyn FsProvider,
+    pub callables: &'env dyn EvalCallables,
+    registry: FunctionRegistry,
+    /// parity: FunctionConfig.disableImports — named-import resolution off.
+    disable_imports: bool,
+    arrow_bodies: BTreeMap<u32, (&'a Expression<'a>, Vec<String>)>,
+    /// Off by default: the transform path still hard-errors on dynamic styles.
+    dynamic_namespaces: bool,
+    depth: u32,
+    /// parity: evaluateCached `seen` — per-`evaluate()` node cache, giving
+    /// same-binding references the same (Rc-identical) value.
+    seen: FxHashMap<(u32, u32), SeenEntry>,
+}
+
+#[derive(Debug, Clone)]
+enum SeenEntry {
+    InFlight,
+    Value(JsValue),
+}
+
+macro_rules! value_or_return {
+    ($self:expr, $expr:expr) => {
+        match $self.eval($expr)? {
+            EvalOutcome::Value(v) => v,
+            deopt => return Ok(deopt),
+        }
+    };
+}
+
+impl<'a, 'env> Evaluator<'a, 'env> {
+    pub fn for_create(
+        state: &'env mut CompileState<'a>,
+        fs: &'env dyn FsProvider,
+        callables: &'env dyn EvalCallables,
+    ) -> Self {
+        let registry = FunctionRegistry::for_create(&state.imports, &state.options.env);
+        Evaluator {
+            state,
+            fs,
+            callables,
+            registry,
+            disable_imports: false,
+            arrow_bodies: BTreeMap::new(),
+            dynamic_namespaces: false,
+            depth: 0,
+            seen: FxHashMap::default(),
+        }
+    }
+
+    /// Enables the parse-stylex-create-arg.js arrow-namespace path.
+    pub fn allow_dynamic_namespaces(&mut self) {
+        self.dynamic_namespaces = true;
+    }
+
+    pub fn with_registry(
+        state: &'env mut CompileState<'a>,
+        fs: &'env dyn FsProvider,
+        callables: &'env dyn EvalCallables,
+        registry: FunctionRegistry,
+        disable_imports: bool,
+    ) -> Self {
+        Evaluator {
+            state,
+            fs,
+            callables,
+            registry,
+            disable_imports,
+            arrow_bodies: BTreeMap::new(),
+            dynamic_namespaces: false,
+            depth: 0,
+            seen: FxHashMap::default(),
+        }
+    }
+
+    fn deopt(&self, span: Span, reason: impl Into<String>) -> EvalResult {
+        Ok(EvalOutcome::NonStatic(Deopt {
+            reason: reason.into(),
+            span,
+        }))
+    }
+
+    fn value(&self, value: JsValue) -> EvalResult {
+        Ok(EvalOutcome::Value(value))
+    }
+
+    /// A fresh top-level `evaluate()` call (fresh `seen`, as upstream defaults).
+    pub fn eval_entry(&mut self, expr: &'a Expression<'a>) -> EvalResult {
+        let _t = crate::timings::start(crate::timings::Stage::Eval);
+        self.seen.clear();
+        self.eval(expr)
+    }
+
+    /// parity: nested `evaluate(...)` without the shared seen map (array
+    /// elements, call-object fallback, arrow-closure bodies).
+    fn eval_fresh(&mut self, expr: &'a Expression<'a>) -> EvalResult {
+        let saved = std::mem::take(&mut self.seen);
+        let result = self.eval(expr);
+        self.seen = saved;
+        result
+    }
+
+    // parity: evaluateCached — value hits replay (preserving identity), and a
+    // node already in flight deopts with literally "Currently evaluating".
+    pub fn eval(&mut self, expr: &'a Expression<'a>) -> EvalResult {
+        let span = expr.span();
+        self.eval_cached(span, |ev| ev.eval_inner(expr))
+    }
+
+    fn eval_cached(
+        &mut self,
+        span: Span,
+        eval_fn: impl FnOnce(&mut Self) -> EvalResult,
+    ) -> EvalResult {
+        self.depth += 1;
+        if self.depth > 128 {
+            self.depth -= 1;
+            return Err(StylexError::new(
+                ErrorCode::NonStaticValue,
+                "StyleX evaluation exceeded the recursion limit.",
+            ));
+        }
+        let key = (span.start, span.end);
+        match self.seen.get(&key) {
+            Some(SeenEntry::InFlight) => {
+                self.depth -= 1;
+                return self.deopt(span, "Currently evaluating");
+            }
+            Some(SeenEntry::Value(v)) => {
+                let v = v.clone();
+                self.depth -= 1;
+                return self.value(v);
+            }
+            None => {}
+        }
+        self.seen.insert(key, SeenEntry::InFlight);
+        let result = eval_fn(self);
+        if let Ok(EvalOutcome::Value(v)) = &result {
+            self.seen.insert(key, SeenEntry::Value(v.clone()));
+        }
+        self.depth -= 1;
+        result
+    }
+
+    fn eval_inner(&mut self, expr: &'a Expression<'a>) -> EvalResult {
+        match expr {
+            Expression::ParenthesizedExpression(e) => self.eval(&e.expression),
+            Expression::TSAsExpression(e) => self.eval(&e.expression),
+            Expression::TSSatisfiesExpression(e) => self.eval(&e.expression),
+            Expression::ArrowFunctionExpression(arrow) => {
+                let simple_params = arrow.params.rest.is_none();
+                let expression_body =
+                    !matches!(arrow.body, oxc_ast::ast::ArrowFunctionBody::FunctionBody(_));
+                // parity: evaluate-path.js:369 builds a callable closure only
+                // for direct-identifier params; anything else deopts.
+                let strict: Option<Vec<String>> = arrow
+                    .params
+                    .items
+                    .iter()
+                    .map(|p| match &p.pattern {
+                        // Defaulted params are babel AssignmentPatterns: no closure.
+                        oxc_ast::ast::BindingPattern::BindingIdentifier(id)
+                            if p.initializer.is_none() =>
+                        {
+                            Some(id.name.to_string())
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                if let (true, Some(params), Some(body)) = (
+                    simple_params && expression_body,
+                    strict,
+                    arrow.body.as_expression(),
+                ) {
+                    self.arrow_bodies.insert(arrow.span.start, (body, params));
+                    self.value(JsValue::Callable(Callable::Arrow(arrow.span.start)))
+                } else {
+                    self.deopt(
+                        arrow.span,
+                        errs::unsupported_expression("ArrowFunctionExpression"),
+                    )
+                }
+            }
+            Expression::SequenceExpression(seq) => match seq.expressions.last() {
+                Some(last) => self.eval(last),
+                None => self.deopt(seq.span, errs::PATH_WITHOUT_NODE),
+            },
+            Expression::StringLiteral(lit) => {
+                if lit.lone_surrogates {
+                    return Err(StylexError::lone_surrogate("a string literal"));
+                }
+                self.value(JsValue::Str(lit.value.to_string()))
+            }
+            Expression::NumericLiteral(lit) => self.value(JsValue::Num(lit.value)),
+            Expression::BooleanLiteral(lit) => self.value(JsValue::Bool(lit.value)),
+            Expression::NullLiteral(_) => self.value(JsValue::Null),
+            Expression::TemplateLiteral(tpl) => self.eval_template(tpl),
+            Expression::ConditionalExpression(cond) => {
+                let test = value_or_return!(self, &cond.test);
+                if truthy(&test) {
+                    self.eval(&cond.consequent)
+                } else {
+                    self.eval(&cond.alternate)
+                }
+            }
+            Expression::StaticMemberExpression(_) | Expression::ComputedMemberExpression(_) => {
+                self.eval_member(expr)
+            }
+            Expression::Identifier(id) => self.eval_identifier(id),
+            Expression::UnaryExpression(unary) => self.eval_unary(unary),
+            Expression::ArrayExpression(array) => {
+                let mut out = Vec::with_capacity(array.elements.len());
+                for element in &array.elements {
+                    match element {
+                        ArrayExpressionElement::Elision(elision) => {
+                            return self.deopt(elision.span, errs::PATH_WITHOUT_NODE);
+                        }
+                        ArrayExpressionElement::SpreadElement(spread) => {
+                            return self
+                                .deopt(spread.span, errs::unsupported_expression("SpreadElement"));
+                        }
+                        _ => {
+                            let expr = element.to_expression();
+                            match self.eval_fresh(expr)? {
+                                EvalOutcome::Value(v) => out.push(v),
+                                deopt => return Ok(deopt),
+                            }
+                        }
+                    }
+                }
+                self.value(JsValue::array(out))
+            }
+            Expression::ObjectExpression(object) => self.eval_object(object),
+            Expression::LogicalExpression(logical) => self.eval_logical(logical),
+            Expression::BinaryExpression(binary) => self.eval_binary(binary),
+            Expression::CallExpression(call) => self.eval_call(call),
+            Expression::ChainExpression(chain) => {
+                let name = match &chain.expression {
+                    ChainElement::CallExpression(_) => "OptionalCallExpression",
+                    ChainElement::TSNonNullExpression(_) => "TSNonNullExpression",
+                    _ => "OptionalMemberExpression",
+                };
+                self.deopt(chain.span, errs::unsupported_expression(name))
+            }
+            other => self.deopt(
+                other.span(),
+                errs::unsupported_expression(babel_type_name(other)),
+            ),
+        }
+    }
+
+    fn eval_template(&mut self, tpl: &'a TemplateLiteral<'a>) -> EvalResult {
+        let mut out = String::new();
+        for (i, quasi) in tpl.quasis.iter().enumerate() {
+            if quasi.lone_surrogates {
+                return Err(StylexError::lone_surrogate("a template literal"));
+            }
+            match &quasi.value.cooked {
+                Some(cooked) => out.push_str(cooked),
+                None => out.push_str("undefined"),
+            }
+            if let Some(expr) = tpl.expressions.get(i) {
+                let value = value_or_return!(self, expr);
+                match js_to_string(&value) {
+                    Some(s) => out.push_str(&s),
+                    None => {
+                        return self.deopt(
+                            expr.span(),
+                            errs::unsupported_expression(babel_type_name(expr)),
+                        );
+                    }
+                }
+            }
+        }
+        self.value(JsValue::Str(out))
+    }
+
+    // parity: _evaluate isReferencedIdentifier branch — real scope resolution
+    // through oxc_semantic, then babel resolve() through declarator inits.
+    fn eval_identifier(&mut self, id: &'a IdentifierReference<'a>) -> EvalResult {
+        let name = id.name.as_str();
+        let span = id.span;
+        if let Some(entry) = self.registry.identifiers.get(name) {
+            return self.value(match entry {
+                RegistryEntry::Callable(c) => JsValue::Callable(Callable::Stylex(c.clone())),
+                RegistryEntry::Value(v) => v.clone(),
+            });
+        }
+        let Some(symbol) = self.state.symbol_of(id) else {
+            return match name {
+                "undefined" => self.value(JsValue::Undefined),
+                "Infinity" => self.value(JsValue::Num(f64::INFINITY)),
+                "NaN" => self.value(JsValue::Num(f64::NAN)),
+                _ => self.deopt(span, errs::UNDEFINED_CONST),
+            };
+        };
+        let info = self.state.binding_info(symbol);
+        if matches!(info.decl, BindingDecl::NamedImport) && !self.disable_imports {
+            return self.eval_named_import(name, span);
+        }
+        if matches!(info.decl, BindingDecl::DefaultImport) {
+            return self.deopt(span, errs::IMPORT_FILE_EVAL_ERROR);
+        }
+        if self.state.is_non_constant(symbol) || self.state.is_mutated(symbol) {
+            return self.deopt(span, errs::NON_CONSTANT);
+        }
+        if span.start < info.span.end {
+            return self.deopt(span, errs::USED_BEFORE_DECLARATION);
+        }
+        if matches!(name, "undefined" | "Infinity" | "NaN") {
+            return self.deopt(span, errs::UNINITIALIZED_CONST);
+        }
+        // babel resolve(): `binding.kind === 'module'` fails resolution.
+        if matches!(
+            info.decl,
+            BindingDecl::NamedImport | BindingDecl::DefaultImport | BindingDecl::NamespaceImport
+        ) {
+            return self.deopt(span, errs::UNDEFINED_CONST);
+        }
+        let mut visited: Vec<(u32, u32)> = vec![(span.start, span.end)];
+        let resolved = self.resolve_symbol_decl(symbol, &mut visited);
+        if let Some(rspan) = resolved.span()
+            && (rspan == span || (rspan.start <= span.start && span.end <= rspan.end))
+        {
+            // babel: `resolved === path` (or resolved is an ancestor).
+            return self.deopt(span, errs::UNDEFINED_CONST);
+        }
+        match resolved {
+            Resolved::Override(value) => self.value(from_eval_value(&value)),
+            Resolved::Expr(expr) => self.eval(expr),
+            Resolved::Identifier(other) => {
+                self.eval_cached(other.span, |ev| ev.eval_identifier(other))
+            }
+            Resolved::NullInit => self.deopt(span, errs::PATH_WITHOUT_NODE),
+            Resolved::DeclNode(type_name, _) => {
+                self.deopt(span, errs::unsupported_expression(type_name))
+            }
+        }
+    }
+
+    fn eval_named_import(&mut self, name: &str, span: Span) -> EvalResult {
+        let Some(record) = self.state.imports.import_record(name).cloned() else {
+            return self.deopt(span, errs::UNDEFINED_CONST);
+        };
+        let ImportedSymbol::Named(imported) = record.imported else {
+            return self.deopt(span, errs::UNDEFINED_CONST);
+        };
+        match self.state.resolve_import_path(self.fs, &record.source) {
+            Some(canonical) => {
+                self.state.record_treeshake_import(
+                    &record.source,
+                    record.decl_span.start,
+                    record.source_span,
+                );
+                let proxy = VarGroupProxy::new(canonical, imported, self.state.options);
+                self.value(JsValue::proxy(proxy))
+            }
+            None => self.deopt(span, errs::IMPORT_PATH_RESOLUTION_ERROR),
+        }
+    }
+
+    // parity: babel path.resolve() — follows declarator inits through
+    // identifier chains with the `resolved` cycle stack and ancestor checks.
+    fn resolve_symbol_decl(
+        &mut self,
+        symbol: SymbolId,
+        visited: &mut Vec<(u32, u32)>,
+    ) -> Resolved<'a> {
+        let info = self.state.binding_info(symbol);
+        let decl_key = (info.span.start, info.span.end);
+        let terminal = |info: crate::state::BindingInfo<'a>| match info.decl {
+            BindingDecl::Declarator(_) => Resolved::DeclNode("VariableDeclarator", info.span),
+            BindingDecl::Opaque(type_name) => Resolved::DeclNode(type_name, info.span),
+            // Imports never reach here (kind "module" stops resolve earlier).
+            _ => Resolved::DeclNode("Identifier", info.span),
+        };
+        if visited.contains(&decl_key) {
+            // babel: _resolve returns undefined on a revisit; the caller's
+            // `|| this` lands back on the declaration node itself.
+            return terminal(info);
+        }
+        visited.push(decl_key);
+        match info.decl {
+            BindingDecl::Declarator(declarator) => {
+                if declarator.id.get_binding_identifier().is_none() {
+                    return terminal(info);
+                }
+                if let Some(value) = self.state.binding_override(symbol) {
+                    return Resolved::Override(value.clone());
+                }
+                match &declarator.init {
+                    None => Resolved::NullInit,
+                    Some(init) => self.resolve_expr(init, visited),
+                }
+            }
+            _ => terminal(info),
+        }
+    }
+
+    fn resolve_expr(
+        &mut self,
+        expr: &'a Expression<'a>,
+        visited: &mut Vec<(u32, u32)>,
+    ) -> Resolved<'a> {
+        let span = expr.span();
+        let key = (span.start, span.end);
+        if visited.contains(&key) {
+            return Resolved::Expr(expr);
+        }
+        visited.push(key);
+        let Expression::Identifier(id) = expr else {
+            return Resolved::Expr(expr);
+        };
+        let stop = Resolved::Identifier(id);
+        let Some(symbol) = self.state.symbol_of(id) else {
+            return stop;
+        };
+        // babel `binding.constant` counts violations only, not isMutated.
+        if self.state.is_non_constant(symbol) {
+            return stop;
+        }
+        let info = self.state.binding_info(symbol);
+        if matches!(
+            info.decl,
+            BindingDecl::NamedImport | BindingDecl::DefaultImport | BindingDecl::NamespaceImport
+        ) {
+            return stop;
+        }
+        let resolved = self.resolve_symbol_decl(symbol, visited);
+        // babel: a result that is (or contains) this reference fails this level.
+        if let Some(rspan) = resolved.span()
+            && rspan.start <= id.span.start
+            && id.span.end <= rspan.end
+        {
+            return stop;
+        }
+        resolved
+    }
+
+    fn eval_member(&mut self, expr: &'a Expression<'a>) -> EvalResult {
+        // parity: evaluate-path.js getFullMemberPath — a ≥2-part static chain
+        // over a theme proxy resolves as one dotted key.
+        if let Some((base, parts)) = collect_member_chain(expr)
+            && parts.len() >= 2
+        {
+            let base_value = value_or_return!(self, base);
+            if let JsValue::Proxy(proxy) = &base_value {
+                return self.value(JsValue::Str(proxy.resolve_key(&parts.join("."))));
+            }
+            let mut current = base_value;
+            for (i, key) in parts.iter().enumerate() {
+                match self.member_lookup(&current, key, expr.span())? {
+                    EvalOutcome::Value(v) => current = v,
+                    deopt => return Ok(deopt),
+                }
+                if let JsValue::Proxy(proxy) = &current
+                    && i + 1 < parts.len()
+                {
+                    let rest = parts[i + 1..].join(".");
+                    return self.value(JsValue::Str(proxy.resolve_key(&rest)));
+                }
+            }
+            return self.value(current);
+        }
+        let (object_expr, key) = match expr {
+            Expression::StaticMemberExpression(member) => {
+                (&member.object, member.property.name.to_string())
+            }
+            Expression::ComputedMemberExpression(member) => {
+                let key_value = value_or_return!(self, &member.expression);
+                match js_to_string(&key_value) {
+                    Some(key) => (&member.object, key),
+                    None => {
+                        return self
+                            .deopt(member.expression.span(), errs::UNEXPECTED_MEMBER_LOOKUP);
+                    }
+                }
+            }
+            _ => unreachable!("eval_member only receives member expressions"),
+        };
+        let object = value_or_return!(self, object_expr);
+        self.member_lookup(&object, &key, expr.span())
+    }
+
+    fn member_lookup(&mut self, object: &JsValue, key: &str, span: Span) -> EvalResult {
+        match object {
+            JsValue::Proxy(proxy) => self.value(match key {
+                "__IS_PROXY" => JsValue::Bool(true),
+                "__varGroupHash__" => JsValue::Str(proxy.var_group_hash.clone()),
+                "toString" => JsValue::Callable(Callable::Opaque),
+                _ => JsValue::Str(proxy.resolve_key(key)),
+            }),
+            JsValue::Obj(obj) => self.value(obj.get(key).cloned().unwrap_or(JsValue::Undefined)),
+            JsValue::Arr(items) => self.value(match key {
+                "length" => JsValue::Num(items.len() as f64),
+                _ => array_index(key)
+                    .and_then(|i| items.get(i as usize))
+                    .cloned()
+                    .unwrap_or(JsValue::Undefined),
+            }),
+            JsValue::Str(s) => {
+                let value = match key {
+                    "length" => JsValue::Num(s.encode_utf16().count() as f64),
+                    _ => match array_index(key) {
+                        Some(i) if (i as usize) < s.encode_utf16().count() => JsValue::Str(
+                            crate::jsrt::js_slice_utf16_checked(s, i as usize, i as isize + 1)
+                                .map_err(|_| StylexError::lone_surrogate("string indexing"))?,
+                        ),
+                        _ => JsValue::Undefined,
+                    },
+                };
+                self.value(value)
+            }
+            JsValue::Num(_) | JsValue::Bool(_) | JsValue::Callable(_) => {
+                self.value(JsValue::Undefined)
+            }
+            JsValue::Null | JsValue::Undefined => {
+                let kind = if matches!(object, JsValue::Null) {
+                    "null"
+                } else {
+                    "undefined"
+                };
+                let _ = span;
+                // parity: upstream lets the raw TypeError escape the plugin.
+                Err(StylexError::new(
+                    ErrorCode::NonStaticValue,
+                    format!("Cannot read properties of {kind} (reading '{key}')"),
+                ))
+            }
+        }
+    }
+
+    fn eval_unary(&mut self, unary: &'a UnaryExpression<'a>) -> EvalResult {
+        if unary.operator == UnaryOperator::Void {
+            return self.value(JsValue::Undefined);
+        }
+        if unary.operator == UnaryOperator::Typeof
+            && matches!(
+                unary.argument,
+                Expression::FunctionExpression(_)
+                    | Expression::ArrowFunctionExpression(_)
+                    | Expression::ClassExpression(_)
+            )
+        {
+            return self.value(JsValue::Str("function".to_string()));
+        }
+        let arg = value_or_return!(self, &unary.argument);
+        match unary.operator {
+            UnaryOperator::LogicalNot => self.value(JsValue::Bool(!truthy(&arg))),
+            UnaryOperator::UnaryPlus => self.value(JsValue::Num(js_to_number(&arg))),
+            UnaryOperator::UnaryNegation => self.value(JsValue::Num(-js_to_number(&arg))),
+            UnaryOperator::BitwiseNot => {
+                self.value(JsValue::Num(f64::from(!to_int32(js_to_number(&arg)))))
+            }
+            UnaryOperator::Typeof => self.value(JsValue::Str(
+                match arg {
+                    JsValue::Undefined => "undefined",
+                    JsValue::Null | JsValue::Arr(_) | JsValue::Obj(_) | JsValue::Proxy(_) => {
+                        "object"
+                    }
+                    JsValue::Bool(_) => "boolean",
+                    JsValue::Num(_) => "number",
+                    JsValue::Str(_) => "string",
+                    JsValue::Callable(_) => "function",
+                }
+                .to_string(),
+            )),
+            UnaryOperator::Void => unreachable!("handled above"),
+            UnaryOperator::Delete => self.deopt(
+                unary.span,
+                errs::unsupported_operator(unary.operator.as_str()),
+            ),
+        }
+    }
+
+    fn eval_object(&mut self, object: &'a ObjectExpression<'a>) -> EvalResult {
+        let mut obj = JsObj::default();
+        for property in &object.properties {
+            match property {
+                ObjectPropertyKind::SpreadProperty(spread) => {
+                    let value = value_or_return!(self, &spread.argument);
+                    spread_into(&mut obj, &value);
+                }
+                ObjectPropertyKind::ObjectProperty(prop) => {
+                    if prop.method || prop.kind != PropertyKind::Init {
+                        return self.deopt(prop.span, errs::OBJECT_METHOD);
+                    }
+                    let key = if prop.computed {
+                        let value = value_or_return!(
+                            self,
+                            prop.key
+                                .as_expression()
+                                .expect("computed keys are expressions",)
+                        );
+                        match js_to_string(&value) {
+                            Some(key) => key,
+                            None => {
+                                return self.deopt(prop.span, errs::UNEXPECTED_MEMBER_LOOKUP);
+                            }
+                        }
+                    } else {
+                        match static_property_key(&prop.key) {
+                            Some(key) => key,
+                            None => {
+                                return self.deopt(prop.span, errs::UNEXPECTED_MEMBER_LOOKUP);
+                            }
+                        }
+                    };
+                    let value = value_or_return!(self, &prop.value);
+                    obj.insert(key, value);
+                }
+            }
+        }
+        self.value(JsValue::object(obj))
+    }
+
+    // parity: evaluate-path.js isLogicalExpression — both sides evaluate with
+    // fresh confidence; `0 ?? x` deopts with literally "unknown error".
+    fn eval_logical(&mut self, logical: &'a LogicalExpression<'a>) -> EvalResult {
+        let left = self.eval(&logical.left)?;
+        let right = self.eval(&logical.right)?;
+        if let EvalOutcome::Value(l) = &left {
+            match logical.operator {
+                LogicalOperator::Or => {
+                    if truthy(l) {
+                        return Ok(EvalOutcome::Value(l.clone()));
+                    }
+                    if let EvalOutcome::Value(r) = &right {
+                        return Ok(EvalOutcome::Value(r.clone()));
+                    }
+                }
+                LogicalOperator::And => {
+                    if !truthy(l) {
+                        return Ok(EvalOutcome::Value(l.clone()));
+                    }
+                    if let EvalOutcome::Value(r) = &right {
+                        return Ok(EvalOutcome::Value(r.clone()));
+                    }
+                }
+                LogicalOperator::Coalesce => {
+                    if !is_nullish(l) {
+                        if truthy(l) {
+                            return Ok(EvalOutcome::Value(l.clone()));
+                        }
+                        // Non-nullish falsy left: upstream falls to "unknown error".
+                    } else if let EvalOutcome::Value(r) = &right {
+                        return Ok(EvalOutcome::Value(r.clone()));
+                    }
+                }
+            }
+        }
+        match left {
+            EvalOutcome::NonStatic(d) => Ok(EvalOutcome::NonStatic(d)),
+            _ => match right {
+                EvalOutcome::NonStatic(d) => Ok(EvalOutcome::NonStatic(d)),
+                _ => self.deopt(logical.span, "unknown error"),
+            },
+        }
+    }
+
+    fn eval_binary(&mut self, binary: &'a BinaryExpression<'a>) -> EvalResult {
+        let left = value_or_return!(self, &binary.left);
+        let right = value_or_return!(self, &binary.right);
+        let num =
+            |f: fn(f64, f64) -> f64| JsValue::Num(f(js_to_number(&left), js_to_number(&right)));
+        let int = |f: fn(i32, i32) -> i32| {
+            JsValue::Num(f64::from(f(
+                to_int32(js_to_number(&left)),
+                to_int32(js_to_number(&right)),
+            )))
+        };
+        let cmp = |wanted: std::cmp::Ordering, or_equal: bool| -> JsValue {
+            JsValue::Bool(match js_compare(&left, &right) {
+                Some(ordering) => {
+                    ordering == wanted || (or_equal && ordering == std::cmp::Ordering::Equal)
+                }
+                None => false,
+            })
+        };
+        use std::cmp::Ordering::{Greater, Less};
+        let value = match binary.operator {
+            BinaryOperator::Addition => match js_add(&left, &right) {
+                Some(v) => v,
+                None => {
+                    return self.deopt(
+                        binary.span,
+                        errs::unsupported_expression("BinaryExpression"),
+                    );
+                }
+            },
+            BinaryOperator::Subtraction => num(|l, r| l - r),
+            BinaryOperator::Multiplication => num(|l, r| l * r),
+            BinaryOperator::Division => num(|l, r| l / r),
+            BinaryOperator::Remainder => num(|l, r| l % r),
+            BinaryOperator::Exponential => num(js_pow),
+            BinaryOperator::LessThan => cmp(Less, false),
+            BinaryOperator::LessEqualThan => cmp(Less, true),
+            BinaryOperator::GreaterThan => cmp(Greater, false),
+            BinaryOperator::GreaterEqualThan => cmp(Greater, true),
+            BinaryOperator::Equality => JsValue::Bool(js_loose_eq(&left, &right)),
+            // parity: evaluate-path.js:919 — `!=` is (mistakenly) strict upstream.
+            BinaryOperator::Inequality => JsValue::Bool(!js_strict_eq(&left, &right)),
+            BinaryOperator::StrictEquality => JsValue::Bool(js_strict_eq(&left, &right)),
+            BinaryOperator::StrictInequality => JsValue::Bool(!js_strict_eq(&left, &right)),
+            BinaryOperator::BitwiseOR => int(|l, r| l | r),
+            BinaryOperator::BitwiseAnd => int(|l, r| l & r),
+            BinaryOperator::BitwiseXOR => int(|l, r| l ^ r),
+            BinaryOperator::ShiftLeft => int(|l, r| l.wrapping_shl(r as u32 & 31)),
+            BinaryOperator::ShiftRight => int(|l, r| l.wrapping_shr(r as u32 & 31)),
+            BinaryOperator::ShiftRightZeroFill => {
+                let l = to_uint32(js_to_number(&left));
+                let r = to_uint32(js_to_number(&right)) & 31;
+                JsValue::Num(f64::from(l >> r))
+            }
+            BinaryOperator::In => {
+                let key = match js_to_string(&left) {
+                    Some(k) => k,
+                    None => {
+                        return self.deopt(
+                            binary.span,
+                            errs::unsupported_expression("BinaryExpression"),
+                        );
+                    }
+                };
+                match &right {
+                    JsValue::Obj(obj) => JsValue::Bool(obj.get(&key).is_some()),
+                    JsValue::Arr(items) => JsValue::Bool(
+                        key == "length"
+                            || array_index(&key).is_some_and(|i| (i as usize) < items.len()),
+                    ),
+                    JsValue::Proxy(_) => JsValue::Bool(false),
+                    _ => {
+                        return Err(StylexError::new(
+                            ErrorCode::NonStaticValue,
+                            format!(
+                                "Cannot use 'in' operator to search for '{key}' in {}",
+                                js_to_string(&right).unwrap_or_default()
+                            ),
+                        ));
+                    }
+                }
+            }
+            BinaryOperator::Instanceof => match &right {
+                JsValue::Callable(_) => JsValue::Bool(false),
+                _ => {
+                    return Err(StylexError::new(
+                        ErrorCode::NonStaticValue,
+                        "Right-hand side of 'instanceof' is not callable",
+                    ));
+                }
+            },
+        };
+        self.value(value)
+    }
+
+    fn eval_call(&mut self, call: &'a CallExpression<'a>) -> EvalResult {
+        if call.optional {
+            return self.deopt(
+                call.span,
+                errs::unsupported_expression("OptionalCallExpression"),
+            );
+        }
+        let callee = unwrap_parens(&call.callee);
+        if let Expression::Identifier(id) = callee {
+            let name = id.name.as_str();
+            // parity: `!path.scope.getBinding(name) && isValidCallee(name)`.
+            if self.state.symbol_of(id).is_none() && methods::is_valid_callee(name) {
+                let args = match self.eval_arguments_raw(call)? {
+                    Ok(args) => args,
+                    Err(deopt) => return Ok(EvalOutcome::NonStatic(deopt)),
+                };
+                return match methods::call_global_identifier(name, &args)? {
+                    Some(value) => self.value(value),
+                    None => self.deopt(call.span, errs::unsupported_expression("CallExpression")),
+                };
+            }
+            if let Some(entry) = self.registry.identifiers.get(name).cloned() {
+                return match entry {
+                    RegistryEntry::Callable(callable) => self.dispatch(callable, call),
+                    RegistryEntry::Value(value) => self.invoke_value(&value, call),
+                };
+            }
+            return match self.eval_cached(id.span, |ev| ev.eval_identifier(id))? {
+                EvalOutcome::Value(value) => self.invoke_value(&value, call),
+                deopt => Ok(deopt),
+            };
+        }
+        if let Some(member) = callee.as_member_expression() {
+            // babel property extraction: static identifiers, computed
+            // identifiers BY NAME, and computed string literals.
+            let (prop_static, prop_string): (Option<&str>, Option<&str>) = match member {
+                oxc_ast::ast::MemberExpression::StaticMemberExpression(m) => {
+                    (Some(m.property.name.as_str()), None)
+                }
+                oxc_ast::ast::MemberExpression::ComputedMemberExpression(m) => {
+                    match &m.expression {
+                        Expression::Identifier(prop) => (Some(prop.name.as_str()), None),
+                        Expression::StringLiteral(lit) => (None, Some(lit.value.as_str())),
+                        _ => (None, None),
+                    }
+                }
+                oxc_ast::ast::MemberExpression::PrivateFieldExpression(_) => (None, None),
+            };
+            if let Expression::Identifier(object) = member.object() {
+                let object_name = object.name.as_str();
+                if let Some(prop) = prop_static {
+                    // parity: no binding check — a shadowed `Math` still hits
+                    // the global for known methods.
+                    if methods::is_valid_callee(object_name) && !methods::is_invalid_method(prop) {
+                        match methods::lookup_global_static(object_name, prop) {
+                            methods::StaticMember::Fn(found) => {
+                                let args = match self.eval_arguments_raw(call)? {
+                                    Ok(args) => args,
+                                    Err(deopt) => return Ok(EvalOutcome::NonStatic(deopt)),
+                                };
+                                let result =
+                                    methods::call_global_static(self, object_name, found, &args)?;
+                                return self.value(result);
+                            }
+                            methods::StaticMember::NonCallable => {
+                                return self.func_apply_error(call);
+                            }
+                            methods::StaticMember::Unsupported => {
+                                return Err(StylexError::unsupported_api(&format!(
+                                    "compile-time call to {object_name}.{prop}"
+                                )));
+                            }
+                            methods::StaticMember::Unknown => {}
+                        }
+                    }
+                }
+                if let Some(prop) = prop_static.or(prop_string)
+                    && let Some(callable) = self
+                        .registry
+                        .member_callables
+                        .get(&(object_name.to_string(), prop.to_string()))
+                        .cloned()
+                {
+                    return self.dispatch(callable, call);
+                }
+            }
+            // parity: numeric-literal receivers bind no `this`; known Number
+            // methods throw upstream before the value fallback runs.
+            if let Expression::NumericLiteral(_) = unwrap_parens(member.object())
+                && let Some(prop) = prop_static
+                && let Some(known) = methods::NUM_METHODS
+                    .iter()
+                    .chain(methods::NUM_UNSUPPORTED.iter())
+                    .find(|m| **m == prop)
+            {
+                if let Err(deopt) = self.eval_arguments_raw(call)? {
+                    return Ok(EvalOutcome::NonStatic(deopt));
+                }
+                return Err(StylexError::new(
+                    ErrorCode::NonStaticValue,
+                    format!("Number.prototype.{known} requires that 'this' be a Number"),
+                ));
+            }
+            let Some(property) = prop_static.or(prop_string).map(str::to_string) else {
+                return self.deopt(call.span, errs::unsupported_expression("CallExpression"));
+            };
+            // parity: evaluate-path.js:1017-1031 — the object is evaluated in a
+            // fresh state, so its deopt reason never escapes this branch.
+            let object_value = match self.eval_fresh(member.object())? {
+                EvalOutcome::Value(v) => v,
+                EvalOutcome::NonStatic(_) => {
+                    return self.deopt(call.span, errs::unsupported_expression("CallExpression"));
+                }
+            };
+            if let JsValue::Proxy(proxy) = &object_value
+                && property == "toString"
+            {
+                let hash = proxy.var_group_hash.clone();
+                return match self.eval_arguments(call)? {
+                    Ok(_) => self.value(JsValue::Str(hash)),
+                    Err(deopt) => Ok(EvalOutcome::NonStatic(deopt)),
+                };
+            }
+            return self.invoke_member(&object_value, &property, call);
+        }
+        self.deopt(call.span, errs::unsupported_expression("CallExpression"))
+    }
+
+    // parity: the `if (func)` tail — arrows/callables run, truthy non-functions
+    // throw `func.apply is not a function`, falsy values fall to the deopt.
+    fn invoke_value(&mut self, value: &JsValue, call: &'a CallExpression<'a>) -> EvalResult {
+        match value {
+            JsValue::Callable(Callable::Stylex(callable)) => self.dispatch(callable.clone(), call),
+            JsValue::Callable(Callable::Arrow(key)) => self.eval_arrow_call(*key, call),
+            other if truthy(other) => self.func_apply_error(call),
+            _ => self.deopt(call.span, errs::unsupported_expression("CallExpression")),
+        }
+    }
+
+    fn func_apply_error(&mut self, call: &'a CallExpression<'a>) -> EvalResult {
+        if let Err(deopt) = self.eval_arguments_raw(call)? {
+            return Ok(EvalOutcome::NonStatic(deopt));
+        }
+        Err(StylexError::new(
+            ErrorCode::NonStaticValue,
+            "func.apply is not a function",
+        ))
+    }
+
+    fn invoke_member(
+        &mut self,
+        object_value: &JsValue,
+        property: &str,
+        call: &'a CallExpression<'a>,
+    ) -> EvalResult {
+        // Own layer first (a JS property read), then the prototype tables.
+        let own = match object_value {
+            JsValue::Obj(obj) => obj.get(property).cloned(),
+            _ => match self.member_lookup(object_value, property, call.span)? {
+                EvalOutcome::Value(JsValue::Undefined) => None,
+                EvalOutcome::Value(v) => Some(v),
+                deopt => return Ok(deopt),
+            },
+        };
+        if let Some(found) = own {
+            return self.invoke_value(&found, call);
+        }
+        match methods::lookup_proto_method(object_value, property) {
+            methods::ProtoLookup::Fn(found) => {
+                let args = match self.eval_arguments_raw(call)? {
+                    Ok(args) => args,
+                    Err(deopt) => return Ok(EvalOutcome::NonStatic(deopt)),
+                };
+                let receiver = object_value.clone();
+                let result = methods::call_proto_method(self, &receiver, found, &args)?;
+                self.value(result)
+            }
+            methods::ProtoLookup::Unsupported(found) => Err(StylexError::unsupported_api(
+                &format!("compile-time call to {found}"),
+            )),
+            methods::ProtoLookup::NotFound => {
+                self.deopt(call.span, errs::unsupported_expression("CallExpression"))
+            }
+        }
+    }
+
+    // parity: the evaluate-path closure — args bind as identifiers, and a
+    // non-confident body THROWS the deopt reason out of the whole transform.
+    fn eval_arrow_call(&mut self, key: u32, call: &'a CallExpression<'a>) -> EvalResult {
+        if !self.arrow_bodies.contains_key(&key) {
+            return self.deopt(call.span, errs::unsupported_expression("CallExpression"));
+        }
+        let args = match self.eval_arguments_raw(call)? {
+            Ok(args) => args,
+            Err(deopt) => return Ok(EvalOutcome::NonStatic(deopt)),
+        };
+        let value = self.call_arrow_values(key, args)?;
+        self.value(value)
+    }
+
+    /// The evaluatedFn closure body: args bind as registry identifiers over a
+    /// fresh evaluate() call, and a non-confident body THROWS its reason.
+    fn call_arrow_values(&mut self, key: u32, args: Vec<JsValue>) -> Result<JsValue, StylexError> {
+        let Some((body, params)) = self.arrow_bodies.get(&key).map(|(b, p)| (*b, p.clone())) else {
+            return Err(StylexError::new(
+                ErrorCode::NonStaticValue,
+                errs::unsupported_expression("CallExpression"),
+            ));
+        };
+        let mut saved: Vec<(String, Option<RegistryEntry>)> = Vec::with_capacity(params.len());
+        for (i, name) in params.iter().enumerate() {
+            let value = args.get(i).cloned().unwrap_or(JsValue::Undefined);
+            let previous = self
+                .registry
+                .identifiers
+                .insert(name.clone(), RegistryEntry::Value(value));
+            saved.push((name.clone(), previous));
+        }
+        let result = self.eval_fresh(body);
+        for (name, previous) in saved.into_iter().rev() {
+            match previous {
+                Some(entry) => {
+                    self.registry.identifiers.insert(name, entry);
+                }
+                None => {
+                    self.registry.identifiers.remove(&name);
+                }
+            }
+        }
+        match result? {
+            EvalOutcome::Value(v) => Ok(v),
+            EvalOutcome::NonStatic(d) => Err(StylexError::new(ErrorCode::NonStaticValue, d.reason)),
+        }
+    }
+
+    fn dispatch(&mut self, callable: StylexCallable, call: &'a CallExpression<'a>) -> EvalResult {
+        let raw = match self.eval_arguments_raw(call)? {
+            Ok(args) => args,
+            Err(deopt) => return Ok(EvalOutcome::NonStatic(deopt)),
+        };
+        // parity: when.js fromProxy — only the when.* fns read a theme proxy,
+        // via its toString() (the var-group hash).
+        let is_when = matches!(
+            callable,
+            StylexCallable::WhenAncestor
+                | StylexCallable::WhenDescendant
+                | StylexCallable::WhenSiblingBefore
+                | StylexCallable::WhenSiblingAfter
+                | StylexCallable::WhenAnySibling
+        );
+        let args: Vec<EvalValue> = raw
+            .iter()
+            .map(|value| match value {
+                JsValue::Proxy(proxy) if is_when => EvalValue::Str(proxy.var_group_hash.clone()),
+                other => to_eval_value(other),
+            })
+            .collect();
+        let result = self.callables.call(&callable, &args, self.state)?;
+        self.value(from_eval_value(&result))
+    }
+
+    fn eval_arguments(
+        &mut self,
+        call: &'a CallExpression<'a>,
+    ) -> Result<Result<Vec<EvalValue>, Deopt>, StylexError> {
+        Ok(self
+            .eval_arguments_raw(call)?
+            .map(|args| args.iter().map(to_eval_value).collect()))
+    }
+
+    fn eval_arguments_raw(
+        &mut self,
+        call: &'a CallExpression<'a>,
+    ) -> Result<Result<Vec<JsValue>, Deopt>, StylexError> {
+        let mut out = Vec::with_capacity(call.arguments.len());
+        for argument in &call.arguments {
+            match argument {
+                Argument::SpreadElement(spread) => {
+                    return Ok(Err(Deopt {
+                        reason: errs::unsupported_expression("SpreadElement"),
+                        span: spread.span,
+                    }));
+                }
+                _ => match self.eval(argument.to_expression())? {
+                    EvalOutcome::Value(v) => out.push(v),
+                    EvalOutcome::NonStatic(deopt) => return Ok(Err(deopt)),
+                },
+            }
+        }
+        Ok(Ok(out))
+    }
+}
+
+impl ArrowCaller for Evaluator<'_, '_> {
+    fn call_arrow(&mut self, key: u32, args: Vec<JsValue>) -> Result<JsValue, StylexError> {
+        self.call_arrow_values(key, args)
+    }
+}
+
+#[derive(Debug)]
+pub struct EvaluatedCreateArg {
+    pub namespaces: JsObjectMap,
+    /// Source byte offset of each namespace property (first occurrence wins);
+    /// the visitor derives `CreateContext.namespace_lines` from these.
+    pub key_spans: Vec<(String, u32)>,
+    /// Arrow namespaces (`fns` upstream): namespace → params + inline styles.
+    pub fns: Vec<(String, DynamicFn)>,
+}
+
+/// Evaluates one `stylex.create` argument into namespace objects.
+// parity: parse-stylex-create-arg.js evaluateStyleXCreateArg (static namespaces)
+pub fn evaluate_stylex_create_arg<'a>(
+    evaluator: &mut Evaluator<'a, '_>,
+    object: &'a ObjectExpression<'a>,
+) -> Result<EvaluatedCreateArg, StylexError> {
+    let _t = crate::timings::start(crate::timings::Stage::Eval);
+    let mut namespaces = JsObjectMap::new();
+    let mut key_spans: Vec<(String, u32)> = Vec::new();
+    let mut fns: Vec<(String, DynamicFn)> = Vec::new();
+    for property in &object.properties {
+        let prop = match property {
+            ObjectPropertyKind::ObjectProperty(prop)
+                if !prop.method && prop.kind == PropertyKind::Init =>
+            {
+                prop
+            }
+            // parity: non-plain properties re-evaluate the whole argument.
+            _ => return reevaluate_create_object(evaluator, object),
+        };
+        let key = if prop.computed {
+            let key_expr = prop
+                .key
+                .as_expression()
+                .expect("computed keys are expressions");
+            match evaluator.eval_entry(key_expr)? {
+                EvalOutcome::Value(v) => match js_to_string(&v) {
+                    Some(key) => key,
+                    None => return Err(StylexError::non_static_value("create")),
+                },
+                // parity: evaluateObjKey drops the deopt reason for namespace keys.
+                EvalOutcome::NonStatic(_) => {
+                    return Err(StylexError::non_static_value("create"));
+                }
+            }
+        } else {
+            static_property_key(&prop.key).ok_or_else(|| StylexError::non_static_value("create"))?
+        };
+        if let Expression::ArrowFunctionExpression(arrow) = unwrap_parens(&prop.value) {
+            if !evaluator.dynamic_namespaces {
+                return Err(StylexError::unsupported_api(
+                    "dynamic styles (arrow-function namespaces)",
+                ));
+            }
+            // Defaulted params live in `initializer` (babel: AssignmentPattern).
+            let params: Option<Vec<String>> = if arrow.params.rest.is_some() {
+                None
+            } else {
+                arrow
+                    .params
+                    .items
+                    .iter()
+                    .map(|p| match &p.pattern {
+                        oxc_ast::ast::BindingPattern::BindingIdentifier(id)
+                            if p.initializer.is_none() =>
+                        {
+                            Some(id.name.to_string())
+                        }
+                        _ => None,
+                    })
+                    .collect()
+            };
+            let Some(params) = params else {
+                return Err(StylexError::only_named_parameters());
+            };
+            // parity: only expression bodies that are object literals compile;
+            // everything else re-evaluates the whole argument.
+            let body = arrow.body.as_expression().map(unwrap_parens);
+            let Some(Expression::ObjectExpression(body_obj)) = body else {
+                return reevaluate_create_object(evaluator, object);
+            };
+            let mut fn_def = DynamicFn {
+                params,
+                inline_styles: Vec::new(),
+            };
+            let partial = evaluate_partial_object(evaluator, body_obj, &[], &mut fn_def);
+            let Some(value) = partial? else {
+                // parity: the arrow branch drops every partial-eval deopt reason.
+                return Err(StylexError::non_static_value("create"));
+            };
+            if !key_spans.iter().any(|(k, _)| *k == key) {
+                key_spans.push((key.clone(), prop.span.start));
+            }
+            namespaces.insert(key.clone(), to_eval_value(&JsValue::object(value)));
+            // parity: `fns[key] =` is a [[Set]]; "__proto__" never lands.
+            if key != "__proto__" {
+                match fns.iter_mut().find(|(k, _)| *k == key) {
+                    Some(slot) => slot.1 = fn_def,
+                    None => fns.push((key, fn_def)),
+                }
+            }
+            continue;
+        }
+        match evaluator.eval_entry(&prop.value)? {
+            EvalOutcome::Value(v) => {
+                if !key_spans.iter().any(|(k, _)| *k == key) {
+                    key_spans.push((key.clone(), prop.span.start));
+                }
+                namespaces.insert(key, to_eval_value(&v));
+            }
+            EvalOutcome::NonStatic(deopt) => {
+                return Err(StylexError::new(ErrorCode::NonStaticValue, deopt.reason));
+            }
+        }
+    }
+    Ok(EvaluatedCreateArg {
+        namespaces,
+        key_spans,
+        fns,
+    })
+}
+
+// parity: `return evaluate(path, …)` over the whole create argument.
+fn reevaluate_create_object<'a>(
+    evaluator: &mut Evaluator<'a, '_>,
+    object: &'a ObjectExpression<'a>,
+) -> Result<EvaluatedCreateArg, StylexError> {
+    evaluator.seen.clear();
+    match evaluator.eval_object(object)? {
+        EvalOutcome::Value(v) => Ok(EvaluatedCreateArg {
+            namespaces: match to_eval_value(&v) {
+                EvalValue::Obj(map) => Arc::unwrap_or_clone(map),
+                _ => JsObjectMap::new(),
+            },
+            key_spans: Vec::new(),
+            fns: Vec::new(),
+        }),
+        EvalOutcome::NonStatic(deopt) => {
+            Err(StylexError::new(ErrorCode::NonStaticValue, deopt.reason))
+        }
+    }
+}
+
+/// `None` = non-confident: the caller reports the reasonless create error.
+// parity: parse-stylex-create-arg.js evaluatePartialObjectRecursively
+fn evaluate_partial_object<'a>(
+    evaluator: &mut Evaluator<'a, '_>,
+    object: &'a ObjectExpression<'a>,
+    key_path: &[String],
+    fn_def: &mut DynamicFn,
+) -> Result<Option<JsObj>, StylexError> {
+    let mut obj = JsObj::default();
+    for property in &object.properties {
+        match property {
+            ObjectPropertyKind::SpreadProperty(spread) => {
+                match evaluator.eval_entry(&spread.argument)? {
+                    EvalOutcome::Value(v) => spread_into(&mut obj, &v),
+                    EvalOutcome::NonStatic(_) => return Ok(None),
+                }
+            }
+            ObjectPropertyKind::ObjectProperty(prop) => {
+                if prop.method || prop.kind != PropertyKind::Init {
+                    return Ok(None);
+                }
+                let mut key = if prop.computed {
+                    let key_expr = prop
+                        .key
+                        .as_expression()
+                        .expect("computed keys are expressions");
+                    match evaluator.eval_entry(key_expr)? {
+                        EvalOutcome::Value(v) => match js_to_string(&v) {
+                            Some(key) => key,
+                            None => return Ok(None),
+                        },
+                        EvalOutcome::NonStatic(_) => return Ok(None),
+                    }
+                } else {
+                    match static_property_key(&prop.key) {
+                        Some(key) => key,
+                        None => return Ok(None),
+                    }
+                };
+                // defineConsts at-rule placeholders stay wrapped past the root.
+                if key_path.is_empty() && key.starts_with("var(") && key.ends_with(')') {
+                    key = js_slice_utf16(&key, 4, -1);
+                }
+                if let Expression::ObjectExpression(inner) = unwrap_parens(&prop.value) {
+                    let mut nested = key_path.to_vec();
+                    nested.push(key.clone());
+                    match evaluate_partial_object(evaluator, inner, &nested, fn_def)? {
+                        Some(inner_obj) => obj.insert(key, JsValue::object(inner_obj)),
+                        None => return Ok(None),
+                    }
+                } else {
+                    match evaluator.eval_entry(&prop.value)? {
+                        EvalOutcome::Value(v) => obj.insert(key, v),
+                        EvalOutcome::NonStatic(_) => {
+                            let (var_name, style) =
+                                inline_style_for_leaf(&prop.value, key_path, &key);
+                            obj.insert(key, JsValue::Str(format!("var({var_name})")));
+                            fn_def.insert_inline(var_name, style);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(Some(obj))
+}
+
+// parity: stylex-create.js validateStyleXCreate (arg count / object / spread).
+pub fn validate_create_arg<'a, 'b>(
+    call: &'b CallExpression<'a>,
+) -> Result<&'b ObjectExpression<'a>, StylexError> {
+    if call.arguments.len() != 1 {
+        return Err(StylexError::illegal_argument_length("create", 1));
+    }
+    let arg = call.arguments[0]
+        .as_expression()
+        .map(unwrap_parens)
+        .ok_or_else(|| StylexError::non_style_object("create"))?;
+    let Expression::ObjectExpression(object) = arg else {
+        return Err(StylexError::non_style_object("create"));
+    };
+    if object
+        .properties
+        .iter()
+        .any(|p| matches!(p, ObjectPropertyKind::SpreadProperty(_)))
+    {
+        return Err(StylexError::no_object_spreads());
+    }
+    Ok(object)
+}
+
+pub fn unwrap_parens<'a, 'b>(expr: &'b Expression<'a>) -> &'b Expression<'a> {
+    match expr {
+        Expression::ParenthesizedExpression(e) => unwrap_parens(&e.expression),
+        _ => expr,
+    }
+}
+
+fn collect_member_chain<'a, 'b>(
+    expr: &'b Expression<'a>,
+) -> Option<(&'b Expression<'a>, Vec<String>)> {
+    let mut parts: Vec<String> = Vec::new();
+    let mut current = expr;
+    loop {
+        match current {
+            Expression::StaticMemberExpression(member) => {
+                parts.push(member.property.name.to_string());
+                current = &member.object;
+            }
+            Expression::ComputedMemberExpression(member) => {
+                match &member.expression {
+                    Expression::StringLiteral(lit) => parts.push(lit.value.to_string()),
+                    Expression::NumericLiteral(lit) => {
+                        parts.push(js_number_to_string(lit.value));
+                    }
+                    _ => return None,
+                }
+                current = &member.object;
+            }
+            _ => break,
+        }
+    }
+    if parts.len() < 2 {
+        return None;
+    }
+    parts.reverse();
+    Some((current, parts))
+}
+
+fn static_property_key(key: &PropertyKey<'_>) -> Option<String> {
+    match key {
+        PropertyKey::StaticIdentifier(id) => Some(id.name.to_string()),
+        PropertyKey::StringLiteral(lit) => Some(lit.value.to_string()),
+        PropertyKey::NumericLiteral(lit) => Some(js_number_to_string(lit.value)),
+        _ => None,
+    }
+}
+
+// parity: Object.assign source-iteration; non-object primitives are no-ops.
+fn spread_into(target: &mut JsObj, value: &JsValue) {
+    match value {
+        JsValue::Obj(obj) => {
+            for (k, v) in obj.entries() {
+                target.insert(k.to_string(), v.clone());
+            }
+        }
+        JsValue::Arr(items) => {
+            for (i, item) in items.iter().enumerate() {
+                target.insert(i.to_string(), item.clone());
+            }
+        }
+        JsValue::Str(s) => {
+            let units = s.encode_utf16().count();
+            for i in 0..units {
+                let unit = js_slice_utf16_checked(s, i, i as isize + 1)
+                    .unwrap_or_else(|_| '\u{FFFD}'.to_string());
+                target.insert(i.to_string(), JsValue::Str(unit));
+            }
+        }
+        _ => {}
+    }
+}
+
+fn babel_type_name(expr: &Expression<'_>) -> &'static str {
+    match expr {
+        Expression::BigIntLiteral(_) => "BigIntLiteral",
+        Expression::RegExpLiteral(_) => "RegExpLiteral",
+        Expression::FunctionExpression(_) => "FunctionExpression",
+        Expression::ClassExpression(_) => "ClassExpression",
+        Expression::AssignmentExpression(_) => "AssignmentExpression",
+        Expression::AwaitExpression(_) => "AwaitExpression",
+        Expression::NewExpression(_) => "NewExpression",
+        Expression::TaggedTemplateExpression(_) => "TaggedTemplateExpression",
+        Expression::ThisExpression(_) => "ThisExpression",
+        Expression::UpdateExpression(_) => "UpdateExpression",
+        Expression::YieldExpression(_) => "YieldExpression",
+        Expression::ImportExpression(_) | Expression::CallExpression(_) => "CallExpression",
+        Expression::ImportMeta(_) | Expression::NewTarget(_) => "MetaProperty",
+        Expression::JSXElement(_) => "JSXElement",
+        Expression::JSXFragment(_) => "JSXFragment",
+        Expression::TSTypeAssertion(_) => "TSTypeAssertion",
+        Expression::TSNonNullExpression(_) => "TSNonNullExpression",
+        Expression::TSInstantiationExpression(_) => "TSInstantiationExpression",
+        Expression::PrivateInExpression(_) => "BinaryExpression",
+        Expression::ArrowFunctionExpression(_) => "ArrowFunctionExpression",
+        Expression::SequenceExpression(_) => "SequenceExpression",
+        Expression::Identifier(_) => "Identifier",
+        Expression::Super(_) => "Super",
+        Expression::PrivateFieldExpression(_) => "MemberExpression",
+        _ => "Expression",
+    }
+}
+
+const VALID_CALLEES: [&str; 5] = ["String", "Number", "Math", "Object", "Array"];
+const INVALID_METHODS: [&str; 7] = [
+    "random",
+    "assign",
+    "defineProperties",
+    "defineProperty",
+    "freeze",
+    "seal",
+    "splice",
+];
+
+fn is_valid_callee(name: &str) -> bool {
+    VALID_CALLEES.contains(&name)
+}
+
+fn is_invalid_method(name: &str) -> bool {
+    INVALID_METHODS.contains(&name)
+}
+
+pub fn truthy(value: &JsValue) -> bool {
+    match value {
+        JsValue::Null | JsValue::Undefined => false,
+        JsValue::Bool(b) => *b,
+        JsValue::Num(n) => *n != 0.0 && !n.is_nan(),
+        JsValue::Str(s) => !s.is_empty(),
+        _ => true,
+    }
+}
+
+pub fn is_nullish(value: &JsValue) -> bool {
+    matches!(value, JsValue::Null | JsValue::Undefined)
+}
+
+/// JS ToString; `None` for function values (their source text is unmodelled).
+pub fn js_to_string(value: &JsValue) -> Option<String> {
+    Some(match value {
+        JsValue::Null => "null".to_string(),
+        JsValue::Undefined => "undefined".to_string(),
+        JsValue::Bool(b) => b.to_string(),
+        JsValue::Num(n) => js_number_to_string(*n),
+        JsValue::Str(s) => s.clone(),
+        JsValue::Arr(items) => {
+            let parts: Vec<String> = items
+                .iter()
+                .map(|item| {
+                    if is_nullish(item) {
+                        Some(String::new())
+                    } else {
+                        js_to_string(item)
+                    }
+                })
+                .collect::<Option<_>>()?;
+            parts.join(",")
+        }
+        JsValue::Obj(_) => "[object Object]".to_string(),
+        JsValue::Proxy(proxy) => proxy.var_group_hash.clone(),
+        JsValue::Callable(_) => return None,
+    })
+}
+
+pub fn js_to_number(value: &JsValue) -> f64 {
+    match value {
+        JsValue::Null => 0.0,
+        JsValue::Undefined | JsValue::Callable(_) => f64::NAN,
+        JsValue::Bool(b) => f64::from(*b as u8),
+        JsValue::Num(n) => *n,
+        JsValue::Str(s) => string_to_number(s),
+        other => js_to_string(other).map_or(f64::NAN, |s| string_to_number(&s)),
+    }
+}
+
+// parity: ES StringToNumber (TrimString; hex/octal/binary; empty string is 0).
+pub fn string_to_number(s: &str) -> f64 {
+    let trimmed: &str = crate::jsrt::js_trim(s);
+    if trimmed.is_empty() {
+        return 0.0;
+    }
+    if let Some(rest) = trimmed
+        .strip_prefix("0x")
+        .or_else(|| trimmed.strip_prefix("0X"))
+    {
+        return u64::from_str_radix(rest, 16).map_or(f64::NAN, |n| n as f64);
+    }
+    if let Some(rest) = trimmed
+        .strip_prefix("0o")
+        .or_else(|| trimmed.strip_prefix("0O"))
+    {
+        return u64::from_str_radix(rest, 8).map_or(f64::NAN, |n| n as f64);
+    }
+    if let Some(rest) = trimmed
+        .strip_prefix("0b")
+        .or_else(|| trimmed.strip_prefix("0B"))
+    {
+        return u64::from_str_radix(rest, 2).map_or(f64::NAN, |n| n as f64);
+    }
+    match trimmed {
+        "Infinity" | "+Infinity" => return f64::INFINITY,
+        "-Infinity" => return f64::NEG_INFINITY,
+        _ => {}
+    }
+    if !trimmed
+        .bytes()
+        .all(|b| b.is_ascii_digit() || matches!(b, b'+' | b'-' | b'.' | b'e' | b'E'))
+    {
+        return f64::NAN;
+    }
+    trimmed.parse::<f64>().unwrap_or(f64::NAN)
+}
+
+fn js_add(left: &JsValue, right: &JsValue) -> Option<JsValue> {
+    let string_side = |v: &JsValue| {
+        matches!(
+            v,
+            JsValue::Str(_) | JsValue::Arr(_) | JsValue::Obj(_) | JsValue::Proxy(_)
+        )
+    };
+    if string_side(left) || string_side(right) {
+        Some(JsValue::Str(format!(
+            "{}{}",
+            js_to_string(left)?,
+            js_to_string(right)?
+        )))
+    } else if matches!(left, JsValue::Callable(_)) || matches!(right, JsValue::Callable(_)) {
+        None
+    } else {
+        Some(JsValue::Num(js_to_number(left) + js_to_number(right)))
+    }
+}
+
+// parity: JS `**` — |1| ** ±Infinity is NaN where Rust powf returns 1.
+pub(crate) fn js_pow(base: f64, exponent: f64) -> f64 {
+    if exponent.is_infinite() && base.abs() == 1.0 {
+        return f64::NAN;
+    }
+    base.powf(exponent)
+}
+
+fn is_object_like(value: &JsValue) -> bool {
+    matches!(
+        value,
+        JsValue::Obj(_) | JsValue::Arr(_) | JsValue::Proxy(_) | JsValue::Callable(_)
+    )
+}
+
+/// ES OrdinaryToPrimitive for the evaluator's object values: plain objects
+/// and arrays have no useful valueOf, so both hints reach toString.
+fn js_to_primitive(value: &JsValue) -> Option<JsValue> {
+    if is_object_like(value) {
+        js_to_string(value).map(JsValue::Str)
+    } else {
+        Some(value.clone())
+    }
+}
+
+// parity: ES Abstract Relational Comparison (ToPrimitive first; strings
+// compare by UTF-16 code units, everything else through ToNumber).
+fn js_compare(left: &JsValue, right: &JsValue) -> Option<std::cmp::Ordering> {
+    let (left, right) = (js_to_primitive(left)?, js_to_primitive(right)?);
+    if let (JsValue::Str(l), JsValue::Str(r)) = (&left, &right) {
+        return Some(utf16_cmp(l, r));
+    }
+    let l = js_to_number(&left);
+    let r = js_to_number(&right);
+    l.partial_cmp(&r)
+}
+
+pub(crate) fn js_strict_eq(left: &JsValue, right: &JsValue) -> bool {
+    match (left, right) {
+        (JsValue::Null, JsValue::Null) | (JsValue::Undefined, JsValue::Undefined) => true,
+        (JsValue::Bool(l), JsValue::Bool(r)) => l == r,
+        (JsValue::Num(l), JsValue::Num(r)) => l == r,
+        (JsValue::Str(l), JsValue::Str(r)) => l == r,
+        (JsValue::Obj(l), JsValue::Obj(r)) => Rc::ptr_eq(l, r),
+        (JsValue::Arr(l), JsValue::Arr(r)) => Rc::ptr_eq(l, r),
+        (JsValue::Proxy(l), JsValue::Proxy(r)) => Rc::ptr_eq(l, r),
+        // A cached arrow closure keeps its node key; two closures from the
+        // same arrow in one evaluation are the same function upstream.
+        (JsValue::Callable(Callable::Arrow(l)), JsValue::Callable(Callable::Arrow(r))) => l == r,
+        _ => false,
+    }
+}
+
+// parity: ES Abstract Equality Comparison.
+fn js_loose_eq(left: &JsValue, right: &JsValue) -> bool {
+    match (left, right) {
+        (JsValue::Null | JsValue::Undefined, JsValue::Null | JsValue::Undefined) => true,
+        (JsValue::Null | JsValue::Undefined, _) | (_, JsValue::Null | JsValue::Undefined) => false,
+        _ if is_object_like(left) && is_object_like(right) => js_strict_eq(left, right),
+        _ if is_object_like(left) => match js_to_primitive(left) {
+            Some(prim) => js_loose_eq(&prim, right),
+            None => false,
+        },
+        _ if is_object_like(right) => match js_to_primitive(right) {
+            Some(prim) => js_loose_eq(left, &prim),
+            None => false,
+        },
+        (JsValue::Str(l), JsValue::Str(r)) => l == r,
+        _ => js_to_number(left) == js_to_number(right),
+    }
+}
+
+// parity: ES ToInt32/ToUint32.
+pub(crate) fn to_int32(n: f64) -> i32 {
+    to_uint32(n) as i32
+}
+
+pub(crate) fn to_uint32(n: f64) -> u32 {
+    if !n.is_finite() || n == 0.0 {
+        return 0;
+    }
+    let modulus = 2f64.powi(32);
+    let mut m = n.trunc() % modulus;
+    if m < 0.0 {
+        m += modulus;
+    }
+    m as u32
+}
+
+#[cfg(test)]
+mod js_obj_tests {
+    use super::*;
+
+    #[test]
+    fn wide_objects_keep_insertion_order_and_overwrite_position() {
+        let n = value::NAMED_INDEX_THRESHOLD * 3;
+        let mut obj = JsObj::default();
+        for i in 0..n {
+            obj.insert(format!("key{i}"), JsValue::Num(i as f64));
+        }
+        obj.insert("key5".to_string(), JsValue::Str("updated".to_string()));
+        obj.insert("late".to_string(), JsValue::Bool(true));
+        let keys: Vec<&str> = obj.entries().map(|(k, _)| k).collect();
+        let mut expected: Vec<String> = (0..n).map(|i| format!("key{i}")).collect();
+        expected.push("late".to_string());
+        assert_eq!(keys, expected);
+        assert!(matches!(obj.get("key5"), Some(JsValue::Str(s)) if s == "updated"));
+        assert!(obj.get("missing").is_none());
+    }
+}
+
+#[cfg(test)]
+mod coercion_lattice_tests {
+    use super::*;
+
+    fn grid_value(index: usize) -> JsValue {
+        // Positionally mirrors VALUES in conformance/src/gen-pins-coercion.mjs.
+        let n = JsValue::Num;
+        let s = |v: &str| JsValue::Str(v.to_string());
+        match index {
+            0 => JsValue::Undefined,
+            1 => JsValue::Null,
+            2 => JsValue::Bool(true),
+            3 => JsValue::Bool(false),
+            4 => n(0.0),
+            5 => n(-0.0),
+            6 => n(1.0),
+            7 => n(-1.0),
+            8 => n(0.5),
+            9 => n(f64::NAN),
+            10 => n(f64::INFINITY),
+            11 => n(f64::NEG_INFINITY),
+            12 => s(""),
+            13 => s("0"),
+            14 => s("00"),
+            15 => s("1"),
+            16 => s("2"),
+            17 => s("10"),
+            18 => s("a"),
+            19 => s(" "),
+            20 => s("\u{0085}"),
+            21 => s("Infinity"),
+            22 => JsValue::array(vec![]),
+            23 => JsValue::array(vec![n(0.0)]),
+            24 => JsValue::array(vec![n(1.0)]),
+            25 => JsValue::array(vec![JsValue::array(vec![])]),
+            26 => JsValue::array(vec![s("2")]),
+            27 => JsValue::array(vec![s("10")]),
+            28 => JsValue::array(vec![JsValue::Null]),
+            29 => JsValue::array(vec![JsValue::Undefined]),
+            30 => JsValue::array(vec![n(1.0), n(2.0)]),
+            31 => JsValue::array(vec![s("a"), s("b")]),
+            32 => JsValue::object(JsObj::default()),
+            33 => {
+                let mut obj = JsObj::default();
+                obj.insert("a".to_string(), n(1.0));
+                JsValue::object(obj)
+            }
+            _ => unreachable!("grid index"),
+        }
+    }
+
+    #[test]
+    fn lattice_matches_node_pins() {
+        // Vendored copies of this crate ship without testdata; the pin gate
+        // runs wherever the conformance harness lives.
+        let Ok(raw) = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/testdata/pins/eval/coercion.json"
+        )) else {
+            eprintln!("skipping lattice_matches_node_pins: testdata not vendored");
+            return;
+        };
+        let pins: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let values = pins["values"].as_array().unwrap();
+        assert_eq!(values.len(), 34, "grid size drifted; update grid_value");
+        let mut checked = 0;
+        for row in pins["results"].as_array().unwrap() {
+            let i = row["i"].as_u64().unwrap() as usize;
+            let j = row["j"].as_u64().unwrap() as usize;
+            let label = |op: &str| format!("{} {op} {}", values[i], values[j]);
+            let (left, right) = (grid_value(i), grid_value(j));
+            assert_eq!(
+                js_loose_eq(&left, &right),
+                row["=="].as_bool().unwrap(),
+                "{}",
+                label("==")
+            );
+            assert_eq!(
+                js_strict_eq(&left, &right),
+                row["==="].as_bool().unwrap(),
+                "{}",
+                label("===")
+            );
+            use std::cmp::Ordering::{Equal, Greater, Less};
+            let cmp = js_compare(&left, &right);
+            assert_eq!(
+                cmp == Some(Less),
+                row["<"].as_bool().unwrap(),
+                "{}",
+                label("<")
+            );
+            assert_eq!(
+                matches!(cmp, Some(Less | Equal)),
+                row["<="].as_bool().unwrap(),
+                "{}",
+                label("<=")
+            );
+            assert_eq!(
+                cmp == Some(Greater),
+                row[">"].as_bool().unwrap(),
+                "{}",
+                label(">")
+            );
+            assert_eq!(
+                matches!(cmp, Some(Greater | Equal)),
+                row[">="].as_bool().unwrap(),
+                "{}",
+                label(">=")
+            );
+            let sum = js_add(&left, &right).expect("grid holds no function values");
+            let (tag, expected) = (
+                row["add"]["t"].as_str().unwrap(),
+                row["add"]["v"].as_str().unwrap(),
+            );
+            match (tag, &sum) {
+                ("num", JsValue::Num(x)) => {
+                    assert_eq!(js_number_to_string(*x), expected, "{}", label("+"));
+                }
+                ("str", JsValue::Str(x)) => assert_eq!(x, expected, "{}", label("+")),
+                other => panic!("{}: unexpected sum shape {other:?}", label("+")),
+            }
+            checked += 1;
+        }
+        assert_eq!(checked, 34 * 34);
+    }
+}

--- a/crates/stylex/src/eval/mod.rs
+++ b/crates/stylex/src/eval/mod.rs
@@ -6,6 +6,8 @@ pub mod functions;
 pub mod methods;
 pub mod value;
 
+use std::borrow::Cow;
+use std::cell::OnceCell;
 use std::collections::BTreeMap;
 
 use crate::fxhash::FxHashMap;
@@ -74,70 +76,237 @@ pub enum Callable {
 
 /// Insertion-ordered object; ES OwnPropertyKeys ordering is restored when the
 /// value converts to `JsObjectMap`, which every observable path goes through.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct JsObj {
-    entries: Vec<(String, JsValue)>,
-    /// Lazy key→position table so wide objects avoid quadratic scans.
-    // Boxed to keep the usually-None field one word in every JsObj.
-    #[allow(clippy::box_collection)]
-    index: Option<Box<FxHashMap<String, usize>>>,
-    /// CSSType `instanceof` brand (the syntax): out-of-band like a prototype —
-    /// spreads copy entries only, aliases share the allocation.
-    css_type: Option<String>,
+    repr: ObjRepr,
+}
+
+#[derive(Debug, Clone)]
+enum ObjRepr {
+    Built {
+        entries: Vec<(String, JsValue)>,
+        /// Lazy key→position table so wide objects avoid quadratic scans.
+        // Boxed to keep the usually-None field one word in every JsObj.
+        #[allow(clippy::box_collection)]
+        index: Option<Box<FxHashMap<String, usize>>>,
+        /// CSSType `instanceof` brand (the syntax): out-of-band like a prototype —
+        /// spreads copy entries only, aliases share the allocation.
+        css_type: Option<String>,
+    },
+    /// A compiled map read in place; a slot converts once so repeat reads of
+    /// one entry keep one identity (`===`), like a real property.
+    Frozen {
+        map: Arc<JsObjectMap>,
+        slots: OnceCell<Box<[OnceCell<JsValue>]>>,
+    },
+}
+
+type FrozenSlots = OnceCell<Box<[OnceCell<JsValue>]>>;
+
+fn frozen_slot<'o>(map: &'o JsObjectMap, slots: &'o FrozenSlots, i: usize) -> &'o JsValue {
+    let slots = slots.get_or_init(|| {
+        std::iter::repeat_with(OnceCell::new)
+            .take(map.len())
+            .collect()
+    });
+    slots[i].get_or_init(|| from_eval_value(map.entry_at(i).1))
+}
+
+enum Entries<'o> {
+    Built(std::slice::Iter<'o, (String, JsValue)>),
+    Frozen {
+        map: &'o JsObjectMap,
+        slots: &'o FrozenSlots,
+        next: usize,
+    },
+}
+
+impl<'o> Iterator for Entries<'o> {
+    type Item = (&'o str, &'o JsValue);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Entries::Built(iter) => iter.next().map(|(k, v)| (k.as_str(), v)),
+            Entries::Frozen { map, slots, next } => {
+                let i = *next;
+                if i >= map.len() {
+                    return None;
+                }
+                *next += 1;
+                Some((map.entry_at(i).0, frozen_slot(map, slots, i)))
+            }
+        }
+    }
+}
+
+impl Default for JsObj {
+    fn default() -> Self {
+        Self::built(Vec::new())
+    }
 }
 
 impl JsObj {
+    fn built(entries: Vec<(String, JsValue)>) -> Self {
+        Self {
+            repr: ObjRepr::Built {
+                entries,
+                index: None,
+                css_type: None,
+            },
+        }
+    }
+
+    pub fn with_capacity(n: usize) -> Self {
+        Self::built(Vec::with_capacity(n))
+    }
+
+    /// The object sequential `insert` would build from `entries`, which must
+    /// not repeat a key (callers hand over a map's entries).
+    pub fn from_unique_entries(entries: Vec<(String, JsValue)>) -> Self {
+        debug_assert!(
+            entries
+                .iter()
+                .map(|(k, _)| k.as_str())
+                .collect::<crate::fxhash::FxHashSet<_>>()
+                .len()
+                == entries.len()
+        );
+        Self::built(entries)
+    }
+
+    pub fn frozen(map: Arc<JsObjectMap>) -> Self {
+        Self {
+            repr: ObjRepr::Frozen {
+                map,
+                slots: OnceCell::new(),
+            },
+        }
+    }
+
+    fn frozen_map(&self) -> Option<&Arc<JsObjectMap>> {
+        match &self.repr {
+            ObjRepr::Frozen { map, .. } => Some(map),
+            ObjRepr::Built { .. } => None,
+        }
+    }
+
     pub fn get(&self, key: &str) -> Option<&JsValue> {
-        if let Some(index) = &self.index {
-            index.get(key).map(|&i| &self.entries[i].1)
-        } else {
-            self.entries.iter().find(|(k, _)| k == key).map(|(_, v)| v)
+        match &self.repr {
+            ObjRepr::Built { entries, index, .. } => match index {
+                Some(index) => index.get(key).map(|&i| &entries[i].1),
+                None => entries.iter().find(|(k, _)| k == key).map(|(_, v)| v),
+            },
+            ObjRepr::Frozen { map, slots } => {
+                let i = map.position(key)?;
+                Some(frozen_slot(map, slots, i))
+            }
         }
     }
 
     pub fn insert(&mut self, key: String, value: JsValue) {
-        if self.index.is_none() && self.entries.len() >= value::NAMED_INDEX_THRESHOLD {
-            self.index = Some(Box::new(
-                self.entries
+        self.materialize();
+        let ObjRepr::Built { entries, index, .. } = &mut self.repr else {
+            unreachable!("materialize leaves a built object");
+        };
+        if index.is_none() && entries.len() >= value::NAMED_INDEX_THRESHOLD {
+            *index = Some(Box::new(
+                entries
                     .iter()
                     .enumerate()
                     .map(|(i, (k, _))| (k.clone(), i))
                     .collect(),
             ));
         }
-        if let Some(index) = &mut self.index {
+        if let Some(index) = index {
             match index.entry(key) {
                 std::collections::hash_map::Entry::Occupied(e) => {
-                    self.entries[*e.get()].1 = value;
+                    entries[*e.get()].1 = value;
                 }
                 std::collections::hash_map::Entry::Vacant(e) => {
-                    self.entries.push((e.key().clone(), value));
-                    e.insert(self.entries.len() - 1);
+                    entries.push((e.key().clone(), value));
+                    e.insert(entries.len() - 1);
                 }
             }
-        } else if let Some(entry) = self.entries.iter_mut().find(|(k, _)| *k == key) {
+        } else if let Some(entry) = entries.iter_mut().find(|(k, _)| *k == key) {
             entry.1 = value;
         } else {
-            self.entries.push((key, value));
+            entries.push((key, value));
         }
     }
 
     pub fn entries(&self) -> impl Iterator<Item = (&str, &JsValue)> {
-        self.entries.iter().map(|(k, v)| (k.as_str(), v))
+        match &self.repr {
+            ObjRepr::Built { entries, .. } => Entries::Built(entries.iter()),
+            ObjRepr::Frozen { map, slots } => Entries::Frozen {
+                map,
+                slots,
+                next: 0,
+            },
+        }
     }
 
     pub fn css_type(&self) -> Option<&str> {
-        self.css_type.as_deref()
+        match &self.repr {
+            ObjRepr::Built { css_type, .. } => css_type.as_deref(),
+            ObjRepr::Frozen { map, .. } => map.css_type(),
+        }
     }
 
     pub fn set_css_type(&mut self, syntax: String) {
-        self.css_type = Some(syntax);
+        self.materialize();
+        if let ObjRepr::Built { css_type, .. } = &mut self.repr {
+            *css_type = Some(syntax);
+        }
+    }
+
+    /// Frozen → Built; slots already handed out keep their identity.
+    fn materialize(&mut self) {
+        let ObjRepr::Frozen { map, slots } = &mut self.repr else {
+            return;
+        };
+        let mut slots = slots.take();
+        let entries = map
+            .entries()
+            .enumerate()
+            .map(|(i, (k, v))| {
+                let value = slots
+                    .as_mut()
+                    .and_then(|s| s[i].take())
+                    .unwrap_or_else(|| from_eval_value(v));
+                (k.to_string(), value)
+            })
+            .collect();
+        let css_type = map.css_type().map(str::to_string);
+        self.repr = ObjRepr::Built {
+            entries,
+            index: None,
+            css_type,
+        };
+    }
+
+    fn into_map(self) -> Arc<JsObjectMap> {
+        match self.repr {
+            ObjRepr::Built {
+                entries, css_type, ..
+            } => {
+                let entries = entries
+                    .into_iter()
+                    .map(|(k, v)| (k, into_eval_value(v)))
+                    .collect();
+                let mut map = JsObjectMap::from_unique_entries(entries);
+                if let Some(syntax) = css_type {
+                    map.set_css_type(syntax);
+                }
+                Arc::new(map)
+            }
+            ObjRepr::Frozen { map, .. } => map,
+        }
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct Deopt {
-    pub reason: String,
+    pub reason: Cow<'static, str>,
     pub span: Span,
 }
 
@@ -161,16 +330,43 @@ pub fn to_eval_value(value: &JsValue) -> EvalValue {
         JsValue::Num(n) => EvalValue::Num(*n),
         JsValue::Str(s) => EvalValue::Str(s.clone()),
         JsValue::Arr(items) => EvalValue::Arr(items.iter().map(to_eval_value).collect()),
-        JsValue::Obj(obj) => {
-            let mut map = JsObjectMap::new();
-            for (k, v) in obj.entries() {
-                map.insert(k.to_string(), to_eval_value(v));
-            }
-            if let Some(syntax) = obj.css_type() {
-                map.set_css_type(syntax.to_string());
-            }
-            EvalValue::Obj(Arc::new(map))
-        }
+        JsValue::Obj(obj) => EvalValue::Obj(obj_to_map(obj)),
+        JsValue::Proxy(_) => EvalValue::Obj(JsObjectMap::new().into()),
+    }
+}
+
+fn obj_to_map(obj: &JsObj) -> Arc<JsObjectMap> {
+    if let Some(map) = obj.frozen_map() {
+        return Arc::clone(map);
+    }
+    let entries = obj
+        .entries()
+        .map(|(k, v)| (k.to_string(), to_eval_value(v)))
+        .collect();
+    let mut map = JsObjectMap::from_unique_entries(entries);
+    if let Some(syntax) = obj.css_type() {
+        map.set_css_type(syntax.to_string());
+    }
+    Arc::new(map)
+}
+
+/// `to_eval_value` for a value the caller is finished with: strings and
+/// uniquely owned containers move; aliased containers fall back to copying.
+pub fn into_eval_value(value: JsValue) -> EvalValue {
+    match value {
+        JsValue::Null => EvalValue::Null,
+        JsValue::Undefined | JsValue::Callable(_) => EvalValue::Undefined,
+        JsValue::Bool(b) => EvalValue::Bool(b),
+        JsValue::Num(n) => EvalValue::Num(n),
+        JsValue::Str(s) => EvalValue::Str(s),
+        JsValue::Arr(items) => match Rc::try_unwrap(items) {
+            Ok(items) => EvalValue::Arr(items.into_iter().map(into_eval_value).collect()),
+            Err(shared) => EvalValue::Arr(shared.iter().map(to_eval_value).collect()),
+        },
+        JsValue::Obj(obj) => EvalValue::Obj(match Rc::try_unwrap(obj) {
+            Ok(obj) => obj.into_map(),
+            Err(shared) => obj_to_map(&shared),
+        }),
         JsValue::Proxy(_) => EvalValue::Obj(JsObjectMap::new().into()),
     }
 }
@@ -183,16 +379,20 @@ pub fn from_eval_value(value: &EvalValue) -> JsValue {
         EvalValue::Num(n) => JsValue::Num(*n),
         EvalValue::Str(s) => JsValue::Str(s.clone()),
         EvalValue::Arr(items) => JsValue::array(items.iter().map(from_eval_value).collect()),
-        EvalValue::Obj(map) => {
-            let mut obj = JsObj::default();
-            for (k, v) in map.entries() {
-                obj.insert(k.to_string(), from_eval_value(v));
-            }
-            if let Some(syntax) = map.css_type() {
-                obj.set_css_type(syntax.to_string());
-            }
-            JsValue::object(obj)
-        }
+        EvalValue::Obj(map) => JsValue::object(JsObj::frozen(Arc::clone(map))),
+    }
+}
+
+/// `from_eval_value` for a value the caller is finished with.
+pub fn into_js_value(value: EvalValue) -> JsValue {
+    match value {
+        EvalValue::Null => JsValue::Null,
+        EvalValue::Undefined => JsValue::Undefined,
+        EvalValue::Bool(b) => JsValue::Bool(b),
+        EvalValue::Num(n) => JsValue::Num(n),
+        EvalValue::Str(s) => JsValue::Str(s),
+        EvalValue::Arr(items) => JsValue::array(items.into_iter().map(into_js_value).collect()),
+        EvalValue::Obj(map) => JsValue::object(JsObj::frozen(map)),
     }
 }
 
@@ -229,7 +429,7 @@ impl Resolved<'_> {
 #[derive(Debug, Clone, Default)]
 pub struct FunctionRegistry {
     identifiers: BTreeMap<String, RegistryEntry>,
-    member_callables: BTreeMap<(String, String), StylexCallable>,
+    member_callables: Vec<(String, &'static str, StylexCallable)>,
 }
 
 fn when_object() -> JsValue {
@@ -256,8 +456,9 @@ impl FunctionRegistry {
             }
         }
         for namespace in &imports.stylex_namespaces {
-            registry.member_callables.insert(
-                (namespace.clone(), "firstThatWorks".to_string()),
+            registry.add_member_callable(
+                namespace,
+                "firstThatWorks",
                 StylexCallable::FirstThatWorks,
             );
         }
@@ -276,10 +477,7 @@ impl FunctionRegistry {
             }
         }
         for namespace in &imports.stylex_namespaces {
-            registry.member_callables.insert(
-                (namespace.clone(), "defaultMarker".to_string()),
-                StylexCallable::DefaultMarker,
-            );
+            registry.add_member_callable(namespace, "defaultMarker", StylexCallable::DefaultMarker);
         }
         registry
     }
@@ -302,12 +500,34 @@ impl FunctionRegistry {
             }
         }
         for namespace in &imports.stylex_namespaces {
-            registry.member_callables.insert(
-                (namespace.clone(), "keyframes".to_string()),
-                StylexCallable::Keyframes,
-            );
+            registry.add_member_callable(namespace, "keyframes", StylexCallable::Keyframes);
         }
         registry
+    }
+
+    pub(crate) fn add_member_callable(
+        &mut self,
+        object: &str,
+        prop: &'static str,
+        callable: StylexCallable,
+    ) {
+        match self
+            .member_callables
+            .iter_mut()
+            .find(|(o, p, _)| o == object && *p == prop)
+        {
+            Some(slot) => slot.2 = callable,
+            None => self
+                .member_callables
+                .push((object.to_string(), prop, callable)),
+        }
+    }
+
+    pub(crate) fn member_callable(&self, object: &str, prop: &str) -> Option<&StylexCallable> {
+        self.member_callables
+            .iter()
+            .find(|(o, p, _)| o == object && *p == prop)
+            .map(|(_, _, callable)| callable)
     }
 
     fn restricted_base(imports: &ImportTable, env: &EvalValue) -> Self {
@@ -364,9 +584,7 @@ impl FunctionRegistry {
                 ("positionTry", StylexCallable::PositionTry),
                 ("defaultMarker", StylexCallable::DefaultMarker),
             ] {
-                registry
-                    .member_callables
-                    .insert((namespace.clone(), name.to_string()), callable);
+                registry.add_member_callable(namespace, name, callable);
             }
         }
         registry
@@ -377,7 +595,9 @@ pub struct Evaluator<'a, 'env> {
     pub state: &'env mut CompileState<'a>,
     pub fs: &'env dyn FsProvider,
     pub callables: &'env dyn EvalCallables,
-    registry: FunctionRegistry,
+    /// Arrow parameter binding writes through `to_mut`, so a borrowed registry
+    /// is copied only by evaluations that call arrows.
+    registry: Cow<'env, FunctionRegistry>,
     /// parity: FunctionConfig.disableImports — named-import resolution off.
     disable_imports: bool,
     arrow_bodies: BTreeMap<u32, (&'a Expression<'a>, Vec<String>)>,
@@ -397,7 +617,7 @@ enum SeenEntry {
 
 macro_rules! value_or_return {
     ($self:expr, $expr:expr) => {
-        match $self.eval($expr)? {
+        match $self.eval_node($expr)? {
             EvalOutcome::Value(v) => v,
             deopt => return Ok(deopt),
         }
@@ -415,7 +635,7 @@ impl<'a, 'env> Evaluator<'a, 'env> {
             state,
             fs,
             callables,
-            registry,
+            registry: Cow::Owned(registry),
             disable_imports: false,
             arrow_bodies: BTreeMap::new(),
             dynamic_namespaces: false,
@@ -436,6 +656,32 @@ impl<'a, 'env> Evaluator<'a, 'env> {
         registry: FunctionRegistry,
         disable_imports: bool,
     ) -> Self {
+        Self::with_registry_cow(state, fs, callables, Cow::Owned(registry), disable_imports)
+    }
+
+    pub fn with_registry_ref(
+        state: &'env mut CompileState<'a>,
+        fs: &'env dyn FsProvider,
+        callables: &'env dyn EvalCallables,
+        registry: &'env FunctionRegistry,
+        disable_imports: bool,
+    ) -> Self {
+        Self::with_registry_cow(
+            state,
+            fs,
+            callables,
+            Cow::Borrowed(registry),
+            disable_imports,
+        )
+    }
+
+    fn with_registry_cow(
+        state: &'env mut CompileState<'a>,
+        fs: &'env dyn FsProvider,
+        callables: &'env dyn EvalCallables,
+        registry: Cow<'env, FunctionRegistry>,
+        disable_imports: bool,
+    ) -> Self {
         Evaluator {
             state,
             fs,
@@ -449,7 +695,7 @@ impl<'a, 'env> Evaluator<'a, 'env> {
         }
     }
 
-    fn deopt(&self, span: Span, reason: impl Into<String>) -> EvalResult {
+    fn deopt(&self, span: Span, reason: impl Into<Cow<'static, str>>) -> EvalResult {
         Ok(EvalOutcome::NonStatic(Deopt {
             reason: reason.into(),
             span,
@@ -465,6 +711,13 @@ impl<'a, 'env> Evaluator<'a, 'env> {
         let _t = crate::timings::start(crate::timings::Stage::Eval);
         self.seen.clear();
         self.eval(expr)
+    }
+
+    /// Converts a finished `eval_entry` result; the node cache still holds Rc
+    /// clones of its tree and would otherwise force `into_eval_value` to copy.
+    fn consume(&mut self, value: JsValue) -> EvalValue {
+        self.seen.clear();
+        into_eval_value(value)
     }
 
     /// parity: nested `evaluate(...)` without the shared seen map (array
@@ -483,11 +736,16 @@ impl<'a, 'env> Evaluator<'a, 'env> {
         self.eval_cached(span, |ev| ev.eval_inner(expr))
     }
 
-    fn eval_cached(
-        &mut self,
-        span: Span,
-        eval_fn: impl FnOnce(&mut Self) -> EvalResult,
-    ) -> EvalResult {
+    // Only binding resolution (`eval`/`eval_cached`) can revisit a node within
+    // one `seen` lifetime; structural children skip the cache.
+    fn eval_node(&mut self, expr: &'a Expression<'a>) -> EvalResult {
+        self.enter()?;
+        let result = self.eval_inner(expr);
+        self.depth -= 1;
+        result
+    }
+
+    fn enter(&mut self) -> Result<(), StylexError> {
         self.depth += 1;
         if self.depth > 128 {
             self.depth -= 1;
@@ -496,6 +754,15 @@ impl<'a, 'env> Evaluator<'a, 'env> {
                 "StyleX evaluation exceeded the recursion limit.",
             ));
         }
+        Ok(())
+    }
+
+    fn eval_cached(
+        &mut self,
+        span: Span,
+        eval_fn: impl FnOnce(&mut Self) -> EvalResult,
+    ) -> EvalResult {
+        self.enter()?;
         let key = (span.start, span.end);
         match self.seen.get(&key) {
             Some(SeenEntry::InFlight) => {
@@ -520,9 +787,9 @@ impl<'a, 'env> Evaluator<'a, 'env> {
 
     fn eval_inner(&mut self, expr: &'a Expression<'a>) -> EvalResult {
         match expr {
-            Expression::ParenthesizedExpression(e) => self.eval(&e.expression),
-            Expression::TSAsExpression(e) => self.eval(&e.expression),
-            Expression::TSSatisfiesExpression(e) => self.eval(&e.expression),
+            Expression::ParenthesizedExpression(e) => self.eval_node(&e.expression),
+            Expression::TSAsExpression(e) => self.eval_node(&e.expression),
+            Expression::TSSatisfiesExpression(e) => self.eval_node(&e.expression),
             Expression::ArrowFunctionExpression(arrow) => {
                 let simple_params = arrow.params.rest.is_none();
                 let expression_body =
@@ -558,7 +825,7 @@ impl<'a, 'env> Evaluator<'a, 'env> {
                 }
             }
             Expression::SequenceExpression(seq) => match seq.expressions.last() {
-                Some(last) => self.eval(last),
+                Some(last) => self.eval_node(last),
                 None => self.deopt(seq.span, errs::PATH_WITHOUT_NODE),
             },
             Expression::StringLiteral(lit) => {
@@ -574,9 +841,9 @@ impl<'a, 'env> Evaluator<'a, 'env> {
             Expression::ConditionalExpression(cond) => {
                 let test = value_or_return!(self, &cond.test);
                 if truthy(&test) {
-                    self.eval(&cond.consequent)
+                    self.eval_node(&cond.consequent)
                 } else {
-                    self.eval(&cond.alternate)
+                    self.eval_node(&cond.alternate)
                 }
             }
             Expression::StaticMemberExpression(_) | Expression::ComputedMemberExpression(_) => {
@@ -626,7 +893,7 @@ impl<'a, 'env> Evaluator<'a, 'env> {
     }
 
     fn eval_template(&mut self, tpl: &'a TemplateLiteral<'a>) -> EvalResult {
-        let mut out = String::new();
+        let mut out = String::with_capacity(tpl.quasis.iter().map(|q| q.value.raw.len()).sum());
         for (i, quasi) in tpl.quasis.iter().enumerate() {
             if quasi.lone_surrogates {
                 return Err(StylexError::lone_surrogate("a template literal"));
@@ -672,7 +939,7 @@ impl<'a, 'env> Evaluator<'a, 'env> {
         };
         let info = self.state.binding_info(symbol);
         if matches!(info.decl, BindingDecl::NamedImport) && !self.disable_imports {
-            return self.eval_named_import(name, span);
+            return self.eval_named_import(symbol, name, span);
         }
         if matches!(info.decl, BindingDecl::DefaultImport) {
             return self.deopt(span, errs::IMPORT_FILE_EVAL_ERROR);
@@ -702,7 +969,7 @@ impl<'a, 'env> Evaluator<'a, 'env> {
             return self.deopt(span, errs::UNDEFINED_CONST);
         }
         match resolved {
-            Resolved::Override(value) => self.value(from_eval_value(&value)),
+            Resolved::Override(value) => self.value(into_js_value(value)),
             Resolved::Expr(expr) => self.eval(expr),
             Resolved::Identifier(other) => {
                 self.eval_cached(other.span, |ev| ev.eval_identifier(other))
@@ -714,7 +981,10 @@ impl<'a, 'env> Evaluator<'a, 'env> {
         }
     }
 
-    fn eval_named_import(&mut self, name: &str, span: Span) -> EvalResult {
+    fn eval_named_import(&mut self, symbol: SymbolId, name: &str, span: Span) -> EvalResult {
+        if let Some(proxy) = self.state.theme_proxy(symbol) {
+            return self.value(JsValue::proxy(proxy.clone()));
+        }
         let Some(record) = self.state.imports.import_record(name).cloned() else {
             return self.deopt(span, errs::UNDEFINED_CONST);
         };
@@ -729,6 +999,7 @@ impl<'a, 'env> Evaluator<'a, 'env> {
                     record.source_span,
                 );
                 let proxy = VarGroupProxy::new(canonical, imported, self.state.options);
+                self.state.record_theme_proxy(symbol, proxy.clone());
                 self.value(JsValue::proxy(proxy))
             }
             None => self.deopt(span, errs::IMPORT_PATH_RESOLUTION_ERROR),
@@ -838,14 +1109,14 @@ impl<'a, 'env> Evaluator<'a, 'env> {
             }
             return self.value(current);
         }
-        let (object_expr, key) = match expr {
+        let (object_expr, key): (_, Cow<str>) = match expr {
             Expression::StaticMemberExpression(member) => {
-                (&member.object, member.property.name.to_string())
+                (&member.object, Cow::Borrowed(member.property.name.as_str()))
             }
             Expression::ComputedMemberExpression(member) => {
                 let key_value = value_or_return!(self, &member.expression);
                 match js_to_string(&key_value) {
-                    Some(key) => (&member.object, key),
+                    Some(key) => (&member.object, Cow::Owned(key)),
                     None => {
                         return self
                             .deopt(member.expression.span(), errs::UNEXPECTED_MEMBER_LOOKUP);
@@ -862,7 +1133,7 @@ impl<'a, 'env> Evaluator<'a, 'env> {
         match object {
             JsValue::Proxy(proxy) => self.value(match key {
                 "__IS_PROXY" => JsValue::Bool(true),
-                "__varGroupHash__" => JsValue::Str(proxy.var_group_hash.clone()),
+                "__varGroupHash__" => JsValue::Str(proxy.var_group_hash().to_string()),
                 "toString" => JsValue::Callable(Callable::Opaque),
                 _ => JsValue::Str(proxy.resolve_key(key)),
             }),
@@ -950,7 +1221,7 @@ impl<'a, 'env> Evaluator<'a, 'env> {
     }
 
     fn eval_object(&mut self, object: &'a ObjectExpression<'a>) -> EvalResult {
-        let mut obj = JsObj::default();
+        let mut obj = JsObj::with_capacity(object.properties.len());
         for property in &object.properties {
             match property {
                 ObjectPropertyKind::SpreadProperty(spread) => {
@@ -993,8 +1264,8 @@ impl<'a, 'env> Evaluator<'a, 'env> {
     // parity: evaluate-path.js isLogicalExpression — both sides evaluate with
     // fresh confidence; `0 ?? x` deopts with literally "unknown error".
     fn eval_logical(&mut self, logical: &'a LogicalExpression<'a>) -> EvalResult {
-        let left = self.eval(&logical.left)?;
-        let right = self.eval(&logical.right)?;
+        let left = self.eval_node(&logical.left)?;
+        let right = self.eval_node(&logical.right)?;
         if let EvalOutcome::Value(l) = &left {
             match logical.operator {
                 LogicalOperator::Or => {
@@ -1206,11 +1477,8 @@ impl<'a, 'env> Evaluator<'a, 'env> {
                     }
                 }
                 if let Some(prop) = prop_static.or(prop_string)
-                    && let Some(callable) = self
-                        .registry
-                        .member_callables
-                        .get(&(object_name.to_string(), prop.to_string()))
-                        .cloned()
+                    && let Some(callable) =
+                        self.registry.member_callable(object_name, prop).cloned()
                 {
                     return self.dispatch(callable, call);
                 }
@@ -1246,7 +1514,7 @@ impl<'a, 'env> Evaluator<'a, 'env> {
             if let JsValue::Proxy(proxy) = &object_value
                 && property == "toString"
             {
-                let hash = proxy.var_group_hash.clone();
+                let hash = proxy.var_group_hash().to_string();
                 return match self.eval_arguments(call)? {
                     Ok(_) => self.value(JsValue::Str(hash)),
                     Err(deopt) => Ok(EvalOutcome::NonStatic(deopt)),
@@ -1343,18 +1611,20 @@ impl<'a, 'env> Evaluator<'a, 'env> {
             let value = args.get(i).cloned().unwrap_or(JsValue::Undefined);
             let previous = self
                 .registry
+                .to_mut()
                 .identifiers
                 .insert(name.clone(), RegistryEntry::Value(value));
             saved.push((name.clone(), previous));
         }
         let result = self.eval_fresh(body);
+        let identifiers = &mut self.registry.to_mut().identifiers;
         for (name, previous) in saved.into_iter().rev() {
             match previous {
                 Some(entry) => {
-                    self.registry.identifiers.insert(name, entry);
+                    identifiers.insert(name, entry);
                 }
                 None => {
-                    self.registry.identifiers.remove(&name);
+                    identifiers.remove(&name);
                 }
             }
         }
@@ -1382,12 +1652,14 @@ impl<'a, 'env> Evaluator<'a, 'env> {
         let args: Vec<EvalValue> = raw
             .iter()
             .map(|value| match value {
-                JsValue::Proxy(proxy) if is_when => EvalValue::Str(proxy.var_group_hash.clone()),
+                JsValue::Proxy(proxy) if is_when => {
+                    EvalValue::Str(proxy.var_group_hash().to_string())
+                }
                 other => to_eval_value(other),
             })
             .collect();
         let result = self.callables.call(&callable, &args, self.state)?;
-        self.value(from_eval_value(&result))
+        self.value(into_js_value(result))
     }
 
     fn eval_arguments(
@@ -1408,11 +1680,11 @@ impl<'a, 'env> Evaluator<'a, 'env> {
             match argument {
                 Argument::SpreadElement(spread) => {
                     return Ok(Err(Deopt {
-                        reason: errs::unsupported_expression("SpreadElement"),
+                        reason: errs::unsupported_expression("SpreadElement").into(),
                         span: spread.span,
                     }));
                 }
-                _ => match self.eval(argument.to_expression())? {
+                _ => match self.eval_node(argument.to_expression())? {
                     EvalOutcome::Value(v) => out.push(v),
                     EvalOutcome::NonStatic(deopt) => return Ok(Err(deopt)),
                 },
@@ -1445,7 +1717,7 @@ pub fn evaluate_stylex_create_arg<'a>(
     object: &'a ObjectExpression<'a>,
 ) -> Result<EvaluatedCreateArg, StylexError> {
     let _t = crate::timings::start(crate::timings::Stage::Eval);
-    let mut namespaces = JsObjectMap::new();
+    let mut namespaces = JsObjectMap::with_capacity(object.properties.len());
     let mut key_spans: Vec<(String, u32)> = Vec::new();
     let mut fns: Vec<(String, DynamicFn)> = Vec::new();
     for property in &object.properties {
@@ -1521,7 +1793,7 @@ pub fn evaluate_stylex_create_arg<'a>(
             if !key_spans.iter().any(|(k, _)| *k == key) {
                 key_spans.push((key.clone(), prop.span.start));
             }
-            namespaces.insert(key.clone(), to_eval_value(&JsValue::object(value)));
+            namespaces.insert(key.clone(), evaluator.consume(JsValue::object(value)));
             // parity: `fns[key] =` is a [[Set]]; "__proto__" never lands.
             if key != "__proto__" {
                 match fns.iter_mut().find(|(k, _)| *k == key) {
@@ -1536,7 +1808,7 @@ pub fn evaluate_stylex_create_arg<'a>(
                 if !key_spans.iter().any(|(k, _)| *k == key) {
                     key_spans.push((key.clone(), prop.span.start));
                 }
-                namespaces.insert(key, to_eval_value(&v));
+                namespaces.insert(key, evaluator.consume(v));
             }
             EvalOutcome::NonStatic(deopt) => {
                 return Err(StylexError::new(ErrorCode::NonStaticValue, deopt.reason));
@@ -1558,7 +1830,7 @@ fn reevaluate_create_object<'a>(
     evaluator.seen.clear();
     match evaluator.eval_object(object)? {
         EvalOutcome::Value(v) => Ok(EvaluatedCreateArg {
-            namespaces: match to_eval_value(&v) {
+            namespaces: match evaluator.consume(v) {
                 EvalValue::Obj(map) => Arc::unwrap_or_clone(map),
                 _ => JsObjectMap::new(),
             },
@@ -1579,7 +1851,7 @@ fn evaluate_partial_object<'a>(
     key_path: &[String],
     fn_def: &mut DynamicFn,
 ) -> Result<Option<JsObj>, StylexError> {
-    let mut obj = JsObj::default();
+    let mut obj = JsObj::with_capacity(object.properties.len());
     for property in &object.properties {
         match property {
             ObjectPropertyKind::SpreadProperty(spread) => {
@@ -1671,30 +1943,47 @@ pub fn unwrap_parens<'a, 'b>(expr: &'b Expression<'a>) -> &'b Expression<'a> {
 
 fn collect_member_chain<'a, 'b>(
     expr: &'b Expression<'a>,
-) -> Option<(&'b Expression<'a>, Vec<String>)> {
-    let mut parts: Vec<String> = Vec::new();
+) -> Option<(&'b Expression<'a>, Vec<Cow<'b, str>>)> {
+    let mut depth = 0;
+    let mut current = expr;
+    loop {
+        match current {
+            Expression::StaticMemberExpression(member) => current = &member.object,
+            Expression::ComputedMemberExpression(member) => match &member.expression {
+                Expression::StringLiteral(_) | Expression::NumericLiteral(_) => {
+                    current = &member.object;
+                }
+                _ => return None,
+            },
+            _ => break,
+        }
+        depth += 1;
+    }
+    if depth < 2 {
+        return None;
+    }
+    let mut parts: Vec<Cow<'b, str>> = Vec::with_capacity(depth);
     let mut current = expr;
     loop {
         match current {
             Expression::StaticMemberExpression(member) => {
-                parts.push(member.property.name.to_string());
+                parts.push(Cow::Borrowed(member.property.name.as_str()));
                 current = &member.object;
             }
             Expression::ComputedMemberExpression(member) => {
                 match &member.expression {
-                    Expression::StringLiteral(lit) => parts.push(lit.value.to_string()),
-                    Expression::NumericLiteral(lit) => {
-                        parts.push(js_number_to_string(lit.value));
+                    Expression::StringLiteral(lit) => {
+                        parts.push(Cow::Borrowed(lit.value.as_str()));
                     }
-                    _ => return None,
+                    Expression::NumericLiteral(lit) => {
+                        parts.push(Cow::Owned(js_number_to_string(lit.value)));
+                    }
+                    _ => unreachable!("checked by the depth pass"),
                 }
                 current = &member.object;
             }
             _ => break,
         }
-    }
-    if parts.len() < 2 {
-        return None;
     }
     parts.reverse();
     Some((current, parts))
@@ -1819,7 +2108,7 @@ pub fn js_to_string(value: &JsValue) -> Option<String> {
             parts.join(",")
         }
         JsValue::Obj(_) => "[object Object]".to_string(),
-        JsValue::Proxy(proxy) => proxy.var_group_hash.clone(),
+        JsValue::Proxy(proxy) => proxy.var_group_hash().to_string(),
         JsValue::Callable(_) => return None,
     })
 }

--- a/crates/stylex/src/eval/value.rs
+++ b/crates/stylex/src/eval/value.rs
@@ -118,6 +118,46 @@ impl JsObjectMap {
         Self::default()
     }
 
+    pub fn with_capacity(named: usize) -> Self {
+        Self {
+            named_entries: Vec::with_capacity(named),
+            ..Self::default()
+        }
+    }
+
+    /// The map sequential `insert` would build from `entries`, which must not
+    /// repeat a key (callers hand over another map's or object's entries).
+    pub fn from_unique_entries(entries: Vec<(String, EvalValue)>) -> Self {
+        debug_assert!(
+            entries
+                .iter()
+                .map(|(k, _)| k.as_str())
+                .collect::<crate::fxhash::FxHashSet<_>>()
+                .len()
+                == entries.len()
+        );
+        if !entries.iter().any(|(k, _)| array_index(k).is_some()) {
+            return Self {
+                named_entries: entries,
+                ..Self::default()
+            };
+        }
+        let mut index_entries = Vec::new();
+        let mut named_entries = Vec::with_capacity(entries.len() - 1);
+        for (key, value) in entries {
+            match array_index(&key) {
+                Some(n) => index_entries.push((n, key, value)),
+                None => named_entries.push((key, value)),
+            }
+        }
+        index_entries.sort_unstable_by_key(|e| e.0);
+        Self {
+            index_entries,
+            named_entries,
+            ..Self::default()
+        }
+    }
+
     pub fn len(&self) -> usize {
         self.index_entries.len() + self.named_entries.len()
     }
@@ -143,6 +183,30 @@ impl JsObjectMap {
                 .iter()
                 .find(|(k, _)| k == key)
                 .map(|(_, v)| v)
+        }
+    }
+
+    /// Position of `key` in `entries()` order.
+    pub fn position(&self, key: &str) -> Option<usize> {
+        if let Some(n) = array_index(key) {
+            return self.index_entries.binary_search_by_key(&n, |e| e.0).ok();
+        }
+        let named = match &self.named_index {
+            Some(index) => index.get(key).copied(),
+            None => self.named_entries.iter().position(|(k, _)| k == key),
+        };
+        named.map(|i| i + self.index_entries.len())
+    }
+
+    /// The entry at a `position()` / `entries()` index.
+    pub fn entry_at(&self, i: usize) -> (&str, &EvalValue) {
+        let indexed = self.index_entries.len();
+        if i < indexed {
+            let (_, k, v) = &self.index_entries[i];
+            (k, v)
+        } else {
+            let (k, v) = &self.named_entries[i - indexed];
+            (k, v)
         }
     }
 
@@ -377,6 +441,38 @@ mod tests {
         assert_eq!(map.get("missing"), None);
         let narrow: JsObjectMap = scan.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
         assert_eq!(map, narrow);
+    }
+
+    #[test]
+    fn from_unique_entries_matches_sequential_insert() {
+        let n = NAMED_INDEX_THRESHOLD * 2;
+        let entries: Vec<(String, EvalValue)> = (0..n)
+            .map(|i| {
+                let key = match i % 5 {
+                    0 => (n - i).to_string(),
+                    1 => format!("0{i}"),
+                    2 => "4294967295".to_string() + &i.to_string(),
+                    _ => format!("key{i}"),
+                };
+                (key, s(&i.to_string()))
+            })
+            .chain([("__proto__".to_string(), s("p")), ("".to_string(), s("e"))])
+            .collect();
+        let sequential: JsObjectMap = entries.iter().cloned().collect();
+        let direct = JsObjectMap::from_unique_entries(entries.clone());
+        assert_eq!(direct, sequential);
+        assert_eq!(
+            direct.entries().collect::<Vec<_>>(),
+            sequential.entries().collect::<Vec<_>>()
+        );
+        for (k, v) in &entries {
+            assert_eq!(direct.get(k), Some(v));
+        }
+        let named_only: Vec<(String, EvalValue)> =
+            (0..3).map(|i| (format!("k{i}"), s("v"))).collect();
+        let direct = JsObjectMap::from_unique_entries(named_only.clone());
+        assert_eq!(direct, named_only.into_iter().collect());
+        assert!(JsObjectMap::from_unique_entries(Vec::new()).is_empty());
     }
 
     #[test]

--- a/crates/stylex/src/eval/value.rs
+++ b/crates/stylex/src/eval/value.rs
@@ -1,0 +1,409 @@
+use crate::fxhash::FxHashMap;
+use std::sync::Arc;
+
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum EvalValue {
+    Null,
+    Undefined,
+    Bool(bool),
+    Num(f64),
+    Str(String),
+    Arr(Vec<EvalValue>),
+    /// Rc-shared: clones are refcount bumps; mutation goes through make_mut.
+    Obj(Arc<JsObjectMap>),
+}
+
+impl EvalValue {
+    // parity: JSON.stringify — undefined props drop, undefined array elements
+    // and non-finite numbers become null.
+    pub fn to_json(&self) -> Value {
+        match self {
+            EvalValue::Null | EvalValue::Undefined => Value::Null,
+            EvalValue::Bool(b) => Value::Bool(*b),
+            EvalValue::Num(n) => num_to_json(*n),
+            EvalValue::Str(s) => Value::String(s.clone()),
+            EvalValue::Arr(items) => Value::Array(items.iter().map(EvalValue::to_json).collect()),
+            EvalValue::Obj(map) => map.to_json(),
+        }
+    }
+
+    /// Object key order follows the `Value` map's own iteration order
+    /// (alphabetical without serde_json's `preserve_order`); index keys re-sort anyway.
+    pub fn from_json(value: &Value) -> Self {
+        match value {
+            Value::Null => EvalValue::Null,
+            Value::Bool(b) => EvalValue::Bool(*b),
+            Value::Number(n) => EvalValue::Num(n.as_f64().unwrap_or(f64::NAN)),
+            Value::String(s) => EvalValue::Str(s.clone()),
+            Value::Array(items) => EvalValue::Arr(items.iter().map(Self::from_json).collect()),
+            Value::Object(map) => {
+                let mut obj = JsObjectMap::new();
+                for (k, v) in map {
+                    obj.insert(k.clone(), Self::from_json(v));
+                }
+                EvalValue::Obj(Arc::new(obj))
+            }
+        }
+    }
+}
+
+fn num_to_json(n: f64) -> Value {
+    if !n.is_finite() {
+        return Value::Null;
+    }
+    if n.fract() == 0.0 && n.abs() < (i64::MAX as f64) {
+        return Value::Number((n as i64).into());
+    }
+    serde_json::Number::from_f64(n).map_or(Value::Null, Value::Number)
+}
+
+/// String-keyed map iterating in ES OwnPropertyKeys order: canonical array-index
+/// keys ascending first, then the remaining keys in insertion order.
+#[derive(Clone, Default)]
+pub struct JsObjectMap {
+    index_entries: Vec<(u32, String, EvalValue)>,
+    named_entries: Vec<(String, EvalValue)>,
+    /// Lazy key→position table so wide objects avoid quadratic scans.
+    // Boxed to keep the usually-None field one word; the map sits inline in EvalValue.
+    #[allow(clippy::box_collection)]
+    named_index: Option<Box<FxHashMap<String, usize>>>,
+    /// CSSType `instanceof` brand (the syntax) — representation, not data:
+    /// never enumerated, serialized, or copied by spread.
+    css_type: Option<String>,
+}
+
+// Manual Debug: the lazy name index is derived state with randomized HashMap
+// order, and the cache key fingerprints this repr — it must stay canonical.
+impl std::fmt::Debug for JsObjectMap {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JsObjectMap")
+            .field("index_entries", &self.index_entries)
+            .field("named_entries", &self.named_entries)
+            .field("css_type", &self.css_type())
+            .finish()
+    }
+}
+
+impl PartialEq for JsObjectMap {
+    fn eq(&self, other: &Self) -> bool {
+        self.index_entries == other.index_entries
+            && self.named_entries == other.named_entries
+            && self.css_type == other.css_type
+    }
+}
+
+pub(crate) const NAMED_INDEX_THRESHOLD: usize = 32;
+
+// parity: ES ArrayIndex — ToString(ToUint32(key)) == key and key != 2^32 - 1,
+// i.e. the canonical decimal form of an integer in [0, 2^32 - 1).
+pub fn array_index(key: &str) -> Option<u32> {
+    let bytes = key.as_bytes();
+    if bytes.is_empty() || bytes.len() > 10 || !bytes.iter().all(u8::is_ascii_digit) {
+        return None;
+    }
+    if bytes.len() > 1 && bytes[0] == b'0' {
+        return None;
+    }
+    let n: u64 = key.parse().ok()?;
+    if n >= u64::from(u32::MAX) {
+        return None;
+    }
+    Some(n as u32)
+}
+
+impl JsObjectMap {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn len(&self) -> usize {
+        self.index_entries.len() + self.named_entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.index_entries.is_empty() && self.named_entries.is_empty()
+    }
+
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.get(key).is_some()
+    }
+
+    pub fn get(&self, key: &str) -> Option<&EvalValue> {
+        if let Some(n) = array_index(key) {
+            self.index_entries
+                .binary_search_by_key(&n, |e| e.0)
+                .ok()
+                .map(|i| &self.index_entries[i].2)
+        } else if let Some(index) = &self.named_index {
+            index.get(key).map(|&i| &self.named_entries[i].1)
+        } else {
+            self.named_entries
+                .iter()
+                .find(|(k, _)| k == key)
+                .map(|(_, v)| v)
+        }
+    }
+
+    fn named_position(&mut self, key: &str) -> Option<usize> {
+        if self.named_index.is_none() && self.named_entries.len() >= NAMED_INDEX_THRESHOLD {
+            self.named_index = Some(Box::new(
+                self.named_entries
+                    .iter()
+                    .enumerate()
+                    .map(|(i, (k, _))| (k.clone(), i))
+                    .collect(),
+            ));
+        }
+        match &self.named_index {
+            Some(index) => index.get(key).copied(),
+            None => self.named_entries.iter().position(|(k, _)| k == key),
+        }
+    }
+
+    /// Returns the previous value when overwriting; an overwrite keeps the key's position.
+    pub fn insert(&mut self, key: impl Into<String>, value: EvalValue) -> Option<EvalValue> {
+        let key = key.into();
+        if let Some(n) = array_index(&key) {
+            match self.index_entries.binary_search_by_key(&n, |e| e.0) {
+                Ok(i) => Some(std::mem::replace(&mut self.index_entries[i].2, value)),
+                Err(i) => {
+                    self.index_entries.insert(i, (n, key, value));
+                    None
+                }
+            }
+        } else if let Some(i) = self.named_position(&key) {
+            Some(std::mem::replace(&mut self.named_entries[i].1, value))
+        } else {
+            if let Some(index) = &mut self.named_index {
+                index.insert(key.clone(), self.named_entries.len());
+            }
+            self.named_entries.push((key, value));
+            None
+        }
+    }
+
+    pub fn remove(&mut self, key: &str) -> Option<EvalValue> {
+        if let Some(n) = array_index(key) {
+            match self.index_entries.binary_search_by_key(&n, |e| e.0) {
+                Ok(i) => Some(self.index_entries.remove(i).2),
+                Err(_) => None,
+            }
+        } else {
+            let pos = self.named_position(key)?;
+            if let Some(index) = &mut self.named_index {
+                index.remove(key);
+                for i in index.values_mut() {
+                    if *i > pos {
+                        *i -= 1;
+                    }
+                }
+            }
+            Some(self.named_entries.remove(pos).1)
+        }
+    }
+
+    pub fn entries(&self) -> impl Iterator<Item = (&str, &EvalValue)> {
+        self.index_entries
+            .iter()
+            .map(|(_, k, v)| (k.as_str(), v))
+            .chain(self.named_entries.iter().map(|(k, v)| (k.as_str(), v)))
+    }
+
+    pub fn into_entries(self) -> impl Iterator<Item = (String, EvalValue)> {
+        self.index_entries
+            .into_iter()
+            .map(|(_, k, v)| (k, v))
+            .chain(self.named_entries)
+    }
+
+    pub fn keys(&self) -> impl Iterator<Item = &str> {
+        self.entries().map(|(k, _)| k)
+    }
+
+    pub fn css_type(&self) -> Option<&str> {
+        self.css_type.as_deref()
+    }
+
+    pub fn set_css_type(&mut self, syntax: String) {
+        self.css_type = Some(syntax);
+    }
+
+    pub fn to_json(&self) -> Value {
+        let mut map = serde_json::Map::new();
+        for (k, v) in self.entries() {
+            if matches!(v, EvalValue::Undefined) {
+                continue;
+            }
+            map.insert(k.to_string(), v.to_json());
+        }
+        Value::Object(map)
+    }
+}
+
+impl<K: Into<String>> FromIterator<(K, EvalValue)> for JsObjectMap {
+    fn from_iter<T: IntoIterator<Item = (K, EvalValue)>>(iter: T) -> Self {
+        let mut map = Self::new();
+        for (k, v) in iter {
+            map.insert(k, v);
+        }
+        map
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn s(v: &str) -> EvalValue {
+        EvalValue::Str(v.to_string())
+    }
+
+    fn key_vec(map: &JsObjectMap) -> Vec<&str> {
+        map.keys().collect()
+    }
+
+    #[test]
+    fn array_index_recognition() {
+        assert_eq!(array_index("0"), Some(0));
+        assert_eq!(array_index("2"), Some(2));
+        assert_eq!(array_index("10"), Some(10));
+        assert_eq!(array_index("4294967294"), Some(4294967294));
+        // 2^32 - 1 is a valid property key but NOT an array index per spec.
+        assert_eq!(array_index("4294967295"), None);
+        assert_eq!(array_index("4294967296"), None);
+        assert_eq!(array_index("02"), None);
+        assert_eq!(array_index("1.0"), None);
+        assert_eq!(array_index("-1"), None);
+        assert_eq!(array_index("+1"), None);
+        assert_eq!(array_index(""), None);
+        assert_eq!(array_index("00"), None);
+        assert_eq!(array_index("1e3"), None);
+        assert_eq!(array_index("a"), None);
+    }
+
+    #[test]
+    fn numeric_keys_sort_ascending_before_named_keys() {
+        let mut map = JsObjectMap::new();
+        map.insert("b", s("b"));
+        map.insert("10", s("ten"));
+        map.insert("a", s("a"));
+        map.insert("2", s("two"));
+        assert_eq!(key_vec(&map), vec!["2", "10", "b", "a"]);
+    }
+
+    #[test]
+    fn non_canonical_numeric_strings_keep_insertion_order() {
+        let mut map = JsObjectMap::new();
+        map.insert("02", s("x"));
+        map.insert("1", s("one"));
+        map.insert("1.0", s("y"));
+        map.insert("z", s("z"));
+        assert_eq!(key_vec(&map), vec!["1", "02", "1.0", "z"]);
+    }
+
+    #[test]
+    fn overwrite_keeps_position_and_returns_old() {
+        let mut map = JsObjectMap::new();
+        map.insert("a", s("1"));
+        map.insert("b", s("2"));
+        map.insert("c", s("3"));
+        assert_eq!(map.insert("a", s("updated")), Some(s("1")));
+        assert_eq!(key_vec(&map), vec!["a", "b", "c"]);
+        assert_eq!(map.get("a"), Some(&s("updated")));
+        assert_eq!(map.len(), 3);
+
+        map.insert("5", s("five"));
+        map.insert("3", s("three"));
+        assert_eq!(map.insert("5", s("FIVE")), Some(s("five")));
+        assert_eq!(key_vec(&map), vec!["3", "5", "a", "b", "c"]);
+        assert_eq!(map.get("5"), Some(&s("FIVE")));
+    }
+
+    #[test]
+    fn remove_and_len() {
+        let mut map = JsObjectMap::new();
+        map.insert("2", s("two"));
+        map.insert("x", s("x"));
+        map.insert("y", s("y"));
+        assert_eq!(map.remove("x"), Some(s("x")));
+        assert_eq!(map.remove("x"), None);
+        assert_eq!(map.remove("3"), None);
+        assert_eq!(map.remove("2"), Some(s("two")));
+        assert_eq!(key_vec(&map), vec!["y"]);
+        assert_eq!(map.len(), 1);
+        assert!(!map.is_empty());
+        assert!(map.contains_key("y"));
+        assert!(!map.contains_key("x"));
+    }
+
+    #[test]
+    fn iteration_is_stable_across_calls() {
+        let map: JsObjectMap = [
+            ("zeta", s("1")),
+            ("7", s("2")),
+            ("alpha", s("3")),
+            ("0", s("4")),
+        ]
+        .into_iter()
+        .collect();
+        let first: Vec<_> = map.entries().collect();
+        let second: Vec<_> = map.entries().collect();
+        assert_eq!(first, second);
+        assert_eq!(key_vec(&map), vec!["0", "7", "zeta", "alpha"]);
+    }
+
+    #[test]
+    fn wide_maps_keep_scan_semantics_past_the_index_threshold() {
+        let n = NAMED_INDEX_THRESHOLD * 3;
+        let mut map = JsObjectMap::new();
+        let mut scan = Vec::new();
+        for i in 0..n {
+            map.insert(format!("key{i}"), s(&i.to_string()));
+            scan.push((format!("key{i}"), s(&i.to_string())));
+        }
+        assert_eq!(map.insert("key5", s("updated")), Some(s("5")));
+        scan[5].1 = s("updated");
+        assert_eq!(map.remove("key7"), Some(s("7")));
+        assert_eq!(map.remove("key7"), None);
+        scan.remove(7);
+        map.insert("key7", s("readded"));
+        scan.push(("key7".to_string(), s("readded")));
+        let expected: Vec<(&str, &EvalValue)> = scan.iter().map(|(k, v)| (k.as_str(), v)).collect();
+        assert_eq!(map.entries().collect::<Vec<_>>(), expected);
+        assert_eq!(map.get("key5"), Some(&s("updated")));
+        assert_eq!(map.get("missing"), None);
+        let narrow: JsObjectMap = scan.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        assert_eq!(map, narrow);
+    }
+
+    #[test]
+    fn to_json_follows_json_stringify_semantics() {
+        let mut obj = JsObjectMap::new();
+        obj.insert("kept", EvalValue::Num(1.0));
+        obj.insert("dropped", EvalValue::Undefined);
+        obj.insert("nan", EvalValue::Num(f64::NAN));
+        obj.insert("frac", EvalValue::Num(0.5));
+        obj.insert(
+            "arr",
+            EvalValue::Arr(vec![EvalValue::Undefined, EvalValue::Null, s("v")]),
+        );
+        assert_eq!(
+            obj.to_json(),
+            json!({ "kept": 1, "nan": null, "frac": 0.5, "arr": [null, null, "v"] })
+        );
+        assert_eq!(EvalValue::Undefined.to_json(), Value::Null);
+    }
+
+    #[test]
+    fn from_json_roundtrip_reorders_index_keys() {
+        let v = json!({ "10": "ten", "2": "two", "name": "x" });
+        let EvalValue::Obj(map) = EvalValue::from_json(&v) else {
+            panic!("expected object");
+        };
+        assert_eq!(key_vec(&map), vec!["2", "10", "name"]);
+        assert_eq!(map.to_json(), v);
+    }
+}

--- a/crates/stylex/src/fxhash.rs
+++ b/crates/stylex/src/fxhash.rs
@@ -1,0 +1,86 @@
+//! FxHash (the rustc/Firefox hasher): multiply-xor over 8-byte chunks. Internal
+//! maps only — no iteration order reaches output (design-core §7 invariant).
+
+use std::hash::{BuildHasherDefault, Hasher};
+
+const SEED: u64 = 0x51_7c_c1_b7_27_22_0a_95;
+
+pub type FxBuildHasher = BuildHasherDefault<FxHasher>;
+pub type FxHashMap<K, V> = std::collections::HashMap<K, V, FxBuildHasher>;
+pub type FxHashSet<K> = std::collections::HashSet<K, FxBuildHasher>;
+
+#[derive(Default)]
+pub struct FxHasher {
+    hash: u64,
+}
+
+impl FxHasher {
+    #[inline]
+    fn add(&mut self, word: u64) {
+        self.hash = (self.hash.rotate_left(5) ^ word).wrapping_mul(SEED);
+    }
+}
+
+impl Hasher for FxHasher {
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        let mut chunks = bytes.chunks_exact(8);
+        for chunk in &mut chunks {
+            self.add(u64::from_le_bytes(chunk.try_into().expect("8-byte chunk")));
+        }
+        let tail = chunks.remainder();
+        if !tail.is_empty() {
+            let mut word = [0u8; 8];
+            word[..tail.len()].copy_from_slice(tail);
+            self.add(u64::from_le_bytes(word));
+        }
+    }
+
+    #[inline]
+    fn write_u8(&mut self, n: u8) {
+        self.add(u64::from(n));
+    }
+
+    #[inline]
+    fn write_u32(&mut self, n: u32) {
+        self.add(u64::from(n));
+    }
+
+    #[inline]
+    fn write_u64(&mut self, n: u64) {
+        self.add(n);
+    }
+
+    #[inline]
+    fn write_usize(&mut self, n: usize) {
+        self.add(n as u64);
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.hash
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hashes_are_stable_and_distinguish() {
+        let mut a = FxHasher::default();
+        std::hash::Hash::hash("color", &mut a);
+        let mut b = FxHasher::default();
+        std::hash::Hash::hash("color", &mut b);
+        let mut c = FxHasher::default();
+        std::hash::Hash::hash("colour", &mut c);
+        assert_eq!(a.finish(), b.finish());
+        assert_ne!(a.finish(), c.finish());
+        // str Hash writes the bytes plus a 0xff terminator: no prefix collisions.
+        let mut d = FxHasher::default();
+        std::hash::Hash::hash("col", &mut d);
+        let mut e = FxHasher::default();
+        std::hash::Hash::hash("col\0or", &mut e);
+        assert_ne!(d.finish(), e.finish());
+    }
+}

--- a/crates/stylex/src/hash.rs
+++ b/crates/stylex/src/hash.rs
@@ -1,0 +1,109 @@
+// Behavior-equivalent to stylex@0.19.0 babel-plugin/src/shared/hash.js: the JS
+// murmur reads UTF-16 code units masked to their low byte, with length in units.
+
+const M: u32 = 0x5bd1_e995;
+
+pub fn murmur2_32_gc(input: &str, seed: u32) -> u32 {
+    // ASCII fast path: UTF-16 units equal bytes (values and count), so the
+    // per-call Vec<u16> re-encode is pure allocation cost there.
+    if input.is_ascii() {
+        return murmur2_32_units(AsciiUnits(input.as_bytes()), seed);
+    }
+    let units: Vec<u16> = input.encode_utf16().collect();
+    murmur2_32_units(Utf16Units(&units), seed)
+}
+
+struct AsciiUnits<'a>(&'a [u8]);
+struct Utf16Units<'a>(&'a [u16]);
+
+trait Units {
+    fn len(&self) -> usize;
+    fn low_byte(&self, i: usize) -> u32;
+}
+
+impl Units for AsciiUnits<'_> {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+    #[inline]
+    fn low_byte(&self, i: usize) -> u32 {
+        u32::from(self.0[i])
+    }
+}
+
+impl Units for Utf16Units<'_> {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+    #[inline]
+    fn low_byte(&self, i: usize) -> u32 {
+        u32::from(self.0[i]) & 0xff
+    }
+}
+
+fn murmur2_32_units(units: impl Units, seed: u32) -> u32 {
+    let mut l = units.len();
+    let mut h = seed ^ (l as u32);
+    let mut i = 0usize;
+
+    while l >= 4 {
+        let mut k = units.low_byte(i)
+            | (units.low_byte(i + 1) << 8)
+            | (units.low_byte(i + 2) << 16)
+            | (units.low_byte(i + 3) << 24);
+        k = k.wrapping_mul(M);
+        k ^= k >> 24;
+        k = k.wrapping_mul(M);
+        h = h.wrapping_mul(M) ^ k;
+        i += 4;
+        l -= 4;
+    }
+
+    if l >= 3 {
+        h ^= units.low_byte(i + 2) << 16;
+    }
+    if l >= 2 {
+        h ^= units.low_byte(i + 1) << 8;
+    }
+    if l >= 1 {
+        h ^= units.low_byte(i);
+        h = h.wrapping_mul(M);
+    }
+
+    h ^= h >> 13;
+    h = h.wrapping_mul(M);
+    h ^= h >> 15;
+    h
+}
+
+pub fn to_base36(mut n: u32) -> String {
+    if n == 0 {
+        return "0".to_string();
+    }
+    const DIGITS: &[u8; 36] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+    let mut buf = [0u8; 7];
+    let mut idx = buf.len();
+    while n > 0 {
+        idx -= 1;
+        buf[idx] = DIGITS[(n % 36) as usize];
+        n /= 36;
+    }
+    String::from_utf8_lossy(&buf[idx..]).into_owned()
+}
+
+pub fn hash(s: &str) -> String {
+    to_base36(murmur2_32_gc(s, 1))
+}
+
+// Upstream's toBase62 returns "" for 0; replicated deliberately.
+pub fn create_short_hash(s: &str) -> String {
+    const DIGITS: &[u8; 62] = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    let mut n = murmur2_32_gc(s, 1) % 916_132_832;
+    let mut out: Vec<u8> = Vec::new();
+    while n > 0 {
+        out.push(DIGITS[(n % 62) as usize]);
+        n /= 62;
+    }
+    out.reverse();
+    String::from_utf8(out).expect("base62 digits are ASCII")
+}

--- a/crates/stylex/src/imports.rs
+++ b/crates/stylex/src/imports.rs
@@ -1,0 +1,640 @@
+//! Top-level import/require scan feeding the stylex binding tables.
+// parity: babel-plugin src/visitors/imports.js + src/index.js:76-91 (top level only)
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use oxc_ast::ast::{
+    BindingPattern, Expression, ImportDeclaration, ImportDeclarationSpecifier, ModuleExportName,
+    Program, PropertyKey, Statement, VariableDeclaration,
+};
+use oxc_span::Span;
+
+use crate::errors::StylexError;
+use crate::options::ResolvedOptions;
+
+pub const ATOMS_SOURCE: &str = "@stylexjs/atoms";
+
+/// `state.atomImports` marker for a default/namespace/require binding.
+pub const ATOM_NAMESPACE: &str = "*";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum StylexNamedImport {
+    Create,
+    Props,
+    Attrs,
+    Keyframes,
+    PositionTry,
+    ViewTransitionClass,
+    Include,
+    FirstThatWorks,
+    DefineVars,
+    DefineMarker,
+    DefineConsts,
+    CreateTheme,
+    Types,
+    When,
+    DefaultMarker,
+    Env,
+    DefineVarsNested,
+    DefineConstsNested,
+    CreateThemeNested,
+    Conditional,
+}
+
+impl StylexNamedImport {
+    pub fn from_imported_name(name: &str) -> Option<Self> {
+        Some(match name {
+            "create" => Self::Create,
+            "props" => Self::Props,
+            "attrs" => Self::Attrs,
+            "keyframes" => Self::Keyframes,
+            "positionTry" => Self::PositionTry,
+            "viewTransitionClass" => Self::ViewTransitionClass,
+            "include" => Self::Include,
+            "firstThatWorks" => Self::FirstThatWorks,
+            "defineVars" => Self::DefineVars,
+            "defineMarker" => Self::DefineMarker,
+            "defineConsts" => Self::DefineConsts,
+            "createTheme" => Self::CreateTheme,
+            "types" => Self::Types,
+            "when" => Self::When,
+            "defaultMarker" => Self::DefaultMarker,
+            "env" => Self::Env,
+            "unstable_defineVarsNested" => Self::DefineVarsNested,
+            "unstable_defineConstsNested" => Self::DefineConstsNested,
+            "unstable_createThemeNested" => Self::CreateThemeNested,
+            "unstable_conditional" => Self::Conditional,
+            _ => return None,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImportedSymbol {
+    Named(String),
+    Default,
+    Namespace,
+}
+
+/// One import binding as the evaluator sees it (every import declaration in
+/// the file, not just stylex sources).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportRecord {
+    pub local: String,
+    pub source: String,
+    pub imported: ImportedSymbol,
+    /// Span of the declaring ImportDeclaration; treeshake compensation inserts
+    /// exactly before it (babel `importPath.insertBefore`).
+    pub decl_span: Span,
+    /// Span of the declaration's source string literal (raw text incl. quotes).
+    pub source_span: Span,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ImportTable {
+    /// Locals bound to the whole stylex namespace (default/namespace/require).
+    pub stylex_namespaces: BTreeSet<String>,
+    /// The same locals in source order (upstream state.stylexImport is an
+    /// insertion-ordered Set; the sx fallback walks it in order).
+    pub stylex_namespace_order: Vec<String>,
+    /// Locals bound to individual stylex named imports.
+    pub named: BTreeMap<String, StylexNamedImport>,
+    /// Matched import-source specifiers (upstream `state.importPaths`).
+    pub import_paths: BTreeSet<String>,
+    /// Every value import binding in the file, keyed by local name.
+    pub all_imports: BTreeMap<String, ImportRecord>,
+    /// `state.atomImports`: local name → imported name, or [`ATOM_NAMESPACE`].
+    pub atom_imports: BTreeMap<String, String>,
+    /// Locals of every `@stylexjs/atoms` specifier, type-only ones included;
+    /// the atoms visitor's scope-binding fallback accepts these too.
+    pub atom_binding_locals: BTreeSet<String>,
+}
+
+impl ImportTable {
+    /// No stylex binding of any kind: nothing in the file can compile, so the
+    /// caller may skip semantic analysis entirely.
+    pub fn is_dormant(&self) -> bool {
+        self.stylex_namespaces.is_empty()
+            && self.named.is_empty()
+            && self.import_paths.is_empty()
+            && self.atom_imports.is_empty()
+            && self.atom_binding_locals.is_empty()
+    }
+
+    pub fn atom_import(&self, name: &str) -> Option<&str> {
+        self.atom_imports.get(name).map(String::as_str)
+    }
+
+    pub fn is_atom_binding_local(&self, name: &str) -> bool {
+        self.atom_binding_locals.contains(name)
+    }
+
+    fn add_stylex_namespace(&mut self, local: &str) {
+        if self.stylex_namespaces.insert(local.to_string()) {
+            self.stylex_namespace_order.push(local.to_string());
+        }
+    }
+
+    pub fn is_stylex_namespace(&self, name: &str) -> bool {
+        self.stylex_namespaces.contains(name)
+    }
+
+    pub fn named_binding(&self, name: &str) -> Option<StylexNamedImport> {
+        self.named.get(name).copied()
+    }
+
+    pub fn import_record(&self, local: &str) -> Option<&ImportRecord> {
+        self.all_imports.get(local)
+    }
+
+    /// Import records whose specifier passes the theme-file suffix check.
+    pub fn theme_file_imports<'t>(
+        &'t self,
+        theme_extension: &'t str,
+    ) -> impl Iterator<Item = &'t ImportRecord> {
+        self.all_imports.values().filter(move |r| {
+            crate::module_resolution::is_theme_specifier(&r.source, theme_extension)
+        })
+    }
+}
+
+pub fn scan_imports(
+    program: &Program<'_>,
+    options: &ResolvedOptions,
+) -> Result<ImportTable, StylexError> {
+    let mut table = ImportTable::default();
+    for statement in &program.body {
+        match statement {
+            Statement::ImportDeclaration(decl) => {
+                scan_import_declaration(decl, options, &mut table)?
+            }
+            Statement::VariableDeclaration(decl) => scan_requires(decl, options, &mut table)?,
+            _ => {}
+        }
+    }
+    Ok(table)
+}
+
+fn scan_import_declaration(
+    decl: &ImportDeclaration<'_>,
+    options: &ResolvedOptions,
+    table: &mut ImportTable,
+) -> Result<(), StylexError> {
+    let source = decl.source.value.as_str();
+    if source == ATOMS_SOURCE {
+        scan_atoms_declaration(decl, table);
+        return Ok(());
+    }
+    if decl.import_kind.is_type() {
+        return Ok(());
+    }
+    let Some(specifiers) = &decl.specifiers else {
+        return Ok(());
+    };
+    let is_stylex_source = options.is_import_source(source);
+    // `as` is subtractive: it turns off default, namespace and every other
+    // named import for this source, and turns on exactly one named export.
+    let alias = options.import_as(source);
+    for specifier in specifiers {
+        match specifier {
+            ImportDeclarationSpecifier::ImportDefaultSpecifier(spec) => {
+                let local = spec.local.name.to_string();
+                if is_stylex_source && alias.is_none() {
+                    table.import_paths.insert(source.to_string());
+                    table.add_stylex_namespace(&local);
+                }
+                table.all_imports.insert(
+                    local.clone(),
+                    ImportRecord {
+                        local,
+                        source: source.to_string(),
+                        imported: ImportedSymbol::Default,
+                        decl_span: decl.span,
+                        source_span: decl.source.span,
+                    },
+                );
+            }
+            ImportDeclarationSpecifier::ImportNamespaceSpecifier(spec) => {
+                let local = spec.local.name.to_string();
+                if is_stylex_source && alias.is_none() {
+                    table.import_paths.insert(source.to_string());
+                    table.add_stylex_namespace(&local);
+                }
+                table.all_imports.insert(
+                    local.clone(),
+                    ImportRecord {
+                        local,
+                        source: source.to_string(),
+                        imported: ImportedSymbol::Namespace,
+                        decl_span: decl.span,
+                        source_span: decl.source.span,
+                    },
+                );
+            }
+            ImportDeclarationSpecifier::ImportSpecifier(spec) => {
+                if spec.import_kind.is_type() {
+                    continue;
+                }
+                let imported = match &spec.imported {
+                    ModuleExportName::IdentifierName(id) => id.name.to_string(),
+                    ModuleExportName::StringLiteral(lit) => lit.value.to_string(),
+                    ModuleExportName::IdentifierReference(id) => id.name.to_string(),
+                };
+                let local = spec.local.name.to_string();
+                if is_stylex_source {
+                    match alias {
+                        Some(alias) if alias == imported => {
+                            table.import_paths.insert(source.to_string());
+                            table.add_stylex_namespace(&local);
+                        }
+                        Some(_) => {}
+                        None => {
+                            table.import_paths.insert(source.to_string());
+                            if let Some(binding) = StylexNamedImport::from_imported_name(&imported)
+                            {
+                                table.named.insert(local.clone(), binding);
+                            }
+                        }
+                    }
+                }
+                table.all_imports.insert(
+                    local.clone(),
+                    ImportRecord {
+                        local,
+                        source: source.to_string(),
+                        imported: ImportedSymbol::Named(imported),
+                        decl_span: decl.span,
+                        source_span: decl.source.span,
+                    },
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+// parity: imports.js ATOMS_SOURCES branch. `import type` locals are collected
+// anyway: the atoms visitor's scope-binding fallback still resolves them.
+fn scan_atoms_declaration(decl: &ImportDeclaration<'_>, table: &mut ImportTable) {
+    let Some(specifiers) = &decl.specifiers else {
+        return;
+    };
+    let type_only = decl.import_kind.is_type();
+    for specifier in specifiers {
+        let (local, imported) = match specifier {
+            ImportDeclarationSpecifier::ImportDefaultSpecifier(spec) => {
+                (spec.local.name.as_str(), ATOM_NAMESPACE.to_string())
+            }
+            ImportDeclarationSpecifier::ImportNamespaceSpecifier(spec) => {
+                (spec.local.name.as_str(), ATOM_NAMESPACE.to_string())
+            }
+            // An inline `type` specifier is not filtered out here upstream.
+            ImportDeclarationSpecifier::ImportSpecifier(spec) => (
+                spec.local.name.as_str(),
+                match &spec.imported {
+                    ModuleExportName::IdentifierName(id) => id.name.to_string(),
+                    ModuleExportName::StringLiteral(lit) => lit.value.to_string(),
+                    ModuleExportName::IdentifierReference(id) => id.name.to_string(),
+                },
+            ),
+        };
+        table.atom_binding_locals.insert(local.to_string());
+        if !type_only {
+            table.atom_imports.insert(local.to_string(), imported);
+        }
+    }
+}
+
+// parity: imports.js readRequires — top-level `const x = require('src')` only.
+fn scan_requires(
+    decl: &VariableDeclaration<'_>,
+    options: &ResolvedOptions,
+    table: &mut ImportTable,
+) -> Result<(), StylexError> {
+    for declarator in &decl.declarations {
+        let Some(Expression::CallExpression(call)) = &declarator.init else {
+            continue;
+        };
+        let Expression::Identifier(callee) = &call.callee else {
+            continue;
+        };
+        if callee.name != "require" || call.arguments.len() != 1 {
+            continue;
+        }
+        let Some(Expression::StringLiteral(source)) = call.arguments[0].as_expression() else {
+            continue;
+        };
+        let source = source.value.as_str();
+        if source == ATOMS_SOURCE {
+            scan_atoms_require(&declarator.id, table);
+            continue;
+        }
+        // readRequires never calls importAs: an aliased source still binds its
+        // namespace and its individual API names here. Not a bug to "fix".
+        if !options.is_import_source(source) {
+            continue;
+        }
+        table.import_paths.insert(source.to_string());
+        match &declarator.id {
+            BindingPattern::BindingIdentifier(id) => {
+                table.add_stylex_namespace(&id.name);
+            }
+            BindingPattern::ObjectPattern(pattern) => {
+                for property in &pattern.properties {
+                    let PropertyKey::StaticIdentifier(key) = &property.key else {
+                        continue;
+                    };
+                    let BindingPattern::BindingIdentifier(value) = &property.value else {
+                        continue;
+                    };
+                    if let Some(binding) = StylexNamedImport::from_imported_name(&key.name) {
+                        table.named.insert(value.name.to_string(), binding);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+// parity: imports.js readRequires ATOMS_SOURCES branch.
+fn scan_atoms_require(id: &BindingPattern<'_>, table: &mut ImportTable) {
+    match id {
+        BindingPattern::BindingIdentifier(name) => {
+            table
+                .atom_imports
+                .insert(name.name.to_string(), ATOM_NAMESPACE.to_string());
+        }
+        BindingPattern::ObjectPattern(pattern) => {
+            for property in &pattern.properties {
+                let PropertyKey::StaticIdentifier(key) = &property.key else {
+                    continue;
+                };
+                let BindingPattern::BindingIdentifier(value) = &property.value else {
+                    continue;
+                };
+                table
+                    .atom_imports
+                    .insert(value.name.to_string(), key.name.to_string());
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxc_allocator::Allocator;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    fn scan(source: &str) -> ImportTable {
+        let allocator = Allocator::default();
+        let ret = Parser::new(&allocator, source, SourceType::tsx()).parse();
+        assert!(!ret.panicked, "parse failed");
+        scan_imports(&ret.program, &ResolvedOptions::default()).unwrap()
+    }
+
+    #[test]
+    fn namespace_default_and_named_forms() {
+        let table = scan(
+            "import * as stylex from '@stylexjs/stylex';\n\
+             import sx from 'stylex';\n\
+             import { create, keyframes as kf, when } from '@stylexjs/stylex';\n\
+             import { helper } from './helpers';\n",
+        );
+        assert!(table.is_stylex_namespace("stylex"));
+        assert!(table.is_stylex_namespace("sx"));
+        assert_eq!(
+            table.named_binding("create"),
+            Some(StylexNamedImport::Create)
+        );
+        assert_eq!(
+            table.named_binding("kf"),
+            Some(StylexNamedImport::Keyframes)
+        );
+        assert_eq!(table.named_binding("when"), Some(StylexNamedImport::When));
+        assert_eq!(table.named_binding("helper"), None);
+        assert!(table.import_record("helper").is_some());
+        assert_eq!(
+            table.import_record("kf").unwrap().imported,
+            ImportedSymbol::Named("keyframes".to_string())
+        );
+        assert!(table.import_paths.contains("stylex"));
+        assert!(table.import_paths.contains("@stylexjs/stylex"));
+    }
+
+    #[test]
+    fn type_imports_are_skipped() {
+        let table = scan(
+            "import type { create } from '@stylexjs/stylex';\n\
+             import { type props, keyframes } from '@stylexjs/stylex';\n",
+        );
+        assert_eq!(table.named_binding("create"), None);
+        assert_eq!(table.named_binding("props"), None);
+        assert_eq!(
+            table.named_binding("keyframes"),
+            Some(StylexNamedImport::Keyframes)
+        );
+    }
+
+    #[test]
+    fn requires_top_level_only() {
+        let table = scan(
+            "const stylex = require('@stylexjs/stylex');\n\
+             const { create, props: p } = require('stylex');\n\
+             function f() { const nested = require('stylex'); }\n",
+        );
+        assert!(table.is_stylex_namespace("stylex"));
+        assert!(!table.is_stylex_namespace("nested"));
+        assert_eq!(
+            table.named_binding("create"),
+            Some(StylexNamedImport::Create)
+        );
+        assert_eq!(table.named_binding("p"), Some(StylexNamedImport::Props));
+    }
+
+    #[test]
+    fn custom_import_sources() {
+        let allocator = Allocator::default();
+        let ret = Parser::new(
+            &allocator,
+            "import * as css from 'foo-bar';\nimport * as other from 'baz';",
+            SourceType::tsx(),
+        )
+        .parse();
+        let options = crate::options::CompilerOptions::from_json(
+            &serde_json::json!({ "importSources": ["foo-bar"] }),
+        )
+        .unwrap()
+        .resolve()
+        .unwrap();
+        let table = scan_imports(&ret.program, &options).unwrap();
+        assert!(table.is_stylex_namespace("css"));
+        assert!(!table.is_stylex_namespace("other"));
+    }
+
+    fn scan_with(source: &str, options: serde_json::Value) -> ImportTable {
+        let allocator = Allocator::default();
+        let ret = Parser::new(&allocator, source, SourceType::tsx()).parse();
+        assert!(!ret.panicked, "parse failed");
+        let options = crate::options::CompilerOptions::from_json(&options)
+            .unwrap()
+            .resolve()
+            .unwrap();
+        scan_imports(&ret.program, &options).unwrap()
+    }
+
+    fn aliased(source: &str) -> ImportTable {
+        scan_with(
+            source,
+            serde_json::json!({ "importSources": [{ "from": "my-lib", "as": "css" }] }),
+        )
+    }
+
+    #[test]
+    fn aliased_source_binds_only_the_named_export() {
+        for (code, local) in [
+            ("import { css } from 'my-lib';", "css"),
+            ("import { css as sx } from 'my-lib';", "sx"),
+            ("import { 'css' as sx } from 'my-lib';", "sx"),
+        ] {
+            let table = aliased(code);
+            assert!(table.is_stylex_namespace(local), "{code}");
+            assert!(table.import_paths.contains("my-lib"), "{code}");
+        }
+        // `as` is subtractive for everything else on that source.
+        for code in [
+            "import * as css from 'my-lib';",
+            "import css from 'my-lib';",
+            "import { create } from 'my-lib';",
+            "import type { css } from 'my-lib';",
+            "export { css } from 'my-lib';",
+        ] {
+            let table = aliased(code);
+            assert!(table.is_dormant(), "{code}");
+        }
+        // Mixed declarations register only the matching specifier.
+        let table = aliased("import d, { css, create } from 'my-lib';");
+        assert!(table.is_stylex_namespace("css"));
+        assert!(!table.is_stylex_namespace("d"));
+        assert_eq!(table.named_binding("create"), None);
+        // The same export under two locals registers both.
+        let table = aliased("import { css, css as sx } from 'my-lib';");
+        assert!(table.is_stylex_namespace("css"));
+        assert!(table.is_stylex_namespace("sx"));
+    }
+
+    #[test]
+    fn require_ignores_the_alias() {
+        let table = aliased("const css = require('my-lib');");
+        assert!(table.is_stylex_namespace("css"));
+        let table = aliased("const { create } = require('my-lib');");
+        assert_eq!(
+            table.named_binding("create"),
+            Some(StylexNamedImport::Create)
+        );
+        // `css` is not an API name, so the destructure path drops it.
+        let table = aliased("const { css } = require('my-lib');");
+        assert!(!table.is_stylex_namespace("css"));
+        assert_eq!(table.named_binding("css"), None);
+    }
+
+    #[test]
+    fn aliased_and_plain_sources_are_independent() {
+        let table = scan_with(
+            "import { css } from 'my-lib';\nimport * as stylex from 'other-lib';\n",
+            serde_json::json!({
+                "importSources": [{ "from": "my-lib", "as": "css" }, "other-lib"]
+            }),
+        );
+        assert!(table.is_stylex_namespace("css"));
+        assert!(table.is_stylex_namespace("stylex"));
+        // Matching is raw-string equality on the specifier.
+        let table = aliased("import { css } from 'my-lib/css';");
+        assert!(table.is_dormant());
+        // Overriding a built-in switches it to the aliased form too.
+        let table = scan_with(
+            "import * as stylex from '@stylexjs/stylex';\nimport { css } from '@stylexjs/stylex';\n",
+            serde_json::json!({
+                "importSources": [{ "from": "@stylexjs/stylex", "as": "css" }]
+            }),
+        );
+        assert!(!table.is_stylex_namespace("stylex"));
+        assert!(table.is_stylex_namespace("css"));
+    }
+
+    #[test]
+    fn atom_import_forms() {
+        let table = scan(
+            "import d from '@stylexjs/atoms';\n\
+             import * as ns from '@stylexjs/atoms';\n\
+             import { color, 'padding' as p, type gap, default as def } from '@stylexjs/atoms';\n\
+             const r = require('@stylexjs/atoms');\n\
+             let l = require('@stylexjs/atoms');\n\
+             const { color: c2, width } = require('@stylexjs/atoms');\n",
+        );
+        let got: Vec<(&str, &str)> = table
+            .atom_imports
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+        assert_eq!(
+            got,
+            vec![
+                ("c2", "color"),
+                ("color", "color"),
+                ("d", "*"),
+                ("def", "default"),
+                ("gap", "gap"),
+                ("l", "*"),
+                ("ns", "*"),
+                ("p", "padding"),
+                ("r", "*"),
+                ("width", "width"),
+            ]
+        );
+        assert!(!table.is_dormant());
+        assert!(table.import_paths.is_empty());
+    }
+
+    #[test]
+    fn type_atom_imports_bind_without_atom_imports_entries() {
+        let table = scan("import type x from '@stylexjs/atoms';\nexport const a = x.display;\n");
+        assert!(table.atom_imports.is_empty());
+        assert!(table.is_atom_binding_local("x"));
+        assert!(!table.is_dormant());
+    }
+
+    #[test]
+    fn atoms_specifier_is_matched_literally() {
+        for source in [
+            "import x from '@stylexjs/atoms/';",
+            "import x from '@stylexjs/atoms/babel-transform';",
+            "export { color } from '@stylexjs/atoms';",
+            "const x = require('@stylexjs/atoms').default;",
+            "function f() { const x = require('@stylexjs/atoms'); }",
+        ] {
+            let table = scan(source);
+            assert!(table.atom_imports.is_empty(), "{source}");
+            assert!(table.atom_binding_locals.is_empty(), "{source}");
+        }
+    }
+
+    #[test]
+    fn theme_file_imports_are_listed() {
+        let table = scan(
+            "import { colors } from './tokens.stylex';\n\
+             import { sizes } from './sizes.stylex.const';\n\
+             import { helper } from './helpers';\n",
+        );
+        let themed: Vec<&str> = table
+            .theme_file_imports(crate::module_resolution::THEME_FILE_EXTENSION)
+            .map(|r| r.local.as_str())
+            .collect();
+        assert_eq!(themed, vec!["colors", "sizes"]);
+    }
+}

--- a/crates/stylex/src/jsrt.rs
+++ b/crates/stylex/src/jsrt.rs
@@ -1,0 +1,485 @@
+use std::cmp::Ordering;
+
+pub fn js_number_to_string(x: f64) -> String {
+    if x.is_nan() {
+        return "NaN".to_string();
+    }
+    if x.is_infinite() {
+        return if x > 0.0 { "Infinity" } else { "-Infinity" }.to_string();
+    }
+    let mut buf = ryu_js::Buffer::new();
+    buf.format(x).to_string()
+}
+
+// ES Math.round: nearest integer, ties toward +Infinity (not half-away-from-zero).
+// Rounding into zero from x in [-0.5, 0) yields -0, matching JS.
+pub fn js_math_round(x: f64) -> f64 {
+    if !x.is_finite() || x == 0.0 || x.fract() == 0.0 {
+        return x;
+    }
+    let f = x.floor();
+    let r = if x - f >= 0.5 { f + 1.0 } else { f };
+    if r == 0.0 && x < 0.0 { -0.0 } else { r }
+}
+
+#[cfg(test)]
+mod round_tests {
+    use super::js_math_round;
+
+    #[test]
+    fn negative_zero_and_ties() {
+        assert!(js_math_round(-0.1).is_sign_negative());
+        assert!(js_math_round(-0.5).is_sign_negative());
+        assert_eq!(js_math_round(-0.5), 0.0);
+        assert_eq!(js_math_round(0.5), 1.0);
+        assert_eq!(js_math_round(2.5), 3.0);
+        assert_eq!(js_math_round(-2.5), -2.0);
+        assert_eq!(js_math_round(0.49999999999999994), 0.0);
+    }
+}
+
+// JS default string comparison (`<`, Array.prototype.sort) is UTF-16 code-unit
+// order, which diverges from Rust's `str` Ord for astral-plane characters.
+pub fn utf16_cmp(a: &str, b: &str) -> Ordering {
+    a.encode_utf16().cmp(b.encode_utf16())
+}
+
+// JS String.prototype.slice indexes UTF-16 code units; byte slicing panics on
+// multibyte boundaries. Negative end counts from the end, as in JS.
+pub fn js_slice_utf16(s: &str, start: usize, end: isize) -> String {
+    let units: Vec<u16> = s.encode_utf16().collect();
+    let len = units.len() as isize;
+    let end = if end < 0 {
+        (len + end).max(0)
+    } else {
+        end.min(len)
+    } as usize;
+    if start >= end {
+        return String::new();
+    }
+    String::from_utf16_lossy(&units[start..end])
+}
+
+/// A slice boundary split a surrogate pair: the doctrine is loud over lossy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LoneSurrogate;
+
+/// `js_slice_utf16` that refuses to manufacture lone surrogates.
+pub fn js_slice_utf16_checked(s: &str, start: usize, end: isize) -> Result<String, LoneSurrogate> {
+    let units: Vec<u16> = s.encode_utf16().collect();
+    let len = units.len() as isize;
+    let end = if end < 0 {
+        (len + end).max(0)
+    } else {
+        end.min(len)
+    } as usize;
+    if start >= end {
+        return Ok(String::new());
+    }
+    String::from_utf16(&units[start..end]).map_err(|_| LoneSurrogate)
+}
+
+/// JS Number.prototype.toFixed: the spec strips the sign first, then rounds
+/// the exact decimal expansion half-up (ties pick the larger n).
+pub fn js_to_fixed(x: f64, digits: usize) -> String {
+    if x.is_nan() {
+        return "NaN".to_string();
+    }
+    if x.abs() >= 1e21 || x.is_infinite() {
+        return js_number_to_string(x);
+    }
+    let negative = x.is_sign_negative() && x != 0.0;
+    // 1100 fractional digits covers the exact expansion of any finite f64.
+    let exact = format!("{:.1100}", x.abs());
+    let (int_part, frac_part) = exact.split_once('.').unwrap_or((exact.as_str(), ""));
+    let mut int_digits: Vec<u8> = int_part.bytes().map(|b| b - b'0').collect();
+    let mut frac_digits: Vec<u8> = frac_part.bytes().map(|b| b - b'0').collect();
+    frac_digits.resize(1101.max(digits + 1), 0);
+    let kept = frac_digits[..digits].to_vec();
+    let rest = &frac_digits[digits..];
+    let first = rest.first().copied().unwrap_or(0);
+    let round_up = first >= 5;
+    let mut frac = kept;
+    if round_up {
+        let mut carry = 1u8;
+        for digit in frac.iter_mut().rev() {
+            let sum = *digit + carry;
+            *digit = sum % 10;
+            carry = sum / 10;
+            if carry == 0 {
+                break;
+            }
+        }
+        if carry > 0 {
+            for digit in int_digits.iter_mut().rev() {
+                let sum = *digit + carry;
+                *digit = sum % 10;
+                carry = sum / 10;
+                if carry == 0 {
+                    break;
+                }
+            }
+            if carry > 0 {
+                int_digits.insert(0, carry);
+            }
+        }
+    }
+    let int_str: String = int_digits.iter().map(|d| (d + b'0') as char).collect();
+    let int_str = int_str.trim_start_matches('0');
+    let int_str = if int_str.is_empty() { "0" } else { int_str };
+    // JS keeps the sign of tiny negatives ("-0.00"); literal -0 stays "0.00".
+    let sign = if negative { "-" } else { "" };
+    if digits == 0 {
+        format!("{sign}{int_str}")
+    } else {
+        let frac_str: String = frac.iter().map(|d| (d + b'0') as char).collect();
+        format!("{sign}{int_str}.{frac_str}")
+    }
+}
+
+#[cfg(test)]
+mod to_fixed_tests {
+    use super::js_to_fixed;
+
+    #[test]
+    fn ties_round_half_up_on_the_magnitude() {
+        // 0.125 and ±2.5 are exactly representable: true ties (node-pinned).
+        assert_eq!(js_to_fixed(0.125, 2), "0.13");
+        assert_eq!(js_to_fixed(-0.125, 2), "-0.13");
+        // 1.005 is stored below the tie, so it rounds down (JS "1.00").
+        assert_eq!(js_to_fixed(1.005, 2), "1.00");
+        assert_eq!(js_to_fixed(1.5, 0), "2");
+        assert_eq!(js_to_fixed(2.5, 0), "3");
+        assert_eq!(js_to_fixed(-2.5, 0), "-3");
+        assert_eq!(js_to_fixed(1.0, 2), "1.00");
+        assert_eq!(js_to_fixed(0.0, 2), "0.00");
+        assert_eq!(js_to_fixed(-0.0, 2), "0.00");
+        assert_eq!(js_to_fixed(-0.004, 2), "-0.00");
+        assert_eq!(js_to_fixed(f64::NAN, 2), "NaN");
+        assert_eq!(js_to_fixed(1.45, 1), "1.4");
+        assert_eq!(js_to_fixed(9.995, 2), "9.99");
+        assert_eq!(js_to_fixed(0.999, 2), "1.00");
+    }
+}
+
+/// A character outside the collation alphabet verified against Node's ICU
+/// (testdata/pins/collation.json); `locale_cmp` refuses to guess its order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnverifiedChar(pub char);
+
+// (primary, secondary, tertiary) per char; ranks transcribed from the pinned
+// `groups` in collation.json (gen-pins-collation.mjs, node en-US ICU).
+pub(crate) fn locale_key(c: char) -> Result<(u8, u8, u8), UnverifiedChar> {
+    let key = match c {
+        ' ' => (0, 0, 0),
+        '_' => (1, 0, 0),
+        '-' => (2, 0, 0),
+        '–' => (3, 0, 0),
+        '—' => (4, 0, 0),
+        ',' => (5, 0, 0),
+        ';' => (6, 0, 0),
+        ':' => (7, 0, 0),
+        '!' => (8, 0, 0),
+        '¡' => (9, 0, 0),
+        '?' => (10, 0, 0),
+        '¿' => (11, 0, 0),
+        '.' => (12, 0, 0),
+        '·' => (13, 0, 0),
+        '\'' => (14, 0, 0),
+        '‘' => (14, 1, 0),
+        '’' => (14, 2, 0),
+        '‹' => (15, 0, 0),
+        '›' => (16, 0, 0),
+        '"' => (17, 0, 0),
+        '“' => (17, 1, 0),
+        '”' => (17, 2, 0),
+        '«' => (18, 0, 0),
+        '»' => (19, 0, 0),
+        '(' => (20, 0, 0),
+        ')' => (21, 0, 0),
+        '[' => (22, 0, 0),
+        ']' => (23, 0, 0),
+        '{' => (24, 0, 0),
+        '}' => (25, 0, 0),
+        '§' => (26, 0, 0),
+        '¶' => (27, 0, 0),
+        '@' => (28, 0, 0),
+        '*' => (29, 0, 0),
+        '/' => (30, 0, 0),
+        '\\' => (31, 0, 0),
+        '&' => (32, 0, 0),
+        '#' => (33, 0, 0),
+        '%' => (34, 0, 0),
+        '‰' => (35, 0, 0),
+        '†' => (36, 0, 0),
+        '‡' => (37, 0, 0),
+        '•' => (38, 0, 0),
+        '″' => (39, 0, 0),
+        '`' => (40, 0, 0),
+        '´' => (41, 0, 0),
+        '^' => (42, 0, 0),
+        '¯' => (43, 0, 0),
+        '¨' => (44, 0, 0),
+        '¸' => (45, 0, 0),
+        '°' => (46, 0, 0),
+        '©' => (47, 0, 0),
+        '®' => (48, 0, 0),
+        '←' => (49, 0, 0),
+        '→' => (50, 0, 0),
+        '↔' => (51, 0, 0),
+        '⇒' => (52, 0, 0),
+        '+' => (53, 0, 0),
+        '±' => (54, 0, 0),
+        '÷' => (55, 0, 0),
+        '×' => (56, 0, 0),
+        '<' => (57, 0, 0),
+        '=' => (58, 0, 0),
+        '≠' => (58, 1, 0),
+        '>' => (59, 0, 0),
+        '¬' => (60, 0, 0),
+        '|' => (61, 0, 0),
+        '¦' => (62, 0, 0),
+        '~' => (63, 0, 0),
+        '∞' => (64, 0, 0),
+        '≈' => (65, 0, 0),
+        '≤' => (66, 0, 0),
+        '≥' => (67, 0, 0),
+        '★' => (68, 0, 0),
+        '☆' => (69, 0, 0),
+        '♠' => (70, 0, 0),
+        '♣' => (71, 0, 0),
+        '♥' => (72, 0, 0),
+        '♦' => (73, 0, 0),
+        '✓' => (74, 0, 0),
+        '✗' => (75, 0, 0),
+        '✨' => (76, 0, 0),
+        '❤' => (77, 0, 0),
+        '⭐' => (78, 0, 0),
+        '🎉' => (79, 0, 0),
+        '👍' => (80, 0, 0),
+        '💯' => (81, 0, 0),
+        '🔥' => (82, 0, 0),
+        '🦄' => (83, 0, 0),
+        '😀' => (84, 0, 0),
+        '🚀' => (85, 0, 0),
+        '¤' => (86, 0, 0),
+        '¢' => (87, 0, 0),
+        '$' => (88, 0, 0),
+        '£' => (89, 0, 0),
+        '¥' => (90, 0, 0),
+        '€' => (91, 0, 0),
+        '0' => (92, 0, 0),
+        '1' => (93, 0, 0),
+        '2' => (94, 0, 0),
+        '²' => (94, 0, 1),
+        '3' => (95, 0, 0),
+        '³' => (95, 0, 1),
+        '4' => (96, 0, 0),
+        '5' => (97, 0, 0),
+        '6' => (98, 0, 0),
+        '7' => (99, 0, 0),
+        '8' => (100, 0, 0),
+        '9' => (101, 0, 0),
+        'a' => (102, 0, 0),
+        'A' => (102, 0, 1),
+        'ª' => (102, 0, 2),
+        'á' => (102, 1, 0),
+        'Á' => (102, 1, 1),
+        'à' => (102, 2, 0),
+        'À' => (102, 2, 1),
+        'â' => (102, 3, 0),
+        'Â' => (102, 3, 1),
+        'å' => (102, 4, 0),
+        'Å' => (102, 4, 1),
+        'ä' => (102, 5, 0),
+        'Ä' => (102, 5, 1),
+        'ã' => (102, 6, 0),
+        'Ã' => (102, 6, 1),
+        'b' => (103, 0, 0),
+        'B' => (103, 0, 1),
+        'c' => (104, 0, 0),
+        'C' => (104, 0, 1),
+        'ç' => (104, 1, 0),
+        'Ç' => (104, 1, 1),
+        'd' => (105, 0, 0),
+        'D' => (105, 0, 1),
+        'ð' => (105, 1, 0),
+        'Ð' => (105, 1, 1),
+        'e' => (106, 0, 0),
+        'E' => (106, 0, 1),
+        'é' => (106, 1, 0),
+        'É' => (106, 1, 1),
+        'è' => (106, 2, 0),
+        'È' => (106, 2, 1),
+        'ê' => (106, 3, 0),
+        'Ê' => (106, 3, 1),
+        'ë' => (106, 4, 0),
+        'Ë' => (106, 4, 1),
+        'f' => (107, 0, 0),
+        'F' => (107, 0, 1),
+        'g' => (108, 0, 0),
+        'G' => (108, 0, 1),
+        'h' => (109, 0, 0),
+        'H' => (109, 0, 1),
+        'i' => (110, 0, 0),
+        'I' => (110, 0, 1),
+        'í' => (110, 1, 0),
+        'Í' => (110, 1, 1),
+        'ì' => (110, 2, 0),
+        'Ì' => (110, 2, 1),
+        'î' => (110, 3, 0),
+        'Î' => (110, 3, 1),
+        'ï' => (110, 4, 0),
+        'Ï' => (110, 4, 1),
+        'j' => (111, 0, 0),
+        'J' => (111, 0, 1),
+        'k' => (112, 0, 0),
+        'K' => (112, 0, 1),
+        'l' => (113, 0, 0),
+        'L' => (113, 0, 1),
+        'm' => (114, 0, 0),
+        'M' => (114, 0, 1),
+        'n' => (115, 0, 0),
+        'N' => (115, 0, 1),
+        'ñ' => (115, 1, 0),
+        'Ñ' => (115, 1, 1),
+        'o' => (116, 0, 0),
+        'O' => (116, 0, 1),
+        'º' => (116, 0, 2),
+        'ó' => (116, 1, 0),
+        'Ó' => (116, 1, 1),
+        'ò' => (116, 2, 0),
+        'Ò' => (116, 2, 1),
+        'ô' => (116, 3, 0),
+        'Ô' => (116, 3, 1),
+        'ö' => (116, 4, 0),
+        'Ö' => (116, 4, 1),
+        'õ' => (116, 5, 0),
+        'Õ' => (116, 5, 1),
+        'ø' => (116, 6, 0),
+        'Ø' => (116, 6, 1),
+        'p' => (117, 0, 0),
+        'P' => (117, 0, 1),
+        'q' => (118, 0, 0),
+        'Q' => (118, 0, 1),
+        'r' => (119, 0, 0),
+        'R' => (119, 0, 1),
+        's' => (120, 0, 0),
+        'S' => (120, 0, 1),
+        't' => (121, 0, 0),
+        'T' => (121, 0, 1),
+        'u' => (122, 0, 0),
+        'U' => (122, 0, 1),
+        'ú' => (122, 1, 0),
+        'Ú' => (122, 1, 1),
+        'ù' => (122, 2, 0),
+        'Ù' => (122, 2, 1),
+        'û' => (122, 3, 0),
+        'Û' => (122, 3, 1),
+        'ü' => (122, 4, 0),
+        'Ü' => (122, 4, 1),
+        'v' => (123, 0, 0),
+        'V' => (123, 0, 1),
+        'w' => (124, 0, 0),
+        'W' => (124, 0, 1),
+        'x' => (125, 0, 0),
+        'X' => (125, 0, 1),
+        'y' => (126, 0, 0),
+        'Y' => (126, 0, 1),
+        'ý' => (126, 1, 0),
+        'Ý' => (126, 1, 1),
+        'ÿ' => (126, 2, 0),
+        'z' => (127, 0, 0),
+        'Z' => (127, 0, 1),
+        'þ' => (128, 0, 0),
+        'Þ' => (128, 0, 1),
+        'α' => (129, 0, 0),
+        'β' => (130, 0, 0),
+        'γ' => (131, 0, 0),
+        'δ' => (132, 0, 0),
+        'µ' => (133, 0, 0),
+        'π' => (134, 0, 0),
+        'Ω' => (135, 0, 0),
+        'а' => (136, 0, 0),
+        'б' => (137, 0, 0),
+        'в' => (138, 0, 0),
+        '中' => (139, 0, 0),
+        '日' => (140, 0, 0),
+        _ => return Err(UnverifiedChar(c)),
+    };
+    Ok(key)
+}
+
+/// JS localeCompare as the oracle's node runs it: whole-string primary,
+/// secondary (accents), then tertiary (case, quote shape) passes.
+pub fn locale_cmp(a: &str, b: &str) -> Result<Ordering, UnverifiedChar> {
+    let ka = a.chars().map(locale_key).collect::<Result<Vec<_>, _>>()?;
+    let kb = b.chars().map(locale_key).collect::<Result<Vec<_>, _>>()?;
+    let primary = ka.iter().map(|k| k.0).cmp(kb.iter().map(|k| k.0));
+    if primary != Ordering::Equal {
+        return Ok(primary);
+    }
+    let secondary = ka.iter().map(|k| k.1).cmp(kb.iter().map(|k| k.1));
+    if secondary != Ordering::Equal {
+        return Ok(secondary);
+    }
+    Ok(ka.iter().map(|k| k.2).cmp(kb.iter().map(|k| k.2)))
+}
+
+/// The one localeCompare stand-in for rule and pseudo sorting; outside the
+/// verified alphabet it falls back to UTF-16 order (divergence risk vs ICU).
+pub fn default_locale_cmp(a: &str, b: &str) -> Ordering {
+    locale_cmp(a, b).unwrap_or_else(|UnverifiedChar(_)| utf16_cmp(a, b))
+}
+
+/// First char the pinned collation cannot order; hash-feeding sorts hard-error
+/// on it instead of guessing (r4#4 policy), non-hash sorts keep the fallback.
+pub fn unverified_collation_char(s: &str) -> Option<char> {
+    s.chars().find(|&c| locale_key(c).is_err())
+}
+
+// ES TrimString WhiteSpace + LineTerminator: WhiteSpace is TAB VT FF SP NBSP
+// ZWNBSP(FEFF) + Zs; LineTerminator is LF CR LS PS. NEL (U+0085) is excluded.
+pub fn is_js_whitespace(c: char) -> bool {
+    matches!(
+        c,
+        '\u{2000}'
+            ..='\u{200A}'
+                | '\u{0009}'
+                | '\u{000A}'
+                | '\u{000B}'
+                | '\u{000C}'
+                | '\u{000D}'
+                | '\u{0020}'
+                | '\u{00A0}'
+                | '\u{1680}'
+                | '\u{2028}'
+                | '\u{2029}'
+                | '\u{202F}'
+                | '\u{205F}'
+                | '\u{3000}'
+                | '\u{FEFF}'
+    )
+}
+
+pub fn js_trim(s: &str) -> &str {
+    s.trim_matches(is_js_whitespace)
+}
+
+#[cfg(test)]
+mod js_trim_tests {
+    use super::js_trim;
+
+    #[test]
+    fn trims_es_whitespace_rust_trim_misses() {
+        assert_eq!(js_trim("\u{FEFF}--real\u{FEFF}"), "--real");
+        assert_eq!(js_trim(" \u{FEFF}\u{00A0}x\u{2028}\u{2029} "), "x");
+        assert_eq!("\u{FEFF}x".trim(), "\u{FEFF}x");
+    }
+
+    #[test]
+    fn keeps_nel_rust_trim_removes() {
+        assert_eq!(js_trim("\u{0085}x\u{0085}"), "\u{0085}x\u{0085}");
+        assert_eq!("\u{0085}x".trim(), "x");
+    }
+}

--- a/crates/stylex/src/jsrt.rs
+++ b/crates/stylex/src/jsrt.rs
@@ -1,14 +1,30 @@
 use std::cmp::Ordering;
 
-pub fn js_number_to_string(x: f64) -> String {
+fn non_finite_text(x: f64) -> Option<&'static str> {
     if x.is_nan() {
-        return "NaN".to_string();
+        Some("NaN")
+    } else if x.is_infinite() {
+        Some(if x > 0.0 { "Infinity" } else { "-Infinity" })
+    } else {
+        None
     }
-    if x.is_infinite() {
-        return if x > 0.0 { "Infinity" } else { "-Infinity" }.to_string();
+}
+
+pub fn js_number_to_string(x: f64) -> String {
+    if let Some(text) = non_finite_text(x) {
+        return text.to_string();
     }
     let mut buf = ryu_js::Buffer::new();
     buf.format(x).to_string()
+}
+
+pub fn write_js_number(x: f64, out: &mut String) {
+    if let Some(text) = non_finite_text(x) {
+        out.push_str(text);
+        return;
+    }
+    let mut buf = ryu_js::Buffer::new();
+    out.push_str(buf.format(x));
 }
 
 // ES Math.round: nearest integer, ties toward +Infinity (not half-away-from-zero).
@@ -169,7 +185,7 @@ pub struct UnverifiedChar(pub char);
 
 // (primary, secondary, tertiary) per char; ranks transcribed from the pinned
 // `groups` in collation.json (gen-pins-collation.mjs, node en-US ICU).
-pub(crate) fn locale_key(c: char) -> Result<(u8, u8, u8), UnverifiedChar> {
+pub(crate) const fn locale_key(c: char) -> Result<(u8, u8, u8), UnverifiedChar> {
     let key = match c {
         ' ' => (0, 0, 0),
         '_' => (1, 0, 0),
@@ -408,6 +424,35 @@ pub(crate) fn locale_key(c: char) -> Result<(u8, u8, u8), UnverifiedChar> {
         _ => return Err(UnverifiedChar(c)),
     };
     Ok(key)
+}
+
+// 256 wide so a byte index needs no bounds check; only ASCII strings read it.
+pub(crate) static ASCII_LOCALE_KEYS: [Option<(u8, u8, u8)>; 256] = {
+    let mut table = [None; 256];
+    let mut b = 0usize;
+    while b < 128 {
+        table[b] = match locale_key(b as u8 as char) {
+            Ok(key) => Some(key),
+            Err(_) => None,
+        };
+        b += 1;
+    }
+    table
+};
+
+#[cfg(test)]
+mod ascii_locale_key_tests {
+    use super::{ASCII_LOCALE_KEYS, locale_key};
+
+    #[test]
+    fn table_matches_locale_key_for_every_byte() {
+        for b in 0..=255u8 {
+            let want = (b < 128).then(|| locale_key(b as char).ok()).flatten();
+            assert_eq!(ASCII_LOCALE_KEYS[usize::from(b)], want, "byte {b:#x}");
+        }
+        assert!(ASCII_LOCALE_KEYS[usize::from(b'a')].is_some());
+        assert!(ASCII_LOCALE_KEYS[usize::from(b'{')].is_some());
+    }
 }
 
 /// JS localeCompare as the oracle's node runs it: whole-string primary,

--- a/crates/stylex/src/lib.rs
+++ b/crates/stylex/src/lib.rs
@@ -10,6 +10,7 @@ pub mod jsrt;
 pub mod module_resolution;
 pub mod options;
 pub mod rules;
+pub mod scopes;
 pub mod state;
 pub mod timings;
 

--- a/crates/stylex/src/lib.rs
+++ b/crates/stylex/src/lib.rs
@@ -1,0 +1,52 @@
+pub mod api;
+pub mod assemble;
+pub mod cache;
+pub mod errors;
+pub mod eval;
+pub mod fxhash;
+pub mod hash;
+pub mod imports;
+pub mod jsrt;
+pub mod module_resolution;
+pub mod options;
+pub mod rules;
+pub mod state;
+pub mod timings;
+
+pub mod transform {
+    pub mod ast_backend;
+    pub mod atoms;
+    pub mod dce;
+    pub mod js_out;
+    pub mod merge;
+    pub mod visitor;
+}
+
+pub mod shared {
+    pub mod create;
+    pub mod create_theme;
+    pub mod css_value;
+    pub mod dashify;
+    pub mod define_consts;
+    pub mod define_vars;
+    pub mod dev_naming;
+    pub mod dynamic;
+    pub mod fallbacks;
+    pub mod flatten;
+    pub mod generate_rule;
+    pub mod keyframes;
+    pub mod markers;
+    pub mod media_query;
+    pub mod nested;
+    pub mod normalize_value;
+    pub mod position_try;
+    pub mod priorities;
+    pub mod pseudo_sort;
+    pub mod resolution;
+    pub mod rtl;
+    pub mod split_css_value;
+    pub mod transform_value;
+    pub mod types;
+    pub mod view_transition;
+    pub mod when;
+}

--- a/crates/stylex/src/module_resolution.rs
+++ b/crates/stylex/src/module_resolution.rs
@@ -2,8 +2,12 @@
 // parity: babel-plugin src/utils/state-manager.js:566-707 + file-based-identifier.js
 
 use std::path::{Component, Path, PathBuf};
+use std::sync::{LazyLock, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::time::SystemTime;
 
+use crate::fxhash::FxHashMap;
 use crate::options::{AliasMap, ModuleResolutionType, ResolvedOptions};
+use crate::timings::{self, Stage};
 
 // parity: state-manager.js EXTENSIONS — probe order is observable via hashes.
 pub const EXTENSIONS: [&str; 6] = [".js", ".ts", ".tsx", ".jsx", ".mjs", ".cjs"];
@@ -75,6 +79,7 @@ pub struct StdFs;
 
 impl FsProvider for StdFs {
     fn nearest_package(&self, from: &Path) -> Option<(String, PathBuf)> {
+        let _t = timings::start(Stage::Fs);
         nearest_package_walk(from, None)
     }
 
@@ -84,11 +89,279 @@ impl FsProvider for StdFs {
         importer: &Path,
         config: ResolveConfig<'_>,
     ) -> Option<PathBuf> {
+        let _t = timings::start(Stage::Fs);
         resolve_import_with(self, specifier, importer, config)
     }
 
     fn exists(&self, p: &Path) -> bool {
         p.is_file()
+    }
+}
+
+/// Directory-keyed memo over [`StdFs`]: `snapshot()` freezes the fs for the process;
+/// `live()` re-stats package.json per level and re-parses only on an (mtime, size) change.
+pub struct MemoFs {
+    live: bool,
+    nearest: PathMap<Option<(String, PathBuf)>>,
+    manifests: PathMap<Option<Manifest>>,
+    resolve: PathMap<Vec<ResolveMemo>>,
+    exists: PathMap<bool>,
+    exists_any: PathMap<bool>,
+    hashes: PathMap<(Option<Stamp>, Option<String>)>,
+    canon: PathMap<PathBuf>,
+}
+
+// Keyed by the path's raw bytes: `Path` equality folds spellings (`a//b`,
+// `a/b/`) whose walks return differently spelled directories.
+type PathMap<V> = RwLock<FxHashMap<Box<[u8]>, V>>;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct Stamp {
+    modified: Option<SystemTime>,
+    len: u64,
+}
+
+impl Stamp {
+    fn of(meta: &std::fs::Metadata) -> Self {
+        Self {
+            modified: meta.modified().ok(),
+            len: meta.len(),
+        }
+    }
+}
+
+#[derive(Clone)]
+enum PackageProbe {
+    Name(String),
+    Broken,
+}
+
+#[derive(Clone)]
+struct Manifest {
+    stamp: Stamp,
+    probe: PackageProbe,
+}
+
+struct ResolveMemo {
+    aliases: Option<AliasMap>,
+    root_dir: Option<PathBuf>,
+    by_specifier: FxHashMap<String, Option<PathBuf>>,
+}
+
+impl ResolveMemo {
+    fn matches(&self, config: ResolveConfig<'_>) -> bool {
+        self.aliases.as_ref() == config.aliases
+            && self.root_dir.as_deref().map(Path::as_os_str) == config.root_dir.map(Path::as_os_str)
+    }
+}
+
+fn path_key(p: &Path) -> &[u8] {
+    p.as_os_str().as_encoded_bytes()
+}
+
+fn read_lock<T>(lock: &RwLock<T>) -> RwLockReadGuard<'_, T> {
+    lock.read().unwrap_or_else(PoisonError::into_inner)
+}
+
+fn write_lock<T>(lock: &RwLock<T>) -> RwLockWriteGuard<'_, T> {
+    lock.write().unwrap_or_else(PoisonError::into_inner)
+}
+
+static SHARED: LazyLock<MemoFs> = LazyLock::new(MemoFs::live);
+
+impl MemoFs {
+    pub fn snapshot() -> Self {
+        Self::with_mode(false)
+    }
+
+    pub fn live() -> Self {
+        Self::with_mode(true)
+    }
+
+    /// Process-wide live instance: an embedder swaps `&StdFs` for
+    /// `MemoFs::shared()` at its call sites and nothing else changes.
+    pub fn shared() -> &'static MemoFs {
+        &SHARED
+    }
+
+    fn with_mode(live: bool) -> Self {
+        Self {
+            live,
+            nearest: RwLock::default(),
+            manifests: RwLock::default(),
+            resolve: RwLock::default(),
+            exists: RwLock::default(),
+            exists_any: RwLock::default(),
+            hashes: RwLock::default(),
+            canon: RwLock::default(),
+        }
+    }
+
+    pub fn invalidate_all(&self) {
+        write_lock(&self.nearest).clear();
+        write_lock(&self.manifests).clear();
+        write_lock(&self.resolve).clear();
+        write_lock(&self.exists).clear();
+        write_lock(&self.exists_any).clear();
+        write_lock(&self.hashes).clear();
+        write_lock(&self.canon).clear();
+    }
+
+    /// `None` mirrors `!candidate.is_file()`; the walk keeps climbing.
+    fn probe_manifest(&self, candidate: &Path) -> Option<PackageProbe> {
+        let key = path_key(candidate);
+        if !self.live
+            && let Some(hit) = read_lock(&self.manifests).get(key)
+        {
+            return hit.as_ref().map(|m| m.probe.clone());
+        }
+        let stamp = match std::fs::metadata(candidate) {
+            Ok(meta) if meta.is_file() => Stamp::of(&meta),
+            _ => {
+                if !self.live {
+                    write_lock(&self.manifests).insert(key.into(), None);
+                }
+                return None;
+            }
+        };
+        if self.live
+            && let Some(Some(hit)) = read_lock(&self.manifests).get(key)
+            && hit.stamp == stamp
+        {
+            return Some(hit.probe.clone());
+        }
+        let probe = read_manifest(candidate);
+        write_lock(&self.manifests).insert(
+            key.into(),
+            Some(Manifest {
+                stamp,
+                probe: probe.clone(),
+            }),
+        );
+        Some(probe)
+    }
+
+    fn memo_path<T: Clone>(&self, map: &PathMap<T>, p: &Path, compute: impl FnOnce() -> T) -> T {
+        let key = path_key(p);
+        if let Some(hit) = read_lock(map).get(key) {
+            return hit.clone();
+        }
+        let value = compute();
+        write_lock(map).insert(key.into(), value.clone());
+        value
+    }
+}
+
+impl FsProvider for MemoFs {
+    fn nearest_package(&self, from: &Path) -> Option<(String, PathBuf)> {
+        let _t = timings::start(Stage::Fs);
+        let mut folder = from.parent()?;
+        let mut visited: Vec<&Path> = Vec::new();
+        let answer = loop {
+            if !self.live {
+                if let Some(hit) = read_lock(&self.nearest).get(path_key(folder)) {
+                    break hit.clone();
+                }
+                visited.push(folder);
+            }
+            match self.probe_manifest(&folder.join("package.json")) {
+                Some(PackageProbe::Name(name)) => break Some((name, folder.to_path_buf())),
+                Some(PackageProbe::Broken) => break None,
+                None => {}
+            }
+            if folder == Path::new("/") || folder.as_os_str().is_empty() {
+                break None;
+            }
+            match folder.parent() {
+                Some(parent) => folder = parent,
+                None => break None,
+            }
+        };
+        if !visited.is_empty() {
+            let mut nearest = write_lock(&self.nearest);
+            for dir in visited {
+                nearest.insert(path_key(dir).into(), answer.clone());
+            }
+        }
+        answer
+    }
+
+    fn resolve_import(
+        &self,
+        specifier: &str,
+        importer: &Path,
+        config: ResolveConfig<'_>,
+    ) -> Option<PathBuf> {
+        let _t = timings::start(Stage::Fs);
+        let dir = match importer.parent() {
+            Some(dir) if !self.live => dir,
+            _ => return resolve_import_with(self, specifier, importer, config),
+        };
+        let key = path_key(dir);
+        if let Some(memos) = read_lock(&self.resolve).get(key)
+            && let Some(memo) = memos.iter().find(|m| m.matches(config))
+            && let Some(hit) = memo.by_specifier.get(specifier)
+        {
+            return hit.clone();
+        }
+        let resolved = resolve_import_with(self, specifier, importer, config);
+        let mut map = write_lock(&self.resolve);
+        let memos = map.entry(key.into()).or_default();
+        let memo = match memos.iter().position(|m| m.matches(config)) {
+            Some(i) => &mut memos[i],
+            None => {
+                memos.push(ResolveMemo {
+                    aliases: config.aliases.cloned(),
+                    root_dir: config.root_dir.map(Path::to_path_buf),
+                    by_specifier: FxHashMap::default(),
+                });
+                memos.last_mut().expect("just pushed")
+            }
+        };
+        memo.by_specifier
+            .insert(specifier.to_string(), resolved.clone());
+        resolved
+    }
+
+    fn exists(&self, p: &Path) -> bool {
+        if self.live {
+            return p.is_file();
+        }
+        self.memo_path(&self.exists, p, || p.is_file())
+    }
+
+    fn exists_any(&self, p: &Path) -> bool {
+        if self.live {
+            return p.exists();
+        }
+        self.memo_path(&self.exists_any, p, || p.exists())
+    }
+
+    fn hash_file(&self, p: &Path) -> Option<String> {
+        let stamp = if self.live {
+            match std::fs::metadata(p) {
+                Ok(meta) if meta.is_file() => Some(Stamp::of(&meta)),
+                _ => return StdFs.hash_file(p),
+            }
+        } else {
+            None
+        };
+        let key = path_key(p);
+        if let Some((seen, hash)) = read_lock(&self.hashes).get(key)
+            && (stamp.is_none() || *seen == stamp)
+        {
+            return hash.clone();
+        }
+        let hash = StdFs.hash_file(p);
+        write_lock(&self.hashes).insert(key.into(), (stamp, hash.clone()));
+        hash
+    }
+
+    fn canonicalize_root(&self, root: &Path) -> PathBuf {
+        if self.live {
+            return StdFs.canonicalize_root(root);
+        }
+        self.memo_path(&self.canon, root, || StdFs.canonicalize_root(root))
     }
 }
 
@@ -126,14 +399,25 @@ fn nearest_package_walk(from: &Path, stop_at: Option<&Path>) -> Option<(String, 
         }
         let candidate = folder.join("package.json");
         if candidate.is_file() {
-            let raw = std::fs::read_to_string(&candidate).ok()?;
-            let json: serde_json::Value = serde_json::from_str(&raw).ok()?;
-            return Some((js_name_string(json.get("name")), folder.to_path_buf()));
+            return match read_manifest(&candidate) {
+                PackageProbe::Name(name) => Some((name, folder.to_path_buf())),
+                PackageProbe::Broken => None,
+            };
         }
         if folder == Path::new("/") || folder.as_os_str().is_empty() {
             return None;
         }
         folder = folder.parent()?;
+    }
+}
+
+fn read_manifest(candidate: &Path) -> PackageProbe {
+    let Ok(raw) = std::fs::read_to_string(candidate) else {
+        return PackageProbe::Broken;
+    };
+    match serde_json::from_str::<serde_json::Value>(&raw) {
+        Ok(json) => PackageProbe::Name(js_name_string(json.get("name"))),
+        Err(_) => PackageProbe::Broken,
     }
 }
 
@@ -1729,5 +2013,166 @@ mod tests {
             normalize_path(Path::new("/a/b/../c/./d.ts")),
             PathBuf::from("/a/c/d.ts")
         );
+    }
+
+    /// Fresh per test (tests mutate it): root manifest, a nested `pkg`
+    /// manifest, and files two and three levels below `pkg`.
+    fn memo_fixture(tag: &str) -> PathBuf {
+        let root =
+            std::env::temp_dir().join(format!("stylex-rs-memofs-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let write = |rel: &str, content: &str| {
+            let path = root.join(rel);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, content).unwrap();
+        };
+        write("package.json", r#"{"name":"root-pkg"}"#);
+        write("pkg/package.json", r#"{"name":"nested-pkg"}"#);
+        write("pkg/src/a/one.ts", "");
+        write("pkg/src/b/two.ts", "");
+        write("pkg/src/b/tokens.stylex.ts", "");
+        write("other/deep/three.ts", "");
+        std::fs::canonicalize(&root).unwrap_or(root)
+    }
+
+    fn os_eq(a: Option<(String, PathBuf)>, b: Option<(String, PathBuf)>) -> bool {
+        match (a, b) {
+            (None, None) => true,
+            (Some((n1, d1)), Some((n2, d2))) => n1 == n2 && d1.as_os_str() == d2.as_os_str(),
+            _ => false,
+        }
+    }
+
+    #[test]
+    fn memo_snapshot_matches_std_and_fills_every_visited_level() {
+        let root = memo_fixture("snapshot");
+        let memo = MemoFs::snapshot();
+        for rel in [
+            "pkg/src/a/one.ts",
+            "pkg/src/b/two.ts",
+            "other/deep/three.ts",
+            "pkg/src/a/one.ts",
+        ] {
+            let file = root.join(rel);
+            assert!(os_eq(
+                memo.nearest_package(&file),
+                StdFs.nearest_package(&file)
+            ));
+        }
+        let filled = read_lock(&memo.nearest);
+        for dir in ["pkg/src/a", "pkg/src", "pkg", "other/deep", "other"] {
+            assert!(
+                filled.contains_key(path_key(&root.join(dir))),
+                "{dir} not filled"
+            );
+        }
+        // Seven directories were visited (pkg/src/a, pkg/src/b, pkg/src, pkg,
+        // other/deep, other, root), each probed exactly once.
+        let manifests = read_lock(&memo.manifests);
+        assert!(manifests.contains_key(path_key(&root.join("pkg/package.json"))));
+        assert!(manifests.contains_key(path_key(&root.join("package.json"))));
+        assert_eq!(
+            manifests
+                .keys()
+                .filter(|k| k.starts_with(path_key(&root)))
+                .count(),
+            7
+        );
+    }
+
+    #[test]
+    fn memo_snapshot_freezes_while_live_revalidates_edits_and_new_manifests() {
+        let root = memo_fixture("live");
+        let snapshot = MemoFs::snapshot();
+        let live = MemoFs::live();
+        let file = root.join("pkg/src/a/one.ts");
+        let before = Some(("nested-pkg".to_string(), root.join("pkg")));
+        assert!(os_eq(snapshot.nearest_package(&file), before.clone()));
+        assert!(os_eq(live.nearest_package(&file), before.clone()));
+
+        // Edit: a different length guarantees a stamp change even inside one
+        // mtime tick.
+        std::fs::write(
+            root.join("pkg/package.json"),
+            r#"{"name":"nested-pkg-renamed"}"#,
+        )
+        .unwrap();
+        assert!(os_eq(snapshot.nearest_package(&file), before.clone()));
+        assert!(os_eq(
+            live.nearest_package(&file),
+            Some(("nested-pkg-renamed".to_string(), root.join("pkg")))
+        ));
+
+        // A new manifest at an intermediate level is seen live, not by snapshot.
+        std::fs::write(root.join("pkg/src/package.json"), r#"{"name":"src-pkg"}"#).unwrap();
+        assert!(os_eq(snapshot.nearest_package(&file), before));
+        assert!(os_eq(
+            live.nearest_package(&file),
+            Some(("src-pkg".to_string(), root.join("pkg/src")))
+        ));
+        assert!(os_eq(
+            live.nearest_package(&file),
+            StdFs.nearest_package(&file)
+        ));
+
+        // A broken manifest ends the live walk with no answer, like StdFs.
+        std::fs::write(root.join("pkg/src/package.json"), "{").unwrap();
+        assert!(live.nearest_package(&file).is_none());
+        assert!(StdFs.nearest_package(&file).is_none());
+
+        snapshot.invalidate_all();
+        assert!(snapshot.nearest_package(&file).is_none());
+    }
+
+    #[test]
+    fn memo_keys_by_spelling_so_found_dirs_keep_the_callers_spelling() {
+        let root = memo_fixture("spelling");
+        let memo = MemoFs::snapshot();
+        let plain = root.join("pkg/src/a/one.ts");
+        let doubled = PathBuf::from(format!("{}//pkg/src/a/one.ts", root.display()));
+        assert_eq!(Path::new(&plain), Path::new(&doubled));
+        assert!(os_eq(
+            memo.nearest_package(&plain),
+            StdFs.nearest_package(&plain)
+        ));
+        assert!(os_eq(
+            memo.nearest_package(&doubled),
+            StdFs.nearest_package(&doubled)
+        ));
+        assert_ne!(
+            memo.nearest_package(&plain).unwrap().1.as_os_str(),
+            memo.nearest_package(&doubled).unwrap().1.as_os_str()
+        );
+    }
+
+    #[test]
+    fn memo_snapshot_resolve_is_keyed_by_importer_dir_and_config() {
+        let root = memo_fixture("resolve");
+        let memo = MemoFs::snapshot();
+        let a = root.join("pkg/src/b/two.ts");
+        let b = root.join("pkg/src/b/other.ts");
+        let with_root = ResolveConfig {
+            aliases: None,
+            root_dir: Some(&root),
+        };
+        let expected = StdFs.resolve_import("./tokens.stylex", &a, with_root);
+        assert!(expected.is_some());
+        assert_eq!(
+            memo.resolve_import("./tokens.stylex", &a, with_root),
+            expected
+        );
+        assert_eq!(
+            memo.resolve_import("./tokens.stylex", &b, with_root),
+            expected
+        );
+        assert_eq!(
+            memo.resolve_import("./tokens.stylex", &b, ResolveConfig::default()),
+            expected
+        );
+        let memos = read_lock(&memo.resolve);
+        let by_dir = &memos[path_key(&root.join("pkg/src/b"))];
+        assert_eq!(by_dir.len(), 2, "one memo per distinct config");
+        assert!(by_dir.iter().all(|m| m.by_specifier.len() == 1));
+        assert_eq!(memos.len(), 1, "one importer directory");
     }
 }

--- a/crates/stylex/src/module_resolution.rs
+++ b/crates/stylex/src/module_resolution.rs
@@ -1,0 +1,1733 @@
+//! commonJS canonical file names, theme-file suffix checks, import resolution.
+// parity: babel-plugin src/utils/state-manager.js:566-707 + file-based-identifier.js
+
+use std::path::{Component, Path, PathBuf};
+
+use crate::options::{AliasMap, ModuleResolutionType, ResolvedOptions};
+
+// parity: state-manager.js EXTENSIONS — probe order is observable via hashes.
+pub const EXTENSIONS: [&str; 6] = [".js", ".ts", ".tsx", ".jsx", ".mjs", ".cjs"];
+
+pub const THEME_FILE_EXTENSION: &str = ".stylex";
+
+const ROOT_PLACEHOLDER: &str = "/ROOT/";
+
+/// The two `filePathResolver` arguments beyond the specifier and the importer.
+/// `rewriteAliases` passes `root_dir: None` — upstream omits the argument there.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ResolveConfig<'a> {
+    pub aliases: Option<&'a AliasMap>,
+    pub root_dir: Option<&'a Path>,
+}
+
+impl<'a> ResolveConfig<'a> {
+    pub fn of(options: &'a ResolvedOptions) -> Self {
+        Self {
+            aliases: options.aliases.as_ref(),
+            root_dir: options
+                .unstable_module_resolution
+                .as_ref()
+                .and_then(|m| m.root_dir.as_deref()),
+        }
+    }
+
+    /// `rewriteAliases`' call shape: aliases, never a rootDir.
+    pub fn aliases_only(options: &'a ResolvedOptions) -> Self {
+        Self {
+            aliases: options.aliases.as_ref(),
+            root_dir: None,
+        }
+    }
+}
+
+/// Filesystem seam: tests confine walks to a fixture root; oj wraps its resolver.
+pub trait FsProvider: Sync {
+    /// Nearest package.json walking up from dirname(from) — a package.json in
+    /// `from` itself is skipped. Unparseable package.json stops the walk (None).
+    fn nearest_package(&self, from: &Path) -> Option<(String, PathBuf)>;
+    fn resolve_import(
+        &self,
+        specifier: &str,
+        importer: &Path,
+        config: ResolveConfig<'_>,
+    ) -> Option<PathBuf>;
+    fn exists(&self, p: &Path) -> bool;
+    /// `fs.existsSync`: unlike [`FsProvider::exists`] a directory counts, which
+    /// is what the `/ROOT/` and absolute alias branches probe with.
+    fn exists_any(&self, p: &Path) -> bool {
+        p.exists()
+    }
+    /// blake3 hex of the file's bytes; `None` when unreadable. Cache dep
+    /// recording/replay goes through this so one-shot drivers may memoize.
+    fn hash_file(&self, p: &Path) -> Option<String> {
+        std::fs::read(p)
+            .ok()
+            .map(|bytes| blake3::hash(&bytes).to_hex().to_string())
+    }
+    /// Canonical form of a compile root (unreadable roots pass through); cache
+    /// recording/replay anchors relative entry paths to it.
+    fn canonicalize_root(&self, root: &Path) -> PathBuf {
+        std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf())
+    }
+}
+
+pub struct StdFs;
+
+impl FsProvider for StdFs {
+    fn nearest_package(&self, from: &Path) -> Option<(String, PathBuf)> {
+        nearest_package_walk(from, None)
+    }
+
+    fn resolve_import(
+        &self,
+        specifier: &str,
+        importer: &Path,
+        config: ResolveConfig<'_>,
+    ) -> Option<PathBuf> {
+        resolve_import_with(self, specifier, importer, config)
+    }
+
+    fn exists(&self, p: &Path) -> bool {
+        p.is_file()
+    }
+}
+
+/// `StdFs` whose package.json walk stops at `root`; pin fixtures use it so the
+/// walk never escapes into the repository's own package.json files.
+pub struct BoundedFs {
+    pub root: PathBuf,
+}
+
+impl FsProvider for BoundedFs {
+    fn nearest_package(&self, from: &Path) -> Option<(String, PathBuf)> {
+        nearest_package_walk(from, Some(&self.root))
+    }
+
+    fn resolve_import(
+        &self,
+        specifier: &str,
+        importer: &Path,
+        config: ResolveConfig<'_>,
+    ) -> Option<PathBuf> {
+        resolve_import_with(self, specifier, importer, config)
+    }
+
+    fn exists(&self, p: &Path) -> bool {
+        p.is_file()
+    }
+}
+
+// parity: state-manager.js getPackageNameAndPath (dirname-first recursion).
+fn nearest_package_walk(from: &Path, stop_at: Option<&Path>) -> Option<(String, PathBuf)> {
+    let mut folder = from.parent()?;
+    loop {
+        if stop_at.is_some_and(|stop| !folder.starts_with(stop)) {
+            return None;
+        }
+        let candidate = folder.join("package.json");
+        if candidate.is_file() {
+            let raw = std::fs::read_to_string(&candidate).ok()?;
+            let json: serde_json::Value = serde_json::from_str(&raw).ok()?;
+            return Some((js_name_string(json.get("name")), folder.to_path_buf()));
+        }
+        if folder == Path::new("/") || folder.as_os_str().is_empty() {
+            return None;
+        }
+        folder = folder.parent()?;
+    }
+}
+
+// parity: JS template coercion of packageJson.name (missing name → "undefined").
+fn js_name_string(name: Option<&serde_json::Value>) -> String {
+    match name {
+        None => "undefined".to_string(),
+        Some(serde_json::Value::String(s)) => s.clone(),
+        Some(serde_json::Value::Null) => "null".to_string(),
+        Some(serde_json::Value::Bool(b)) => b.to_string(),
+        Some(serde_json::Value::Number(n)) => {
+            crate::jsrt::js_number_to_string(n.as_f64().unwrap_or(f64::NAN))
+        }
+        Some(_) => "[object Object]".to_string(),
+    }
+}
+
+// parity: state-manager.js getPossibleFilePaths — raw path first, then each
+// extension appended to the path with any known code extension stripped.
+pub fn possible_file_paths(file_path: &str) -> Vec<String> {
+    let stripped = EXTENSIONS
+        .iter()
+        .find(|ext| file_path.ends_with(**ext))
+        .map_or(file_path, |ext| &file_path[..file_path.len() - ext.len()]);
+    let mut out = vec![file_path.to_string()];
+    out.extend(EXTENSIONS.iter().map(|ext| format!("{stripped}{ext}")));
+    out
+}
+
+// parity: state-manager.js possibleAliasedPaths — the raw specifier first, then
+// every matching key's values in declaration order, each value array in order.
+fn possible_aliased_paths(import_path: &str, aliases: Option<&AliasMap>) -> Vec<String> {
+    let mut result = vec![import_path.to_string()];
+    let Some(aliases) = aliases.filter(|a| !a.is_empty()) else {
+        return result;
+    };
+    for (alias, values) in aliases {
+        match alias.split_once('*') {
+            // Only the first two split parts are read: a third `*` is ignored.
+            Some((before, rest)) => {
+                let after = rest.split('*').next().unwrap_or("");
+                if !import_path.starts_with(before) || !import_path.ends_with(after) {
+                    continue;
+                }
+                let end = import_path.len() - after.len();
+                let capture = &import_path[before.len().min(end)..end];
+                // Every `*` in the value takes the same capture.
+                result.extend(values.iter().map(|v| v.replace('*', capture)));
+            }
+            None if alias == import_path => result.extend(values.iter().cloned()),
+            None => {}
+        }
+    }
+    result
+}
+
+fn resolve_import_with(
+    fs: &dyn FsProvider,
+    specifier: &str,
+    importer: &Path,
+    config: ResolveConfig<'_>,
+) -> Option<PathBuf> {
+    for candidate in possible_file_paths(specifier) {
+        // A dot-leading specifier short-circuits before aliases are consulted.
+        if candidate.starts_with('.') {
+            if let Some(p) = module_resolve(fs, &candidate, importer) {
+                return Some(p);
+            }
+            continue;
+        }
+        for possible in possible_aliased_paths(&candidate, config.aliases) {
+            // Turbopack's placeholder, honored only when a rootDir is set.
+            if let Some(rest) = possible.strip_prefix(ROOT_PLACEHOLDER)
+                && let Some(root) = config.root_dir
+            {
+                let joined = node_path_join(root, rest);
+                if let Some(p) = first_existing(fs, &joined) {
+                    return Some(p);
+                }
+                continue;
+            }
+            if Path::new(&possible).is_absolute() {
+                if let Some(p) = first_existing(fs, &possible) {
+                    return Some(p);
+                }
+                continue;
+            }
+            if let Some(p) = module_resolve(fs, &possible, importer) {
+                return Some(p);
+            }
+        }
+    }
+    None
+}
+
+/// One `moduleResolve` attempt. It realpaths its answer, which the existsSync
+/// branches never do, so two spellings of one file can hash differently.
+fn module_resolve(fs: &dyn FsProvider, specifier: &str, importer: &Path) -> Option<PathBuf> {
+    let realpath = |p: PathBuf| std::fs::canonicalize(&p).unwrap_or(p);
+    if is_relative_specifier(specifier) {
+        let dir = importer.parent()?;
+        let joined = join_url_segments(
+            &normalize_path(dir),
+            &url_path(strip_query_fragment(specifier)),
+        );
+        return finalize_file(fs, joined).map(realpath);
+    }
+    // Any other dot-leading form is an invalid package name — always an error.
+    if specifier.starts_with('.') {
+        return None;
+    }
+    if specifier.starts_with('#') {
+        return package_imports_resolve(fs, specifier, importer).map(realpath);
+    }
+    package_resolve(fs, specifier, importer).ok().map(realpath)
+}
+
+/// Node `path.join` over two POSIX segments: concatenate, then normalize —
+/// an absolute second segment appends rather than replacing the base.
+fn node_path_join(base: &Path, rest: &str) -> String {
+    let base = base.to_string_lossy();
+    let joined = format!("{}/{rest}", base.trim_end_matches('/'));
+    normalize_path(Path::new(&joined))
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// The `fs.existsSync` sweep both non-moduleResolve branches share: the literal
+/// path first, then each extension; a directory is a valid hit.
+fn first_existing(fs: &dyn FsProvider, path: &str) -> Option<PathBuf> {
+    possible_file_paths(path)
+        .into_iter()
+        .map(PathBuf::from)
+        .find(|p| fs.exists_any(p))
+}
+
+// Node ESM package resolution as executed by import-meta-resolve 4.2.1 (the
+// oracle's resolver); every throw collapses to None per specifier candidate.
+
+const CONDITIONS: [&str; 2] = ["node", "import"];
+
+// parity: moduleResolve shouldBeTreatedAsRelativeOrAbsolutePath.
+fn is_relative_specifier(s: &str) -> bool {
+    s == "." || s == ".." || s.starts_with("./") || s.starts_with("../")
+}
+
+// URL joins turn `\` into `/` before file paths are resolved.
+fn url_path(s: &str) -> String {
+    s.replace('\\', "/")
+}
+
+// parity: URL parsing — the first `?` or `#` ends the pathname; query and
+// fragment never reach the filesystem lookup.
+fn strip_query_fragment(s: &str) -> &str {
+    &s[..s.find(['?', '#']).unwrap_or(s.len())]
+}
+
+/// URL-reference join: empty and single-dot segments drop, double-dot pops
+/// (clamped at the root). Percent-encoded dot variants count (WHATWG URL).
+fn join_url_segments(base: &Path, rel: &str) -> PathBuf {
+    let mut out = base.to_path_buf();
+    for seg in rel.split('/') {
+        if seg.is_empty() || matches_encoded(seg, ".") {
+            continue;
+        }
+        if matches_encoded(seg, "..") {
+            out.pop();
+        } else {
+            out.push(seg);
+        }
+    }
+    out
+}
+
+// parity: finalizeResolution's encoded-separator rejection (`%2f`/`%5c`, /i).
+fn has_encoded_separator(p: &Path) -> bool {
+    let s = p.to_string_lossy();
+    s.as_bytes().windows(3).any(|w| {
+        w[0] == b'%'
+            && ((w[1] == b'2' && (w[2] | 0x20) == b'f') || (w[1] == b'5' && (w[2] | 0x20) == b'c'))
+    })
+}
+
+/// fileURLToPath's percent-decode of the pathname; `None` mirrors the
+/// URIError on a malformed escape (decode-to-invalid-UTF-8 included).
+fn percent_decode_path(p: &Path) -> Option<PathBuf> {
+    let s = p.to_str()?;
+    if !s.contains('%') {
+        return Some(p.to_path_buf());
+    }
+    let hex = |b: u8| (b as char).to_digit(16).map(|d| d as u8);
+    let mut bytes = Vec::with_capacity(s.len());
+    let mut rest = s.as_bytes();
+    while let Some((&b, tail)) = rest.split_first() {
+        if b == b'%' {
+            let [hi, lo, tail @ ..] = tail else {
+                return None;
+            };
+            bytes.push(hex(*hi)? * 16 + hex(*lo)?);
+            rest = tail;
+        } else {
+            bytes.push(b);
+            rest = tail;
+        }
+    }
+    Some(PathBuf::from(String::from_utf8(bytes).ok()?))
+}
+
+fn finalize_file(fs: &dyn FsProvider, p: PathBuf) -> Option<PathBuf> {
+    if has_encoded_separator(&p) {
+        return None;
+    }
+    let decoded = percent_decode_path(&p)?;
+    fs.exists(&decoded).then_some(decoded)
+}
+
+/// One expected char matches its literal (ASCII case-insensitive) or `%XX`
+/// with hex decoding to either case, mirroring the upstream regex /i flag.
+fn matches_encoded(segment: &str, word: &str) -> bool {
+    let mut rest = segment.as_bytes();
+    for &want in word.as_bytes() {
+        let hex = |b: u8| (b as char).to_digit(16).map(|d| d as u8);
+        rest = match rest {
+            [b'%', hi, lo, tail @ ..]
+                if hex(*hi)
+                    .zip(hex(*lo))
+                    .is_some_and(|(a, b)| (a * 16 + b).eq_ignore_ascii_case(&want)) =>
+            {
+                tail
+            }
+            [b, tail @ ..] if *b != b'%' && b.eq_ignore_ascii_case(&want) => tail,
+            _ => return false,
+        };
+    }
+    rest.is_empty()
+}
+
+// parity: deprecatedInvalidSegmentRegEx — a `.`/`..`/`node_modules` segment
+// (encoded variants included) anywhere; these throw, empty segments only warn.
+fn has_deprecated_segment(text: &str) -> bool {
+    text.split(['/', '\\']).any(|seg| {
+        matches_encoded(seg, ".")
+            || matches_encoded(seg, "..")
+            || matches_encoded(seg, "node_modules")
+    })
+}
+
+// parity: isArrayIndex — canonical JS number round-trip within [0, 2^32-1).
+fn is_js_array_index(key: &str) -> bool {
+    key.parse::<f64>().is_ok_and(|n| {
+        crate::jsrt::js_number_to_string(n) == key && (0.0..4_294_967_295.0).contains(&n)
+    })
+}
+
+// parity: the `new URL(target)` probe — an ASCII-alpha scheme then `:`.
+fn parses_as_url(s: &str) -> bool {
+    let Some(colon) = s.find(':') else {
+        return false;
+    };
+    let mut chars = s[..colon].chars();
+    chars.next().is_some_and(|c| c.is_ascii_alphabetic())
+        && chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'))
+}
+
+struct PackageJson {
+    name: Option<String>,
+    main: Option<String>,
+    exports: Option<serde_json::Value>,
+    imports: Option<serde_json::Value>,
+}
+
+/// `Malformed` (unparseable JSON, or JSON `null`) aborts the candidate —
+/// unlike `Missing`, which downstream treats as an empty config.
+enum PackageRead {
+    Missing,
+    Malformed,
+    Parsed(PackageJson),
+}
+
+fn read_package_json(dir: &Path) -> PackageRead {
+    let Ok(raw) = std::fs::read_to_string(dir.join("package.json")) else {
+        return PackageRead::Missing;
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return PackageRead::Malformed;
+    };
+    if json.is_null() {
+        return PackageRead::Malformed;
+    }
+    let string_field = |key: &str| json.get(key).and_then(|v| v.as_str()).map(str::to_string);
+    let value_field = |key: &str| json.get(key).filter(|v| !v.is_null()).cloned();
+    PackageRead::Parsed(PackageJson {
+        name: string_field("name"),
+        main: string_field("main"),
+        exports: value_field("exports"),
+        imports: value_field("imports"),
+    })
+}
+
+fn parse_package_name(specifier: &str) -> Option<(&str, String)> {
+    let mut separator = specifier.find('/');
+    if specifier.starts_with('@') {
+        let scope_sep = separator?;
+        separator = specifier[scope_sep + 1..]
+            .find('/')
+            .map(|i| i + scope_sep + 1);
+    }
+    let name = separator.map_or(specifier, |i| &specifier[..i]);
+    if name.is_empty() || name.starts_with('.') || name.contains('%') || name.contains('\\') {
+        return None;
+    }
+    let subpath = format!(".{}", separator.map_or("", |i| &specifier[i..]));
+    Some((name, subpath))
+}
+
+enum ScopeConfig {
+    Found(PathBuf, Box<PackageJson>),
+    NotFound,
+    Malformed,
+}
+
+// parity: getPackageScopeConfig — nearest package.json above `from`, never
+// crossing a node_modules boundary; a malformed read throws mid-walk.
+fn package_scope_config(from: &Path) -> ScopeConfig {
+    let Some(mut dir) = from.parent() else {
+        return ScopeConfig::NotFound;
+    };
+    loop {
+        if dir.file_name().is_some_and(|f| f == "node_modules") {
+            return ScopeConfig::NotFound;
+        }
+        match read_package_json(dir) {
+            PackageRead::Parsed(pkg) => {
+                return ScopeConfig::Found(dir.to_path_buf(), Box::new(pkg));
+            }
+            PackageRead::Malformed => return ScopeConfig::Malformed,
+            PackageRead::Missing => {}
+        }
+        let Some(parent) = dir.parent() else {
+            return ScopeConfig::NotFound;
+        };
+        dir = parent;
+    }
+}
+
+/// `Invalid` mirrors thrown ERR_INVALID_PACKAGE_TARGET (target arrays skip
+/// past it); `Fatal` mirrors every other throw (they abort the candidate).
+#[derive(Clone, Copy)]
+enum ResolveErrKind {
+    Invalid,
+    Fatal,
+}
+
+fn package_resolve(
+    fs: &dyn FsProvider,
+    specifier: &str,
+    importer: &Path,
+) -> Result<PathBuf, ResolveErrKind> {
+    let (name, subpath) = parse_package_name(specifier).ok_or(ResolveErrKind::Fatal)?;
+    // ResolveSelf: the importer's own scope wins when named + exporting.
+    match package_scope_config(importer) {
+        ScopeConfig::Malformed => return Err(ResolveErrKind::Fatal),
+        ScopeConfig::Found(scope_dir, pkg) => {
+            if pkg.name.as_deref() == Some(name)
+                && let Some(exports) = &pkg.exports
+            {
+                return package_exports_resolve(fs, &scope_dir, &subpath, exports);
+            }
+        }
+        ScopeConfig::NotFound => {}
+    }
+    let mut dir = importer.parent();
+    while let Some(d) = dir {
+        let pkg_dir = d.join("node_modules").join(name);
+        if pkg_dir.is_dir() {
+            let pkg = match read_package_json(&pkg_dir) {
+                PackageRead::Malformed => return Err(ResolveErrKind::Fatal),
+                PackageRead::Parsed(pkg) => Some(pkg),
+                PackageRead::Missing => None,
+            };
+            if let Some(exports) = pkg.as_ref().and_then(|p| p.exports.as_ref()) {
+                return package_exports_resolve(fs, &pkg_dir, &subpath, exports);
+            }
+            if subpath == "." {
+                return legacy_main_resolve(fs, &pkg_dir, pkg.and_then(|p| p.main))
+                    .ok_or(ResolveErrKind::Fatal);
+            }
+            let file = join_url_segments(&pkg_dir, &url_path(strip_query_fragment(&subpath[2..])));
+            return finalize_file(fs, file).ok_or(ResolveErrKind::Fatal);
+        }
+        dir = d.parent();
+    }
+    Err(ResolveErrKind::Fatal)
+}
+
+// parity: legacyMainResolve — main, main+ext, main/index.*, then index.*.
+fn legacy_main_resolve(
+    fs: &dyn FsProvider,
+    pkg_dir: &Path,
+    main: Option<String>,
+) -> Option<PathBuf> {
+    let mut guesses: Vec<String> = Vec::new();
+    if let Some(main) = &main {
+        guesses.push(main.clone());
+        for ext in [".js", ".json", ".node"] {
+            guesses.push(format!("{main}{ext}"));
+        }
+        for ext in [".js", ".json", ".node"] {
+            guesses.push(format!("{main}/index{ext}"));
+        }
+    }
+    for ext in [".js", ".json", ".node"] {
+        guesses.push(format!("index{ext}"));
+    }
+    guesses
+        .iter()
+        .map(|g| join_url_segments(pkg_dir, &url_path(strip_query_fragment(g))))
+        .find_map(|p| finalize_file(fs, p))
+}
+
+/// resolvePackageTarget result algebra: `Null` mirrors JS null — target
+/// arrays keep going, condition objects and top-level lookups stop on it.
+enum TargetOutcome {
+    Resolved(PathBuf),
+    Null,
+    Invalid,
+    Fatal,
+}
+
+fn finish_exports_target(
+    fs: &dyn FsProvider,
+    outcome: TargetOutcome,
+) -> Result<PathBuf, ResolveErrKind> {
+    match outcome {
+        // Existence is checked once at the end, never inside target arrays.
+        TargetOutcome::Resolved(p) => finalize_file(fs, p).ok_or(ResolveErrKind::Fatal),
+        TargetOutcome::Null | TargetOutcome::Fatal => Err(ResolveErrKind::Fatal),
+        TargetOutcome::Invalid => Err(ResolveErrKind::Invalid),
+    }
+}
+
+fn package_exports_resolve(
+    fs: &dyn FsProvider,
+    pkg_dir: &Path,
+    subpath: &str,
+    exports: &serde_json::Value,
+) -> Result<PathBuf, ResolveErrKind> {
+    // parity: isConditionalExportsMainSugar — string/array, or an object with
+    // no dot-keys, stands for { ".": exports }; mixed keys are invalid.
+    let sugar_map;
+    let map: &serde_json::Map<String, serde_json::Value> = match exports {
+        serde_json::Value::Object(map) => {
+            let dotted = map.keys().filter(|k| k.starts_with('.')).count();
+            if dotted == map.len() {
+                map
+            } else if dotted == 0 {
+                sugar_map = serde_json::Map::from_iter([(".".to_string(), exports.clone())]);
+                &sugar_map
+            } else {
+                return Err(ResolveErrKind::Fatal);
+            }
+        }
+        serde_json::Value::String(_) | serde_json::Value::Array(_) => {
+            sugar_map = serde_json::Map::from_iter([(".".to_string(), exports.clone())]);
+            &sugar_map
+        }
+        // A boolean/number root is neither sugar nor a map: hasOwnProperty
+        // and getOwnPropertyNames both miss — always PATH_NOT_EXPORTED.
+        _ => return Err(ResolveErrKind::Fatal),
+    };
+    if let Some(target) = map.get(subpath)
+        && !subpath.contains('*')
+        && !subpath.ends_with('/')
+    {
+        let outcome = resolve_package_target(fs, pkg_dir, target, "", false, false);
+        return finish_exports_target(fs, outcome);
+    }
+    let subpath_units: Vec<u16> = subpath.encode_utf16().collect();
+    let mut best_match: Option<(&str, String)> = None;
+    for key in map.keys() {
+        let key_units: Vec<u16> = key.encode_utf16().collect();
+        let Some(star) = key_units.iter().position(|&u| u == u16::from(b'*')) else {
+            continue;
+        };
+        if key_units[star + 1..].contains(&u16::from(b'*')) {
+            continue;
+        }
+        let (prefix, trailer) = (&key_units[..star], &key_units[star + 1..]);
+        if subpath_units.starts_with(prefix)
+            && subpath_units.len() >= key_units.len()
+            && subpath_units.ends_with(trailer)
+            && best_match
+                .as_ref()
+                .is_none_or(|(best, _)| pattern_key_compare(best, key) == 1)
+            && let Ok(matched) =
+                String::from_utf16(&subpath_units[star..subpath_units.len() - trailer.len()])
+        {
+            best_match = Some((key, matched));
+        }
+    }
+    let (key, matched) = best_match.ok_or(ResolveErrKind::Fatal)?;
+    let outcome = resolve_package_target(fs, pkg_dir, &map[key], &matched, true, false);
+    finish_exports_target(fs, outcome)
+}
+
+// parity: patternKeyCompare — -1 when `a` sorts first (wins), 1 when `b`
+// does; positions and lengths count UTF-16 units like JS string indexing.
+fn pattern_key_compare(a: &str, b: &str) -> i32 {
+    let a: Vec<u16> = a.encode_utf16().collect();
+    let b: Vec<u16> = b.encode_utf16().collect();
+    let a_star = a.iter().position(|&u| u == u16::from(b'*'));
+    let b_star = b.iter().position(|&u| u == u16::from(b'*'));
+    let base_a = a_star.map_or(a.len(), |i| i + 1);
+    let base_b = b_star.map_or(b.len(), |i| i + 1);
+    if base_a > base_b {
+        return -1;
+    }
+    if base_b > base_a {
+        return 1;
+    }
+    if a_star.is_none() {
+        return 1;
+    }
+    if b_star.is_none() {
+        return -1;
+    }
+    if a.len() > b.len() {
+        return -1;
+    }
+    if b.len() > a.len() {
+        return 1;
+    }
+    0
+}
+
+fn resolve_package_target(
+    fs: &dyn FsProvider,
+    pkg_dir: &Path,
+    target: &serde_json::Value,
+    matched: &str,
+    pattern: bool,
+    internal: bool,
+) -> TargetOutcome {
+    match target {
+        serde_json::Value::String(target) => {
+            resolve_target_string(fs, pkg_dir, target, matched, pattern, internal)
+        }
+        serde_json::Value::Array(items) => {
+            if items.is_empty() {
+                return TargetOutcome::Null;
+            }
+            let mut last_invalid = false;
+            for item in items {
+                match resolve_package_target(fs, pkg_dir, item, matched, pattern, internal) {
+                    TargetOutcome::Null => last_invalid = false,
+                    TargetOutcome::Invalid => last_invalid = true,
+                    other => return other,
+                }
+            }
+            if last_invalid {
+                TargetOutcome::Invalid
+            } else {
+                TargetOutcome::Null
+            }
+        }
+        serde_json::Value::Object(map) => {
+            if map.keys().any(|k| is_js_array_index(k)) {
+                return TargetOutcome::Fatal;
+            }
+            for (key, value) in map {
+                if key == "default" || CONDITIONS.contains(&key.as_str()) {
+                    return resolve_package_target(fs, pkg_dir, value, matched, pattern, internal);
+                }
+            }
+            TargetOutcome::Null
+        }
+        serde_json::Value::Null => TargetOutcome::Null,
+        _ => TargetOutcome::Invalid,
+    }
+}
+
+fn resolve_target_string(
+    fs: &dyn FsProvider,
+    pkg_dir: &Path,
+    target: &str,
+    matched: &str,
+    pattern: bool,
+    internal: bool,
+) -> TargetOutcome {
+    if !matched.is_empty() && !pattern && !target.ends_with('/') {
+        return TargetOutcome::Invalid;
+    }
+    if !target.starts_with("./") {
+        // Internal (#imports) targets may re-enter bare package resolution,
+        // but a target that parses as a URL is invalid outright.
+        if internal && !target.starts_with("../") && !target.starts_with('/') {
+            if parses_as_url(target) {
+                return TargetOutcome::Invalid;
+            }
+            let expanded = if pattern {
+                target.replace('*', matched)
+            } else {
+                format!("{target}{matched}")
+            };
+            return match package_resolve(fs, &expanded, &pkg_dir.join("package.json")) {
+                Ok(p) => TargetOutcome::Resolved(p),
+                Err(ResolveErrKind::Invalid) => TargetOutcome::Invalid,
+                Err(ResolveErrKind::Fatal) => TargetOutcome::Fatal,
+            };
+        }
+        return TargetOutcome::Invalid;
+    }
+    if has_deprecated_segment(&target[2..]) {
+        return TargetOutcome::Invalid;
+    }
+    let resolved = join_url_segments(pkg_dir, &url_path(strip_query_fragment(&target[2..])));
+    // Containment: checked before `*` substitution, like upstream.
+    if !resolved.starts_with(normalize_path(pkg_dir)) {
+        return TargetOutcome::Invalid;
+    }
+    if matched.is_empty() {
+        return TargetOutcome::Resolved(resolved);
+    }
+    if has_deprecated_segment(matched) {
+        // parity: throwInvalidSubpath — not an invalid-target, arrays abort.
+        return TargetOutcome::Fatal;
+    }
+    let path = if pattern {
+        // parity: `*` substitutes into the href, so a `?`/`#` inside the
+        // matched subpath truncates the pathname there.
+        let replaced = resolved.to_string_lossy().replace('*', &url_path(matched));
+        normalize_path(Path::new(strip_query_fragment(&replaced)))
+    } else {
+        join_url_segments(&resolved, &url_path(strip_query_fragment(matched)))
+    };
+    TargetOutcome::Resolved(path)
+}
+
+// parity: PACKAGE_IMPORTS_RESOLVE over the importer scope's "imports" map.
+fn package_imports_resolve(
+    fs: &dyn FsProvider,
+    specifier: &str,
+    importer: &Path,
+) -> Option<PathBuf> {
+    if specifier == "#" || specifier.starts_with("#/") || specifier.ends_with('/') {
+        return None;
+    }
+    let ScopeConfig::Found(scope_dir, pkg) = package_scope_config(importer) else {
+        return None;
+    };
+    let Some(serde_json::Value::Object(map)) = pkg.imports else {
+        return None;
+    };
+    if let Some(target) = map.get(specifier)
+        && !specifier.contains('*')
+    {
+        return match resolve_package_target(fs, &scope_dir, target, "", false, true) {
+            TargetOutcome::Resolved(p) => finalize_file(fs, p),
+            _ => None,
+        };
+    }
+    let specifier_units: Vec<u16> = specifier.encode_utf16().collect();
+    let mut best_match: Option<(&str, String)> = None;
+    for key in map.keys() {
+        let key_units: Vec<u16> = key.encode_utf16().collect();
+        let Some(star) = key_units.iter().position(|&u| u == u16::from(b'*')) else {
+            continue;
+        };
+        if key_units[star + 1..].contains(&u16::from(b'*')) {
+            continue;
+        }
+        // Oracle quirk (import-meta-resolve 4.2.1): the startsWith prefix is
+        // the key minus its LAST UTF-16 unit, so only star-final keys match.
+        let (prefix, trailer) = (&key_units[..key_units.len() - 1], &key_units[star + 1..]);
+        if specifier_units.starts_with(prefix)
+            && specifier_units.len() >= key_units.len()
+            && specifier_units.ends_with(trailer)
+            && best_match
+                .as_ref()
+                .is_none_or(|(best, _)| pattern_key_compare(best, key) == 1)
+            && let Ok(matched) =
+                String::from_utf16(&specifier_units[star..specifier_units.len() - trailer.len()])
+        {
+            best_match = Some((key, matched));
+        }
+    }
+    let (key, matched) = best_match?;
+    match resolve_package_target(fs, &scope_dir, &map[key].clone(), &matched, true, true) {
+        TargetOutcome::Resolved(p) => finalize_file(fs, p),
+        _ => None,
+    }
+}
+
+// parity: state-manager.js matchesFileSuffix — bare suffix or suffix + code ext.
+pub fn matches_file_suffix(suffix: &str, filename: &str) -> bool {
+    if filename.ends_with(suffix) {
+        return true;
+    }
+    EXTENSIONS
+        .iter()
+        .any(|ext| filename.ends_with(&format!("{suffix}{ext}")))
+}
+
+// `.transformed` is a literal upstream, never derived from the option.
+pub fn is_theme_specifier(specifier: &str, theme_extension: &str) -> bool {
+    matches_file_suffix(theme_extension, specifier)
+        || matches_file_suffix(&format!("{theme_extension}.const"), specifier)
+        || matches_file_suffix(".transformed", specifier)
+}
+
+// parity: state-manager.js getCanonicalFilePath.
+pub fn canonical_file_path(fs: &dyn FsProvider, file: &Path, root_dir: Option<&Path>) -> String {
+    if let Some((name, dir)) = fs.nearest_package(file) {
+        return format!("{name}:{}", path_relative(&dir, file));
+    }
+    if let Some(root) = root_dir {
+        return path_relative(root, file);
+    }
+    let basename = file
+        .file_name()
+        .map(|f| f.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    format!("_unknown_path_:{basename}")
+}
+
+/// `importPathResolver`: `Some(canonical theme name)` mirrors
+/// `['themeNameRef', …]`, `None` mirrors `false`.
+pub fn import_path_resolver(
+    fs: &dyn FsProvider,
+    specifier: &str,
+    source_file: Option<&Path>,
+    options: &ResolvedOptions,
+) -> Option<String> {
+    let source_file = source_file?;
+    let module_resolution = options.unstable_module_resolution.as_ref()?;
+    if !is_theme_specifier(specifier, &module_resolution.theme_file_extension) {
+        return None;
+    }
+    match module_resolution.kind {
+        // Haste never touches the filesystem: the specifier is the module name.
+        ModuleResolutionType::Haste => Some(add_file_extension(specifier, source_file)),
+        ModuleResolutionType::CommonJs => {
+            let resolved = fs.resolve_import(specifier, source_file, ResolveConfig::of(options))?;
+            Some(canonical_file_path(
+                fs,
+                &resolved,
+                module_resolution.root_dir.as_deref(),
+            ))
+        }
+    }
+}
+
+/// `rewriteAliases`' new import source, or `None` to leave it alone. parity:
+/// index.js Program.exit hardcodes `.stylex` and passes no rootDir.
+pub fn rewritten_import_source(
+    fs: &dyn FsProvider,
+    source: &str,
+    filename: &Path,
+    options: &ResolvedOptions,
+) -> Option<String> {
+    if !matches_file_suffix(THEME_FILE_EXTENSION, source) {
+        return None;
+    }
+    let resolved = fs.resolve_import(source, filename, ResolveConfig::aliases_only(options))?;
+    let relative = get_relative_path(filename, &resolved);
+    let stripped = EXTENSIONS
+        .iter()
+        .find(|ext| relative.ends_with(**ext))
+        .map_or(relative.as_str(), |ext| {
+            &relative[..relative.len() - ext.len()]
+        });
+    Some(stripped.to_string())
+}
+
+// parity: state-manager.js getRelativePath — posix, always `./`-prefixed.
+pub fn get_relative_path(from: &Path, to: &Path) -> String {
+    let dir = from.parent().unwrap_or(Path::new(""));
+    let relative = path_relative(dir, to);
+    if relative.starts_with('.') {
+        relative
+    } else {
+        format!("./{relative}")
+    }
+}
+
+// parity: state-manager.js addFileExtension — the extension is taken from the
+// importing file, never validated, because haste cannot resolve the real one.
+pub fn add_file_extension(imported: &str, source_file: &Path) -> String {
+    if EXTENSIONS.iter().any(|ext| imported.ends_with(ext)) {
+        return imported.to_string();
+    }
+    format!("{imported}{}", node_extname(&source_file.to_string_lossy()))
+}
+
+// parity: Node path.basename — trailing separators are ignored.
+pub fn node_basename(path: &str) -> &str {
+    let trimmed = path.trim_end_matches('/');
+    match trimmed.rfind('/') {
+        Some(idx) => &trimmed[idx + 1..],
+        None => trimmed,
+    }
+}
+
+// parity: Node path.extname's scan-from-the-end state machine, including its
+// empty answers for a dot-only basename (".stylex", "..").
+pub fn node_extname(path: &str) -> &str {
+    let bytes = path.as_bytes();
+    let (mut start_dot, mut start_part, mut end) = (usize::MAX, 0usize, usize::MAX);
+    let mut matched_slash = true;
+    let mut pre_dot_state = 0i32;
+    for i in (0..bytes.len()).rev() {
+        let code = bytes[i];
+        if code == b'/' {
+            if !matched_slash {
+                start_part = i + 1;
+                break;
+            }
+            continue;
+        }
+        if end == usize::MAX {
+            matched_slash = false;
+            end = i + 1;
+        }
+        if code == b'.' {
+            if start_dot == usize::MAX {
+                start_dot = i;
+            } else if pre_dot_state != 1 {
+                pre_dot_state = 1;
+            }
+        } else if start_dot != usize::MAX {
+            pre_dot_state = -1;
+        }
+    }
+    if start_dot == usize::MAX
+        || end == usize::MAX
+        || pre_dot_state == 0
+        || (pre_dot_state == 1 && start_dot == end - 1 && start_dot == start_part + 1)
+    {
+        return "";
+    }
+    &path[start_dot..end]
+}
+
+// parity: shared/utils/file-based-identifier.js genFileBasedIdentifier.
+pub fn gen_file_based_identifier(file_name: &str, export_name: &str, key: Option<&str>) -> String {
+    match key {
+        Some(key) => format!("{file_name}//{export_name}.{key}"),
+        None => format!("{file_name}//{export_name}"),
+    }
+}
+
+/// Node `path.relative` over absolute POSIX-style paths.
+pub fn path_relative(from: &Path, to: &Path) -> String {
+    let from = normalize_path(from);
+    let to = normalize_path(to);
+    let from_parts: Vec<&std::ffi::OsStr> = from
+        .components()
+        .filter_map(|c| match c {
+            Component::Normal(p) => Some(p),
+            _ => None,
+        })
+        .collect();
+    let to_parts: Vec<&std::ffi::OsStr> = to
+        .components()
+        .filter_map(|c| match c {
+            Component::Normal(p) => Some(p),
+            _ => None,
+        })
+        .collect();
+    let common = from_parts
+        .iter()
+        .zip(&to_parts)
+        .take_while(|(a, b)| **a == **b)
+        .count();
+    let mut segments: Vec<String> = vec!["..".to_string(); from_parts.len() - common];
+    segments.extend(
+        to_parts[common..]
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned()),
+    );
+    segments.join("/")
+}
+
+/// Lexical `.`/`..` folding (no symlink resolution, matching Node URL joins).
+pub fn normalize_path(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !out.pop() {
+                    out.push("..");
+                }
+            }
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn probe_order_is_raw_then_each_extension() {
+        assert_eq!(
+            possible_file_paths("./a.stylex"),
+            vec![
+                "./a.stylex",
+                "./a.stylex.js",
+                "./a.stylex.ts",
+                "./a.stylex.tsx",
+                "./a.stylex.jsx",
+                "./a.stylex.mjs",
+                "./a.stylex.cjs",
+            ]
+        );
+        // A known code extension is stripped before probing, raw stays first.
+        assert_eq!(
+            possible_file_paths("./a.stylex.js")[..3],
+            ["./a.stylex.js", "./a.stylex.js", "./a.stylex.ts"].map(String::from)
+        );
+        assert_eq!(possible_file_paths("./a.stylex.cjs")[0], "./a.stylex.cjs");
+        assert_eq!(possible_file_paths("./a.stylex.cjs")[1], "./a.stylex.js");
+    }
+
+    fn expansions(specifier: &str, aliases: &[(&str, &[&str])]) -> Vec<String> {
+        let map: AliasMap = aliases
+            .iter()
+            .map(|(k, v)| {
+                (
+                    (*k).to_string(),
+                    v.iter().map(|s| (*s).to_string()).collect(),
+                )
+            })
+            .collect();
+        possible_aliased_paths(specifier, Some(&map))
+    }
+
+    #[test]
+    fn alias_expansion_order_and_capture() {
+        // The raw specifier is always candidate #0; matches follow in
+        // declaration order, each value array in its own order.
+        assert_eq!(
+            expansions(
+                "@lib/c.stylex",
+                &[("@lib/*", &["/a/*", "/b/*"]), ("@x", &["/z"])]
+            ),
+            ["@lib/c.stylex", "/a/c.stylex", "/b/c.stylex"]
+        );
+        // A star-free key is exact equality, not a prefix.
+        assert_eq!(
+            expansions("@lib/c.stylex", &[("@lib", &["/a"])]),
+            ["@lib/c.stylex"]
+        );
+        // Suffix keys, a bare star, and the ignored third star.
+        assert_eq!(
+            expansions("~c.stylex", &[("~*.stylex", &["/a/*.stylex.ts"])])[1],
+            "/a/c.stylex.ts"
+        );
+        assert_eq!(
+            expansions("@x/c.stylex", &[("*", &["/a/*"])])[1],
+            "/a/@x/c.stylex"
+        );
+        assert_eq!(
+            expansions("@a/c.stylex", &[("@a/*.stylex*", &["/a/*.stylex.ts"])])[1],
+            "/a/c.stylex.ts"
+        );
+        // Every star in the value takes the same capture; overlapping
+        // before/after (JS slice with start > end) captures the empty string.
+        assert_eq!(
+            expansions("@d/d.stylex", &[("@d/*", &["/l/*/*"])])[1],
+            "/l/d.stylex/d.stylex"
+        );
+        assert_eq!(
+            expansions(
+                "@lib/c.stylex",
+                &[("@lib/c.stylex*c.stylex", &["/alt/*c.stylex"])]
+            )[1],
+            "/alt/c.stylex"
+        );
+        // An empty map short-circuits to the raw specifier alone.
+        assert_eq!(expansions("@lib/c.stylex", &[]), ["@lib/c.stylex"]);
+        assert_eq!(
+            possible_aliased_paths("@lib/c.stylex", None),
+            ["@lib/c.stylex"]
+        );
+    }
+
+    #[test]
+    fn relative_paths_for_rewritten_sources() {
+        let rel = |from: &str, to: &str| get_relative_path(Path::new(from), Path::new(to));
+        assert_eq!(
+            rel("/r/src/input.ts", "/r/lib/c.stylex.ts"),
+            "../lib/c.stylex.ts"
+        );
+        // A same-directory target still gains the `./` prefix.
+        assert_eq!(
+            rel("/r/src/input.ts", "/r/src/c.stylex.ts"),
+            "./c.stylex.ts"
+        );
+        assert_eq!(rel("/r/src/input.ts", "/r/lib"), "../lib");
+    }
+
+    #[test]
+    fn root_placeholder_joins_like_node() {
+        assert_eq!(node_path_join(Path::new("/r"), "lib/c.ts"), "/r/lib/c.ts");
+        // An absolute rest appends instead of replacing the base.
+        assert_eq!(node_path_join(Path::new("/r"), "/lib/c.ts"), "/r/lib/c.ts");
+        assert_eq!(
+            node_path_join(Path::new("/r/"), "lib/deep/../c.ts"),
+            "/r/lib/c.ts"
+        );
+    }
+
+    #[test]
+    fn suffix_matching() {
+        assert!(matches_file_suffix(".stylex", "foo.stylex"));
+        assert!(matches_file_suffix(".stylex", "foo.stylex.ts"));
+        assert!(matches_file_suffix(".stylex", "a/b/foo.stylex.mjs"));
+        assert!(!matches_file_suffix(".stylex", "foo.stylex.const.ts"));
+        assert!(!matches_file_suffix(".stylex", "foostylex.ts"));
+        assert!(matches_file_suffix(".stylex.const", "foo.stylex.const.ts"));
+        assert!(is_theme_specifier("./x.stylex", THEME_FILE_EXTENSION));
+        assert!(is_theme_specifier(
+            "./x.stylex.const.js",
+            THEME_FILE_EXTENSION
+        ));
+        assert!(is_theme_specifier(
+            "./x.transformed.js",
+            THEME_FILE_EXTENSION
+        ));
+        assert!(!is_theme_specifier("./helpers", THEME_FILE_EXTENSION));
+        assert!(!is_theme_specifier("./helpers.ts", THEME_FILE_EXTENSION));
+    }
+
+    #[test]
+    fn suffix_matching_under_a_configured_extension() {
+        assert!(matches_file_suffix("cssvars", "src/defaultcssvars.js"));
+        assert!(matches_file_suffix("", "src/whatever.ts"));
+        assert!(matches_file_suffix("/vars", "src/theme/vars.ts"));
+        assert!(!matches_file_suffix(".css", "src/tokens.css.mts"));
+        assert!(!matches_file_suffix(".css", "src/tokens.CSS.ts"));
+        assert!(!matches_file_suffix(".css", "src/tokensXcssY.ts"));
+        assert!(is_theme_specifier("./tokens.css", ".css"));
+        assert!(is_theme_specifier("./tokens.css.const", ".css"));
+        // `.transformed` stays allowed, the default extension stops resolving.
+        assert!(is_theme_specifier("./tokens.transformed", ".css"));
+        assert!(!is_theme_specifier("./tokens.stylex", ".css"));
+    }
+
+    #[test]
+    fn file_based_identifier() {
+        assert_eq!(
+            gen_file_based_identifier("pkg:src/t.stylex.ts", "colors", None),
+            "pkg:src/t.stylex.ts//colors"
+        );
+        assert_eq!(
+            gen_file_based_identifier("pkg:t.stylex.ts", "colors", Some("accent")),
+            "pkg:t.stylex.ts//colors.accent"
+        );
+        assert_eq!(
+            gen_file_based_identifier("f", "e", Some("button.primary")),
+            "f//e.button.primary"
+        );
+    }
+
+    fn node_fixture() -> PathBuf {
+        static ONCE: std::sync::Once = std::sync::Once::new();
+        let root = std::env::temp_dir().join("stylex-rs-node-resolution-fixture");
+        ONCE.call_once(|| {
+            let write = |rel: &str, content: &str| {
+                let path = root.join(rel);
+                std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+                std::fs::write(path, content).unwrap();
+            };
+            write(
+                "package.json",
+                r##"{"name":"self-pkg","exports":{"./self.stylex":"./src/self.stylex.js"},"imports":{"#tok/*":"./src/hashed/*.js","#hash/*.stylex":"./src/hashed/*.stylex.js"}}"##,
+            );
+            write("src/self.stylex.js", "");
+            write("src/hashed/deep.stylex.js", "");
+            write(
+                "node_modules/design-tokens/package.json",
+                r#"{"name":"design-tokens","exports":{"./theme.stylex":"./out/theme.stylex.js","./pat/*.stylex":"./out/pat-*.stylex.js","./cond.stylex":{"browser":"./out/browser.js","node":"./out/node.js","default":"./out/default.js"},"./blocked.stylex":null}}"#,
+            );
+            write("node_modules/design-tokens/out/theme.stylex.js", "");
+            write("node_modules/design-tokens/out/pat-deep.stylex.js", "");
+            write("node_modules/design-tokens/out/node.js", "");
+            write("node_modules/design-tokens/out/default.js", "");
+            write("node_modules/plain-tokens/package.json", r#"{"name":"plain-tokens"}"#);
+            write("node_modules/plain-tokens/lib/theme.stylex.js", "");
+            write(
+                "node_modules/tokens.stylex/package.json",
+                r#"{"name":"tokens.stylex","main":"lib/entry"}"#,
+            );
+            write("node_modules/tokens.stylex/lib/entry.js", "");
+        });
+        // resolve_import realpaths results; macOS tempdirs live under a
+        // /var → /private/var symlink, so compare against the real root.
+        std::fs::canonicalize(&root).unwrap_or(root)
+    }
+
+    #[test]
+    fn node_package_resolution() {
+        let root = node_fixture();
+        let importer = root.join("src/input.ts");
+        let resolve = |spec: &str| {
+            StdFs
+                .resolve_import(spec, &importer, ResolveConfig::default())
+                .map(|p| path_relative(&root, &p))
+        };
+        // exports: exact, pattern, conditions (node beats default), blocked.
+        assert_eq!(
+            resolve("design-tokens/theme.stylex").as_deref(),
+            Some("node_modules/design-tokens/out/theme.stylex.js")
+        );
+        assert_eq!(
+            resolve("design-tokens/pat/deep.stylex").as_deref(),
+            Some("node_modules/design-tokens/out/pat-deep.stylex.js")
+        );
+        assert_eq!(
+            resolve("design-tokens/cond.stylex").as_deref(),
+            Some("node_modules/design-tokens/out/node.js")
+        );
+        assert_eq!(resolve("design-tokens/blocked.stylex"), None);
+        assert_eq!(resolve("design-tokens/missing.stylex"), None);
+        // no exports: URL-join subpath; bare root: legacy main resolution.
+        assert_eq!(
+            resolve("plain-tokens/lib/theme.stylex").as_deref(),
+            Some("node_modules/plain-tokens/lib/theme.stylex.js")
+        );
+        assert_eq!(
+            resolve("tokens.stylex").as_deref(),
+            Some("node_modules/tokens.stylex/lib/entry.js")
+        );
+        // self-reference through the scope package's own exports.
+        assert_eq!(
+            resolve("self-pkg/self.stylex").as_deref(),
+            Some("src/self.stylex.js")
+        );
+        // imports maps: star-final keys match; the oracle's non-final-star
+        // quirk (prefix = key minus last char) keeps #hash/*.stylex dead.
+        assert_eq!(
+            resolve("#tok/deep.stylex").as_deref(),
+            Some("src/hashed/deep.stylex.js")
+        );
+        assert_eq!(resolve("#hash/deep.stylex"), None);
+    }
+
+    /// Every expectation here was executed against import-meta-resolve 4.2.1
+    /// (scratchpad imr-r4-probe.mjs, 2026-08-28) — codex r4 findings 2 + 11.
+    fn hostile_fixture() -> PathBuf {
+        static ONCE: std::sync::Once = std::sync::Once::new();
+        let root = std::env::temp_dir().join("stylex-rs-node-resolution-hostile");
+        ONCE.call_once(|| {
+            let write = |rel: &str, content: &str| {
+                let path = root.join(rel);
+                std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+                std::fs::write(path, content).unwrap();
+            };
+            write(
+                "package.json",
+                r##"{"name":"hostile-root","imports":{"#tok/*":"./src/hashed/*.js","#url":"https://example.com/x.js","#bare":"sealed/tokens/x.stylex","#barestar/*":"sealed/tokens/*.stylex","#arr/*":[null,"./src/hashed/*.js"],"#dead/*.stylex":"./src/hashed/*.stylex.js"}}"##,
+            );
+            write("src/input.ts", "");
+            write("src/hashed/deep.stylex.js", "");
+            write("src/hashed/x.js", "");
+            write("src/esc.js", "");
+            write("src/esc%2fx.stylex.js", "");
+            write("src/.hidden.stylex.js", "");
+            write(
+                "node_modules/sealed/package.json",
+                r#"{"name":"sealed","exports":{
+                    "./tokens/*.stylex":"./public/*.stylex.js",
+                    "./arrnull.stylex":[null,"./ok.stylex.js"],
+                    "./arrbad.stylex":["bad-no-dot-slash","./ok.stylex.js"],
+                    "./arrempty.stylex":[],
+                    "./arrnested.stylex":[[],"./ok.stylex.js"],
+                    "./arrmiss.stylex":["./gone.stylex.js","./ok.stylex.js"],
+                    "./multistar/*.stylex":"./out/*-*.stylex.js",
+                    "./nested.stylex":{"node":{"unknown":"./inner.stylex.js"},"default":"./default.stylex.js"},
+                    "./nesteddef.stylex":{"node":{"unknown":"./inner.stylex.js","default":"./innerdef.stylex.js"},"default":"./default.stylex.js"},
+                    "./num.stylex":{"0":"./zero.stylex.js","default":"./default.stylex.js"},
+                    "./numarr.stylex":[{"0":"./zero.stylex.js"},"./ok.stylex.js"],
+                    "./badtarget.stylex":"./../escape.stylex.js",
+                    "./nmtarget.stylex":"./node_modules/inner.stylex.js",
+                    "./dslash.stylex":".//ok.stylex.js",
+                    "./dotseg.stylex":"./././ok.stylex.js",
+                    "./urltarget.stylex":"file:///etc/passwd",
+                    "./numtarget.stylex":[42,"./ok.stylex.js"]
+                }}"#,
+            );
+            for f in [
+                "public/x.stylex.js",
+                "public/a%2fb.stylex.js",
+                "public/a\\b.stylex.js",
+                "public/a/b.stylex.js",
+                "ok.stylex.js",
+                "out/deep-deep.stylex.js",
+                "default.stylex.js",
+                "inner.stylex.js",
+                "innerdef.stylex.js",
+                "zero.stylex.js",
+                "private.stylex.js",
+                "node_modules/inner.stylex.js",
+            ] {
+                write(&format!("node_modules/sealed/{f}"), "");
+            }
+            write("node_modules/escape.stylex.js", "");
+            write("node_modules/badjson/package.json", "{ nope");
+            write("node_modules/badjson/lib/x.stylex.js", "");
+            write("node_modules/badjson/index.js", "");
+            write("node_modules/plain/lib/x.stylex.js", "");
+            write("node_modules/plain/index.js", "");
+            write("scoped/package.json", "{ also nope");
+            write("scoped/input.ts", "");
+        });
+        std::fs::canonicalize(&root).unwrap_or(root)
+    }
+
+    #[test]
+    fn exports_invalid_segments_reject() {
+        let root = hostile_fixture();
+        let importer = root.join("src/input.ts");
+        let resolve = |spec: &str| {
+            StdFs
+                .resolve_import(spec, &importer, ResolveConfig::default())
+                .map(|p| path_relative(&root, &p))
+        };
+        assert_eq!(
+            resolve("sealed/tokens/x.stylex").as_deref(),
+            Some("node_modules/sealed/public/x.stylex.js")
+        );
+        // `..`/`.`/node_modules subpath segments reject even when the
+        // normalized file exists (finding 2's private-file escape).
+        assert_eq!(resolve("sealed/tokens/../private.stylex"), None);
+        assert_eq!(resolve("sealed/tokens/%2e%2e/private.stylex"), None);
+        assert_eq!(resolve("sealed/tokens/%2E%2E/private.stylex"), None);
+        assert_eq!(resolve("sealed/tokens/./x.stylex"), None);
+        assert_eq!(resolve("sealed/tokens/node_modules/x.stylex"), None);
+        assert_eq!(resolve("sealed/tokens/NoDe_MoDuLeS/x.stylex"), None);
+        assert_eq!(resolve("sealed/tokens/%6eode_modules/x.stylex"), None);
+        assert_eq!(resolve("sealed/tokens/..\\private.stylex"), None);
+        // Encoded separators reject at finalize; the literal files exist.
+        assert_eq!(resolve("sealed/tokens/a%2fb.stylex"), None);
+        assert_eq!(resolve("sealed/tokens/a%5Cb.stylex"), None);
+        assert_eq!(resolve("./esc%2fx.stylex"), None);
+        // A raw backslash is a URL path separator, not a filename char.
+        assert_eq!(
+            resolve("sealed/tokens/a\\b.stylex").as_deref(),
+            Some("node_modules/sealed/public/a/b.stylex.js")
+        );
+        // Target-side invalid segments reject; empty segments only warn.
+        assert_eq!(resolve("sealed/badtarget.stylex"), None);
+        assert_eq!(resolve("sealed/nmtarget.stylex"), None);
+        assert_eq!(resolve("sealed/dotseg.stylex"), None);
+        assert_eq!(
+            resolve("sealed/dslash.stylex").as_deref(),
+            Some("node_modules/sealed/ok.stylex.js")
+        );
+        assert_eq!(resolve("sealed/urltarget.stylex"), None);
+        // No-exports packages take the raw URL join — `..` allowed there.
+        assert_eq!(
+            resolve("plain/lib/x.stylex").as_deref(),
+            Some("node_modules/plain/lib/x.stylex.js")
+        );
+        assert_eq!(
+            resolve("plain/lib/../lib/x.stylex").as_deref(),
+            Some("node_modules/plain/lib/x.stylex.js")
+        );
+        assert_eq!(
+            resolve("plain/lib/../../escape.stylex").as_deref(),
+            Some("node_modules/escape.stylex.js")
+        );
+        // Dot-leading non-relative specifiers are invalid package names.
+        assert_eq!(resolve(".hidden.stylex"), None);
+    }
+
+    #[test]
+    fn exports_result_algebra() {
+        let root = hostile_fixture();
+        let importer = root.join("src/input.ts");
+        let resolve = |spec: &str| {
+            StdFs
+                .resolve_import(spec, &importer, ResolveConfig::default())
+                .map(|p| path_relative(&root, &p))
+        };
+        // Arrays: null and invalid targets fall through; fatal errors and
+        // missing files do not; an exhausted/empty array is not exported.
+        assert_eq!(
+            resolve("sealed/arrnull.stylex").as_deref(),
+            Some("node_modules/sealed/ok.stylex.js")
+        );
+        assert_eq!(
+            resolve("sealed/arrbad.stylex").as_deref(),
+            Some("node_modules/sealed/ok.stylex.js")
+        );
+        assert_eq!(
+            resolve("sealed/arrnested.stylex").as_deref(),
+            Some("node_modules/sealed/ok.stylex.js")
+        );
+        assert_eq!(
+            resolve("sealed/numtarget.stylex").as_deref(),
+            Some("node_modules/sealed/ok.stylex.js")
+        );
+        assert_eq!(resolve("sealed/arrempty.stylex"), None);
+        assert_eq!(resolve("sealed/arrmiss.stylex"), None);
+        // Multi-star targets replace every star with the matched subpath.
+        assert_eq!(
+            resolve("sealed/multistar/deep.stylex").as_deref(),
+            Some("node_modules/sealed/out/deep-deep.stylex.js")
+        );
+        // A matched condition whose object has no active inner key yields
+        // null and STOPS — the outer default is never consulted.
+        assert_eq!(resolve("sealed/nested.stylex"), None);
+        assert_eq!(
+            resolve("sealed/nesteddef.stylex").as_deref(),
+            Some("node_modules/sealed/innerdef.stylex.js")
+        );
+        // Numeric condition keys are invalid-package-config, even alongside
+        // a default, and abort target arrays instead of falling through.
+        assert_eq!(resolve("sealed/num.stylex"), None);
+        assert_eq!(resolve("sealed/numarr.stylex"), None);
+        // Malformed package.json is fatal, not absent-with-legacy-fallback.
+        assert_eq!(resolve("badjson/lib/x.stylex"), None);
+        assert_eq!(resolve("badjson"), None);
+        // Missing package.json (dir exists) still gets legacy resolution.
+        assert_eq!(
+            resolve("plain").as_deref(),
+            Some("node_modules/plain/index.js")
+        );
+    }
+
+    #[test]
+    fn imports_algebra_and_malformed_scope() {
+        let root = hostile_fixture();
+        let importer = root.join("src/input.ts");
+        let resolve = |spec: &str| {
+            StdFs
+                .resolve_import(spec, &importer, ResolveConfig::default())
+                .map(|p| path_relative(&root, &p))
+        };
+        assert_eq!(
+            resolve("#tok/deep.stylex").as_deref(),
+            Some("src/hashed/deep.stylex.js")
+        );
+        // Subpath validation applies to imports patterns too.
+        assert_eq!(resolve("#tok/../esc"), None);
+        assert_eq!(resolve("#tok/x/"), None);
+        // Internal targets that parse as URLs are invalid.
+        assert_eq!(resolve("#url"), None);
+        // Bare re-entry through another package's exports, exact + pattern.
+        assert_eq!(
+            resolve("#bare").as_deref(),
+            Some("node_modules/sealed/public/x.stylex.js")
+        );
+        assert_eq!(
+            resolve("#barestar/x").as_deref(),
+            Some("node_modules/sealed/public/x.stylex.js")
+        );
+        // Null-in-array fallback holds for imports maps as well.
+        assert_eq!(resolve("#arr/x").as_deref(), Some("src/hashed/x.js"));
+        // Non-star-final keys stay dead (prefix = key minus last char).
+        assert_eq!(resolve("#dead/deep.stylex"), None);
+        // A malformed scope package.json is fatal for every bare/# import.
+        let scoped = root.join("scoped/input.ts");
+        assert_eq!(
+            StdFs.resolve_import("sealed/tokens/x.stylex", &scoped, ResolveConfig::default()),
+            None
+        );
+        assert_eq!(
+            StdFs.resolve_import("#tok/deep.stylex", &scoped, ResolveConfig::default()),
+            None
+        );
+    }
+
+    /// Every expectation executed against import-meta-resolve 4.2.1
+    /// (scratchpad imr-r5-probe.mjs, 2026-08-28) — codex r5 findings 3-5.
+    fn r5_fixture() -> PathBuf {
+        static ONCE: std::sync::Once = std::sync::Once::new();
+        let root = std::env::temp_dir().join("stylex-rs-node-resolution-r5");
+        ONCE.call_once(|| {
+            let write = |rel: &str, content: &str| {
+                let path = root.join(rel);
+                std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+                std::fs::write(path, content).unwrap();
+            };
+            write(
+                "package.json",
+                r##"{"name":"r5-root","imports":{"#x*é":"./src/star/*.stylex.js","#y*":"./src/star/*.stylex.js","#q*":"./src/star/*.stylex.js?mode=theme","#é*":"./src/star/*.stylex.js","#bool.stylex":["bad-bool","./src/fallback.stylex.js"],"#num.stylex":["bad-num","./src/fallback.stylex.js"]}}"##,
+            );
+            for f in [
+                "src/input.ts",
+                "src/star/foo.stylex.stylex.js",
+                "src/star/*foo.stylex.stylex.js",
+                "src/star/-theme.stylex.js",
+                "src/fallback.stylex.js",
+                "src/x%20.stylex.js",
+                "src/x .stylex.js",
+                "src/only-enc%21.stylex.js",
+                "src/pct é.stylex.js",
+                "src/q.stylex",
+            ] {
+                write(f, "");
+            }
+            write(
+                "node_modules/bad-bool/package.json",
+                r#"{"name":"bad-bool","exports":true}"#,
+            );
+            write("node_modules/bad-bool/index.js", "");
+            write(
+                "node_modules/bad-num/package.json",
+                r#"{"name":"bad-num","exports":42}"#,
+            );
+            write("node_modules/bad-num/index.js", "");
+            write(
+                "node_modules/qexp/package.json",
+                r##"{"name":"qexp","exports":{
+                    "./q.stylex":"./out/q.stylex.js?mode=x",
+                    "./frag.stylex":"./out/q.stylex.js#frag",
+                    "./qstar/*.stylex":"./out/*.stylex.js?v=*",
+                    "./enc/*.stylex":"./out/*.stylex.js",
+                    "./malformed.stylex":"./out/q%2g.stylex.js",
+                    "./encdot/*.stylex":"./out/%2e%2e/*.stylex.js"
+                }}"##,
+            );
+            for f in [
+                "out/q.stylex.js",
+                "out/deep.stylex.js",
+                "out/sp ace.stylex.js",
+                "out/q%2g.stylex.js",
+                "escape.stylex.js",
+            ] {
+                write(&format!("node_modules/qexp/{f}"), "");
+            }
+        });
+        std::fs::canonicalize(&root).unwrap_or(root)
+    }
+
+    #[test]
+    fn r5_unicode_imports_keys() {
+        let root = r5_fixture();
+        let importer = root.join("src/input.ts");
+        let resolve = |spec: &str| {
+            StdFs
+                .resolve_import(spec, &importer, ResolveConfig::default())
+                .map(|p| path_relative(&root, &p))
+        };
+        // The é key's quirk prefix is "#x*" (slice(0,-1) in UTF-16 units);
+        // this specifier byte-panicked before the fix.
+        assert_eq!(resolve("#xfoo.stylex"), None);
+        // A literal-star specifier does satisfy the quirk prefix; matched
+        // starts at the star's UNIT index, keeping the star itself.
+        assert_eq!(
+            resolve("#x*foo.stylexé").as_deref(),
+            Some("src/star/*foo.stylex.stylex.js")
+        );
+        assert_eq!(
+            resolve("#yfoo.stylex").as_deref(),
+            Some("src/star/foo.stylex.stylex.js")
+        );
+        // Multibyte prefix: matched must slice at unit index 2, not byte 3.
+        assert_eq!(
+            resolve("#éfoo.stylex").as_deref(),
+            Some("src/star/foo.stylex.stylex.js")
+        );
+    }
+
+    #[test]
+    fn r5_file_url_semantics() {
+        let root = r5_fixture();
+        let importer = root.join("src/input.ts");
+        let resolve = |spec: &str| {
+            StdFs
+                .resolve_import(spec, &importer, ResolveConfig::default())
+                .map(|p| path_relative(&root, &p))
+        };
+        // Percent-decoding at finalization: the literal-percent file loses.
+        assert_eq!(
+            resolve("./x%20.stylex").as_deref(),
+            Some("src/x .stylex.js")
+        );
+        assert_eq!(resolve("./x .stylex").as_deref(), Some("src/x .stylex.js"));
+        assert_eq!(resolve("./only-enc%21.stylex"), None);
+        assert_eq!(
+            resolve("./pct%20é.stylex").as_deref(),
+            Some("src/pct é.stylex.js")
+        );
+        // Query/fragment end the pathname (extensions append after them, so
+        // only the raw extensionless candidate can hit).
+        assert_eq!(
+            resolve("./q.stylex?mode=theme").as_deref(),
+            Some("src/q.stylex")
+        );
+        assert_eq!(resolve("./q.stylex#frag").as_deref(), Some("src/q.stylex"));
+        // Malformed escapes reject (fileURLToPath URIError).
+        assert_eq!(resolve("./q%2g.stylex"), None);
+        assert_eq!(resolve("./x%2G.stylex"), None);
+        // Encoded dot-dot pops in relative URL joins.
+        assert_eq!(
+            resolve("./star/%2e%2e/q.stylex").as_deref(),
+            Some("src/q.stylex")
+        );
+        // Targets: query/fragment stripped for the fs lookup.
+        assert_eq!(
+            resolve("qexp/q.stylex").as_deref(),
+            Some("node_modules/qexp/out/q.stylex.js")
+        );
+        assert_eq!(
+            resolve("qexp/frag.stylex").as_deref(),
+            Some("node_modules/qexp/out/q.stylex.js")
+        );
+        assert_eq!(
+            resolve("qexp/qstar/deep.stylex").as_deref(),
+            Some("node_modules/qexp/out/deep.stylex.js")
+        );
+        assert_eq!(
+            resolve("qexp/enc/sp%20ace.stylex").as_deref(),
+            Some("node_modules/qexp/out/sp ace.stylex.js")
+        );
+        assert_eq!(
+            resolve("#q-theme").as_deref(),
+            Some("src/star/-theme.stylex.js")
+        );
+        // A query inside the subpath is part of the exports-key match.
+        assert_eq!(resolve("qexp/enc/deep.stylex?x"), None);
+        assert_eq!(resolve("qexp/malformed.stylex"), None);
+        // Encoded dot-dot in a target is invalid-segment, never a pop.
+        assert_eq!(resolve("qexp/encdot/deep.stylex"), None);
+    }
+
+    #[test]
+    fn r5_primitive_exports_roots_are_fatal() {
+        let root = r5_fixture();
+        let importer = root.join("src/input.ts");
+        let resolve = |spec: &str| {
+            StdFs
+                .resolve_import(spec, &importer, ResolveConfig::default())
+                .map(|p| path_relative(&root, &p))
+        };
+        // exports:true / exports:42 → PATH_NOT_EXPORTED, aborting the target
+        // array — the fallback entry must never resolve.
+        assert_eq!(resolve("#bool.stylex"), None);
+        assert_eq!(resolve("#num.stylex"), None);
+        assert_eq!(resolve("bad-bool"), None);
+        assert_eq!(resolve("bad-bool/sub.stylex"), None);
+    }
+
+    #[test]
+    fn segment_and_key_helpers() {
+        assert!(has_deprecated_segment(".."));
+        assert!(has_deprecated_segment("a/../b"));
+        assert!(has_deprecated_segment("a/%2e%2E/b"));
+        assert!(has_deprecated_segment("%2e."));
+        assert!(has_deprecated_segment("a\\..\\b"));
+        assert!(has_deprecated_segment("x/node_modules/y"));
+        assert!(has_deprecated_segment("x/NODE_MODULES/y"));
+        assert!(has_deprecated_segment("x/%6eode_modul%65s/y"));
+        assert!(!has_deprecated_segment("a//b"));
+        assert!(!has_deprecated_segment("a/.b/b"));
+        assert!(!has_deprecated_segment("a/..b/b"));
+        assert!(!has_deprecated_segment("a/node_modulesx/b"));
+        assert!(!has_deprecated_segment("a/%2f/b"));
+        assert!(is_js_array_index("0"));
+        assert!(is_js_array_index("42"));
+        assert!(is_js_array_index("1.5"));
+        assert!(!is_js_array_index("01"));
+        assert!(!is_js_array_index("-1"));
+        assert!(!is_js_array_index("0x10"));
+        assert!(!is_js_array_index(" 1"));
+        assert!(!is_js_array_index("4294967295"));
+        assert!(is_js_array_index("4294967294"));
+        assert!(!is_js_array_index("default"));
+        assert!(!is_js_array_index("NaN"));
+        assert!(!is_js_array_index("Infinity"));
+        assert!(parses_as_url("https://example.com/x.js"));
+        assert!(parses_as_url("file:///etc/passwd"));
+        assert!(parses_as_url("a:"));
+        assert!(!parses_as_url("1a:b"));
+        assert!(!parses_as_url("a/b:c"));
+        assert!(!parses_as_url("no-colon"));
+    }
+
+    #[test]
+    fn relative_paths() {
+        let rel = |a: &str, b: &str| path_relative(Path::new(a), Path::new(b));
+        assert_eq!(rel("/a/b", "/a/b/c/d.ts"), "c/d.ts");
+        assert_eq!(rel("/a/b", "/a/x/d.ts"), "../x/d.ts");
+        assert_eq!(rel("/a/b/c", "/a"), "../..");
+        assert_eq!(
+            normalize_path(Path::new("/a/b/../c/./d.ts")),
+            PathBuf::from("/a/c/d.ts")
+        );
+    }
+}

--- a/crates/stylex/src/options.rs
+++ b/crates/stylex/src/options.rs
@@ -1,0 +1,632 @@
+use std::path::PathBuf;
+
+use serde_json::Value;
+
+use crate::errors::{ErrorCode, StylexError};
+use crate::eval::value::{EvalValue, JsObjectMap};
+use crate::module_resolution::THEME_FILE_EXTENSION;
+
+/// Raw `@stylexjs/babel-plugin` options as they appear in conformance jobs.
+/// Fields hold unvalidated JSON; all typing happens in [`CompilerOptions::resolve`].
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct CompilerOptions {
+    pub dev: Option<Value>,
+    pub test: Option<Value>,
+    pub debug: Option<Value>,
+    pub class_name_prefix: Option<Value>,
+    pub import_sources: Option<Value>,
+    pub runtime_injection: Option<Value>,
+    pub style_resolution: Option<Value>,
+    pub property_validation_mode: Option<Value>,
+    pub unstable_module_resolution: Option<Value>,
+    pub treeshake_compensation: Option<Value>,
+    pub sx_prop_name: Option<Value>,
+    pub enable_debug_class_names: Option<Value>,
+    pub enable_debug_data_prop: Option<Value>,
+    pub enable_dev_class_names: Option<Value>,
+    pub enable_font_size_px_to_rem: Option<Value>,
+    pub enable_inlined_conditional_merge: Option<Value>,
+    pub enable_media_query_order: Option<Value>,
+    pub enable_minified_keys: Option<Value>,
+    pub enable_legacy_value_flipping: Option<Value>,
+    pub enable_logical_styles_polyfill: Option<Value>,
+    pub enable_ltr_rtl_comments: Option<Value>,
+    pub aliases: Option<Value>,
+    pub rewrite_aliases: Option<Value>,
+    pub debug_file_path: Option<Value>,
+    pub env: Option<Value>,
+    pub include: Option<Value>,
+    pub exclude: Option<Value>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum StyleResolution {
+    PropertySpecificity,
+    ApplicationOrder,
+    LegacyExpandShorthands,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum PropertyValidationMode {
+    Silent,
+    Warn,
+    Throw,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ModuleResolutionType {
+    CommonJs,
+    Haste,
+}
+
+/// `custom` / `experimental_crossFileParsing` stay unsupported; `root_dir` is
+/// always `None` under haste (see below).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModuleResolution {
+    pub kind: ModuleResolutionType,
+    pub root_dir: Option<PathBuf>,
+    /// `themeFileExtension ?? '.stylex'`; gates hashing only, never hashed.
+    pub theme_file_extension: String,
+}
+
+impl ModuleResolution {
+    /// Upstream derives the consts suffix, it is never configured separately.
+    pub fn consts_file_extension(&self) -> String {
+        format!("{}.const", self.theme_file_extension)
+    }
+}
+
+/// `aliases` in declaration order: the candidate list is consumed in order and
+/// the first target that resolves on disk wins, so a map would lose the answer.
+pub type AliasMap = Vec<(String, Vec<String>)>;
+/// One resolved `importSources` entry. `Aliased` names the single named export
+/// that carries the whole stylex namespace for that source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImportSource {
+    Plain(String),
+    Aliased { from: String, as_name: String },
+}
+
+impl ImportSource {
+    pub fn from_specifier(&self) -> &str {
+        match self {
+            ImportSource::Plain(s) => s,
+            ImportSource::Aliased { from, .. } => from,
+        }
+    }
+}
+
+/// Resolved `runtimeInjection`: the module the inject call is imported from,
+/// plus the named export to import (`None` = default import).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeInjection {
+    pub from: String,
+    pub as_name: Option<String>,
+}
+
+const DEFAULT_INJECT_PATH: &str = "@stylexjs/stylex/lib/stylex-inject";
+
+// parity: babel-plugin src/utils/state-manager.js setOptions +
+// src/shared/utils/default-options.js (0.19.0 ??-chains).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedOptions {
+    pub class_name_prefix: String,
+    pub dev: bool,
+    pub debug: bool,
+    pub test: bool,
+    pub enable_debug_class_names: bool,
+    pub enable_debug_data_prop: bool,
+    pub enable_dev_class_names: bool,
+    pub enable_font_size_px_to_rem: bool,
+    pub enable_inlined_conditional_merge: bool,
+    pub enable_media_query_order: bool,
+    pub enable_minified_keys: bool,
+    pub enable_legacy_value_flipping: bool,
+    pub enable_logical_styles_polyfill: bool,
+    pub enable_ltr_rtl_comments: bool,
+    pub sx_prop_name: Option<String>,
+    /// `Object.freeze({...options.env})`: always an object, injected into the
+    /// evaluator as `stylex.env` / the `env` named import.
+    pub env: EvalValue,
+    pub import_sources: Vec<ImportSource>,
+    pub runtime_injection: Option<RuntimeInjection>,
+    pub style_resolution: StyleResolution,
+    pub property_validation_mode: PropertyValidationMode,
+    pub treeshake_compensation: bool,
+    pub unstable_module_resolution: Option<ModuleResolution>,
+    pub aliases: Option<AliasMap>,
+    pub rewrite_aliases: bool,
+    /// Canonical `{:?}` capture of every other field, computed once at
+    /// resolve: cache/memo keys read it instead of reformatting per call.
+    pub cache_repr: String,
+}
+
+impl ResolvedOptions {
+    /// parity: `state.importSources.includes(source)` — the `.map(from)` list.
+    pub fn is_import_source(&self, source: &str) -> bool {
+        self.import_sources
+            .iter()
+            .any(|entry| entry.from_specifier() == source)
+    }
+
+    /// parity: `state.importAs(source)` — first object entry whose `from`
+    /// matches; string entries are invisible to it.
+    pub fn import_as(&self, source: &str) -> Option<&str> {
+        self.import_sources.iter().find_map(|entry| match entry {
+            ImportSource::Aliased { from, as_name } if from == source => Some(as_name.as_str()),
+            _ => None,
+        })
+    }
+
+    /// parity: `state.importSources[i]` after the `.map(from)` projection.
+    pub fn import_source_at(&self, index: usize) -> Option<&str> {
+        self.import_sources
+            .get(index)
+            .map(ImportSource::from_specifier)
+    }
+}
+
+impl Default for ResolvedOptions {
+    fn default() -> Self {
+        CompilerOptions::default()
+            .resolve()
+            .expect("empty options always resolve")
+    }
+}
+
+pub fn resolve_options(raw: &CompilerOptions) -> Result<ResolvedOptions, StylexError> {
+    raw.resolve()
+}
+
+impl CompilerOptions {
+    pub fn from_json(value: &Value) -> Result<Self, StylexError> {
+        let mut opts = Self::default();
+        let map = match value {
+            Value::Null => return Ok(opts),
+            Value::Object(map) => map,
+            other => {
+                return Err(StylexError::new(
+                    ErrorCode::InvalidOptionValue,
+                    format!(
+                        "Expected the @stylexjs/babel-plugin options to be an object, but got `{}`.",
+                        json_text(other)
+                    ),
+                ));
+            }
+        };
+        for (key, v) in map {
+            let slot = match key.as_str() {
+                "dev" => &mut opts.dev,
+                "test" => &mut opts.test,
+                "debug" => &mut opts.debug,
+                "classNamePrefix" => &mut opts.class_name_prefix,
+                "importSources" => &mut opts.import_sources,
+                "runtimeInjection" => &mut opts.runtime_injection,
+                "styleResolution" => &mut opts.style_resolution,
+                "propertyValidationMode" => &mut opts.property_validation_mode,
+                "unstable_moduleResolution" => &mut opts.unstable_module_resolution,
+                "treeshakeCompensation" => &mut opts.treeshake_compensation,
+                "sxPropName" => &mut opts.sx_prop_name,
+                "enableDebugClassNames" => &mut opts.enable_debug_class_names,
+                "enableDebugDataProp" => &mut opts.enable_debug_data_prop,
+                "enableDevClassNames" => &mut opts.enable_dev_class_names,
+                "enableFontSizePxToRem" => &mut opts.enable_font_size_px_to_rem,
+                "enableInlinedConditionalMerge" => &mut opts.enable_inlined_conditional_merge,
+                "enableMediaQueryOrder" => &mut opts.enable_media_query_order,
+                "enableMinifiedKeys" => &mut opts.enable_minified_keys,
+                "enableLegacyValueFlipping" => &mut opts.enable_legacy_value_flipping,
+                "enableLogicalStylesPolyfill" => &mut opts.enable_logical_styles_polyfill,
+                "enableLTRRTLComments" => &mut opts.enable_ltr_rtl_comments,
+                "aliases" => &mut opts.aliases,
+                "rewriteAliases" => &mut opts.rewrite_aliases,
+                "debugFilePath" => &mut opts.debug_file_path,
+                "env" => &mut opts.env,
+                "include" => &mut opts.include,
+                "exclude" => &mut opts.exclude,
+                // Inert upstream: state-manager.js hardcodes definedStylexCSSVariables to `{}`,
+                // and useLayers is a processStylexRules config key the plugin never reads.
+                "definedStylexCSSVariables" | "useLayers" => continue,
+                _ => return Err(StylexError::unknown_option(key)),
+            };
+            *slot = Some(v.clone());
+        }
+        Ok(opts)
+    }
+
+    // Divergence from upstream: type-invalid values hard-error (InvalidOptionValue)
+    // instead of logAndDefault's log-and-fall-back, except runtimeInjection below.
+    pub fn resolve(&self) -> Result<ResolvedOptions, StylexError> {
+        let dev = bool_opt("options.dev", &self.dev)?.unwrap_or(false);
+        let debug = bool_opt("options.debug", &self.debug)?.unwrap_or(dev);
+        let enable_debug_class_names = bool_opt(
+            "options.enableDebugClassNames",
+            &self.enable_debug_class_names,
+        )?
+        .unwrap_or(false);
+        let enable_debug_data_prop =
+            bool_opt("options.enableDebugDataProp", &self.enable_debug_data_prop)?.unwrap_or(debug);
+        let enable_dev_class_names =
+            bool_opt("options.enableDevClassNames", &self.enable_dev_class_names)?.unwrap_or(dev);
+
+        let enable_font_size_px_to_rem = bool_opt(
+            "options.enableFontSizePxToRem",
+            &self.enable_font_size_px_to_rem,
+        )?
+        .unwrap_or(false);
+
+        let enable_inlined_conditional_merge = bool_opt(
+            "options.enableInlinedConditionalMerge",
+            &self.enable_inlined_conditional_merge,
+        )?
+        .unwrap_or(true);
+        let enable_minified_keys =
+            bool_opt("options.enableMinifiedKeys", &self.enable_minified_keys)?.unwrap_or(true);
+        let enable_media_query_order = bool_opt(
+            "options.enableMediaQueryOrder",
+            &self.enable_media_query_order,
+        )?
+        .unwrap_or(true);
+
+        let enable_legacy_value_flipping = bool_opt(
+            "options.enableLegacyValueFlipping",
+            &self.enable_legacy_value_flipping,
+        )?
+        .unwrap_or(false);
+        let enable_logical_styles_polyfill = bool_opt(
+            "options.enableLogicalStylesPolyfill",
+            &self.enable_logical_styles_polyfill,
+        )?
+        .unwrap_or(false);
+        let enable_ltr_rtl_comments = bool_opt(
+            "options.enableLTRRTLComments",
+            &self.enable_ltr_rtl_comments,
+        )?
+        .unwrap_or(false);
+        if enable_ltr_rtl_comments {
+            return Err(StylexError::unsupported_option(
+                "enableLTRRTLComments: true",
+            ));
+        }
+
+        let sx_prop_name = match get(&self.sx_prop_name) {
+            None => Some("sx".to_string()),
+            Some(Value::String(s)) => Some(s.clone()),
+            Some(Value::Bool(false)) => None,
+            Some(other) => {
+                return Err(invalid_value(
+                    "options.sxPropName",
+                    other,
+                    "a string or the literal false",
+                ));
+            }
+        };
+
+        let test = bool_opt("options.test", &self.test)?.unwrap_or(false);
+
+        // The one logAndDefault shape reproduced here: a type-invalid value
+        // (null and `{from}` included) falls back to off instead of throwing.
+        let runtime_injection = match get(&self.runtime_injection) {
+            Some(Value::Bool(true)) => Some(RuntimeInjection {
+                from: DEFAULT_INJECT_PATH.to_string(),
+                as_name: None,
+            }),
+            Some(Value::String(s)) => Some(RuntimeInjection {
+                from: s.clone(),
+                as_name: None,
+            }),
+            Some(Value::Object(map)) => match (map.get("from"), map.get("as")) {
+                (Some(Value::String(from)), Some(Value::String(as_name))) => {
+                    Some(RuntimeInjection {
+                        from: from.clone(),
+                        as_name: Some(as_name.clone()),
+                    })
+                }
+                _ => None,
+            },
+            _ => None,
+        };
+
+        let class_name_prefix = match get(&self.class_name_prefix) {
+            None => "x".to_string(),
+            Some(Value::String(s)) => s.clone(),
+            Some(other) => return Err(invalid_value("options.classNamePrefix", other, "a string")),
+        };
+
+        let mut import_sources = vec![
+            ImportSource::Plain("@stylexjs/stylex".to_string()),
+            ImportSource::Plain("stylex".to_string()),
+        ];
+        match get(&self.import_sources) {
+            None => {}
+            Some(Value::Array(items)) => {
+                for item in items {
+                    match item {
+                        Value::String(s) => import_sources.push(ImportSource::Plain(s.clone())),
+                        // Upstream's z.object strips keys outside the shape.
+                        Value::Object(map) => match (map.get("from"), map.get("as")) {
+                            (Some(Value::String(from)), Some(Value::String(as_name))) => {
+                                import_sources.push(ImportSource::Aliased {
+                                    from: from.clone(),
+                                    as_name: as_name.clone(),
+                                });
+                            }
+                            _ => {
+                                return Err(invalid_value(
+                                    "options.importSources[]",
+                                    item,
+                                    "a string or an object with string `from` and `as`",
+                                ));
+                            }
+                        },
+                        other => {
+                            return Err(invalid_value(
+                                "options.importSources[]",
+                                other,
+                                "a string or an object with string `from` and `as`",
+                            ));
+                        }
+                    }
+                }
+            }
+            Some(other) => return Err(invalid_value("options.importSources", other, "an array")),
+        }
+
+        let style_resolution = match get(&self.style_resolution) {
+            None => StyleResolution::PropertySpecificity,
+            Some(v) => match v.as_str() {
+                Some("property-specificity") => StyleResolution::PropertySpecificity,
+                Some("application-order") => StyleResolution::ApplicationOrder,
+                Some("legacy-expand-shorthands") => StyleResolution::LegacyExpandShorthands,
+                _ => {
+                    return Err(invalid_value(
+                        "options.styleResolution",
+                        v,
+                        "one of \"application-order\" | \"property-specificity\" | \"legacy-expand-shorthands\"",
+                    ));
+                }
+            },
+        };
+
+        let property_validation_mode = match get(&self.property_validation_mode) {
+            None => PropertyValidationMode::Silent,
+            Some(v) => match v.as_str() {
+                Some("silent") => PropertyValidationMode::Silent,
+                Some("throw") => PropertyValidationMode::Throw,
+                Some("warn") => PropertyValidationMode::Warn,
+                _ => {
+                    return Err(invalid_value(
+                        "options.propertyValidationMode",
+                        v,
+                        "one of \"throw\" | \"warn\" | \"silent\"",
+                    ));
+                }
+            },
+        };
+
+        let unstable_module_resolution =
+            resolve_module_resolution(&self.unstable_module_resolution)?;
+
+        let treeshake_compensation = bool_opt(
+            "options.treeshakeCompensation",
+            &self.treeshake_compensation,
+        )?
+        .unwrap_or(false);
+
+        let env = match get(&self.env) {
+            None => EvalValue::Obj(JsObjectMap::new().into()),
+            Some(value @ Value::Object(_)) => EvalValue::from_json(value),
+            Some(other) => return Err(invalid_value("options.env", other, "an object")),
+        };
+        let aliases = resolve_aliases(get(&self.aliases));
+        // parity: `typeof options.rewriteAliases === 'boolean' ? … : false` —
+        // a non-boolean reads as off with no diagnostic.
+        let rewrite_aliases = get(&self.rewrite_aliases) == Some(&Value::Bool(true));
+        if get(&self.debug_file_path).is_some() {
+            return Err(StylexError::unsupported_option("debugFilePath"));
+        }
+        if get(&self.include).is_some() {
+            return Err(StylexError::unsupported_option("include"));
+        }
+        if get(&self.exclude).is_some() {
+            return Err(StylexError::unsupported_option("exclude"));
+        }
+
+        let mut resolved = ResolvedOptions {
+            class_name_prefix,
+            dev,
+            debug,
+            test,
+            enable_debug_class_names,
+            enable_debug_data_prop,
+            enable_dev_class_names,
+            enable_font_size_px_to_rem,
+            enable_inlined_conditional_merge,
+            enable_media_query_order,
+            enable_minified_keys,
+            enable_legacy_value_flipping,
+            enable_logical_styles_polyfill,
+            enable_ltr_rtl_comments,
+            sx_prop_name,
+            env,
+            import_sources,
+            runtime_injection,
+            style_resolution,
+            property_validation_mode,
+            treeshake_compensation,
+            unstable_module_resolution,
+            aliases,
+            rewrite_aliases,
+            cache_repr: String::new(),
+        };
+        // The empty-field capture keeps the repr a pure function of the inputs.
+        resolved.cache_repr = format!("{resolved:?}");
+        Ok(resolved)
+    }
+}
+
+/// The second reproduced `logAndDefault` (see `runtime_injection` above): one
+/// malformed entry discards the whole map, valid siblings included.
+fn resolve_aliases(raw: Option<&Value>) -> Option<AliasMap> {
+    let raw = raw?;
+    match parse_alias_map(raw) {
+        Some(map) => Some(map),
+        None => {
+            eprintln!(
+                "[fru] Expected (options.aliases) to be a map of string to string or \
+                 string[], but got `{}`. Ignoring every alias.",
+                json_text(raw)
+            );
+            None
+        }
+    }
+}
+
+fn parse_alias_map(raw: &Value) -> Option<AliasMap> {
+    let entries: Vec<(String, &Value)> = match raw {
+        // parity: z.objectOf only checks `typeof value === 'object'`, then
+        // `for (const key in value)` — an array validates with index keys.
+        Value::Object(map) => map.iter().map(|(k, v)| (k.clone(), v)).collect(),
+        Value::Array(items) => items
+            .iter()
+            .enumerate()
+            .map(|(i, v)| (i.to_string(), v))
+            .collect(),
+        _ => return None,
+    };
+    entries
+        .into_iter()
+        .map(|(key, value)| {
+            let values = match value {
+                Value::String(s) => vec![s.clone()],
+                Value::Array(items) => items
+                    .iter()
+                    .map(|item| item.as_str().map(str::to_string))
+                    .collect::<Option<Vec<String>>>()?,
+                _ => return None,
+            };
+            Some((key, values))
+        })
+        .collect()
+}
+
+// parity: validate.js logAndDefault — upstream reports the bad value and falls
+// back to the default rather than failing the build.
+fn warn_and_default<T>(name: &str, value: &Value, expected: &str, default: T) -> T {
+    eprintln!("[fru] Expected ({name}) to be {expected}, but got `{value}`; using the default",);
+    default
+}
+
+fn resolve_module_resolution(raw: &Option<Value>) -> Result<Option<ModuleResolution>, StylexError> {
+    let map = match get(raw) {
+        None => return Ok(None),
+        Some(Value::Object(map)) => map,
+        Some(other) => {
+            return Ok(warn_and_default(
+                "options.unstable_moduleResolution",
+                other,
+                "an object",
+                None,
+            ));
+        }
+    };
+    let ty = match map.get("type") {
+        Some(Value::String(s)) => s.as_str(),
+        _ => {
+            return Ok(warn_and_default(
+                "options.unstable_moduleResolution.type",
+                map.get("type").unwrap_or(&Value::Null),
+                "a string",
+                None,
+            ));
+        }
+    };
+    let kind = match ty {
+        "commonJS" => ModuleResolutionType::CommonJs,
+        "haste" => ModuleResolutionType::Haste,
+        "custom" | "experimental_crossFileParsing" => {
+            return Err(StylexError::unsupported_option(&format!(
+                "unstable_moduleResolution.type: \"{ty}\""
+            )));
+        }
+        _ => {
+            return Ok(warn_and_default(
+                "options.unstable_moduleResolution.type",
+                map.get("type").unwrap(),
+                "one of \"commonJS\" | \"haste\" | \"custom\" | \"experimental_crossFileParsing\"",
+                None,
+            ));
+        }
+    };
+    // parity: validate.js's object combinator iterates the SHAPE's keys and
+    // builds a fresh result, so anything else in the map is simply dropped.
+    let theme_file_extension = match map.get("themeFileExtension") {
+        None | Some(Value::Null) => THEME_FILE_EXTENSION.to_string(),
+        Some(Value::String(s)) => s.clone(),
+        Some(other) => {
+            return Ok(warn_and_default(
+                "options.unstable_moduleResolution.themeFileExtension",
+                other,
+                "a string",
+                None,
+            ));
+        }
+    };
+    // Haste's validator shape has no rootDir, so whatever is passed is dropped
+    // before any type check ever sees it.
+    if kind == ModuleResolutionType::Haste {
+        return Ok(Some(ModuleResolution {
+            kind,
+            root_dir: None,
+            theme_file_extension,
+        }));
+    }
+    let root_dir = match map.get("rootDir") {
+        Some(Value::String(s)) => Some(PathBuf::from(s)),
+        None | Some(Value::Null) => None,
+        Some(other) => {
+            return Err(invalid_value(
+                "options.unstable_moduleResolution.rootDir",
+                other,
+                "a string",
+            ));
+        }
+    };
+    Ok(Some(ModuleResolution {
+        kind,
+        root_dir,
+        theme_file_extension,
+    }))
+}
+
+// Upstream `??` semantics: an explicit null reads as absent.
+fn get(v: &Option<Value>) -> Option<&Value> {
+    match v {
+        Some(Value::Null) | None => None,
+        Some(x) => Some(x),
+    }
+}
+
+fn bool_opt(name: &str, v: &Option<Value>) -> Result<Option<bool>, StylexError> {
+    match get(v) {
+        None => Ok(None),
+        Some(Value::Bool(b)) => Ok(Some(*b)),
+        Some(other) => Err(invalid_value(name, other, "a boolean")),
+    }
+}
+
+fn invalid_value(name: &str, got: &Value, expected: &str) -> StylexError {
+    StylexError::new(
+        ErrorCode::InvalidOptionValue,
+        format!(
+            "Expected ({name}) to be {expected}, but got `{}`.",
+            json_text(got)
+        ),
+    )
+}
+
+fn json_text(v: &Value) -> String {
+    serde_json::to_string(v).unwrap_or_else(|_| "<unserializable>".to_string())
+}

--- a/crates/stylex/src/rules.rs
+++ b/crates/stylex/src/rules.rs
@@ -21,9 +21,8 @@ pub fn non_finite_from_tag(v: &serde_json::Value) -> Option<f64> {
     }
 }
 
-// Wire mirror of babel metadata.stylex tuples [className, {ltr, rtl?, constKey?,
-// constVal?}, priority]; shared with the oj fork — change only with both sides.
-// Arc'd text: clones are refcount bumps; the convert memo shares strings.
+// Wire mirror of babel metadata.stylex tuples; shared with the oj fork by type, change both sides.
+// Arc'd text so clones are refcount bumps; const_val boxed because almost every rule is None.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StylexRule {
     pub class_name: Arc<str>,
@@ -33,7 +32,7 @@ pub struct StylexRule {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub const_key: Option<Arc<str>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub const_val: Option<serde_json::Value>,
+    pub const_val: Option<Box<serde_json::Value>>,
     pub priority: f64,
 }
 
@@ -60,7 +59,7 @@ impl StylexRule {
             Some(serde_json::Value::String(s)) => Some(s.as_str().into()),
             Some(_) => return Err("constKey must be a string or null".to_string()),
         };
-        let const_val = obj.get("constVal").cloned();
+        let const_val = obj.get("constVal").cloned().map(Box::new);
         let priority = tuple[2].as_f64().ok_or("priority must be a number")?;
         Ok(StylexRule {
             class_name: class_name.into(),
@@ -91,9 +90,17 @@ impl StylexRule {
             );
         }
         if let Some(const_val) = &self.const_val {
-            body.insert("constVal".to_string(), const_val.clone());
+            body.insert("constVal".to_string(), (**const_val).clone());
         }
         serde_json::json!([self.class_name, body, self.priority])
+    }
+}
+
+#[cfg(test)]
+mod layout_tests {
+    #[test]
+    fn rule_struct_stays_compact() {
+        assert!(std::mem::size_of::<super::StylexRule>() <= 80);
     }
 }
 
@@ -115,11 +122,11 @@ mod non_finite_tag_tests {
                 ltr: "".into(),
                 rtl: None,
                 const_key: Some("xc".into()),
-                const_val: Some(tagged.clone()),
+                const_val: Some(Box::new(tagged.clone())),
                 priority: 0.0,
             };
             let round = StylexRule::from_metadata_tuple(&rule.to_metadata_tuple()).unwrap();
-            assert_eq!(round.const_val, Some(tagged.clone()));
+            assert_eq!(round.const_val.as_deref(), Some(&tagged));
             let decoded = non_finite_from_tag(&tagged).unwrap();
             assert!(decoded.is_nan() == x.is_nan() && (x.is_nan() || decoded == x));
         }

--- a/crates/stylex/src/rules.rs
+++ b/crates/stylex/src/rules.rs
@@ -1,0 +1,133 @@
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+// JSON cannot carry non-finite constVal numbers, so runners and pins tag them
+// as {"__jsnum": "Infinity"|"-Infinity"|"NaN"}; assembly decodes via this pair.
+pub fn non_finite_to_tag(x: f64) -> Option<serde_json::Value> {
+    if x.is_finite() {
+        return None;
+    }
+    Some(serde_json::json!({ "__jsnum": crate::jsrt::js_number_to_string(x) }))
+}
+
+pub fn non_finite_from_tag(v: &serde_json::Value) -> Option<f64> {
+    let obj = v.as_object().filter(|o| o.len() == 1)?;
+    match obj.get("__jsnum")?.as_str()? {
+        "Infinity" => Some(f64::INFINITY),
+        "-Infinity" => Some(f64::NEG_INFINITY),
+        "NaN" => Some(f64::NAN),
+        _ => None,
+    }
+}
+
+// Wire mirror of babel metadata.stylex tuples [className, {ltr, rtl?, constKey?,
+// constVal?}, priority]; shared with the oj fork — change only with both sides.
+// Arc'd text: clones are refcount bumps; the convert memo shares strings.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StylexRule {
+    pub class_name: Arc<str>,
+    pub ltr: Arc<str>,
+    #[serde(default)]
+    pub rtl: Option<Arc<str>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub const_key: Option<Arc<str>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub const_val: Option<serde_json::Value>,
+    pub priority: f64,
+}
+
+impl StylexRule {
+    // [className, {ltr, rtl?, constKey?, constVal?}, priority] as babel emits it.
+    pub fn from_metadata_tuple(v: &serde_json::Value) -> Result<Self, String> {
+        let tuple = v
+            .as_array()
+            .filter(|a| a.len() == 3)
+            .ok_or("expected a 3-tuple")?;
+        let class_name = tuple[0].as_str().ok_or("className must be a string")?;
+        let obj = tuple[1].as_object().ok_or("rule body must be an object")?;
+        let ltr = obj
+            .get("ltr")
+            .and_then(|l| l.as_str())
+            .ok_or("ltr must be a string")?;
+        let rtl = match obj.get("rtl") {
+            None | Some(serde_json::Value::Null) => None,
+            Some(serde_json::Value::String(s)) => Some(s.as_str().into()),
+            Some(_) => return Err("rtl must be a string or null".to_string()),
+        };
+        let const_key = match obj.get("constKey") {
+            None | Some(serde_json::Value::Null) => None,
+            Some(serde_json::Value::String(s)) => Some(s.as_str().into()),
+            Some(_) => return Err("constKey must be a string or null".to_string()),
+        };
+        let const_val = obj.get("constVal").cloned();
+        let priority = tuple[2].as_f64().ok_or("priority must be a number")?;
+        Ok(StylexRule {
+            class_name: class_name.into(),
+            ltr: ltr.into(),
+            rtl,
+            const_key,
+            const_val,
+            priority,
+        })
+    }
+
+    pub fn to_metadata_tuple(&self) -> serde_json::Value {
+        let mut body = serde_json::Map::new();
+        body.insert(
+            "ltr".to_string(),
+            serde_json::Value::String(self.ltr.to_string()),
+        );
+        if let Some(rtl) = &self.rtl {
+            body.insert(
+                "rtl".to_string(),
+                serde_json::Value::String(rtl.to_string()),
+            );
+        }
+        if let Some(const_key) = &self.const_key {
+            body.insert(
+                "constKey".to_string(),
+                serde_json::Value::String(const_key.to_string()),
+            );
+        }
+        if let Some(const_val) = &self.const_val {
+            body.insert("constVal".to_string(), const_val.clone());
+        }
+        serde_json::json!([self.class_name, body, self.priority])
+    }
+}
+
+#[cfg(test)]
+mod non_finite_tag_tests {
+    use super::*;
+
+    #[test]
+    fn tagged_const_val_round_trips_through_metadata_tuples() {
+        for (x, tag) in [
+            (f64::INFINITY, "Infinity"),
+            (f64::NEG_INFINITY, "-Infinity"),
+            (f64::NAN, "NaN"),
+        ] {
+            let tagged = non_finite_to_tag(x).unwrap();
+            assert_eq!(tagged, serde_json::json!({ "__jsnum": tag }));
+            let rule = StylexRule {
+                class_name: "xc".into(),
+                ltr: "".into(),
+                rtl: None,
+                const_key: Some("xc".into()),
+                const_val: Some(tagged.clone()),
+                priority: 0.0,
+            };
+            let round = StylexRule::from_metadata_tuple(&rule.to_metadata_tuple()).unwrap();
+            assert_eq!(round.const_val, Some(tagged.clone()));
+            let decoded = non_finite_from_tag(&tagged).unwrap();
+            assert!(decoded.is_nan() == x.is_nan() && (x.is_nan() || decoded == x));
+        }
+        assert_eq!(non_finite_to_tag(1.5), None);
+        assert_eq!(
+            non_finite_from_tag(&serde_json::json!({"__jsnum": "1"})),
+            None
+        );
+        assert_eq!(non_finite_from_tag(&serde_json::json!("Infinity")), None);
+    }
+}

--- a/crates/stylex/src/scopes.rs
+++ b/crates/stylex/src/scopes.rs
@@ -1,0 +1,2081 @@
+//! fru-native binding analysis (`FRU_NATIVE_SCOPES=1`): CompileState's queries from one Visit walk.
+// parity: oxc_semantic 0.146 SemanticBuilder + Binder (declaration, hoisting, flags, resolution).
+
+use std::cell::Cell;
+use std::sync::OnceLock;
+
+use oxc_ast::AstKind;
+use oxc_ast::ast::*;
+use oxc_ast_visit::{Visit, walk};
+use oxc_span::{GetSpan, Span};
+use oxc_str::{Ident, IdentBuildHasher, IdentHashMap};
+use oxc_syntax::node::NodeId;
+use oxc_syntax::operator::UnaryOperator;
+use oxc_syntax::reference::{ReferenceFlags, ReferenceId};
+use oxc_syntax::scope::{ScopeFlags, ScopeId};
+use oxc_syntax::symbol::{SymbolFlags, SymbolId};
+
+use crate::state::{
+    BindingDecl, BindingInfo, MUTATING_ARRAY_METHODS, RefParent, RefSite,
+    babel_is_export_declaration, babel_is_statement, binding_pattern_type_name,
+    callee_is_object_mutator, member_object_span,
+};
+
+/// Which scope analysis backs a [`crate::state::CompileState`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ScopeBackend {
+    Oxc,
+    Native,
+}
+
+impl ScopeBackend {
+    /// `FRU_NATIVE_SCOPES=1` selects the native walk; anything else keeps oxc.
+    pub fn from_env() -> Self {
+        static NATIVE: OnceLock<bool> = OnceLock::new();
+        let native =
+            *NATIVE.get_or_init(|| std::env::var("FRU_NATIVE_SCOPES").is_ok_and(|v| v == "1"));
+        if native {
+            ScopeBackend::Native
+        } else {
+            ScopeBackend::Oxc
+        }
+    }
+}
+
+type Idx = u32;
+
+const ROOT: Idx = 0;
+
+enum DeclSite<'a> {
+    Declarator(&'a VariableDeclarator<'a>),
+    NamedImport,
+    DefaultImport,
+    NamespaceImport,
+    Param(&'static str),
+    Catch,
+    Function { expression: bool },
+    Class { expression: bool },
+    Enum,
+    Other,
+}
+
+struct Symbol<'a> {
+    name: Ident<'a>,
+    flags: SymbolFlags,
+    /// The declaring node's span (babel `binding.path.node`), not the identifier's.
+    span: Span,
+    decl: DeclSite<'a>,
+    redeclared: bool,
+    var_for_head: bool,
+    violated: bool,
+    mutated: bool,
+}
+
+struct Reference<'a> {
+    name: Ident<'a>,
+    start: u32,
+    scope: Idx,
+    flags: ReferenceFlags,
+    symbol: Option<Idx>,
+    parent: RefParent<'a>,
+    mutation: bool,
+}
+
+struct Scope<'a> {
+    parent: Option<Idx>,
+    flags: ScopeFlags,
+    bindings: Vec<(Ident<'a>, Idx)>,
+    /// oxc `hoisting_variables`: `var` names that passed through this scope.
+    hoisted: Vec<(Ident<'a>, Idx)>,
+    /// Union of [`name_bit`] over `bindings`: a clear bit skips the scan.
+    mask: u64,
+}
+
+/// `Ident::hash` writes its precomputed word once; this hasher just keeps it.
+struct HashWord(u64);
+
+impl std::hash::Hasher for HashWord {
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    fn write(&mut self, _: &[u8]) {}
+
+    fn write_u64(&mut self, word: u64) {
+        self.0 = word;
+    }
+}
+
+fn name_bit(name: Ident<'_>) -> u64 {
+    let mut word = HashWord(0);
+    std::hash::Hash::hash(&name, &mut word);
+    1u64 << (word.0.wrapping_mul(0x9E37_79B9_7F4A_7C15) >> 58)
+}
+
+struct Site {
+    scope: Idx,
+    top_stmt_start: u32,
+    program_level: bool,
+}
+
+pub struct ScopeModel<'a> {
+    scopes: Vec<Scope<'a>>,
+    root_bindings: IdentHashMap<'a, Idx>,
+    symbols: Vec<Symbol<'a>>,
+    refs: Vec<Reference<'a>>,
+    /// Indexed by the `NodeId` written into call/member/JSX-opening cells.
+    sites: Vec<Site>,
+    root_unresolved: Vec<Idx>,
+}
+
+impl<'a> ScopeModel<'a> {
+    pub fn build(program: &'a Program<'a>) -> Self {
+        let mut builder = Builder::new(program.source_text.len());
+        builder.visit_program(program);
+        builder.model
+    }
+
+    fn get_binding(&self, scope: Idx, name: Ident<'_>) -> Option<Idx> {
+        self.get_binding_masked(scope, name, name_bit(name))
+    }
+
+    fn get_binding_masked(&self, scope: Idx, name: Ident<'_>, bit: u64) -> Option<Idx> {
+        if scope == ROOT {
+            return self.root_bindings.get(&name).copied();
+        }
+        let s = &self.scopes[scope as usize];
+        if s.mask & bit == 0 {
+            return None;
+        }
+        s.bindings.iter().find(|(n, _)| *n == name).map(|(_, s)| *s)
+    }
+
+    fn find_binding(&self, mut scope: Idx, name: Ident<'_>) -> Option<Idx> {
+        let bit = name_bit(name);
+        loop {
+            if let Some(symbol) = self.get_binding_masked(scope, name, bit) {
+                return Some(symbol);
+            }
+            scope = self.scopes[scope as usize].parent?;
+        }
+    }
+
+    fn site(&self, node: NodeId) -> &Site {
+        debug_assert!(node.index() != 0, "untagged node queried");
+        &self.sites[node.index()]
+    }
+
+    pub fn symbol_of(&self, id: &IdentifierReference<'a>) -> Option<SymbolId> {
+        let reference = id.reference_id.get()?;
+        self.refs
+            .get(reference.index())?
+            .symbol
+            .map(|s| SymbolId::from_usize(s as usize))
+    }
+
+    /// (constantViolations non-empty, isMutated) for one symbol.
+    pub fn constness(&self, symbol: SymbolId) -> (bool, bool) {
+        let s = &self.symbols[symbol.index()];
+        (s.redeclared || s.var_for_head || s.violated, s.mutated)
+    }
+
+    pub fn binding_info(&self, symbol: SymbolId) -> BindingInfo<'a> {
+        let s = &self.symbols[symbol.index()];
+        let decl = match s.decl {
+            DeclSite::Declarator(declarator) => BindingDecl::Declarator(declarator),
+            DeclSite::NamedImport => BindingDecl::NamedImport,
+            DeclSite::DefaultImport => BindingDecl::DefaultImport,
+            DeclSite::NamespaceImport => BindingDecl::NamespaceImport,
+            DeclSite::Param(type_name) => BindingDecl::Opaque(type_name),
+            DeclSite::Catch => BindingDecl::Opaque("CatchClause"),
+            DeclSite::Function { expression } => BindingDecl::Opaque(if expression {
+                "FunctionExpression"
+            } else {
+                "FunctionDeclaration"
+            }),
+            DeclSite::Class { expression } => BindingDecl::Opaque(if expression {
+                "ClassExpression"
+            } else {
+                "ClassDeclaration"
+            }),
+            DeclSite::Enum => BindingDecl::Opaque("TSEnumDeclaration"),
+            DeclSite::Other => BindingDecl::Opaque("Identifier"),
+        };
+        BindingInfo { decl, span: s.span }
+    }
+
+    pub fn root_binding(&self, name: &str) -> Option<SymbolId> {
+        self.get_binding(ROOT, Ident::from(name))
+            .map(|s| SymbolId::from_usize(s as usize))
+    }
+
+    pub fn uid_name_taken(&self, name: &str) -> bool {
+        let name = Ident::from(name);
+        self.root_unresolved
+            .iter()
+            .any(|&r| self.refs[r as usize].name == name)
+            || self.symbols.iter().any(|s| s.name == name)
+    }
+
+    pub fn reference_starts_where(
+        &self,
+        names: &[&str],
+        keep: impl Fn(&str, RefSite<'_, 'a>) -> bool,
+    ) -> Vec<u32> {
+        let mut starts: Vec<u32> = self
+            .refs
+            .iter()
+            .filter(|r| {
+                names.contains(&r.name.as_str()) && keep(r.name.as_str(), RefSite::native(r.parent))
+            })
+            .map(|r| r.start)
+            .collect();
+        starts.sort_unstable();
+        starts
+    }
+
+    pub fn resolves_to_root_binding(&self, node: NodeId, name: &str) -> bool {
+        let name = Ident::from(name);
+        let Some(root) = self.get_binding(ROOT, name) else {
+            return false;
+        };
+        self.find_binding(self.site(node).scope, name) == Some(root)
+    }
+
+    pub fn any_binding_at(&self, node: NodeId, name: &str) -> bool {
+        self.find_binding(self.site(node).scope, Ident::from(name))
+            .is_some()
+    }
+
+    pub fn is_program_level(&self, node: NodeId) -> bool {
+        self.site(node).program_level
+    }
+
+    pub fn program_statement_start(&self, node: NodeId) -> u32 {
+        self.site(node).top_stmt_start
+    }
+
+    #[cfg(test)]
+    pub(crate) fn symbol_ids(&self) -> impl Iterator<Item = SymbolId> + '_ {
+        (0..self.symbols.len()).map(SymbolId::from_usize)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn symbol_name(&self, symbol: SymbolId) -> &'a str {
+        self.symbols[symbol.index()].name.as_str()
+    }
+}
+
+fn bound_names<'a>(pattern: &'a BindingPattern<'a>, f: &mut impl FnMut(&'a BindingIdentifier<'a>)) {
+    match pattern {
+        BindingPattern::BindingIdentifier(id) => f(id),
+        BindingPattern::ObjectPattern(object) => {
+            for property in &object.properties {
+                bound_names(&property.value, f);
+            }
+            if let Some(rest) = &object.rest {
+                bound_names(&rest.argument, f);
+            }
+        }
+        BindingPattern::ArrayPattern(array) => {
+            for element in array.elements.iter().flatten() {
+                bound_names(element, f);
+            }
+            if let Some(rest) = &array.rest {
+                bound_names(&rest.argument, f);
+            }
+        }
+        BindingPattern::AssignmentPattern(assignment) => bound_names(&assignment.left, f),
+    }
+}
+
+fn upsert<'a>(entries: &mut Vec<(Ident<'a>, Idx)>, name: Ident<'a>, symbol: Idx) {
+    match entries.iter_mut().find(|(n, _)| *n == name) {
+        Some(entry) => entry.1 = symbol,
+        None => entries.push((name, symbol)),
+    }
+}
+
+struct Builder<'a> {
+    model: ScopeModel<'a>,
+    current_scope: Idx,
+    /// Ancestor kinds, `Program` first; the parent of the node being visited.
+    stack: Vec<AstKind<'a>>,
+    /// Ancestors that make a node non-program-level (functions, nested statements).
+    opaque_depth: u32,
+    top_stmt_start: u32,
+    reference_flags: ReferenceFlags,
+    pending: Vec<Idx>,
+    ambient_depth: u32,
+    var_decl: Option<(VariableDeclarationKind, bool)>,
+    var_head: Option<*const VariableDeclarator<'a>>,
+    import_is_type: bool,
+    catch_clause_span: Span,
+}
+
+impl<'a> Builder<'a> {
+    fn new(source_len: usize) -> Self {
+        let per_kb = |n: usize| ((source_len * n) / 1024).max(16);
+        let mut scopes = Vec::with_capacity(per_kb(6));
+        scopes.push(Scope {
+            parent: None,
+            flags: ScopeFlags::Top,
+            bindings: Vec::new(),
+            hoisted: Vec::new(),
+            mask: 0,
+        });
+        let mut sites = Vec::with_capacity(per_kb(12));
+        sites.push(Site {
+            scope: ROOT,
+            top_stmt_start: 0,
+            program_level: false,
+        });
+        Builder {
+            model: ScopeModel {
+                scopes,
+                root_bindings: IdentHashMap::with_capacity_and_hasher(per_kb(3), IdentBuildHasher),
+                symbols: Vec::with_capacity(per_kb(4)),
+                refs: Vec::with_capacity(per_kb(20)),
+                sites,
+                root_unresolved: Vec::new(),
+            },
+            current_scope: ROOT,
+            stack: Vec::with_capacity(64),
+            opaque_depth: 0,
+            top_stmt_start: 0,
+            reference_flags: ReferenceFlags::empty(),
+            pending: Vec::with_capacity(per_kb(20)),
+            ambient_depth: 0,
+            var_decl: None,
+            var_head: None,
+            import_is_type: false,
+            catch_clause_span: Span::default(),
+        }
+    }
+
+    fn scope_flags(&self, scope: Idx) -> ScopeFlags {
+        self.model.scopes[scope as usize].flags
+    }
+
+    fn scope_has_binding(&self, scope: Idx, name: Ident<'a>) -> bool {
+        self.model.get_binding(scope, name).is_some()
+    }
+
+    fn add_binding(&mut self, scope: Idx, name: Ident<'a>, symbol: Idx) {
+        if scope == ROOT {
+            self.model.root_bindings.insert(name, symbol);
+        } else {
+            let s = &mut self.model.scopes[scope as usize];
+            s.mask |= name_bit(name);
+            upsert(&mut s.bindings, name, symbol);
+        }
+    }
+
+    fn remove_binding(&mut self, scope: Idx, name: Ident<'a>) {
+        if scope == ROOT {
+            self.model.root_bindings.remove(&name);
+        } else {
+            self.model.scopes[scope as usize]
+                .bindings
+                .retain(|(n, _)| *n != name);
+        }
+    }
+
+    fn check_redeclaration(&self, scope: Idx, name: Ident<'a>) -> Option<Idx> {
+        let symbol = self.model.get_binding(scope, name).or_else(|| {
+            self.model.scopes[scope as usize]
+                .hoisted
+                .iter()
+                .find(|(n, _)| *n == name)
+                .map(|(_, s)| *s)
+        })?;
+        if self.model.symbols[symbol as usize]
+            .flags
+            .contains(SymbolFlags::FunctionExpression)
+        {
+            return None;
+        }
+        Some(symbol)
+    }
+
+    fn create_symbol(
+        &mut self,
+        span: Span,
+        name: Ident<'a>,
+        flags: SymbolFlags,
+        scope: Idx,
+        decl: DeclSite<'a>,
+    ) -> Idx {
+        let var_for_head =
+            matches!(decl, DeclSite::Declarator(d) if self.var_head == Some(d as *const _));
+        let symbol = self.model.symbols.len() as Idx;
+        self.model.symbols.push(Symbol {
+            name,
+            flags,
+            span,
+            decl,
+            redeclared: false,
+            var_for_head,
+            violated: false,
+            mutated: false,
+        });
+        self.add_binding(scope, name, symbol);
+        symbol
+    }
+
+    fn declare_symbol_on_scope(
+        &mut self,
+        span: Span,
+        name: Ident<'a>,
+        scope: Idx,
+        includes: SymbolFlags,
+        decl: DeclSite<'a>,
+    ) -> Idx {
+        if let Some(symbol) = self.check_redeclaration(scope, name) {
+            let s = &mut self.model.symbols[symbol as usize];
+            s.redeclared = true;
+            s.flags |= includes;
+            return symbol;
+        }
+        self.create_symbol(span, name, includes, scope, decl)
+    }
+
+    fn declare_symbol(
+        &mut self,
+        span: Span,
+        name: Ident<'a>,
+        includes: SymbolFlags,
+        decl: DeclSite<'a>,
+    ) -> Idx {
+        self.declare_symbol_on_scope(span, name, self.current_scope, includes, decl)
+    }
+
+    fn declare_pattern(
+        &mut self,
+        pattern: &'a BindingPattern<'a>,
+        span: Span,
+        includes: SymbolFlags,
+        decl: impl Fn() -> DeclSite<'a>,
+    ) {
+        bound_names(pattern, &mut |ident| {
+            self.declare_symbol(span, ident.name, includes, decl());
+        });
+    }
+
+    // parity: Binder for VariableDeclarator — lexical names bind here; `var`
+    // hoists to the nearest var scope, merging with any name met on the way.
+    fn bind_declarator(&mut self, decl: &'a VariableDeclarator<'a>) {
+        let (kind, declare) = self.var_decl.expect("declarator outside a declaration");
+        let mut includes = match kind {
+            VariableDeclarationKind::Const
+            | VariableDeclarationKind::Using
+            | VariableDeclarationKind::AwaitUsing => {
+                SymbolFlags::BlockScopedVariable | SymbolFlags::ConstVariable
+            }
+            VariableDeclarationKind::Let => SymbolFlags::BlockScopedVariable,
+            VariableDeclarationKind::Var => SymbolFlags::FunctionScopedVariable,
+        };
+        if declare {
+            includes |= SymbolFlags::Ambient;
+        }
+        if kind.is_lexical() {
+            self.declare_pattern(&decl.id, decl.span, includes, || DeclSite::Declarator(decl));
+            return;
+        }
+        let mut target = self.current_scope;
+        let mut var_scopes: Vec<Idx> = Vec::new();
+        let mut scope = Some(self.current_scope);
+        while let Some(s) = scope {
+            if self.scope_flags(s).is_var() {
+                target = s;
+                break;
+            }
+            var_scopes.push(s);
+            scope = self.model.scopes[s as usize].parent;
+        }
+        bound_names(&decl.id, &mut |ident| {
+            let name = ident.name;
+            let mut declared = None;
+            for &s in &var_scopes {
+                if let Some(symbol) = self.check_redeclaration(s, name) {
+                    self.model.symbols[symbol as usize].redeclared = true;
+                    declared = Some(symbol);
+                    if !self.scope_has_binding(target, name) {
+                        self.remove_binding(s, name);
+                        self.add_binding(target, name, symbol);
+                    }
+                    break;
+                }
+            }
+            let symbol = declared.unwrap_or_else(|| {
+                self.declare_symbol_on_scope(
+                    decl.span,
+                    name,
+                    target,
+                    includes,
+                    DeclSite::Declarator(decl),
+                )
+            });
+            for &s in &var_scopes {
+                upsert(&mut self.model.scopes[s as usize].hoisted, name, symbol);
+            }
+        });
+    }
+
+    fn bind_function(&mut self, func: &'a Function<'a>) {
+        let Some(ident) = &func.id else {
+            return;
+        };
+        let mut includes = SymbolFlags::Function;
+        if func.declare {
+            includes |= SymbolFlags::Ambient;
+        }
+        if func.is_expression() {
+            includes |= SymbolFlags::FunctionExpression;
+        }
+        if func.r#async || func.generator {
+            includes |= SymbolFlags::AsyncOrGeneratorFunction;
+        }
+        self.declare_symbol(
+            func.span,
+            ident.name,
+            includes,
+            DeclSite::Function {
+                expression: func.is_expression(),
+            },
+        );
+    }
+
+    fn bind_class(&mut self, class: &'a Class<'a>) {
+        let Some(ident) = &class.id else {
+            return;
+        };
+        let mut includes = SymbolFlags::Class;
+        if class.declare {
+            includes |= SymbolFlags::Ambient;
+        }
+        self.declare_symbol(
+            class.span,
+            ident.name,
+            includes,
+            DeclSite::Class {
+                expression: class.is_expression(),
+            },
+        );
+    }
+
+    fn take_reference_flags(&mut self) -> ReferenceFlags {
+        if self.reference_flags.is_empty() {
+            ReferenceFlags::Read
+        } else {
+            std::mem::take(&mut self.reference_flags)
+        }
+    }
+
+    // parity: state.rs reference_is_mutation + the pass-A member check, read
+    // off the ancestor stack instead of the node table.
+    fn reference_parent(&self, ref_span: Span) -> (RefParent<'a>, bool) {
+        let stack = &self.stack;
+        let mut i = stack.len();
+        let mut child_span = ref_span;
+        while i > 0 {
+            match stack[i - 1] {
+                AstKind::ParenthesizedExpression(paren) => {
+                    child_span = paren.span;
+                    i -= 1;
+                }
+                _ => break,
+            }
+        }
+        if i == 0 {
+            return (RefParent::Other, false);
+        }
+        let parent = stack[i - 1];
+        if let Some((object_span, property)) = member_object_span(parent) {
+            let info = RefParent::Member { property };
+            if object_span != child_span {
+                return (info, false);
+            }
+            let mut j = i - 1;
+            let mut member_span = parent.span();
+            while j > 0 {
+                match stack[j - 1] {
+                    AstKind::ParenthesizedExpression(paren) => {
+                        member_span = paren.span;
+                        j -= 1;
+                    }
+                    _ => break,
+                }
+            }
+            if j == 0 {
+                return (info, false);
+            }
+            let mutation = match stack[j - 1] {
+                AstKind::AssignmentExpression(assignment) => assignment.left.span() == member_span,
+                AstKind::UpdateExpression(_) => true,
+                AstKind::UnaryExpression(unary) => unary.operator == UnaryOperator::Delete,
+                AstKind::CallExpression(call) => {
+                    call.callee.span() == member_span
+                        && property.is_some_and(|p| MUTATING_ARRAY_METHODS.contains(&p))
+                }
+                _ => false,
+            };
+            return (info, mutation);
+        }
+        if let AstKind::CallExpression(call) = parent {
+            let first_arg_span = call
+                .arguments
+                .first()
+                .and_then(|a| a.as_expression())
+                .map(GetSpan::span);
+            let mutation =
+                first_arg_span == Some(child_span) && callee_is_object_mutator(&call.callee);
+            return (RefParent::Other, mutation);
+        }
+        (RefParent::Other, false)
+    }
+
+    fn push_site(&mut self, cell: &Cell<NodeId>) {
+        let index = self.model.sites.len();
+        cell.set(NodeId::from_usize(index));
+        self.model.sites.push(Site {
+            scope: self.current_scope,
+            top_stmt_start: self.top_stmt_start,
+            program_level: self.opaque_depth == 0,
+        });
+    }
+
+    // parity: SemanticBuilder try_resolve_reference, flag rewrites included.
+    fn try_resolve(&mut self, reference: Idx, symbol: Idx) -> bool {
+        let symbol_flags = self.model.symbols[symbol as usize].flags;
+        let r = &mut self.model.refs[reference as usize];
+        let flags = &mut r.flags;
+        let can_resolve = if flags.is_namespace()
+            && !flags.is_value_as_type()
+            && !symbol_flags.can_be_referenced_as_namespace()
+        {
+            false
+        } else {
+            (flags.is_value() && symbol_flags.can_be_referenced_by_value())
+                || (flags.is_type() && symbol_flags.can_be_referenced_by_type())
+                || (flags.is_value_as_type() && symbol_flags.can_be_referenced_by_value_as_type())
+        };
+        if !can_resolve {
+            return false;
+        }
+        if (symbol_flags.is_value() && flags.is_value())
+            || (flags.is_namespace() && flags.is_read())
+        {
+            *flags -= ReferenceFlags::Type;
+        } else {
+            *flags = ReferenceFlags::Type;
+        }
+        r.symbol = Some(symbol);
+        let s = &mut self.model.symbols[symbol as usize];
+        if r.flags.is_write() {
+            s.violated = true;
+        } else if r.mutation {
+            s.mutated = true;
+        }
+        true
+    }
+
+    fn walk_up_resolve(&mut self, reference: Idx) -> bool {
+        let r = &self.model.refs[reference as usize];
+        let name = r.name;
+        let bit = name_bit(name);
+        let mut scope = Some(r.scope);
+        while let Some(s) = scope {
+            if let Some(symbol) = self.model.get_binding_masked(s, name, bit)
+                && self.try_resolve(reference, symbol)
+            {
+                return true;
+            }
+            scope = self.model.scopes[s as usize].parent;
+        }
+        false
+    }
+
+    /// Resolves the references recorded since `checkpoint` against the scopes
+    /// open now (parameters must not see body declarations).
+    fn resolve_pending_from(&mut self, checkpoint: usize) {
+        let mut write = checkpoint;
+        for read in checkpoint..self.pending.len() {
+            let reference = self.pending[read];
+            if !self.walk_up_resolve(reference) {
+                self.pending[write] = reference;
+                write += 1;
+            }
+        }
+        self.pending.truncate(write);
+    }
+
+    fn resolve_all(&mut self) {
+        let pending = std::mem::take(&mut self.pending);
+        for reference in pending {
+            if !self.walk_up_resolve(reference) {
+                self.model.root_unresolved.push(reference);
+            }
+        }
+    }
+
+    fn enter_ambient(&mut self, is_ambient: bool) {
+        self.ambient_depth += u32::from(is_ambient);
+    }
+
+    fn leave_ambient(&mut self, is_ambient: bool) {
+        self.ambient_depth -= u32::from(is_ambient);
+    }
+
+    fn in_ambient_context(&self) -> bool {
+        self.ambient_depth > 0
+    }
+
+    // parity: TSNamespaceDeclaration binder — a namespace holding only types
+    // is a NamespaceModule; `export { x }` aliases are read as instantiating.
+    fn namespace_is_instantiated(decl: &TSNamespaceDeclaration<'a>) -> bool {
+        match &decl.body {
+            TSNamespaceDeclarationBody::TSNamespaceDeclaration(inner) => {
+                Self::namespace_is_instantiated(inner)
+            }
+            TSNamespaceDeclarationBody::TSModuleBlock(block) => {
+                block.body.iter().any(Self::statement_instantiates)
+            }
+        }
+    }
+
+    fn statement_instantiates(stmt: &Statement<'a>) -> bool {
+        match stmt {
+            Statement::TSInterfaceDeclaration(_)
+            | Statement::TSTypeAliasDeclaration(_)
+            | Statement::TSImportEqualsDeclaration(_) => false,
+            Statement::ExportDefaultDeclaration(export) => !matches!(
+                export.declaration,
+                ExportDefaultDeclarationKind::TSInterfaceDeclaration(_)
+            ),
+            Statement::ExportDeclaration(export) => match &export.declaration {
+                Declaration::TSNamespaceDeclaration(inner) => {
+                    Self::namespace_is_instantiated(inner)
+                }
+                decl => !decl.is_type(),
+            },
+            Statement::TSNamespaceDeclaration(inner) => Self::namespace_is_instantiated(inner),
+            _ => true,
+        }
+    }
+}
+
+// parity: ast-helpers.js isProgramLevel, kept as a depth counter: a node counts
+// when it is function-like or a statement not hanging off Program/export.
+fn opaque_step(kind: AstKind<'_>, parent: Option<AstKind<'_>>) -> bool {
+    kind.is_function_like()
+        || (babel_is_statement(kind)
+            && !parent.is_some_and(|p| {
+                matches!(p, AstKind::Program(_)) || babel_is_export_declaration(p)
+            }))
+}
+
+impl<'a> Visit<'a> for Builder<'a> {
+    fn enter_node(&mut self, kind: AstKind<'a>) {
+        if self.stack.len() == 1 {
+            self.top_stmt_start = kind.span().start;
+        }
+        if opaque_step(kind, self.stack.last().copied()) {
+            self.opaque_depth += 1;
+        }
+        self.stack.push(kind);
+    }
+
+    fn leave_node(&mut self, kind: AstKind<'a>) {
+        self.stack.pop();
+        if opaque_step(kind, self.stack.last().copied()) {
+            self.opaque_depth -= 1;
+        }
+    }
+
+    fn enter_scope(&mut self, flags: ScopeFlags, _scope_id: &Cell<Option<ScopeId>>) {
+        let index = self.model.scopes.len() as Idx;
+        self.model.scopes.push(Scope {
+            parent: Some(self.current_scope),
+            flags,
+            bindings: Vec::new(),
+            hoisted: Vec::new(),
+            mask: 0,
+        });
+        self.current_scope = index;
+    }
+
+    fn leave_scope(&mut self) {
+        self.current_scope = self.model.scopes[self.current_scope as usize]
+            .parent
+            .expect("leave_scope on the root scope");
+    }
+
+    fn visit_program(&mut self, program: &Program<'a>) {
+        self.stack.push(AstKind::Program(self.alloc(program)));
+        self.visit_statements(&program.body);
+        self.resolve_all();
+        self.stack.pop();
+    }
+
+    // Leaves never parent a reference and are bound by their parents: skip
+    // their enter/leave bookkeeping (about half of all nodes).
+    fn visit_identifier_name(&mut self, _: &IdentifierName<'a>) {}
+    fn visit_binding_identifier(&mut self, _: &BindingIdentifier<'a>) {}
+    fn visit_label_identifier(&mut self, _: &LabelIdentifier<'a>) {}
+    fn visit_private_identifier(&mut self, _: &PrivateIdentifier<'a>) {}
+    fn visit_this_expression(&mut self, _: &ThisExpression) {}
+    fn visit_super(&mut self, _: &Super) {}
+    fn visit_boolean_literal(&mut self, _: &BooleanLiteral) {}
+    fn visit_null_literal(&mut self, _: &NullLiteral) {}
+    fn visit_numeric_literal(&mut self, _: &NumericLiteral<'a>) {}
+    fn visit_string_literal(&mut self, _: &StringLiteral<'a>) {}
+    fn visit_big_int_literal(&mut self, _: &BigIntLiteral<'a>) {}
+    fn visit_reg_exp_literal(&mut self, _: &RegExpLiteral<'a>) {}
+    fn visit_template_element(&mut self, _: &TemplateElement<'a>) {}
+    fn visit_jsx_text(&mut self, _: &JSXText<'a>) {}
+    fn visit_jsx_identifier(&mut self, _: &JSXIdentifier<'a>) {}
+    fn visit_jsx_empty_expression(&mut self, _: &JSXEmptyExpression) {}
+    fn visit_empty_statement(&mut self, _: &EmptyStatement) {}
+    fn visit_debugger_statement(&mut self, _: &DebuggerStatement) {}
+    fn visit_directive(&mut self, _: &Directive<'a>) {}
+    fn visit_hashbang(&mut self, _: &Hashbang<'a>) {}
+    fn visit_ts_type_annotation(&mut self, it: &TSTypeAnnotation<'a>) {
+        if !matches!(
+            it.type_annotation,
+            TSType::TSAnyKeyword(_)
+                | TSType::TSStringKeyword(_)
+                | TSType::TSNumberKeyword(_)
+                | TSType::TSBooleanKeyword(_)
+                | TSType::TSVoidKeyword(_)
+                | TSType::TSUndefinedKeyword(_)
+                | TSType::TSNullKeyword(_)
+                | TSType::TSUnknownKeyword(_)
+                | TSType::TSNeverKeyword(_)
+        ) {
+            walk::walk_ts_type_annotation(self, it);
+        }
+    }
+
+    fn visit_identifier_reference(&mut self, ident: &IdentifierReference<'a>) {
+        let ident = self.alloc(ident);
+        let flags = self.take_reference_flags();
+        let (parent, mutation) = self.reference_parent(ident.span);
+        let index = self.model.refs.len() as Idx;
+        self.model.refs.push(Reference {
+            name: ident.name,
+            start: ident.span.start,
+            scope: self.current_scope,
+            flags,
+            symbol: None,
+            parent,
+            mutation,
+        });
+        ident
+            .reference_id
+            .set(Some(ReferenceId::from_usize(index as usize)));
+        self.pending.push(index);
+    }
+
+    fn visit_call_expression(&mut self, expr: &CallExpression<'a>) {
+        let expr = self.alloc(expr);
+        let kind = AstKind::CallExpression(expr);
+        self.enter_node(kind);
+        self.push_site(&expr.node_id);
+        self.visit_expression(&expr.callee);
+        if let Some(type_arguments) = &expr.type_arguments {
+            self.visit_ts_type_parameter_instantiation(type_arguments);
+        }
+        self.visit_arguments(&expr.arguments);
+        self.leave_node(kind);
+    }
+
+    fn visit_jsx_opening_element(&mut self, it: &JSXOpeningElement<'a>) {
+        let it = self.alloc(it);
+        let kind = AstKind::JSXOpeningElement(it);
+        self.enter_node(kind);
+        self.push_site(&it.node_id);
+        self.visit_jsx_element_name(&it.name);
+        if let Some(type_arguments) = &it.type_arguments {
+            self.visit_ts_type_parameter_instantiation(type_arguments);
+        }
+        self.visit_jsx_attribute_items(&it.attributes);
+        self.leave_node(kind);
+    }
+
+    fn visit_member_expression(&mut self, it: &MemberExpression<'a>) {
+        if self.reference_flags.is_write() {
+            self.reference_flags = ReferenceFlags::Read | ReferenceFlags::MemberWriteTarget;
+        } else {
+            self.reference_flags -= ReferenceFlags::Write;
+        }
+        match it {
+            MemberExpression::ComputedMemberExpression(it) => {
+                self.visit_computed_member_expression(it);
+            }
+            MemberExpression::StaticMemberExpression(it) => self.visit_static_member_expression(it),
+            MemberExpression::PrivateFieldExpression(it) => self.visit_private_field_expression(it),
+        }
+        self.reference_flags = ReferenceFlags::empty();
+    }
+
+    fn visit_static_member_expression(&mut self, it: &StaticMemberExpression<'a>) {
+        let it = self.alloc(it);
+        let kind = AstKind::StaticMemberExpression(it);
+        self.enter_node(kind);
+        self.push_site(&it.node_id);
+        self.visit_expression(&it.object);
+        self.visit_identifier_name(&it.property);
+        self.leave_node(kind);
+    }
+
+    fn visit_computed_member_expression(&mut self, it: &ComputedMemberExpression<'a>) {
+        let it = self.alloc(it);
+        let kind = AstKind::ComputedMemberExpression(it);
+        self.enter_node(kind);
+        self.push_site(&it.node_id);
+        self.visit_expression(&it.object);
+        self.reference_flags -= ReferenceFlags::MemberWriteTarget;
+        self.visit_expression(&it.expression);
+        self.leave_node(kind);
+    }
+
+    fn visit_update_expression(&mut self, it: &UpdateExpression<'a>) {
+        let kind = AstKind::UpdateExpression(self.alloc(it));
+        self.enter_node(kind);
+        self.reference_flags = ReferenceFlags::read_write();
+        self.visit_simple_assignment_target(&it.argument);
+        self.leave_node(kind);
+    }
+
+    fn visit_unary_expression(&mut self, it: &UnaryExpression<'a>) {
+        let kind = AstKind::UnaryExpression(self.alloc(it));
+        self.enter_node(kind);
+        if it.operator == UnaryOperator::Delete && it.argument.is_member_expression() {
+            self.reference_flags = ReferenceFlags::Write;
+        }
+        self.visit_expression(&it.argument);
+        self.leave_node(kind);
+    }
+
+    fn visit_assignment_expression(&mut self, expr: &AssignmentExpression<'a>) {
+        let kind = AstKind::AssignmentExpression(self.alloc(expr));
+        self.enter_node(kind);
+        if !expr.operator.is_assign() {
+            self.reference_flags = ReferenceFlags::read_write();
+        }
+        self.visit_assignment_target(&expr.left);
+        self.visit_expression(&expr.right);
+        self.leave_node(kind);
+    }
+
+    fn visit_conditional_expression(&mut self, expr: &ConditionalExpression<'a>) {
+        let kind = AstKind::ConditionalExpression(self.alloc(expr));
+        self.enter_node(kind);
+        let saved_flags = self.reference_flags;
+        self.reference_flags -= ReferenceFlags::MemberWriteTarget;
+        self.visit_expression(&expr.test);
+        self.reference_flags = saved_flags;
+        self.visit_expression(&expr.consequent);
+        self.visit_expression(&expr.alternate);
+        self.leave_node(kind);
+    }
+
+    fn visit_simple_assignment_target(&mut self, it: &SimpleAssignmentTarget<'a>) {
+        if !self.reference_flags.is_write() {
+            self.reference_flags = ReferenceFlags::Write;
+        }
+        match it {
+            SimpleAssignmentTarget::AssignmentTargetIdentifier(it) => {
+                self.visit_identifier_reference(it);
+            }
+            SimpleAssignmentTarget::TSAsExpression(it) => self.visit_ts_as_expression(it),
+            SimpleAssignmentTarget::TSSatisfiesExpression(it) => {
+                self.visit_ts_satisfies_expression(it);
+            }
+            SimpleAssignmentTarget::TSNonNullExpression(it) => {
+                self.visit_ts_non_null_expression(it)
+            }
+            SimpleAssignmentTarget::TSTypeAssertion(it) => self.visit_ts_type_assertion(it),
+            _ => self.visit_member_expression(it.to_member_expression()),
+        }
+    }
+
+    fn visit_assignment_target_property_identifier(
+        &mut self,
+        it: &AssignmentTargetPropertyIdentifier<'a>,
+    ) {
+        let kind = AstKind::AssignmentTargetPropertyIdentifier(self.alloc(it));
+        self.enter_node(kind);
+        self.reference_flags = ReferenceFlags::Write;
+        self.visit_identifier_reference(&it.binding);
+        if let Some(init) = &it.init {
+            self.visit_expression(init);
+        }
+        self.leave_node(kind);
+    }
+
+    fn visit_export_default_declaration_kind(&mut self, it: &ExportDefaultDeclarationKind<'a>) {
+        match it {
+            ExportDefaultDeclarationKind::FunctionDeclaration(it) => {
+                self.visit_function(it, ScopeFlags::Function);
+            }
+            ExportDefaultDeclarationKind::ClassDeclaration(it) => self.visit_class(it),
+            ExportDefaultDeclarationKind::TSInterfaceDeclaration(it) => {
+                self.visit_ts_interface_declaration(it);
+            }
+            ExportDefaultDeclarationKind::Identifier(it) => {
+                self.reference_flags = ReferenceFlags::Read | ReferenceFlags::Type;
+                self.visit_identifier_reference(it);
+            }
+            _ => self.visit_expression(it.to_expression()),
+        }
+    }
+
+    fn visit_export_named_declaration(&mut self, it: &ExportNamedDeclaration<'a>) {
+        let kind = AstKind::ExportNamedDeclaration(self.alloc(it));
+        self.enter_node(kind);
+        for specifier in &it.specifiers {
+            self.reference_flags = if it.export_kind.is_type() || specifier.export_kind.is_type() {
+                ReferenceFlags::Type
+            } else {
+                ReferenceFlags::Read | ReferenceFlags::Type
+            };
+            self.visit_export_specifier(specifier);
+        }
+        self.leave_node(kind);
+    }
+
+    fn visit_ts_export_assignment(&mut self, it: &TSExportAssignment<'a>) {
+        let kind = AstKind::TSExportAssignment(self.alloc(it));
+        self.enter_node(kind);
+        if it.expression.is_identifier_reference() {
+            self.reference_flags = ReferenceFlags::Read | ReferenceFlags::Type;
+        }
+        self.visit_expression(&it.expression);
+        self.leave_node(kind);
+    }
+
+    fn visit_ts_type_query(&mut self, ty: &TSTypeQuery<'a>) {
+        let kind = AstKind::TSTypeQuery(self.alloc(ty));
+        self.enter_node(kind);
+        self.reference_flags = ReferenceFlags::ValueAsType;
+        self.visit_ts_type_query_expr_name(&ty.expr_name);
+        if let Some(type_arguments) = &ty.type_arguments {
+            self.visit_ts_type_parameter_instantiation(type_arguments);
+        }
+        self.reference_flags = ReferenceFlags::empty();
+        self.leave_node(kind);
+    }
+
+    fn visit_ts_property_signature(&mut self, sig: &TSPropertySignature<'a>) {
+        let kind = AstKind::TSPropertySignature(self.alloc(sig));
+        self.enter_node(kind);
+        if sig.key.is_expression() {
+            self.reference_flags = ReferenceFlags::ValueAsType;
+        }
+        self.visit_property_key(&sig.key);
+        if let Some(type_annotation) = &sig.type_annotation {
+            self.visit_ts_type_annotation(type_annotation);
+        }
+        self.reference_flags = ReferenceFlags::empty();
+        self.leave_node(kind);
+    }
+
+    fn visit_ts_method_signature(&mut self, sig: &TSMethodSignature<'a>) {
+        let kind = AstKind::TSMethodSignature(self.alloc(sig));
+        self.enter_node(kind);
+        self.enter_scope(ScopeFlags::empty(), &sig.scope_id);
+        if sig.computed {
+            self.reference_flags = ReferenceFlags::ValueAsType;
+        }
+        self.visit_property_key(&sig.key);
+        self.reference_flags = ReferenceFlags::empty();
+        if let Some(type_parameters) = &sig.type_parameters {
+            self.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        if let Some(this_param) = &sig.this_param {
+            self.visit_ts_this_parameter(this_param);
+        }
+        self.visit_formal_parameters(&sig.params);
+        if let Some(return_type) = &sig.return_type {
+            self.visit_ts_type_annotation(return_type);
+        }
+        self.leave_scope();
+        self.leave_node(kind);
+    }
+
+    fn visit_method_definition(&mut self, method: &MethodDefinition<'a>) {
+        let kind = AstKind::MethodDefinition(self.alloc(method));
+        self.enter_node(kind);
+        self.visit_decorators(&method.decorators);
+        if method.computed && (method.r#type.is_abstract() || self.in_ambient_context()) {
+            self.reference_flags = ReferenceFlags::ValueAsType;
+        }
+        self.visit_property_key(&method.key);
+        self.reference_flags = ReferenceFlags::empty();
+        let flags = match method.kind {
+            MethodDefinitionKind::Get => ScopeFlags::Function | ScopeFlags::GetAccessor,
+            MethodDefinitionKind::Set => ScopeFlags::Function | ScopeFlags::SetAccessor,
+            MethodDefinitionKind::Constructor => ScopeFlags::Function | ScopeFlags::Constructor,
+            MethodDefinitionKind::Method => ScopeFlags::Function,
+        };
+        self.visit_function(&method.value, flags);
+        self.leave_node(kind);
+    }
+
+    fn visit_property_definition(&mut self, prop: &PropertyDefinition<'a>) {
+        let kind = AstKind::PropertyDefinition(self.alloc(prop));
+        self.enter_node(kind);
+        self.visit_decorators(&prop.decorators);
+        self.enter_ambient(prop.declare);
+        if prop.computed && (prop.r#type.is_abstract() || self.in_ambient_context()) {
+            self.reference_flags = ReferenceFlags::ValueAsType;
+        }
+        self.visit_property_key(&prop.key);
+        self.reference_flags = ReferenceFlags::empty();
+        if let Some(type_annotation) = &prop.type_annotation {
+            self.visit_ts_type_annotation(type_annotation);
+        }
+        if let Some(value) = &prop.value {
+            self.visit_expression(value);
+        }
+        self.leave_node(kind);
+        self.leave_ambient(prop.declare);
+    }
+
+    fn visit_ts_interface_heritage(&mut self, heritage: &TSInterfaceHeritage<'a>) {
+        let kind = AstKind::TSInterfaceHeritage(self.alloc(heritage));
+        self.enter_node(kind);
+        self.reference_flags = ReferenceFlags::Type;
+        self.visit_ts_type_name(&heritage.type_name);
+        if let Some(type_arguments) = &heritage.type_arguments {
+            self.visit_ts_type_parameter_instantiation(type_arguments);
+        }
+        self.leave_node(kind);
+    }
+
+    fn visit_ts_class_implements(&mut self, implements: &TSClassImplements<'a>) {
+        let kind = AstKind::TSClassImplements(self.alloc(implements));
+        self.enter_node(kind);
+        self.reference_flags = ReferenceFlags::Type;
+        self.visit_ts_type_name(&implements.expression);
+        if let Some(type_arguments) = &implements.type_arguments {
+            self.visit_ts_type_parameter_instantiation(type_arguments);
+        }
+        self.leave_node(kind);
+    }
+
+    fn visit_ts_type_reference(&mut self, ty: &TSTypeReference<'a>) {
+        let kind = AstKind::TSTypeReference(self.alloc(ty));
+        self.enter_node(kind);
+        self.reference_flags = ReferenceFlags::Type;
+        self.visit_ts_type_name(&ty.type_name);
+        if let Some(type_arguments) = &ty.type_arguments {
+            self.visit_ts_type_parameter_instantiation(type_arguments);
+        }
+        self.leave_node(kind);
+    }
+
+    fn visit_ts_qualified_name(&mut self, name: &TSQualifiedName<'a>) {
+        let kind = AstKind::TSQualifiedName(self.alloc(name));
+        self.enter_node(kind);
+        if self.reference_flags.is_empty() {
+            self.reference_flags =
+                ReferenceFlags::Read | ReferenceFlags::Type | ReferenceFlags::Namespace;
+        } else {
+            self.reference_flags |= ReferenceFlags::Namespace;
+        }
+        self.visit_ts_type_name(&name.left);
+        self.visit_identifier_name(&name.right);
+        self.leave_node(kind);
+    }
+
+    fn visit_class(&mut self, class: &Class<'a>) {
+        let class = self.alloc(class);
+        let kind = AstKind::Class(class);
+        self.enter_node(kind);
+        if class.is_declaration() {
+            self.bind_class(class);
+        }
+        self.visit_decorators(&class.decorators);
+        self.enter_ambient(class.declare);
+        self.enter_scope(ScopeFlags::StrictMode, &class.scope_id);
+        if class.is_expression() {
+            self.bind_class(class);
+        }
+        if let Some(type_parameters) = &class.type_parameters {
+            self.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        if let Some(heritage) = &class.heritage {
+            if self.in_ambient_context() {
+                self.reference_flags = ReferenceFlags::ValueAsType;
+            }
+            self.visit_expression(&heritage.expression);
+            self.reference_flags = ReferenceFlags::empty();
+            if let Some(type_arguments) = &heritage.type_arguments {
+                self.visit_ts_type_parameter_instantiation(type_arguments);
+            }
+        }
+        self.visit_ts_class_implements_list(&class.implements);
+        self.visit_class_body(&class.body);
+        self.leave_scope();
+        self.leave_node(kind);
+        self.leave_ambient(class.declare);
+    }
+
+    fn visit_function(&mut self, func: &Function<'a>, flags: ScopeFlags) {
+        let func = self.alloc(func);
+        let kind = AstKind::Function(func);
+        self.enter_node(kind);
+        self.enter_ambient(func.declare);
+        if func.is_declaration() {
+            self.bind_function(func);
+        }
+        self.enter_scope(flags, &func.scope_id);
+        if func.is_expression() {
+            self.bind_function(func);
+        }
+        let checkpoint = self.pending.len();
+        if let Some(type_parameters) = &func.type_parameters {
+            self.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        if let Some(this_param) = &func.this_param {
+            self.visit_ts_this_parameter(this_param);
+        }
+        self.visit_formal_parameters(&func.params);
+        if let Some(return_type) = &func.return_type {
+            self.visit_ts_type_annotation(return_type);
+        }
+        if func.params.has_parameter() || func.return_type.is_some() {
+            self.resolve_pending_from(checkpoint);
+        }
+        if let Some(body) = &func.body {
+            self.visit_function_body(body);
+        }
+        self.leave_scope();
+        self.leave_node(kind);
+        self.leave_ambient(func.declare);
+    }
+
+    fn visit_arrow_function_expression(&mut self, expr: &ArrowFunctionExpression<'a>) {
+        let kind = AstKind::ArrowFunctionExpression(self.alloc(expr));
+        self.enter_node(kind);
+        self.enter_scope(ScopeFlags::Function | ScopeFlags::Arrow, &expr.scope_id);
+        let checkpoint = self.pending.len();
+        if let Some(parameters) = &expr.type_parameters {
+            self.visit_ts_type_parameter_declaration(parameters);
+        }
+        self.visit_formal_parameters(&expr.params);
+        if let Some(return_type) = &expr.return_type {
+            self.visit_ts_type_annotation(return_type);
+        }
+        if expr.params.has_parameter() || expr.return_type.is_some() {
+            self.resolve_pending_from(checkpoint);
+        }
+        self.visit_arrow_function_body(&expr.body);
+        self.leave_scope();
+        self.leave_node(kind);
+    }
+
+    fn visit_formal_parameter(&mut self, param: &FormalParameter<'a>) {
+        let param = self.alloc(param);
+        let kind = AstKind::FormalParameter(param);
+        self.enter_node(kind);
+        let type_name = binding_pattern_type_name(&param.pattern);
+        self.declare_pattern(
+            &param.pattern,
+            param.span,
+            SymbolFlags::FunctionScopedVariable,
+            || DeclSite::Param(type_name),
+        );
+        self.visit_decorators(&param.decorators);
+        self.visit_binding_pattern(&param.pattern);
+        if let Some(type_annotation) = &param.type_annotation {
+            self.visit_ts_type_annotation(type_annotation);
+        }
+        if let Some(initializer) = &param.initializer {
+            self.visit_expression(initializer);
+        }
+        self.leave_node(kind);
+    }
+
+    fn visit_formal_parameter_rest(&mut self, param: &FormalParameterRest<'a>) {
+        let param = self.alloc(param);
+        let kind = AstKind::FormalParameterRest(param);
+        self.enter_node(kind);
+        self.declare_pattern(
+            &param.rest.argument,
+            param.span,
+            SymbolFlags::FunctionScopedVariable,
+            || DeclSite::Other,
+        );
+        self.visit_decorators(&param.decorators);
+        self.visit_binding_rest_element(&param.rest);
+        if let Some(type_annotation) = &param.type_annotation {
+            self.visit_ts_type_annotation(type_annotation);
+        }
+        self.leave_node(kind);
+    }
+
+    fn visit_catch_clause(&mut self, clause: &CatchClause<'a>) {
+        self.catch_clause_span = clause.span;
+        walk::walk_catch_clause(self, clause);
+    }
+
+    fn visit_catch_parameter(&mut self, param: &CatchParameter<'a>) {
+        let param = self.alloc(param);
+        let kind = AstKind::CatchParameter(param);
+        self.enter_node(kind);
+        let clause_span = self.catch_clause_span;
+        if let BindingPattern::BindingIdentifier(ident) = &param.pattern {
+            self.create_symbol(
+                clause_span,
+                ident.name,
+                SymbolFlags::FunctionScopedVariable | SymbolFlags::CatchVariable,
+                self.current_scope,
+                DeclSite::Catch,
+            );
+        } else {
+            self.declare_pattern(
+                &param.pattern,
+                clause_span,
+                SymbolFlags::BlockScopedVariable | SymbolFlags::CatchVariable,
+                || DeclSite::Catch,
+            );
+        }
+        let checkpoint = self.pending.len();
+        self.visit_binding_pattern(&param.pattern);
+        if let Some(type_annotation) = &param.type_annotation {
+            self.visit_ts_type_annotation(type_annotation);
+        }
+        self.resolve_pending_from(checkpoint);
+        self.leave_node(kind);
+    }
+
+    fn visit_block_statement(&mut self, it: &BlockStatement<'a>) {
+        let kind = AstKind::BlockStatement(self.alloc(it));
+        self.enter_node(kind);
+        let parent_scope = self.current_scope;
+        self.enter_scope(ScopeFlags::empty(), &it.scope_id);
+        if self.scope_flags(parent_scope).is_catch_clause() {
+            let parent = &mut self.model.scopes[parent_scope as usize];
+            let (moved, mask) = (std::mem::take(&mut parent.bindings), parent.mask);
+            let block = &mut self.model.scopes[self.current_scope as usize];
+            block.bindings = moved;
+            block.mask |= mask;
+        }
+        self.visit_statements(&it.body);
+        self.leave_scope();
+        self.leave_node(kind);
+    }
+
+    fn visit_for_in_statement(&mut self, stmt: &ForInStatement<'a>) {
+        let kind = AstKind::ForInStatement(self.alloc(stmt));
+        self.enter_node(kind);
+        self.enter_scope(ScopeFlags::empty(), &stmt.scope_id);
+        self.var_head = var_head_declarator(&stmt.left);
+        self.visit_for_statement_left(&stmt.left);
+        self.var_head = None;
+        self.visit_expression(&stmt.right);
+        self.visit_statement(&stmt.body);
+        self.leave_scope();
+        self.leave_node(kind);
+    }
+
+    fn visit_for_of_statement(&mut self, stmt: &ForOfStatement<'a>) {
+        let kind = AstKind::ForOfStatement(self.alloc(stmt));
+        self.enter_node(kind);
+        self.enter_scope(ScopeFlags::empty(), &stmt.scope_id);
+        self.var_head = var_head_declarator(&stmt.left);
+        self.visit_for_statement_left(&stmt.left);
+        self.var_head = None;
+        self.visit_expression(&stmt.right);
+        self.visit_statement(&stmt.body);
+        self.leave_scope();
+        self.leave_node(kind);
+    }
+
+    fn visit_variable_declaration(&mut self, it: &VariableDeclaration<'a>) {
+        let kind = AstKind::VariableDeclaration(self.alloc(it));
+        self.enter_node(kind);
+        self.enter_ambient(it.declare);
+        let saved = self.var_decl.replace((it.kind, it.declare));
+        self.visit_variable_declarators(&it.declarations);
+        self.var_decl = saved;
+        self.leave_node(kind);
+        self.leave_ambient(it.declare);
+    }
+
+    fn visit_variable_declarator(&mut self, decl: &VariableDeclarator<'a>) {
+        let decl = self.alloc(decl);
+        let kind = AstKind::VariableDeclarator(decl);
+        self.enter_node(kind);
+        self.bind_declarator(decl);
+        self.visit_binding_pattern(&decl.id);
+        if let Some(type_annotation) = &decl.type_annotation {
+            self.visit_ts_type_annotation(type_annotation);
+        }
+        if let Some(init) = &decl.init {
+            self.visit_expression(init);
+        }
+        self.leave_node(kind);
+    }
+
+    fn visit_import_declaration(&mut self, decl: &ImportDeclaration<'a>) {
+        let kind = AstKind::ImportDeclaration(self.alloc(decl));
+        self.enter_node(kind);
+        self.import_is_type = decl.import_kind.is_type();
+        if let Some(specifiers) = &decl.specifiers {
+            for specifier in specifiers {
+                self.visit_import_declaration_specifier(specifier);
+            }
+        }
+        self.leave_node(kind);
+    }
+
+    fn visit_import_specifier(&mut self, specifier: &ImportSpecifier<'a>) {
+        let specifier = self.alloc(specifier);
+        let kind = AstKind::ImportSpecifier(specifier);
+        self.enter_node(kind);
+        let includes = if specifier.import_kind.is_type() || self.import_is_type {
+            SymbolFlags::TypeImport
+        } else {
+            SymbolFlags::Import
+        };
+        self.declare_symbol(
+            specifier.span,
+            specifier.local.name,
+            includes,
+            DeclSite::NamedImport,
+        );
+        self.leave_node(kind);
+    }
+
+    fn visit_import_default_specifier(&mut self, specifier: &ImportDefaultSpecifier<'a>) {
+        let specifier = self.alloc(specifier);
+        let kind = AstKind::ImportDefaultSpecifier(specifier);
+        self.enter_node(kind);
+        let includes = if self.import_is_type {
+            SymbolFlags::TypeImport
+        } else {
+            SymbolFlags::Import
+        };
+        self.declare_symbol(
+            specifier.span,
+            specifier.local.name,
+            includes,
+            DeclSite::DefaultImport,
+        );
+        self.leave_node(kind);
+    }
+
+    fn visit_import_namespace_specifier(&mut self, specifier: &ImportNamespaceSpecifier<'a>) {
+        let specifier = self.alloc(specifier);
+        let kind = AstKind::ImportNamespaceSpecifier(specifier);
+        self.enter_node(kind);
+        let includes = if self.import_is_type {
+            SymbolFlags::TypeImport
+        } else {
+            SymbolFlags::Import
+        };
+        self.declare_symbol(
+            specifier.span,
+            specifier.local.name,
+            includes,
+            DeclSite::NamespaceImport,
+        );
+        self.leave_node(kind);
+    }
+
+    fn visit_ts_import_equals_declaration(&mut self, decl: &TSImportEqualsDeclaration<'a>) {
+        let decl = self.alloc(decl);
+        let kind = AstKind::TSImportEqualsDeclaration(decl);
+        self.enter_node(kind);
+        self.declare_symbol(
+            decl.span,
+            decl.id.name,
+            SymbolFlags::Import,
+            DeclSite::Other,
+        );
+        self.reference_flags = if decl.import_kind.is_type() {
+            ReferenceFlags::Type
+        } else {
+            ReferenceFlags::Read | ReferenceFlags::Type
+        };
+        self.visit_ts_module_reference(&decl.module_reference);
+        self.reference_flags = ReferenceFlags::empty();
+        self.leave_node(kind);
+    }
+
+    fn visit_ts_module_reference(&mut self, module_reference: &TSModuleReference<'a>) {
+        match module_reference {
+            TSModuleReference::ExternalModuleReference(reference) => {
+                self.visit_ts_external_module_reference(reference);
+            }
+            TSModuleReference::IdentifierReference(reference) => {
+                self.reference_flags |= ReferenceFlags::Namespace;
+                self.visit_identifier_reference(reference);
+            }
+            TSModuleReference::QualifiedName(name) => self.visit_ts_qualified_name(name),
+        }
+    }
+
+    fn visit_ts_external_module_declaration(&mut self, decl: &TSExternalModuleDeclaration<'a>) {
+        self.enter_ambient(decl.declare);
+        walk::walk_ts_external_module_declaration(self, decl);
+        self.leave_ambient(decl.declare);
+    }
+
+    fn visit_ts_global_declaration(&mut self, decl: &TSGlobalDeclaration<'a>) {
+        self.enter_ambient(decl.declare);
+        walk::walk_ts_global_declaration(self, decl);
+        self.leave_ambient(decl.declare);
+    }
+
+    fn visit_ts_namespace_declaration(&mut self, decl: &TSNamespaceDeclaration<'a>) {
+        let decl = self.alloc(decl);
+        let kind = AstKind::TSNamespaceDeclaration(decl);
+        self.enter_node(kind);
+        self.enter_ambient(decl.declare);
+        let mut includes = if Self::namespace_is_instantiated(decl) {
+            SymbolFlags::ValueModule
+        } else {
+            SymbolFlags::NamespaceModule
+        };
+        if decl.declare {
+            includes |= SymbolFlags::Ambient;
+        }
+        self.declare_symbol(decl.span, decl.id.name, includes, DeclSite::Other);
+        self.enter_scope(ScopeFlags::TsModuleBlock, &decl.scope_id);
+        self.visit_ts_namespace_declaration_body(&decl.body);
+        self.leave_scope();
+        self.leave_node(kind);
+        self.leave_ambient(decl.declare);
+    }
+
+    fn visit_ts_type_alias_declaration(&mut self, decl: &TSTypeAliasDeclaration<'a>) {
+        let decl = self.alloc(decl);
+        let kind = AstKind::TSTypeAliasDeclaration(decl);
+        self.enter_node(kind);
+        self.enter_ambient(decl.declare);
+        let mut includes = SymbolFlags::TypeAlias;
+        if decl.declare {
+            includes |= SymbolFlags::Ambient;
+        }
+        self.declare_symbol(decl.span, decl.id.name, includes, DeclSite::Other);
+        self.enter_scope(ScopeFlags::empty(), &decl.scope_id);
+        if let Some(type_parameters) = &decl.type_parameters {
+            self.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        self.visit_ts_type(&decl.type_annotation);
+        self.leave_scope();
+        self.leave_node(kind);
+        self.leave_ambient(decl.declare);
+    }
+
+    fn visit_ts_interface_declaration(&mut self, decl: &TSInterfaceDeclaration<'a>) {
+        let decl = self.alloc(decl);
+        let kind = AstKind::TSInterfaceDeclaration(decl);
+        self.enter_node(kind);
+        self.enter_ambient(decl.declare);
+        let mut includes = SymbolFlags::Interface;
+        if decl.declare {
+            includes |= SymbolFlags::Ambient;
+        }
+        self.declare_symbol(decl.span, decl.id.name, includes, DeclSite::Other);
+        self.enter_scope(ScopeFlags::empty(), &decl.scope_id);
+        if let Some(type_parameters) = &decl.type_parameters {
+            self.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        self.visit_ts_interface_heritages(&decl.extends);
+        self.visit_ts_interface_body(&decl.body);
+        self.leave_scope();
+        self.leave_node(kind);
+        self.leave_ambient(decl.declare);
+    }
+
+    fn visit_ts_enum_declaration(&mut self, decl: &TSEnumDeclaration<'a>) {
+        let decl = self.alloc(decl);
+        let kind = AstKind::TSEnumDeclaration(decl);
+        self.enter_node(kind);
+        self.enter_ambient(decl.declare);
+        let mut includes = if decl.r#const {
+            SymbolFlags::ConstEnum
+        } else {
+            SymbolFlags::RegularEnum
+        };
+        if decl.declare {
+            includes |= SymbolFlags::Ambient;
+        }
+        self.declare_symbol(decl.span, decl.id.name, includes, DeclSite::Enum);
+        self.visit_ts_enum_body(&decl.body);
+        self.leave_node(kind);
+        self.leave_ambient(decl.declare);
+    }
+
+    fn visit_ts_enum_member(&mut self, member: &TSEnumMember<'a>) {
+        let member = self.alloc(member);
+        let kind = AstKind::TSEnumMember(member);
+        self.enter_node(kind);
+        let name = match &member.id {
+            TSEnumMemberName::Identifier(ident) => ident.name,
+            TSEnumMemberName::String(lit) | TSEnumMemberName::ComputedString(lit) => {
+                Ident::from(lit.value)
+            }
+            TSEnumMemberName::ComputedTemplateString(template) => {
+                template.quasis.first().map_or(Ident::empty(), |quasi| {
+                    Ident::from(quasi.value.cooked.unwrap_or(quasi.value.raw))
+                })
+            }
+        };
+        self.declare_symbol(member.span, name, SymbolFlags::EnumMember, DeclSite::Other);
+        self.visit_ts_enum_member_name(&member.id);
+        if let Some(initializer) = &member.initializer {
+            self.visit_expression(initializer);
+        }
+        self.leave_node(kind);
+    }
+
+    fn visit_ts_type_parameter(&mut self, param: &TSTypeParameter<'a>) {
+        let param = self.alloc(param);
+        let kind = AstKind::TSTypeParameter(param);
+        self.enter_node(kind);
+        let mut scope = self.current_scope;
+        if matches!(
+            self.stack.get(self.stack.len().wrapping_sub(2)),
+            Some(AstKind::TSInferType(_))
+        ) {
+            let mut candidate = Some(self.current_scope);
+            while let Some(s) = candidate {
+                if self.scope_flags(s).is_ts_conditional() {
+                    scope = s;
+                    break;
+                }
+                candidate = self.model.scopes[s as usize].parent;
+            }
+        }
+        self.declare_symbol_on_scope(
+            param.span,
+            param.name.name,
+            scope,
+            SymbolFlags::TypeParameter,
+            DeclSite::Other,
+        );
+        if let Some(constraint) = &param.constraint {
+            self.visit_ts_type(constraint);
+        }
+        if let Some(default) = &param.default {
+            self.visit_ts_type(default);
+        }
+        self.leave_node(kind);
+    }
+
+    fn visit_ts_mapped_type(&mut self, it: &TSMappedType<'a>) {
+        let it = self.alloc(it);
+        let kind = AstKind::TSMappedType(it);
+        self.enter_node(kind);
+        self.enter_scope(ScopeFlags::empty(), &it.scope_id);
+        self.declare_symbol(
+            it.span,
+            it.key.name,
+            SymbolFlags::TypeParameter,
+            DeclSite::Other,
+        );
+        self.visit_ts_type(&it.constraint);
+        if let Some(name_type) = &it.name_type {
+            self.visit_ts_type(name_type);
+        }
+        if let Some(type_annotation) = &it.type_annotation {
+            self.visit_ts_type(type_annotation);
+        }
+        self.leave_scope();
+        self.leave_node(kind);
+    }
+}
+
+fn var_head_declarator<'a>(left: &ForStatementLeft<'a>) -> Option<*const VariableDeclarator<'a>> {
+    match left {
+        ForStatementLeft::VariableDeclaration(decl)
+            if decl.kind == VariableDeclarationKind::Var =>
+        {
+            decl.declarations.first().map(|d| d as *const _)
+        }
+        _ => None,
+    }
+}
+
+/// Differential harness: every CompileState query answered by both backends
+/// over the same program, compared by content (ids differ by construction).
+#[cfg(test)]
+pub(crate) mod tests {
+    use std::cell::RefCell;
+    use std::collections::BTreeSet;
+
+    use oxc_allocator::Allocator;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    use super::*;
+    use crate::imports::ImportTable;
+    use crate::options::ResolvedOptions;
+    use crate::state::CompileState;
+
+    struct Collector<'a> {
+        refs: Vec<&'a IdentifierReference<'a>>,
+        sites: Vec<(&'a Cell<NodeId>, u32)>,
+    }
+
+    impl<'a> Visit<'a> for Collector<'a> {
+        fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
+            self.refs.push(self.alloc(it));
+        }
+
+        fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
+            let it = self.alloc(it);
+            self.sites.push((&it.node_id, it.span.start));
+            walk::walk_call_expression(self, it);
+        }
+
+        fn visit_static_member_expression(&mut self, it: &StaticMemberExpression<'a>) {
+            let it = self.alloc(it);
+            self.sites.push((&it.node_id, it.span.start));
+            walk::walk_static_member_expression(self, it);
+        }
+
+        fn visit_computed_member_expression(&mut self, it: &ComputedMemberExpression<'a>) {
+            let it = self.alloc(it);
+            self.sites.push((&it.node_id, it.span.start));
+            walk::walk_computed_member_expression(self, it);
+        }
+
+        fn visit_jsx_opening_element(&mut self, it: &JSXOpeningElement<'a>) {
+            let it = self.alloc(it);
+            self.sites.push((&it.node_id, it.span.start));
+            walk::walk_jsx_opening_element(self, it);
+        }
+    }
+
+    const PROBES: [&str; 7] = [
+        "stylex", "_stylex", "_temp", "_styles", "_inject", "React", "x",
+    ];
+
+    /// One query surface, rendered as sorted text lines so a diff names the
+    /// exact query and construct.
+    fn snapshot(
+        state: &CompileState<'_>,
+        collector: &Collector<'_>,
+        names: &[String],
+    ) -> Vec<String> {
+        let mut lines = Vec::new();
+        let label = |decl: BindingDecl<'_>| match decl {
+            BindingDecl::Declarator(_) => "VariableDeclarator",
+            BindingDecl::NamedImport => "NamedImport",
+            BindingDecl::DefaultImport => "DefaultImport",
+            BindingDecl::NamespaceImport => "NamespaceImport",
+            BindingDecl::Opaque(type_name) => type_name,
+        };
+        for id in &collector.refs {
+            let binding = state.symbol_of(id).map(|symbol| {
+                let info = state.binding_info(symbol);
+                format!(
+                    "{} {}..{} violated={} mutated={}",
+                    label(info.decl),
+                    info.span.start,
+                    info.span.end,
+                    state.is_non_constant(symbol),
+                    state.is_mutated(symbol)
+                )
+            });
+            lines.push(format!(
+                "ref {}@{} -> {:?}",
+                id.name, id.span.start, binding
+            ));
+        }
+        for (name, kind, span) in state.debug_symbols() {
+            lines.push(format!("symbol {name} {kind} {}..{}", span.start, span.end));
+        }
+        let name_refs: Vec<&str> = names.iter().map(String::as_str).collect();
+        let parents = RefCell::new(Vec::new());
+        let starts = state.reference_starts_where(&name_refs, |name, site| {
+            parents
+                .borrow_mut()
+                .push(format!("parent {name} {:?}", site.parent()));
+            true
+        });
+        lines.push(format!("starts {starts:?}"));
+        lines.extend(parents.into_inner());
+        for name in names {
+            lines.push(format!(
+                "uid {name} taken={} root={}",
+                state.uid_name_taken(name),
+                state.root_binding(name).is_some()
+            ));
+        }
+        let sampled: Vec<&String> = names
+            .iter()
+            .step_by(names.len().div_ceil(40).max(1))
+            .collect();
+        for (cell, start) in &collector.sites {
+            let node = cell.get();
+            lines.push(format!(
+                "site @{start} program_level={} stmt={}",
+                state.is_program_level(node),
+                state.program_statement_start(node)
+            ));
+            for name in &sampled {
+                lines.push(format!(
+                    "site @{start} {name} any={} root={}",
+                    state.any_binding_at(node, name),
+                    state.resolves_to_root_binding(node, name)
+                ));
+            }
+        }
+        lines.sort();
+        lines
+    }
+
+    /// Lines the two backends disagree on for `source` (empty = parity).
+    pub(crate) fn diff_backends(source: &str) -> Vec<String> {
+        let allocator = Allocator::default();
+        let ret = Parser::new(&allocator, source, SourceType::tsx()).parse();
+        if ret.panicked || ret.diagnostics.has_errors() {
+            return Vec::new();
+        }
+        let program = &ret.program;
+        let mut collector = Collector {
+            refs: Vec::new(),
+            sites: Vec::new(),
+        };
+        collector.visit_program(program);
+        let options = ResolvedOptions::default();
+        let build = |backend| {
+            CompileState::build_with_imports_using(
+                program,
+                &options,
+                None,
+                String::new(),
+                ImportTable::default(),
+                backend,
+            )
+        };
+        let oxc = build(ScopeBackend::Oxc);
+        let mut names: BTreeSet<String> =
+            collector.refs.iter().map(|r| r.name.to_string()).collect();
+        names.extend(oxc.debug_symbols().into_iter().map(|(name, _, _)| name));
+        names.extend(PROBES.iter().map(|p| p.to_string()));
+        let names: Vec<String> = names.into_iter().collect();
+        let expected = snapshot(&oxc, &collector, &names);
+        drop(oxc);
+        let native = build(ScopeBackend::Native);
+        let actual = snapshot(&native, &collector, &names);
+        let expected_set: BTreeSet<&String> = expected.iter().collect();
+        let actual_set: BTreeSet<&String> = actual.iter().collect();
+        let mut out: Vec<String> = expected_set
+            .difference(&actual_set)
+            .map(|line| format!("oxc only:    {line}"))
+            .collect();
+        out.extend(
+            actual_set
+                .difference(&expected_set)
+                .map(|line| format!("native only: {line}")),
+        );
+        out
+    }
+
+    fn assert_parity(label: &str, source: &str) {
+        let diff = diff_backends(source);
+        assert!(diff.is_empty(), "{label}:\n{}", diff.join("\n"));
+    }
+
+    /// An empty diff must mean parity, not an empty snapshot.
+    #[test]
+    fn harness_records_every_query_kind() {
+        let source = "import * as stylex from '@stylexjs/stylex'; const s = stylex.create({});\n\
+function f() { return stylex.props(s.a); }";
+        let allocator = Allocator::default();
+        let ret = Parser::new(&allocator, source, SourceType::tsx()).parse();
+        let mut collector = Collector {
+            refs: Vec::new(),
+            sites: Vec::new(),
+        };
+        collector.visit_program(&ret.program);
+        let options = ResolvedOptions::default();
+        let state = CompileState::build_with_imports_using(
+            &ret.program,
+            &options,
+            None,
+            String::new(),
+            ImportTable::default(),
+            ScopeBackend::Native,
+        );
+        let names = vec!["stylex".to_string(), "s".to_string()];
+        let lines = snapshot(&state, &collector, &names);
+        let has = |prefix: &str| lines.iter().any(|l| l.starts_with(prefix));
+        assert!(
+            has("ref stylex@54 -> Some(\"NamespaceImport 7..18"),
+            "{lines:#?}"
+        );
+        assert!(has("symbol s VariableDeclarator 50..71"), "{lines:#?}");
+        assert!(
+            has("parent stylex Member { property: Some(\"create\") }"),
+            "{lines:#?}"
+        );
+        assert!(has("uid stylex taken=true root=true"), "{lines:#?}");
+        assert!(has("site @54 program_level=true stmt=44"), "{lines:#?}");
+        assert!(
+            lines.iter().any(|l| l.contains("program_level=false")),
+            "{lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|l| l.contains(" s any=true root=true")),
+            "{lines:#?}"
+        );
+    }
+
+    #[test]
+    fn native_matches_oxc_on_binding_shapes() {
+        let snippets: [(&str, &str); 24] = [
+            (
+                "var hoisting",
+                "{ var a = 1; } { var a = 2; } function f() { { var b; } var b; b; } a; b;",
+            ),
+            (
+                "catch clauses",
+                "try {} catch (e) { var e; e; } try {} catch ({ m }) { m; } try {} catch { x; }",
+            ),
+            (
+                "function expression name",
+                "const f = function n(n) { return n; }; (function g(g) {}); f; n;",
+            ),
+            (
+                "params before body",
+                "function f(a = b, { c } = d) { var b, d; a; c; } const g = (p = q) => { let q; p; };",
+            ),
+            (
+                "class shapes",
+                "class A extends B { static x = A; [k]() {} } const C = class D extends A {}; D; new A();",
+            ),
+            (
+                "ts declarations",
+                "type T = number; interface I { x: T } enum E { A, B = A } namespace N { export const v = 1; } declare const d: E; N.v; E.A; d;",
+            ),
+            (
+                "type-only references",
+                "const v = 1; type Q = typeof v; type R = v; let w: Q; import type { TT } from './t'; TT; w;",
+            ),
+            (
+                "exports",
+                "const a = 1, b = 2; export { a, b as c }; export default a; export type { T }; type T = 1;",
+            ),
+            (
+                "writes",
+                "let a = 1, b = 2, c = 3, d = {}, e = []; a = 2; b += 1; c++; d.x = 1; e.push(1); [a, b] = [b, a]; ({ a } = d); for (a of e) {} for (b in d) {}",
+            ),
+            (
+                "mutations through parens",
+                "const u = {}; (u).x = 1; const v = {}; Object.assign((v), {}); const w = {}; Object.assign((w as any), {}); const q = []; (q)[\"x\"] = 1; delete (u).y; (v.z)++;",
+            ),
+            (
+                "member keys",
+                "const o = {}, k = 'a'; o[k] = 1; o[k]; o.k; this[k] = 2; (o ? k : o).x = 1;",
+            ),
+            (
+                "jsx",
+                "import * as React from 'react'; import { Foo } from './f'; const el = <Foo.Bar a={x} {...rest}><div>{y}</div></Foo.Bar>; <foo />; <this.Comp />;",
+            ),
+            (
+                "nested statements",
+                "if (a) f(); else { g(); } for (;;) h(); while (x) { i(); } label: j(); switch (k) { case 1: l(); } try { m(); } finally { n(); }",
+            ),
+            (
+                "stylex shapes",
+                "import * as stylex from '@stylexjs/stylex'; const s = stylex.create({ a: { color: 'red' } }); function C() { const t = stylex.create({}); return <div {...stylex.props(s.a, t)} />; }",
+            ),
+            (
+                "shadowed stylex",
+                "import * as stylex from '@stylexjs/stylex'; function f(stylex) { stylex.create({}); } { const stylex = 1; stylex.create({}); }",
+            ),
+            (
+                "labels and breaks",
+                "outer: for (const a of b) { inner: for (const c of d) { if (c) break outer; continue inner; } }",
+            ),
+            (
+                "generators and async",
+                "async function* g() { yield await p; } const h = async () => { for await (const x of y) {} };",
+            ),
+            (
+                "destructuring params",
+                "function f({ a, b: [c, ...d] }, ...rest) { a; c; d; rest; } const g = ([p, { q = r }]) => p + q;",
+            ),
+            (
+                "type params",
+                "function f<T extends U, V = T>(a: T): V { return a as any; } type M<K extends string> = { [P in K]: P }; type C<X> = X extends infer R ? R : never;",
+            ),
+            (
+                "declare contexts",
+                "declare class A extends B {} declare module 'm' { export const x: number; } declare global { interface Window { w: 1 } } abstract class Q { abstract [k](): void; declare [j]: 1; }",
+            ),
+            (
+                "import equals",
+                "import fs = require('fs'); import n = N.M; namespace N { export namespace M {} } fs; n;",
+            ),
+            (
+                "template and tagged",
+                "const t = `${a} ${b.c}`; tag`x${d}`; const { [e]: f } = g;",
+            ),
+            (
+                "switch scope",
+                "switch (x) { case y: { let z = 1; z; } default: let w; w; } let v; v;",
+            ),
+            (
+                "enum member names",
+                "enum E { 'a b' = 1, [`c`] = 2, D } E['a b'];",
+            ),
+        ];
+        for (label, source) in snippets {
+            assert_parity(label, source);
+        }
+    }
+
+    #[test]
+    fn native_matches_oxc_on_corpora() {
+        let mut sources = crate::transform::visitor::tests::corpus_sources();
+        if let Ok(paths) = std::env::var("FRU_SCOPES_CORPUS") {
+            for path in paths.split(':').filter(|p| !p.is_empty()) {
+                let text = std::fs::read_to_string(path).expect("corpus ndjson");
+                for line in text.lines() {
+                    let job: serde_json::Value = serde_json::from_str(line).unwrap();
+                    let Some(source) = job.get("source").and_then(|s| s.as_str()) else {
+                        continue;
+                    };
+                    let id = job["id"].as_str().unwrap_or("?");
+                    sources.push((format!("{path}:{id}"), source.to_string()));
+                }
+            }
+        }
+        if sources.is_empty() {
+            eprintln!("skipping native_matches_oxc_on_corpora: conformance corpus not vendored");
+            return;
+        }
+        let mut failures = Vec::new();
+        let mut checked = 0usize;
+        for (filename, source) in &sources {
+            let diff = diff_backends(source);
+            checked += 1;
+            if !diff.is_empty() {
+                failures.push(format!("{filename}:\n  {}", diff.join("\n  ")));
+            }
+        }
+        eprintln!(
+            "scope parity: {checked} files, {} with differences",
+            failures.len()
+        );
+        assert!(
+            failures.is_empty(),
+            "{} files differ:\n{}",
+            failures.len(),
+            failures.join("\n")
+        );
+    }
+}

--- a/crates/stylex/src/shared/create.rs
+++ b/crates/stylex/src/shared/create.rs
@@ -1,0 +1,332 @@
+//! `stylex.create` namespace compilation over already-evaluated style objects.
+// parity: babel-plugin src/shared/stylex-create.js + visitors/stylex-create.js:252-283
+
+use crate::errors::StylexError;
+use crate::eval::value::{EvalValue, JsObjectMap};
+use crate::fxhash::FxHashMap;
+use crate::fxhash::FxHashSet;
+use crate::hash::create_short_hash;
+use crate::options::{ModuleResolutionType, ResolvedOptions};
+use crate::rules::StylexRule;
+use crate::shared::dev_naming::{
+    DebugPathInfo, add_source_map_data, convert_to_test_styles, inject_dev_class_names,
+};
+use crate::shared::flatten::{
+    PreRule, flatten_raw_style_object, media_order_transform, validate_namespace,
+};
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+/// Per-call inputs the babel visitor reads from the AST / process state.
+/// Wave 3 (AST front end) fills these; pins feed them synthetically.
+#[derive(Debug, Clone)]
+pub struct CreateContext<'a> {
+    pub options: &'a ResolvedOptions,
+    /// Absolute source filename ('/'-separated); `None` only in AST-less tests.
+    pub filename: Option<String>,
+    /// process.cwd() equivalent; unused until wave 3 resolves packages itself.
+    pub cwd: String,
+    /// Name of the variable the create() result is assigned to, if any.
+    pub var_name: Option<String>,
+    /// 1-based source line of each namespace property (babel `loc.start.line`).
+    pub namespace_lines: Option<BTreeMap<String, u32>>,
+    /// Nearest package.json walking up from dirname(filename): (name, dir).
+    pub file_package: Option<(String, String)>,
+    /// Name of the nearest package.json walking up from dirname(cwd).
+    pub cwd_package_name: Option<String>,
+}
+
+impl<'a> CreateContext<'a> {
+    pub fn new(options: &'a ResolvedOptions) -> Self {
+        CreateContext {
+            options,
+            filename: None,
+            cwd: String::new(),
+            var_name: None,
+            namespace_lines: None,
+            file_package: None,
+            cwd_package_name: None,
+        }
+    }
+}
+
+/// className → keyPath, first-seen order with last-write-wins values.
+pub type ClassPathsInNamespace = Vec<(String, Vec<String>)>;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateOutput {
+    /// namespace name → compiled object (className strings / null, `$$css`).
+    /// Rc-shared with the namespace memo: prod-mode consumers never clone.
+    pub compiled: Arc<JsObjectMap>,
+    /// Injected rules in traversal order, deduped by className (first wins).
+    pub rules: Vec<StylexRule>,
+    /// namespace → className → keyPath (classPathsPerNamespace upstream);
+    /// built only when the caller has dynamic-fn namespaces to rewrite.
+    pub class_paths: Vec<(String, ClassPathsInNamespace)>,
+}
+
+/// The namespace an atom compiles under (`@stylexjs/atoms` styleInput key).
+pub const INLINE_NAMESPACE: &str = "__inline__";
+
+/// parity: atoms babel-transform compileStaticStyle — styleXCreateSet plus the
+/// dev-class step only, never source-map data and never test styles.
+pub fn compile_atom(
+    property: &str,
+    value: &str,
+    ctx: &CreateContext<'_>,
+) -> Result<CreateOutput, StylexError> {
+    let mut raw = JsObjectMap::new();
+    raw.insert(property, EvalValue::Str(value.to_string()));
+    let mut namespaces = JsObjectMap::new();
+    namespaces.insert(INLINE_NAMESPACE, EvalValue::Obj(raw.into()));
+    let mut out = compile_namespaces_core(&namespaces, ctx, false)?;
+    if ctx.options.dev && ctx.options.enable_dev_class_names {
+        out.compiled = inject_dev_class_names(out.compiled, None, ctx.filename.as_deref());
+    }
+    Ok(out)
+}
+
+/// Dynamic-fn namespaces are wave 3: callers reject them with `unsupported_api`
+/// before this point (`EvalValue` cannot represent functions).
+pub fn compile_namespaces(
+    namespaces: &JsObjectMap,
+    ctx: &CreateContext<'_>,
+    need_class_paths: bool,
+) -> Result<CreateOutput, StylexError> {
+    let mut out = compile_namespaces_core(namespaces, ctx, need_class_paths)?;
+    let options = ctx.options;
+    if options.debug && options.enable_debug_data_prop {
+        let debug_paths = DebugPathInfo {
+            file_package: ctx.file_package.clone(),
+            cwd_package_name: ctx.cwd_package_name.clone(),
+            root_dir: options
+                .unstable_module_resolution
+                .as_ref()
+                .and_then(|m| m.root_dir.as_ref())
+                .map(|r| r.to_string_lossy().into_owned()),
+            is_haste: options
+                .unstable_module_resolution
+                .as_ref()
+                .is_some_and(|m| m.kind == ModuleResolutionType::Haste),
+        };
+        out.compiled = add_source_map_data(
+            out.compiled,
+            ctx.namespace_lines.as_ref(),
+            ctx.filename.as_deref(),
+            &debug_paths,
+        );
+    }
+    if options.dev && options.enable_dev_class_names {
+        out.compiled = inject_dev_class_names(
+            out.compiled,
+            ctx.var_name.as_deref(),
+            ctx.filename.as_deref(),
+        );
+    }
+    if options.test {
+        out.compiled = convert_to_test_styles(
+            &out.compiled,
+            ctx.var_name.as_deref(),
+            ctx.filename.as_deref(),
+        );
+    }
+    Ok(out)
+}
+
+fn compile_namespaces_core(
+    namespaces: &JsObjectMap,
+    ctx: &CreateContext<'_>,
+    need_class_paths: bool,
+) -> Result<CreateOutput, StylexError> {
+    let _t = crate::timings::start(crate::timings::Stage::Create);
+    let options = ctx.options;
+    let mut resolved_namespaces = JsObjectMap::new();
+    let mut rules: Vec<StylexRule> = Vec::new();
+    let mut class_paths: Vec<(String, ClassPathsInNamespace)> = Vec::new();
+    let mut seen_class_names: FxHashSet<Arc<str>> = FxHashSet::default();
+
+    for (namespace_name, namespace_value) in namespaces.entries() {
+        // The evaluator's `value[key] =` [[Set]] never creates a "__proto__"
+        // namespace, and Object.keys(namespaces) cannot see prototype entries.
+        if namespace_name == "__proto__" {
+            continue;
+        }
+        validate_namespace(namespace_value, &[])?;
+        let EvalValue::Obj(namespace) = namespace_value else {
+            unreachable!("validate_namespace only accepts objects");
+        };
+
+        let transformed;
+        let namespace_ref = match media_order_transform(namespace, options)? {
+            Some(rebuilt) => {
+                transformed = rebuilt;
+                &transformed
+            }
+            None => namespace,
+        };
+        let flattened = flatten_raw_style_object(namespace_ref, options)?;
+        let deduped = dedupe_last_wins(flattened);
+
+        let mut namespace_obj = JsObjectMap::new();
+        let mut paths_in_namespace: Vec<(String, Vec<String>)> = Vec::new();
+        let mut namespace_rules: Vec<StylexRule> = Vec::new();
+        for (key, pre_rule) in &deduped {
+            // Variables-as-keys skip minification to avoid dynamic-style regressions.
+            let display_key = if options.enable_minified_keys && !key.starts_with("--") {
+                let hashed = minified_key_hash(key.as_ref());
+                if options.debug {
+                    format!("{key}-k{hashed}")
+                } else {
+                    format!("k{hashed}")
+                }
+            } else {
+                key.to_string()
+            };
+
+            let computed = pre_rule.compiled(options)?;
+            let mut class_names: Vec<&str> = Vec::new();
+            for entry in computed.iter().flatten() {
+                let name: &str = &entry.0.class_name;
+                if !class_names.contains(&name) {
+                    class_names.push(name);
+                }
+            }
+            let joined = class_names.join(" ");
+            namespace_obj.insert(
+                display_key,
+                if joined.is_empty() {
+                    EvalValue::Null
+                } else {
+                    EvalValue::Str(joined)
+                },
+            );
+            for (decl, key_path) in computed.into_iter().flatten() {
+                if need_class_paths {
+                    match paths_in_namespace
+                        .iter_mut()
+                        .find(|(name, _)| name.as_str() == &*decl.class_name)
+                    {
+                        Some(slot) => {
+                            slot.1 = key_path.iter().map(|c| c.to_string()).collect();
+                        }
+                        None => paths_in_namespace.push((
+                            decl.class_name.to_string(),
+                            key_path.iter().map(|c| c.to_string()).collect(),
+                        )),
+                    }
+                }
+                namespace_rules.push((*decl).clone());
+            }
+        }
+        namespace_obj.insert("$$css", EvalValue::Bool(true));
+        resolved_namespaces.insert(
+            namespace_name.to_string(),
+            EvalValue::Obj(Arc::new(namespace_obj)),
+        );
+        for rule in namespace_rules {
+            if seen_class_names.insert(rule.class_name.clone()) {
+                rules.push(rule);
+            }
+        }
+        if need_class_paths {
+            class_paths.push((namespace_name.to_string(), paths_in_namespace));
+        }
+    }
+
+    Ok(CreateOutput {
+        compiled: Arc::new(resolved_namespaces),
+        rules,
+        class_paths,
+    })
+}
+
+// parity: stylex-create.js reduceRight dedupe — the LAST occurrence of a key
+// wins and keeps its (last) position.
+fn dedupe_last_wins<'a>(
+    flattened: Vec<(Cow<'a, str>, PreRule<'a>)>,
+) -> Vec<(Cow<'a, str>, PreRule<'a>)> {
+    let mut seen: FxHashSet<&str> = FxHashSet::default();
+    let mut keep = vec![false; flattened.len()];
+    for (i, (key, _)) in flattened.iter().enumerate().rev() {
+        if seen.insert(key) {
+            keep[i] = true;
+        }
+    }
+    flattened
+        .into_iter()
+        .zip(keep)
+        .filter_map(|(entry, keep)| keep.then_some(entry))
+        .collect()
+}
+
+thread_local! {
+    // createShortHash('<'+'>'+key) is pure; flattened keys repeat across every
+    // file in a design-system corpus, so the hash is computed once per process.
+    static MINIFIED_KEYS: std::cell::RefCell<FxHashMap<String, String>> =
+        std::cell::RefCell::new(FxHashMap::default());
+}
+
+fn minified_key_hash(key: &str) -> String {
+    MINIFIED_KEYS.with(|memo| {
+        let mut memo = memo.borrow_mut();
+        match memo.get(key) {
+            Some(hashed) => hashed.clone(),
+            None => {
+                let hashed = create_short_hash(&format!("<>{key}"));
+                memo.insert(key.to_string(), hashed.clone());
+                hashed
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn obj(entries: &[(&str, EvalValue)]) -> EvalValue {
+        EvalValue::Obj(
+            entries
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), v.clone()))
+                .collect::<JsObjectMap>()
+                .into(),
+        )
+    }
+
+    fn s(v: &str) -> EvalValue {
+        EvalValue::Str(v.to_string())
+    }
+
+    #[test]
+    fn minimal_namespace_compiles_to_known_answers() {
+        let namespaces: JsObjectMap = [(
+            "a".to_string(),
+            obj(&[("color", s("blue")), ("backgroundColor", s("red"))]),
+        )]
+        .into_iter()
+        .collect();
+        let options = ResolvedOptions::default();
+        let ctx = CreateContext::new(&options);
+        let out = compile_namespaces(&namespaces, &ctx, false).unwrap();
+        assert_eq!(
+            out.compiled.to_json(),
+            serde_json::json!({
+                "a": { "kMwMTN": "xju2f9n", "kWkggS": "xrkmrrc", "$$css": true }
+            })
+        );
+        assert_eq!(out.rules.len(), 2);
+        assert_eq!(&*out.rules[0].ltr, ".xju2f9n{color:blue}");
+        assert_eq!(&*out.rules[1].ltr, ".xrkmrrc{background-color:red}");
+    }
+
+    #[test]
+    fn non_object_namespace_errors() {
+        let namespaces: JsObjectMap = [("a".to_string(), EvalValue::Null)].into_iter().collect();
+        let options = ResolvedOptions::default();
+        let ctx = CreateContext::new(&options);
+        let err = compile_namespaces(&namespaces, &ctx, false).unwrap_err();
+        assert_eq!(err.message, "A StyleX namespace must be an object.");
+    }
+}

--- a/crates/stylex/src/shared/create.rs
+++ b/crates/stylex/src/shared/create.rs
@@ -8,12 +8,14 @@ use crate::fxhash::FxHashSet;
 use crate::hash::create_short_hash;
 use crate::options::{ModuleResolutionType, ResolvedOptions};
 use crate::rules::StylexRule;
+use crate::shared::dashify::sanitize_dev_class_name;
 use crate::shared::dev_naming::{
-    DebugPathInfo, add_source_map_data, convert_to_test_styles, inject_dev_class_names,
+    DebugPathInfo, convert_to_test_styles, create_short_filename, dev_class_prefix,
 };
 use crate::shared::flatten::{
     PreRule, flatten_raw_style_object, media_order_transform, validate_namespace,
 };
+use crate::shared::generate_rule::CompiledDecl;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -80,11 +82,11 @@ pub fn compile_atom(
     raw.insert(property, EvalValue::Str(value.to_string()));
     let mut namespaces = JsObjectMap::new();
     namespaces.insert(INLINE_NAMESPACE, EvalValue::Obj(raw.into()));
-    let mut out = compile_namespaces_core(&namespaces, ctx, false)?;
-    if ctx.options.dev && ctx.options.enable_dev_class_names {
-        out.compiled = inject_dev_class_names(out.compiled, None, ctx.filename.as_deref());
-    }
-    Ok(out)
+    let mut shape = DevShape {
+        dev_prefix: dev_prefix_for(ctx, None),
+        debug: None,
+    };
+    compile_namespaces_core(&namespaces, ctx, false, &mut shape)
 }
 
 /// Dynamic-fn namespaces are wave 3: callers reject them with `unsupported_api`
@@ -94,36 +96,37 @@ pub fn compile_namespaces(
     ctx: &CreateContext<'_>,
     need_class_paths: bool,
 ) -> Result<CreateOutput, StylexError> {
-    let mut out = compile_namespaces_core(namespaces, ctx, need_class_paths)?;
     let options = ctx.options;
-    if options.debug && options.enable_debug_data_prop {
-        let debug_paths = DebugPathInfo {
-            file_package: ctx.file_package.clone(),
-            cwd_package_name: ctx.cwd_package_name.clone(),
-            root_dir: options
-                .unstable_module_resolution
-                .as_ref()
-                .and_then(|m| m.root_dir.as_ref())
-                .map(|r| r.to_string_lossy().into_owned()),
-            is_haste: options
-                .unstable_module_resolution
-                .as_ref()
-                .is_some_and(|m| m.kind == ModuleResolutionType::Haste),
-        };
-        out.compiled = add_source_map_data(
-            out.compiled,
-            ctx.namespace_lines.as_ref(),
-            ctx.filename.as_deref(),
-            &debug_paths,
-        );
-    }
-    if options.dev && options.enable_dev_class_names {
-        out.compiled = inject_dev_class_names(
-            out.compiled,
-            ctx.var_name.as_deref(),
-            ctx.filename.as_deref(),
-        );
-    }
+    let debug = if options.debug && options.enable_debug_data_prop {
+        ctx.namespace_lines
+            .as_ref()
+            .zip(ctx.filename.as_deref())
+            .map(|(lines, filename)| DebugSource {
+                lines,
+                filename,
+                info: DebugPathInfo {
+                    file_package: ctx.file_package.clone(),
+                    cwd_package_name: ctx.cwd_package_name.clone(),
+                    root_dir: options
+                        .unstable_module_resolution
+                        .as_ref()
+                        .and_then(|m| m.root_dir.as_ref())
+                        .map(|r| r.to_string_lossy().into_owned()),
+                    is_haste: options
+                        .unstable_module_resolution
+                        .as_ref()
+                        .is_some_and(|m| m.kind == ModuleResolutionType::Haste),
+                },
+                short: None,
+            })
+    } else {
+        None
+    };
+    let mut shape = DevShape {
+        dev_prefix: dev_prefix_for(ctx, ctx.var_name.as_deref()),
+        debug,
+    };
+    let mut out = compile_namespaces_core(namespaces, ctx, need_class_paths, &mut shape)?;
     if options.test {
         out.compiled = convert_to_test_styles(
             &out.compiled,
@@ -134,17 +137,65 @@ pub fn compile_namespaces(
     Ok(out)
 }
 
+struct DevShape<'a> {
+    dev_prefix: Option<String>,
+    debug: Option<DebugSource<'a>>,
+}
+
+struct DebugSource<'a> {
+    lines: &'a BTreeMap<String, u32>,
+    filename: &'a str,
+    info: DebugPathInfo,
+    short: Option<String>,
+}
+
+impl DevShape<'_> {
+    // parity: dev-classname.js — `{[devClass]: devClass, ...namespace}`
+    fn dev_class(&self, namespace: &str) -> Option<String> {
+        let prefix = self.dev_prefix.as_ref()?;
+        Some(sanitize_dev_class_name(&format!("{prefix}{namespace}")))
+    }
+
+    // parity: add-sourcemap-data.js — namespaces without a known source line
+    // (upstream cannot find them in the AST) keep `$$css: true`.
+    fn css_marker(&mut self, namespace: &str) -> EvalValue {
+        let Some(debug) = &mut self.debug else {
+            return EvalValue::Bool(true);
+        };
+        match debug.lines.get(namespace) {
+            Some(&line) if line > 0 => {
+                let short = debug
+                    .short
+                    .get_or_insert_with(|| create_short_filename(debug.filename, &debug.info));
+                if short.is_empty() {
+                    EvalValue::Bool(true)
+                } else {
+                    EvalValue::Str(format!("{short}:{line}"))
+                }
+            }
+            _ => EvalValue::Bool(true),
+        }
+    }
+}
+
+fn dev_prefix_for(ctx: &CreateContext<'_>, var_name: Option<&str>) -> Option<String> {
+    (ctx.options.dev && ctx.options.enable_dev_class_names)
+        .then(|| dev_class_prefix(var_name, ctx.filename.as_deref().unwrap_or("UnknownFile")))
+}
+
 fn compile_namespaces_core(
     namespaces: &JsObjectMap,
     ctx: &CreateContext<'_>,
     need_class_paths: bool,
+    shape: &mut DevShape<'_>,
 ) -> Result<CreateOutput, StylexError> {
     let _t = crate::timings::start(crate::timings::Stage::Create);
     let options = ctx.options;
-    let mut resolved_namespaces = JsObjectMap::new();
+    let mut resolved_namespaces = JsObjectMap::with_capacity(namespaces.len());
     let mut rules: Vec<StylexRule> = Vec::new();
     let mut class_paths: Vec<(String, ClassPathsInNamespace)> = Vec::new();
     let mut seen_class_names: FxHashSet<Arc<str>> = FxHashSet::default();
+    let mut decls: Vec<CompiledDecl> = Vec::new();
 
     for (namespace_name, namespace_value) in namespaces.entries() {
         // The evaluator's `value[key] =` [[Set]] never creates a "__proto__"
@@ -152,7 +203,7 @@ fn compile_namespaces_core(
         if namespace_name == "__proto__" {
             continue;
         }
-        validate_namespace(namespace_value, &[])?;
+        validate_namespace(namespace_value)?;
         let EvalValue::Obj(namespace) = namespace_value else {
             unreachable!("validate_namespace only accepts objects");
         };
@@ -168,40 +219,21 @@ fn compile_namespaces_core(
         let flattened = flatten_raw_style_object(namespace_ref, options)?;
         let deduped = dedupe_last_wins(flattened);
 
-        let mut namespace_obj = JsObjectMap::new();
+        let mut namespace_obj = JsObjectMap::with_capacity(deduped.len() + 2);
+        if let Some(dev_class) = shape.dev_class(namespace_name) {
+            namespace_obj.insert(dev_class.clone(), EvalValue::Str(dev_class));
+        }
         let mut paths_in_namespace: Vec<(String, Vec<String>)> = Vec::new();
-        let mut namespace_rules: Vec<StylexRule> = Vec::new();
         for (key, pre_rule) in &deduped {
             // Variables-as-keys skip minification to avoid dynamic-style regressions.
             let display_key = if options.enable_minified_keys && !key.starts_with("--") {
-                let hashed = minified_key_hash(key.as_ref());
-                if options.debug {
-                    format!("{key}-k{hashed}")
-                } else {
-                    format!("k{hashed}")
-                }
+                minified_display_key(key, options.debug)
             } else {
                 key.to_string()
             };
 
-            let computed = pre_rule.compiled(options)?;
-            let mut class_names: Vec<&str> = Vec::new();
-            for entry in computed.iter().flatten() {
-                let name: &str = &entry.0.class_name;
-                if !class_names.contains(&name) {
-                    class_names.push(name);
-                }
-            }
-            let joined = class_names.join(" ");
-            namespace_obj.insert(
-                display_key,
-                if joined.is_empty() {
-                    EvalValue::Null
-                } else {
-                    EvalValue::Str(joined)
-                },
-            );
-            for (decl, key_path) in computed.into_iter().flatten() {
+            decls.clear();
+            pre_rule.for_each_compiled(options, &mut |decl, key_path| {
                 if need_class_paths {
                     match paths_in_namespace
                         .iter_mut()
@@ -216,19 +248,44 @@ fn compile_namespaces_core(
                         )),
                     }
                 }
-                namespace_rules.push((*decl).clone());
+                decls.push(decl);
+            })?;
+
+            let mut joined =
+                String::with_capacity(decls.iter().map(|d| d.class_name.len() + 1).sum());
+            let mut first = true;
+            for (i, decl) in decls.iter().enumerate() {
+                if decls[..i]
+                    .iter()
+                    .any(|seen| seen.class_name == decl.class_name)
+                {
+                    continue;
+                }
+                if !first {
+                    joined.push(' ');
+                }
+                first = false;
+                joined.push_str(&decl.class_name);
+            }
+            namespace_obj.insert(
+                display_key,
+                if joined.is_empty() {
+                    EvalValue::Null
+                } else {
+                    EvalValue::Str(joined)
+                },
+            );
+            for decl in &decls {
+                if seen_class_names.insert(decl.class_name.clone()) {
+                    rules.push((**decl).clone());
+                }
             }
         }
-        namespace_obj.insert("$$css", EvalValue::Bool(true));
+        namespace_obj.insert("$$css", shape.css_marker(namespace_name));
         resolved_namespaces.insert(
             namespace_name.to_string(),
             EvalValue::Obj(Arc::new(namespace_obj)),
         );
-        for rule in namespace_rules {
-            if seen_class_names.insert(rule.class_name.clone()) {
-                rules.push(rule);
-            }
-        }
         if need_class_paths {
             class_paths.push((namespace_name.to_string(), paths_in_namespace));
         }
@@ -246,7 +303,12 @@ fn compile_namespaces_core(
 fn dedupe_last_wins<'a>(
     flattened: Vec<(Cow<'a, str>, PreRule<'a>)>,
 ) -> Vec<(Cow<'a, str>, PreRule<'a>)> {
-    let mut seen: FxHashSet<&str> = FxHashSet::default();
+    let mut seen: FxHashSet<&str> =
+        FxHashSet::with_capacity_and_hasher(flattened.len(), Default::default());
+    if flattened.iter().all(|(key, _)| seen.insert(key)) {
+        return flattened;
+    }
+    seen.clear();
     let mut keep = vec![false; flattened.len()];
     for (i, (key, _)) in flattened.iter().enumerate().rev() {
         if seen.insert(key) {
@@ -262,20 +324,35 @@ fn dedupe_last_wins<'a>(
 
 thread_local! {
     // createShortHash('<'+'>'+key) is pure; flattened keys repeat across every
-    // file in a design-system corpus, so the hash is computed once per process.
+    // file in a design-system corpus, so `k{hash}` is computed once per process.
     static MINIFIED_KEYS: std::cell::RefCell<FxHashMap<String, String>> =
         std::cell::RefCell::new(FxHashMap::default());
 }
 
-fn minified_key_hash(key: &str) -> String {
+fn minified_display_key(key: &str, debug: bool) -> String {
+    let display = |k_hash: &str| {
+        if debug {
+            let mut out = String::with_capacity(key.len() + 1 + k_hash.len());
+            out.push_str(key);
+            out.push('-');
+            out.push_str(k_hash);
+            out
+        } else {
+            k_hash.to_string()
+        }
+    };
     MINIFIED_KEYS.with(|memo| {
         let mut memo = memo.borrow_mut();
         match memo.get(key) {
-            Some(hashed) => hashed.clone(),
+            Some(k_hash) => display(k_hash),
             None => {
                 let hashed = create_short_hash(&format!("<>{key}"));
-                memo.insert(key.to_string(), hashed.clone());
-                hashed
+                let mut k_hash = String::with_capacity(hashed.len() + 1);
+                k_hash.push('k');
+                k_hash.push_str(&hashed);
+                let out = display(&k_hash);
+                memo.insert(key.to_string(), k_hash);
+                out
             }
         }
     })

--- a/crates/stylex/src/shared/create.rs
+++ b/crates/stylex/src/shared/create.rs
@@ -13,9 +13,11 @@ use crate::shared::dev_naming::{
     DebugPathInfo, convert_to_test_styles, create_short_filename, dev_class_prefix,
 };
 use crate::shared::flatten::{
-    PreRule, flatten_raw_style_object, media_order_transform, validate_namespace,
+    PreRule, PreRuleValue, StyleScalar, flatten_raw_style_object, media_order_transform,
+    validate_namespace,
 };
 use crate::shared::generate_rule::CompiledDecl;
+use crate::shared::resolution::is_unexpanded_property;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -59,7 +61,6 @@ pub type ClassPathsInNamespace = Vec<(String, Vec<String>)>;
 #[derive(Debug, Clone, PartialEq)]
 pub struct CreateOutput {
     /// namespace name → compiled object (className strings / null, `$$css`).
-    /// Rc-shared with the namespace memo: prod-mode consumers never clone.
     pub compiled: Arc<JsObjectMap>,
     /// Injected rules in traversal order, deduped by className (first wins).
     pub rules: Vec<StylexRule>,
@@ -203,31 +204,46 @@ fn compile_namespaces_core(
         if namespace_name == "__proto__" {
             continue;
         }
-        validate_namespace(namespace_value)?;
         let EvalValue::Obj(namespace) = namespace_value else {
-            unreachable!("validate_namespace only accepts objects");
+            return Err(StylexError::illegal_namespace_value());
         };
 
         let transformed;
-        let namespace_ref = match media_order_transform(namespace, options)? {
-            Some(rebuilt) => {
-                transformed = rebuilt;
-                &transformed
+        let entries = if namespace.get("__proto__").is_none()
+            && namespace.entries().all(|(key, value)| {
+                matches!(
+                    value,
+                    EvalValue::Null | EvalValue::Str(_) | EvalValue::Num(_)
+                ) && !key.contains('(')
+                    && is_unexpanded_property(key, options.style_resolution)
+            }) {
+            NamespaceEntries::Raw {
+                namespace,
+                index: 0,
             }
-            None => namespace,
+        } else {
+            validate_namespace(namespace_value)?;
+            let namespace_ref = match media_order_transform(namespace, options)? {
+                Some(rebuilt) => {
+                    transformed = rebuilt;
+                    &transformed
+                }
+                None => namespace,
+            };
+            NamespaceEntries::Prepared(
+                dedupe_last_wins(flatten_raw_style_object(namespace_ref, options)?).into_iter(),
+            )
         };
-        let flattened = flatten_raw_style_object(namespace_ref, options)?;
-        let deduped = dedupe_last_wins(flattened);
 
-        let mut namespace_obj = JsObjectMap::with_capacity(deduped.len() + 2);
+        let mut namespace_obj = JsObjectMap::with_capacity(entries.len() + 2);
         if let Some(dev_class) = shape.dev_class(namespace_name) {
             namespace_obj.insert(dev_class.clone(), EvalValue::Str(dev_class));
         }
         let mut paths_in_namespace: Vec<(String, Vec<String>)> = Vec::new();
-        for (key, pre_rule) in &deduped {
+        for (key, pre_rule) in entries {
             // Variables-as-keys skip minification to avoid dynamic-style regressions.
             let display_key = if options.enable_minified_keys && !key.starts_with("--") {
-                minified_display_key(key, options.debug)
+                minified_display_key(&key, options.debug)
             } else {
                 key.to_string()
             };
@@ -298,6 +314,58 @@ fn compile_namespaces_core(
     })
 }
 
+enum NamespaceEntries<'a> {
+    Raw {
+        namespace: &'a JsObjectMap,
+        index: usize,
+    },
+    Prepared(std::vec::IntoIter<(Cow<'a, str>, PreRule<'a>)>),
+}
+
+impl<'a> Iterator for NamespaceEntries<'a> {
+    type Item = (Cow<'a, str>, PreRule<'a>);
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len(), Some(self.len()))
+    }
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Prepared(entries) => entries.next(),
+            Self::Raw { namespace, index } => {
+                if *index == namespace.len() {
+                    return None;
+                }
+                let (key, value) = namespace.entry_at(*index);
+                *index += 1;
+                let key = Cow::Borrowed(key);
+                let scalar = match value {
+                    EvalValue::Null => return Some((key, PreRule::Null)),
+                    EvalValue::Num(n) => StyleScalar::Num(*n),
+                    EvalValue::Str(s) => StyleScalar::Str(Cow::Borrowed(s)),
+                    _ => unreachable!("raw entries are scalar"),
+                };
+                Some((
+                    key.clone(),
+                    PreRule::Rule {
+                        property: key,
+                        value: PreRuleValue::Single(scalar),
+                        key_path: None,
+                    },
+                ))
+            }
+        }
+    }
+}
+
+impl ExactSizeIterator for NamespaceEntries<'_> {
+    fn len(&self) -> usize {
+        match self {
+            Self::Raw { namespace, index } => namespace.len() - index,
+            Self::Prepared(entries) => entries.len(),
+        }
+    }
+}
+
 // parity: stylex-create.js reduceRight dedupe — the LAST occurrence of a key
 // wins and keeps its (last) position.
 fn dedupe_last_wins<'a>(
@@ -361,6 +429,7 @@ fn minified_display_key(key: &str, debug: bool) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::options::StyleResolution;
 
     fn obj(entries: &[(&str, EvalValue)]) -> EvalValue {
         EvalValue::Obj(
@@ -396,6 +465,58 @@ mod tests {
         assert_eq!(out.rules.len(), 2);
         assert_eq!(&*out.rules[0].ltr, ".xju2f9n{color:blue}");
         assert_eq!(&*out.rules[1].ltr, ".xrkmrrc{background-color:red}");
+    }
+
+    #[test]
+    fn flat_namespace_keeps_numeric_order_and_css_marker_position() {
+        let mut namespaces = JsObjectMap::new();
+        namespaces.insert(
+            "a",
+            obj(&[
+                ("color", s("blue")),
+                ("2", s("b")),
+                ("1", s("a")),
+                ("$$css", EvalValue::Null),
+                ("width", EvalValue::Null),
+            ]),
+        );
+        let options = ResolvedOptions {
+            style_resolution: StyleResolution::PropertySpecificity,
+            enable_minified_keys: false,
+            ..ResolvedOptions::default()
+        };
+        let output = compile_namespaces(&namespaces, &CreateContext::new(&options), true).unwrap();
+        let Some(EvalValue::Obj(namespace)) = output.compiled.get("a") else {
+            panic!("compiled namespace");
+        };
+        assert_eq!(
+            namespace.keys().collect::<Vec<_>>(),
+            ["1", "2", "color", "$$css", "width"]
+        );
+        assert_eq!(namespace.get("$$css"), Some(&EvalValue::Bool(true)));
+        assert_eq!(namespace.get("width"), Some(&EvalValue::Null));
+        assert_eq!(
+            output.class_paths[0]
+                .1
+                .iter()
+                .map(|(_, path)| path.clone())
+                .collect::<Vec<_>>(),
+            vec![vec!["1"], vec!["2"], vec!["color"]]
+        );
+    }
+
+    #[test]
+    fn flattening_errors_precede_scalar_normalization_errors() {
+        let mut namespaces = JsObjectMap::new();
+        namespaces.insert("a", obj(&[("color", s("")), ("all", s("initial"))]));
+        let options = ResolvedOptions {
+            style_resolution: StyleResolution::PropertySpecificity,
+            property_validation_mode: crate::options::PropertyValidationMode::Throw,
+            ..ResolvedOptions::default()
+        };
+        let error =
+            compile_namespaces(&namespaces, &CreateContext::new(&options), false).unwrap_err();
+        assert_eq!(error, StylexError::banned_shorthand("all").unwrap());
     }
 
     #[test]

--- a/crates/stylex/src/shared/create_theme.rs
+++ b/crates/stylex/src/shared/create_theme.rs
@@ -40,7 +40,7 @@ pub fn create_theme(
         _ => return Err(StylexError::non_style_object("createTheme")),
     };
     let var_group_hash = match theme_vars {
-        JsValue::Proxy(proxy) => proxy.var_group_hash.clone(),
+        JsValue::Proxy(proxy) => proxy.var_group_hash().to_string(),
         JsValue::Obj(obj) => match obj.get("__varGroupHash__") {
             Some(JsValue::Str(s)) if !s.is_empty() => s.clone(),
             _ => return Err(StylexError::theme_without_var_group()),
@@ -145,7 +145,7 @@ fn theme_var_name_hash(theme_vars: &JsValue, key: &str) -> Result<String, Stylex
         JsValue::Proxy(proxy) => {
             // Mirror the proxy traps: __varGroupHash__ answers the hash string.
             let resolved = match key {
-                "__varGroupHash__" => proxy.var_group_hash.clone(),
+                "__varGroupHash__" => proxy.var_group_hash().to_string(),
                 "__IS_PROXY" | "toString" => {
                     return Err(StylexError::upstream_type_crash(
                         "a proxy trap value without .slice in createTheme",

--- a/crates/stylex/src/shared/create_theme.rs
+++ b/crates/stylex/src/shared/create_theme.rs
@@ -1,0 +1,363 @@
+//! `stylex.createTheme` over evaluated theme vars + overrides.
+// parity: babel-plugin src/shared/stylex-create-theme.js + visitors/stylex-create-theme.js
+
+use crate::errors::StylexError;
+use crate::eval::JsValue;
+use crate::eval::value::{EvalValue, JsObjectMap};
+use crate::hash::hash;
+use crate::jsrt::{js_slice_utf16, locale_cmp, unverified_collation_char, utf16_cmp};
+use crate::options::ResolvedOptions;
+use crate::rules::StylexRule;
+use crate::shared::define_vars::{
+    collect_vars_by_at_rule, es_ordered_entries, priority_for_at_rule, wrap_with_at_rules,
+};
+use crate::shared::types::as_css_type_js;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateThemeOutput {
+    /// Replaces the call: `{[varGroupHash]: "overrideClass varGroupHash", $$css}`.
+    pub js_output: JsObjectMap,
+    /// One rule per at-rule bucket, priority 0.4 + n/10, "default" first.
+    pub rules: Vec<StylexRule>,
+}
+
+pub fn create_theme(
+    theme_vars: &JsValue,
+    overrides: &JsValue,
+    options: &ResolvedOptions,
+) -> Result<CreateThemeOutput, StylexError> {
+    let override_entries: Vec<(String, JsValue)> = match overrides {
+        JsValue::Obj(obj) => es_ordered_entries(obj)
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect(),
+        JsValue::Arr(items) => items
+            .iter()
+            .enumerate()
+            .map(|(i, v)| (i.to_string(), v.clone()))
+            .collect(),
+        JsValue::Proxy(_) => Vec::new(),
+        _ => return Err(StylexError::non_style_object("createTheme")),
+    };
+    let var_group_hash = match theme_vars {
+        JsValue::Proxy(proxy) => proxy.var_group_hash.clone(),
+        JsValue::Obj(obj) => match obj.get("__varGroupHash__") {
+            Some(JsValue::Str(s)) if !s.is_empty() => s.clone(),
+            _ => return Err(StylexError::theme_without_var_group()),
+        },
+        _ => return Err(StylexError::theme_without_var_group()),
+    };
+
+    // Sorted with the default comparator (plain UTF-16), not localeCompare.
+    let mut sorted_keys: Vec<&str> = override_entries.iter().map(|(k, _)| k.as_str()).collect();
+    sorted_keys.sort_by(|a, b| utf16_cmp(a, b));
+
+    let mut collection: Vec<(String, Vec<String>)> = Vec::new();
+    for key in sorted_keys {
+        let raw = override_entries
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.clone())
+            .expect("key comes from the entry list");
+        let value = match as_css_type_js(&raw) {
+            Some((_, inner)) => inner,
+            None => raw,
+        };
+        let name_hash = theme_var_name_hash(theme_vars, key)?;
+        collect_vars_by_at_rule(key, &name_hash, &value, &mut collection, &[])?;
+    }
+
+    let mut sorted_at_rules: Vec<&str> = collection.iter().map(|(k, _)| k.as_str()).collect();
+    // This sort feeds atRulesStringForHash: an unverified collation char would
+    // silently change class names, so it hard-errors (r4#4 policy).
+    for at_rule in &sorted_at_rules {
+        if let Some(c) = unverified_collation_char(at_rule) {
+            return Err(StylexError::new(
+                crate::errors::ErrorCode::UnsupportedApi,
+                format!(
+                    "createTheme() cannot sort at-rule {at_rule:?}: {c:?} is outside the pinned collation alphabet and the order feeds the theme hash"
+                ),
+            ));
+        }
+    }
+    sorted_at_rules.sort_by(|a, b| {
+        if *a == "default" {
+            std::cmp::Ordering::Less
+        } else if *b == "default" {
+            std::cmp::Ordering::Greater
+        } else {
+            locale_cmp(a, b).expect("unverified chars rejected above")
+        }
+    });
+
+    let decls_of = |at_rule: &str| -> String {
+        collection
+            .iter()
+            .find(|(k, _)| k == at_rule)
+            .map(|(_, decls)| decls.concat())
+            .unwrap_or_default()
+    };
+    // The hash input wraps every bucket, the "default" one literally as default{…}.
+    let at_rules_string_for_hash: String = sorted_at_rules
+        .iter()
+        .map(|at_rule| wrap_with_at_rules(&decls_of(at_rule), at_rule))
+        .collect();
+    let override_class_name = format!(
+        "{}{}",
+        options.class_name_prefix,
+        hash(&at_rules_string_for_hash)
+    );
+
+    let mut rules = Vec::new();
+    for at_rule in &sorted_at_rules {
+        let decls = decls_of(at_rule);
+        let rule = format!(".{override_class_name}, .{override_class_name}:root{{{decls}}}");
+        let (ltr, suffix) = if *at_rule == "default" {
+            (rule, String::new())
+        } else {
+            (
+                wrap_with_at_rules(&rule, at_rule),
+                format!("-{}", hash(at_rule)),
+            )
+        };
+        rules.push(StylexRule {
+            class_name: format!("{override_class_name}{suffix}").into(),
+            ltr: ltr.into(),
+            rtl: None,
+            const_key: None,
+            const_val: None,
+            priority: 0.4 + priority_for_at_rule(at_rule) / 10.0,
+        });
+    }
+
+    let mut js_output = JsObjectMap::new();
+    js_output.insert(
+        var_group_hash.clone(),
+        EvalValue::Str(format!("{override_class_name} {var_group_hash}")),
+    );
+    js_output.insert("$$css", EvalValue::Bool(true));
+    Ok(CreateThemeOutput { js_output, rules })
+}
+
+// parity: `themeVars[key].slice(6, -1)` — trims `var(--` and `)`.
+fn theme_var_name_hash(theme_vars: &JsValue, key: &str) -> Result<String, StylexError> {
+    match theme_vars {
+        JsValue::Proxy(proxy) => {
+            // Mirror the proxy traps: __varGroupHash__ answers the hash string.
+            let resolved = match key {
+                "__varGroupHash__" => proxy.var_group_hash.clone(),
+                "__IS_PROXY" | "toString" => {
+                    return Err(StylexError::upstream_type_crash(
+                        "a proxy trap value without .slice in createTheme",
+                    ));
+                }
+                _ => proxy.resolve_key(key),
+            };
+            Ok(js_slice_utf16(&resolved, 6, -1))
+        }
+        JsValue::Obj(obj) => match obj.get(key) {
+            Some(JsValue::Str(s)) => Ok(js_slice_utf16(s, 6, -1)),
+            None | Some(JsValue::Undefined) => Err(StylexError::new(
+                crate::errors::ErrorCode::NonStaticValue,
+                "Cannot read properties of undefined (reading 'slice')",
+            )),
+            Some(_) => Err(StylexError::upstream_type_crash(
+                "a non-string theme variable in createTheme",
+            )),
+        },
+        _ => Err(StylexError::theme_without_var_group()),
+    }
+}
+
+/// Visitor-level JS-output rewrite for `dev`/`test`; no-op otherwise.
+// parity: visitors/stylex-create-theme.js isTest/isDev branches
+pub fn apply_theme_dev_naming(
+    js_output: JsObjectMap,
+    filename: Option<&str>,
+    var_name: &str,
+    options: &ResolvedOptions,
+) -> JsObjectMap {
+    if !options.test && !options.dev {
+        return js_output;
+    }
+    let filename = filename.unwrap_or("UnknownFile");
+    let basename = filename
+        .rsplit('/')
+        .next()
+        .unwrap_or(filename)
+        .split('.')
+        .next()
+        .unwrap_or_default();
+    let dev_class_name = format!("{basename}__{var_name}");
+    let mut out = JsObjectMap::new();
+    out.insert(
+        dev_class_name.clone(),
+        EvalValue::Str(dev_class_name.clone()),
+    );
+    if options.test {
+        out.insert("$$css", EvalValue::Bool(true));
+        return out;
+    }
+    for (k, v) in js_output.entries() {
+        out.insert(k, v.clone());
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eval::JsObj;
+    use crate::eval::cross_file::VarGroupProxy;
+
+    fn probe_proxy() -> VarGroupProxy {
+        // Pinned via live-oracle probe 2026-08-28 (probe3, /tmp fixture pkg).
+        VarGroupProxy::new(
+            "probe-pkg:src/tokens.stylex.ts".to_string(),
+            "vars".to_string(),
+            &ResolvedOptions::default(),
+        )
+    }
+
+    fn overrides(entries: &[(&str, JsValue)]) -> JsValue {
+        let mut obj = JsObj::default();
+        for (k, v) in entries {
+            obj.insert((*k).to_string(), v.clone());
+        }
+        JsValue::object(obj)
+    }
+
+    #[test]
+    fn cross_file_basic_matches_oracle() {
+        let options = ResolvedOptions::default();
+        let proxy = JsValue::proxy(probe_proxy());
+        let out = create_theme(
+            &proxy,
+            &overrides(&[
+                ("accent", JsValue::Str("rebeccapurple".into())),
+                ("gap", JsValue::Str("12px".into())),
+            ]),
+            &options,
+        )
+        .unwrap();
+        assert_eq!(out.rules.len(), 1);
+        assert_eq!(&*out.rules[0].class_name, "xxlf0b4");
+        assert_eq!(
+            &*out.rules[0].ltr,
+            ".xxlf0b4, .xxlf0b4:root{--x15glzcj:rebeccapurple;--x1e9wu2u:12px;}"
+        );
+        assert!(out.rules[0].priority == 0.5);
+        assert_eq!(
+            out.js_output.get("xf9pnhg"),
+            Some(&EvalValue::Str("xxlf0b4 xf9pnhg".to_string()))
+        );
+        assert_eq!(out.js_output.get("$$css"), Some(&EvalValue::Bool(true)));
+    }
+
+    #[test]
+    fn empty_and_all_null_overrides_hash_the_empty_string() {
+        // Pinned via live-oracle probe 2026-08-28: both compile to xph554m.
+        let options = ResolvedOptions::default();
+        let proxy = JsValue::proxy(probe_proxy());
+        let empty = create_theme(&proxy, &overrides(&[]), &options).unwrap();
+        assert!(empty.rules.is_empty());
+        assert_eq!(
+            empty.js_output.get("xf9pnhg"),
+            Some(&EvalValue::Str("xph554m xf9pnhg".to_string()))
+        );
+        let all_null =
+            create_theme(&proxy, &overrides(&[("accent", JsValue::Null)]), &options).unwrap();
+        assert_eq!(
+            all_null.js_output.get("xf9pnhg"),
+            empty.js_output.get("xf9pnhg")
+        );
+    }
+
+    #[test]
+    fn missing_var_group_hash_is_rejected() {
+        let options = ResolvedOptions::default();
+        let err = create_theme(
+            &JsValue::object(JsObj::default()),
+            &overrides(&[]),
+            &options,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.message,
+            "Can only override variables theme created with defineVars()."
+        );
+        let err =
+            create_theme(&JsValue::Str("nope".into()), &overrides(&[]), &options).unwrap_err();
+        assert_eq!(err.code, crate::errors::ErrorCode::ThemeWithoutVarGroup);
+    }
+
+    #[test]
+    fn same_file_map_lookup_and_unknown_key() {
+        let options = ResolvedOptions::default();
+        let mut vars = JsObj::default();
+        vars.insert("accent".to_string(), JsValue::Str("var(--xx91c37)".into()));
+        vars.insert(
+            "__varGroupHash__".to_string(),
+            JsValue::Str("x7tlvcs".into()),
+        );
+        let theme_vars = JsValue::object(vars);
+        // Pinned via live-oracle probe 2026-08-28 (probe3 same-file green theme).
+        let out = create_theme(
+            &theme_vars,
+            &overrides(&[("accent", JsValue::Str("green".into()))]),
+            &options,
+        )
+        .unwrap();
+        assert_eq!(&*out.rules[0].class_name, "x7u453x");
+        assert_eq!(
+            &*out.rules[0].ltr,
+            ".x7u453x, .x7u453x:root{--xx91c37:green;}"
+        );
+        let err = create_theme(
+            &theme_vars,
+            &overrides(&[("missing", JsValue::Str("green".into()))]),
+            &options,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.message,
+            "Cannot read properties of undefined (reading 'slice')"
+        );
+    }
+
+    #[test]
+    fn dev_and_test_naming() {
+        let dev_options = ResolvedOptions {
+            dev: true,
+            debug: true,
+            ..ResolvedOptions::default()
+        };
+        let mut js = JsObjectMap::new();
+        js.insert("x7tlvcs", EvalValue::Str("x7u453x x7tlvcs".into()));
+        js.insert("$$css", EvalValue::Bool(true));
+        let dev = apply_theme_dev_naming(
+            js.clone(),
+            Some("/fix/src/both.stylex.ts"),
+            "myT",
+            &dev_options,
+        );
+        let keys: Vec<&str> = dev.keys().collect();
+        assert_eq!(keys, vec!["both__myT", "x7tlvcs", "$$css"]);
+        assert_eq!(
+            dev.get("both__myT"),
+            Some(&EvalValue::Str("both__myT".into()))
+        );
+
+        let test_options = ResolvedOptions {
+            test: true,
+            ..ResolvedOptions::default()
+        };
+        let test =
+            apply_theme_dev_naming(js.clone(), Some("/x/theme.ts"), "myTheme", &test_options);
+        let keys: Vec<&str> = test.keys().collect();
+        assert_eq!(keys, vec!["theme__myTheme", "$$css"]);
+
+        let plain = apply_theme_dev_naming(js.clone(), None, "t", &ResolvedOptions::default());
+        assert_eq!(plain, js);
+    }
+}

--- a/crates/stylex/src/shared/css_value.rs
+++ b/crates/stylex/src/shared/css_value.rs
@@ -1,0 +1,579 @@
+//! CSS value tokenizer, behavior-equivalent to postcss-value-parser@4.2.0.
+// parity: postcss-value-parser lib/{parse,walk,stringify,unit}.js
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Kind {
+    Word,
+    Space,
+    Div,
+    Str,
+    Comment,
+    Func,
+    UnicodeRange,
+}
+
+// Flat node shape mirroring the JS objects; unused fields stay at defaults.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Node {
+    pub kind: Kind,
+    pub value: String,
+    pub source_index: usize,
+    pub source_end_index: usize,
+    pub before: String,
+    pub after: String,
+    pub quote: u8,
+    pub unclosed: bool,
+    pub nodes: Vec<Node>,
+}
+
+impl Node {
+    fn new(kind: Kind) -> Self {
+        Node {
+            kind,
+            value: String::new(),
+            source_index: 0,
+            source_end_index: 0,
+            before: String::new(),
+            after: String::new(),
+            quote: 0,
+            unclosed: false,
+            nodes: Vec::new(),
+        }
+    }
+
+    fn leaf(kind: Kind, value: String, source_index: usize, source_end_index: usize) -> Self {
+        Node {
+            value,
+            source_index,
+            source_end_index,
+            ..Node::new(kind)
+        }
+    }
+}
+
+fn utf8(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+fn find_byte(haystack: &[u8], needle: u8, from: usize) -> Option<usize> {
+    if from >= haystack.len() {
+        return None;
+    }
+    memchr::memchr(needle, &haystack[from..]).map(|i| i + from)
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8], from: usize) -> Option<usize> {
+    if from >= haystack.len() {
+        return None;
+    }
+    haystack[from..]
+        .windows(needle.len())
+        .position(|w| w == needle)
+        .map(|i| i + from)
+}
+
+fn tokens<'a>(stack: &'a mut [Node], root: &'a mut Vec<Node>) -> &'a mut Vec<Node> {
+    match stack.last_mut() {
+        Some(top) => &mut top.nodes,
+        None => root,
+    }
+}
+
+fn is_unicode_range(token: &[u8]) -> bool {
+    token.len() > 2
+        && (token[0] == b'u' || token[0] == b'U')
+        && token[1] == b'+'
+        && token[2..]
+            .iter()
+            .all(|c| c.is_ascii_hexdigit() || *c == b'?' || *c == b'-')
+}
+
+pub fn parse(input: &str) -> Vec<Node> {
+    // The buffer can grow (unclosed string/url get a synthetic closer); `max`
+    // stays at the original length, exactly like upstream's captured `value.length`.
+    let mut value: Vec<u8> = input.as_bytes().to_vec();
+    let max = value.len();
+    let mut pos: usize = 0;
+
+    let mut root: Vec<Node> = Vec::new();
+    let mut stack: Vec<Node> = Vec::new();
+    // Upstream's `parent` is undefined until the first function opens and stays
+    // the root wrapper afterwards; that changes the whitespace-before-'/' rule.
+    let mut entered_function = false;
+
+    let mut name = String::new();
+    let mut before_pending = String::new();
+    let mut after_pending = String::new();
+
+    while pos < max {
+        let code = value[pos];
+        let in_calc = stack.last().is_some_and(|f| f.value == "calc");
+
+        if code <= 32 {
+            // whitespace run
+            let mut next = pos + 1;
+            while value.get(next).is_some_and(|c| *c <= 32) {
+                next += 1;
+            }
+            let token = utf8(&value[pos..next]);
+            let next_code = value.get(next).copied();
+            let in_function = !stack.is_empty();
+            let slash_takes_before = match stack.last() {
+                Some(f) => f.value != "calc",
+                None => !entered_function,
+            };
+            let cur = tokens(&mut stack, &mut root);
+            if next_code == Some(b')') && in_function {
+                after_pending = token;
+            } else if let Some(prev) = cur.last_mut().filter(|p| p.kind == Kind::Div) {
+                prev.source_end_index += token.len();
+                prev.after = token;
+            } else if next_code == Some(b',')
+                || next_code == Some(b':')
+                || (next_code == Some(b'/')
+                    && value.get(next + 1) != Some(&b'*')
+                    && slash_takes_before)
+            {
+                before_pending = token;
+            } else {
+                cur.push(Node::leaf(Kind::Space, token, pos, next));
+            }
+            pos = next;
+        } else if code == b'\'' || code == b'"' {
+            let quote = code;
+            let mut next = pos;
+            let mut unclosed = false;
+            loop {
+                let mut escape = false;
+                match find_byte(&value, quote, next + 1) {
+                    Some(idx) => {
+                        next = idx;
+                        let mut escape_pos = next;
+                        while escape_pos > 0 && value[escape_pos - 1] == b'\\' {
+                            escape_pos -= 1;
+                            escape = !escape;
+                        }
+                    }
+                    None => {
+                        value.push(quote);
+                        next = value.len() - 1;
+                        unclosed = true;
+                    }
+                }
+                if !escape {
+                    break;
+                }
+            }
+            let mut node = Node::leaf(
+                Kind::Str,
+                utf8(&value[pos + 1..next]),
+                pos,
+                if unclosed { next } else { next + 1 },
+            );
+            node.quote = quote;
+            node.unclosed = unclosed;
+            tokens(&mut stack, &mut root).push(node);
+            pos = next + 1;
+        } else if code == b'/' && value.get(pos + 1) == Some(&b'*') {
+            let mut node = Node::new(Kind::Comment);
+            node.source_index = pos;
+            let next = match find_subslice(&value, b"*/", pos) {
+                Some(idx) => {
+                    node.source_end_index = idx + 2;
+                    idx
+                }
+                None => {
+                    node.unclosed = true;
+                    node.source_end_index = value.len();
+                    value.len()
+                }
+            };
+            if next > pos + 2 {
+                node.value = utf8(&value[pos + 2..next]);
+            }
+            tokens(&mut stack, &mut root).push(node);
+            pos = next + 2;
+        } else if (code == b'/' || code == b'*') && in_calc {
+            // operator word directly inside calc()
+            let node = Node::leaf(
+                Kind::Word,
+                (code as char).to_string(),
+                pos - before_pending.len(),
+                pos + 1,
+            );
+            tokens(&mut stack, &mut root).push(node);
+            pos += 1;
+        } else if code == b'/' || code == b',' || code == b':' {
+            let mut node = Node::leaf(
+                Kind::Div,
+                (code as char).to_string(),
+                pos - before_pending.len(),
+                pos + 1,
+            );
+            node.before = std::mem::take(&mut before_pending);
+            tokens(&mut stack, &mut root).push(node);
+            pos += 1;
+        } else if code == b'(' {
+            let mut next = pos + 1;
+            while value.get(next).is_some_and(|c| *c <= 32) {
+                next += 1;
+            }
+            let paren_open = pos;
+            let mut func = Node::new(Kind::Func);
+            func.source_index = pos - name.len();
+            func.value = std::mem::take(&mut name);
+            func.before = utf8(&value[paren_open + 1..next]);
+            let code_at_next = value.get(next).copied();
+            pos = next;
+
+            if func.value == "url" && code_at_next != Some(b'\'') && code_at_next != Some(b'"') {
+                // unquoted url(): raw consumption up to the matching ')'
+                let mut next2 = next - 1;
+                loop {
+                    let mut escape = false;
+                    match find_byte(&value, b')', next2 + 1) {
+                        Some(idx) => {
+                            next2 = idx;
+                            let mut escape_pos = next2;
+                            while escape_pos > 0 && value[escape_pos - 1] == b'\\' {
+                                escape_pos -= 1;
+                                escape = !escape;
+                            }
+                        }
+                        None => {
+                            value.push(b')');
+                            next2 = value.len() - 1;
+                            func.unclosed = true;
+                        }
+                    }
+                    if !escape {
+                        break;
+                    }
+                }
+                let mut whitespace_pos = next2;
+                loop {
+                    whitespace_pos -= 1;
+                    if value[whitespace_pos] > 32 {
+                        break;
+                    }
+                }
+                if paren_open < whitespace_pos {
+                    if pos != whitespace_pos + 1 {
+                        func.nodes = vec![Node::leaf(
+                            Kind::Word,
+                            utf8(&value[pos..whitespace_pos + 1]),
+                            pos,
+                            whitespace_pos + 1,
+                        )];
+                    }
+                    if func.unclosed && whitespace_pos + 1 != next2 {
+                        func.nodes.push(Node::leaf(
+                            Kind::Space,
+                            utf8(&value[whitespace_pos + 1..next2]),
+                            whitespace_pos + 1,
+                            next2,
+                        ));
+                    } else {
+                        func.after = utf8(&value[whitespace_pos + 1..next2]);
+                    }
+                }
+                pos = next2 + 1;
+                func.source_end_index = if func.unclosed { next2 } else { pos };
+                tokens(&mut stack, &mut root).push(func);
+            } else {
+                entered_function = true;
+                func.source_end_index = pos + 1;
+                stack.push(func);
+            }
+        } else if code == b')' && !stack.is_empty() {
+            pos += 1;
+            let mut func = stack.pop().expect("checked non-empty");
+            func.after = std::mem::take(&mut after_pending);
+            func.source_end_index = pos;
+            tokens(&mut stack, &mut root).push(func);
+        } else {
+            // word
+            let mut next = pos;
+            let mut cur = code;
+            loop {
+                if cur == b'\\' {
+                    next += 1;
+                }
+                next += 1;
+                if next >= max {
+                    break;
+                }
+                let c = value[next];
+                let is_break = c <= 32
+                    || c == b'\''
+                    || c == b'"'
+                    || c == b','
+                    || c == b':'
+                    || c == b'/'
+                    || c == b'('
+                    || (c == b'*' && in_calc)
+                    || (c == b')' && !stack.is_empty());
+                if is_break {
+                    break;
+                }
+                cur = c;
+            }
+            let token = utf8(&value[pos..next.min(value.len())]);
+            if value.get(next) == Some(&b'(') {
+                name = token;
+            } else if is_unicode_range(token.as_bytes()) {
+                tokens(&mut stack, &mut root).push(Node::leaf(
+                    Kind::UnicodeRange,
+                    token,
+                    pos,
+                    next,
+                ));
+            } else {
+                tokens(&mut stack, &mut root).push(Node::leaf(Kind::Word, token, pos, next));
+            }
+            pos = next;
+        }
+    }
+
+    while let Some(mut func) = stack.pop() {
+        func.unclosed = true;
+        func.source_end_index = value.len();
+        tokens(&mut stack, &mut root).push(func);
+    }
+    root
+}
+
+pub fn walk<F: FnMut(&mut Node)>(nodes: &mut [Node], f: &mut F) {
+    for node in nodes.iter_mut() {
+        f(node);
+        if node.kind == Kind::Func {
+            walk(&mut node.nodes, f);
+        }
+    }
+}
+
+pub fn stringify(nodes: &[Node]) -> String {
+    let mut out = String::new();
+    for node in nodes {
+        stringify_node(node, &mut out);
+    }
+    out
+}
+
+fn stringify_node(node: &Node, out: &mut String) {
+    match node.kind {
+        Kind::Word | Kind::Space | Kind::UnicodeRange => out.push_str(&node.value),
+        Kind::Str => {
+            let quote = node.quote as char;
+            out.push(quote);
+            out.push_str(&node.value);
+            if !node.unclosed {
+                out.push(quote);
+            }
+        }
+        Kind::Comment => {
+            out.push_str("/*");
+            out.push_str(&node.value);
+            if !node.unclosed {
+                out.push_str("*/");
+            }
+        }
+        Kind::Div => {
+            out.push_str(&node.before);
+            out.push_str(&node.value);
+            out.push_str(&node.after);
+        }
+        Kind::Func => {
+            out.push_str(&node.value);
+            out.push('(');
+            out.push_str(&node.before);
+            for child in &node.nodes {
+                stringify_node(child, out);
+            }
+            out.push_str(&node.after);
+            if !node.unclosed {
+                out.push(')');
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Dimension {
+    pub number: String,
+    pub unit: String,
+}
+
+// https://www.w3.org/TR/css-syntax-3/#starts-with-a-number
+fn like_number(b: &[u8]) -> bool {
+    match b.first() {
+        Some(b'+') | Some(b'-') => match b.get(1) {
+            Some(c) if c.is_ascii_digit() => true,
+            Some(b'.') => b.get(2).is_some_and(|c| c.is_ascii_digit()),
+            _ => false,
+        },
+        Some(b'.') => b.get(1).is_some_and(|c| c.is_ascii_digit()),
+        Some(c) => c.is_ascii_digit(),
+        None => false,
+    }
+}
+
+pub fn unit(value: &str) -> Option<Dimension> {
+    let b = value.as_bytes();
+    if b.is_empty() || !like_number(b) {
+        return None;
+    }
+    let mut pos = 0;
+    if b[0] == b'+' || b[0] == b'-' {
+        pos += 1;
+    }
+    while b.get(pos).is_some_and(|c| c.is_ascii_digit()) {
+        pos += 1;
+    }
+    if b.get(pos) == Some(&b'.') && b.get(pos + 1).is_some_and(|c| c.is_ascii_digit()) {
+        pos += 2;
+        while b.get(pos).is_some_and(|c| c.is_ascii_digit()) {
+            pos += 1;
+        }
+    }
+    if matches!(b.get(pos), Some(b'e') | Some(b'E')) {
+        let c1 = b.get(pos + 1);
+        let c2 = b.get(pos + 2);
+        let consumed = if c1.is_some_and(|c| c.is_ascii_digit()) {
+            Some(2)
+        } else if matches!(c1, Some(b'+') | Some(b'-')) && c2.is_some_and(|c| c.is_ascii_digit()) {
+            Some(3)
+        } else {
+            None
+        };
+        if let Some(n) = consumed {
+            pos += n;
+            while b.get(pos).is_some_and(|c| c.is_ascii_digit()) {
+                pos += 1;
+            }
+        }
+    }
+    Some(Dimension {
+        number: value[..pos].to_string(),
+        unit: value[pos..].to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip(input: &str) -> String {
+        stringify(&parse(input))
+    }
+
+    #[test]
+    fn roundtrips_preserve_source() {
+        for input in [
+            "1px solid red",
+            "  1px   solid   red  ",
+            "calc( 100% - 10px )",
+            "calc(100%/3)",
+            "url( ./a.png )",
+            "url(data:image/png;base64,iVBOR)",
+            "url(\"a b.png\")",
+            "var(--x, 10px)",
+            "\"say \\\"hi\\\"\"",
+            "'a' \"b\"",
+            "U+0025-00FF",
+            "translateX(0px) translateY(0px)",
+            "16 / 9",
+            "16/9",
+            "/* c */ 10px",
+            "rgb(255 0 0 / 0.5)",
+        ] {
+            assert_eq!(roundtrip(input), input, "roundtrip({input:?})");
+        }
+    }
+
+    #[test]
+    fn unclosed_string_and_function() {
+        let nodes = parse("\"abc");
+        assert_eq!(nodes.len(), 1);
+        assert!(nodes[0].unclosed);
+        assert_eq!(nodes[0].kind, Kind::Str);
+        assert_eq!(stringify(&nodes), "\"abc");
+
+        let nodes = parse("calc(100%");
+        assert_eq!(nodes.len(), 1);
+        assert!(nodes[0].unclosed);
+        assert_eq!(nodes[0].kind, Kind::Func);
+        assert_eq!(stringify(&nodes), "calc(100%");
+    }
+
+    #[test]
+    fn whitespace_before_div_becomes_before() {
+        let nodes = parse("a , b");
+        let div = nodes.iter().find(|n| n.kind == Kind::Div).unwrap();
+        assert_eq!(div.before, " ");
+        assert_eq!(div.after, " ");
+    }
+
+    // parity: parse.js keeps `parent` pointing at the root wrapper after a
+    // function closes, so whitespace before '/' stays a space node there.
+    #[test]
+    fn slash_whitespace_after_closed_function_stays_space() {
+        let nodes = parse("calc(10px) 2px / 3px");
+        let kinds: Vec<Kind> = nodes.iter().map(|n| n.kind).collect();
+        assert_eq!(
+            kinds,
+            vec![
+                Kind::Func,
+                Kind::Space,
+                Kind::Word,
+                Kind::Space,
+                Kind::Div,
+                Kind::Word
+            ]
+        );
+        let div = &nodes[4];
+        assert_eq!(div.before, "");
+    }
+
+    #[test]
+    fn unit_matches_reference_behavior() {
+        assert_eq!(
+            unit("500ms"),
+            Some(Dimension {
+                number: "500".into(),
+                unit: "ms".into()
+            })
+        );
+        assert_eq!(
+            unit(".5.5px"),
+            Some(Dimension {
+                number: ".5".into(),
+                unit: ".5px".into()
+            })
+        );
+        assert_eq!(
+            unit("1e-7px"),
+            Some(Dimension {
+                number: "1e-7".into(),
+                unit: "px".into()
+            })
+        );
+        assert_eq!(
+            unit("-0px"),
+            Some(Dimension {
+                number: "-0".into(),
+                unit: "px".into()
+            })
+        );
+        assert_eq!(unit("Infinityms"), None);
+        assert_eq!(unit("px"), None);
+        assert_eq!(unit(""), None);
+        assert_eq!(
+            unit("5e"),
+            Some(Dimension {
+                number: "5".into(),
+                unit: "e".into()
+            })
+        );
+    }
+}

--- a/crates/stylex/src/shared/css_value.rs
+++ b/crates/stylex/src/shared/css_value.rs
@@ -1,6 +1,8 @@
 //! CSS value tokenizer, behavior-equivalent to postcss-value-parser@4.2.0.
 // parity: postcss-value-parser lib/{parse,walk,stringify,unit}.js
 
+use std::borrow::Cow;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Kind {
     Word,
@@ -91,7 +93,7 @@ fn is_unicode_range(token: &[u8]) -> bool {
 pub fn parse(input: &str) -> Vec<Node> {
     // The buffer can grow (unclosed string/url get a synthetic closer); `max`
     // stays at the original length, exactly like upstream's captured `value.length`.
-    let mut value: Vec<u8> = input.as_bytes().to_vec();
+    let mut value: Cow<[u8]> = Cow::Borrowed(input.as_bytes());
     let max = value.len();
     let mut pos: usize = 0;
 
@@ -155,7 +157,7 @@ pub fn parse(input: &str) -> Vec<Node> {
                         }
                     }
                     None => {
-                        value.push(quote);
+                        value.to_mut().push(quote);
                         next = value.len() - 1;
                         unclosed = true;
                     }
@@ -241,7 +243,7 @@ pub fn parse(input: &str) -> Vec<Node> {
                             }
                         }
                         None => {
-                            value.push(b')');
+                            value.to_mut().push(b')');
                             next2 = value.len() - 1;
                             func.unclosed = true;
                         }
@@ -399,9 +401,9 @@ fn stringify_node(node: &Node, out: &mut String) {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Dimension {
-    pub number: String,
-    pub unit: String,
+pub struct Dimension<'a> {
+    pub number: &'a str,
+    pub unit: &'a str,
 }
 
 // https://www.w3.org/TR/css-syntax-3/#starts-with-a-number
@@ -418,7 +420,7 @@ fn like_number(b: &[u8]) -> bool {
     }
 }
 
-pub fn unit(value: &str) -> Option<Dimension> {
+pub fn unit(value: &str) -> Option<Dimension<'_>> {
     let b = value.as_bytes();
     if b.is_empty() || !like_number(b) {
         return None;
@@ -454,8 +456,8 @@ pub fn unit(value: &str) -> Option<Dimension> {
         }
     }
     Some(Dimension {
-        number: value[..pos].to_string(),
-        unit: value[pos..].to_string(),
+        number: &value[..pos],
+        unit: &value[pos..],
     })
 }
 
@@ -540,29 +542,29 @@ mod tests {
         assert_eq!(
             unit("500ms"),
             Some(Dimension {
-                number: "500".into(),
-                unit: "ms".into()
+                number: "500",
+                unit: "ms"
             })
         );
         assert_eq!(
             unit(".5.5px"),
             Some(Dimension {
-                number: ".5".into(),
-                unit: ".5px".into()
+                number: ".5",
+                unit: ".5px"
             })
         );
         assert_eq!(
             unit("1e-7px"),
             Some(Dimension {
-                number: "1e-7".into(),
-                unit: "px".into()
+                number: "1e-7",
+                unit: "px"
             })
         );
         assert_eq!(
             unit("-0px"),
             Some(Dimension {
-                number: "-0".into(),
-                unit: "px".into()
+                number: "-0",
+                unit: "px"
             })
         );
         assert_eq!(unit("Infinityms"), None);
@@ -571,8 +573,8 @@ mod tests {
         assert_eq!(
             unit("5e"),
             Some(Dimension {
-                number: "5".into(),
-                unit: "e".into()
+                number: "5",
+                unit: "e"
             })
         );
     }

--- a/crates/stylex/src/shared/dashify.rs
+++ b/crates/stylex/src/shared/dashify.rs
@@ -1,5 +1,7 @@
 //! camelCase -> dash-case plus the dev-classname sanitizer.
 
+use std::borrow::Cow;
+
 /// Equivalent of `str.replace(/(^|[a-z])([A-Z])/g, '$1-$2').toLowerCase()`.
 // parity: babel-plugin src/shared/utils/dashify.js
 pub fn dashify(s: &str) -> String {
@@ -17,9 +19,9 @@ pub fn dashify(s: &str) -> String {
 
 /// Custom properties keep their exact spelling; everything else is dashified.
 // parity: babel-plugin src/shared/utils/convert-to-className.js:40
-pub fn dashed_key(key: &str) -> String {
+pub fn dashed_key(key: &str) -> Cow<'_, str> {
     if key.starts_with("--") {
-        return key.to_string();
+        return Cow::Borrowed(key);
     }
     // ASCII lower/digit/'-'/'_' strings are dashify fixed points (no dash
     // insertion, toLowerCase identity): skip the two-string rebuild.
@@ -27,9 +29,9 @@ pub fn dashed_key(key: &str) -> String {
         .bytes()
         .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-' || b == b'_')
     {
-        return key.to_string();
+        return Cow::Borrowed(key);
     }
-    dashify(key)
+    Cow::Owned(dashify(key))
 }
 
 /// Equivalent of `className.replace(/[^.a-zA-Z0-9_-]/g, '')`.

--- a/crates/stylex/src/shared/dashify.rs
+++ b/crates/stylex/src/shared/dashify.rs
@@ -1,0 +1,73 @@
+//! camelCase -> dash-case plus the dev-classname sanitizer.
+
+/// Equivalent of `str.replace(/(^|[a-z])([A-Z])/g, '$1-$2').toLowerCase()`.
+// parity: babel-plugin src/shared/utils/dashify.js
+pub fn dashify(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 4);
+    let mut prev_is_ascii_lower = false;
+    for (i, c) in s.chars().enumerate() {
+        if c.is_ascii_uppercase() && (i == 0 || prev_is_ascii_lower) {
+            out.push('-');
+        }
+        prev_is_ascii_lower = c.is_ascii_lowercase();
+        out.push(c);
+    }
+    out.to_lowercase()
+}
+
+/// Custom properties keep their exact spelling; everything else is dashified.
+// parity: babel-plugin src/shared/utils/convert-to-className.js:40
+pub fn dashed_key(key: &str) -> String {
+    if key.starts_with("--") {
+        return key.to_string();
+    }
+    // ASCII lower/digit/'-'/'_' strings are dashify fixed points (no dash
+    // insertion, toLowerCase identity): skip the two-string rebuild.
+    if key
+        .bytes()
+        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-' || b == b'_')
+    {
+        return key.to_string();
+    }
+    dashify(key)
+}
+
+/// Equivalent of `className.replace(/[^.a-zA-Z0-9_-]/g, '')`.
+// parity: babel-plugin src/utils/dev-classname.js
+pub fn sanitize_dev_class_name(class_name: &str) -> String {
+    class_name
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dashify_basics() {
+        assert_eq!(dashify("backgroundColor"), "background-color");
+        // leading uppercase gets a leading dash (the `^` alternative)
+        assert_eq!(dashify("WebkitTransform"), "-webkit-transform");
+        // consecutive capitals only split after a lowercase
+        assert_eq!(dashify("backgroundURL"), "background-url");
+        assert_eq!(dashify("notARealProp"), "not-areal-prop");
+    }
+
+    #[test]
+    fn custom_property_passthrough() {
+        assert_eq!(dashed_key("--customProp"), "--customProp");
+        assert_eq!(dashify("--customProp"), "--custom-prop");
+        assert_eq!(dashed_key("borderTopColor"), "border-top-color");
+    }
+
+    #[test]
+    fn sanitizer_strips_disallowed() {
+        assert_eq!(
+            sanitize_dev_class_name("My File__s.a b?c\u{2192}d"),
+            "MyFile__s.abcd"
+        );
+        assert_eq!(sanitize_dev_class_name(""), "");
+    }
+}

--- a/crates/stylex/src/shared/define_consts.rs
+++ b/crates/stylex/src/shared/define_consts.rs
@@ -56,7 +56,7 @@ pub fn define_consts(
             ltr: "".into(),
             rtl: None,
             const_key: Some(const_key.into()),
-            const_val: Some(value.to_json()),
+            const_val: Some(Box::new(value.to_json())),
             priority: 0.0,
         });
     }
@@ -129,12 +129,18 @@ mod tests {
         assert_eq!(out.rules.len(), 2);
         assert_eq!(&*out.rules[0].class_name, "xjvywqn");
         assert_eq!(out.rules[0].const_key.as_deref(), Some("xjvywqn"));
-        assert_eq!(out.rules[0].const_val, Some(serde_json::json!("red")));
+        assert_eq!(
+            out.rules[0].const_val.as_deref(),
+            Some(&serde_json::json!("red"))
+        );
         assert_eq!(&*out.rules[0].ltr, "");
         assert_eq!(out.rules[0].rtl, None);
         assert!(out.rules[0].priority == 0.0);
         assert_eq!(&*out.rules[1].class_name, "xont6ws");
-        assert_eq!(out.rules[1].const_val, Some(serde_json::json!(12)));
+        assert_eq!(
+            out.rules[1].const_val.as_deref(),
+            Some(&serde_json::json!(12))
+        );
     }
 
     #[test]

--- a/crates/stylex/src/shared/define_consts.rs
+++ b/crates/stylex/src/shared/define_consts.rs
@@ -1,0 +1,189 @@
+//! `stylex.defineConsts` over an already-evaluated constants object.
+// parity: babel-plugin src/shared/stylex-define-consts.js + visitors/stylex-define-consts.js
+
+use crate::errors::StylexError;
+use crate::eval::value::{EvalValue, JsObjectMap};
+use crate::hash::hash;
+use crate::options::ResolvedOptions;
+use crate::rules::StylexRule;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DefineConstsOutput {
+    /// Replaces the call: the input values verbatim.
+    pub js_output: JsObjectMap,
+    /// One `[constKey, {constKey, constVal, ltr: "", rtl: null}, 0]` per entry.
+    pub rules: Vec<StylexRule>,
+}
+
+/// `canonical_file_name` is state-manager fileNameForHashing output; callers
+/// map a missing one to `cannot_generate_hash("defineConsts")` first.
+pub fn define_consts(
+    constants: &EvalValue,
+    canonical_file_name: &str,
+    export_name: &str,
+    options: &ResolvedOptions,
+) -> Result<DefineConstsOutput, StylexError> {
+    let entries = object_entries(constants, "defineConsts")?;
+    let export_id = format!("{canonical_file_name}//{export_name}");
+
+    let mut js_output = JsObjectMap::new();
+    let mut rules = Vec::new();
+    for (key, value) in entries {
+        if matches!(value, EvalValue::Undefined) {
+            return Err(StylexError::upstream_type_crash(
+                "an undefined defineConsts value",
+            ));
+        }
+        let const_key = if let Some(rest) = key.strip_prefix("--") {
+            rest.to_string()
+        } else if options.debug && options.enable_debug_class_names {
+            format!(
+                "{}-{}{}",
+                var_safe_key(&key),
+                options.class_name_prefix,
+                hash(&format!("{export_id}.{key}"))
+            )
+        } else {
+            format!(
+                "{}{}",
+                options.class_name_prefix,
+                hash(&format!("{export_id}.{key}"))
+            )
+        };
+        js_output.insert(key, value.clone());
+        rules.push(StylexRule {
+            class_name: const_key.as_str().into(),
+            ltr: "".into(),
+            rtl: None,
+            const_key: Some(const_key.into()),
+            const_val: Some(value.to_json()),
+            priority: 0.0,
+        });
+    }
+    Ok(DefineConstsOutput { js_output, rules })
+}
+
+// parity: visitor `typeof value !== 'object' || value == null` — arrays pass
+// and Object.entries turns them into index-keyed entries.
+fn object_entries(
+    value: &EvalValue,
+    fn_name: &str,
+) -> Result<Vec<(String, EvalValue)>, StylexError> {
+    match value {
+        EvalValue::Obj(map) => Ok(map
+            .entries()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()),
+        EvalValue::Arr(items) => Ok(items
+            .iter()
+            .enumerate()
+            .map(|(i, v)| (i.to_string(), v.clone()))
+            .collect()),
+        _ => Err(StylexError::non_style_object(fn_name)),
+    }
+}
+
+// parity: `(key[0] >= '0' && key[0] <= '9' ? '_' + key : key).replace(/[^a-zA-Z0-9]/g, '_')`
+// — the replace runs per UTF-16 unit (astral chars become two underscores).
+fn var_safe_key(key: &str) -> String {
+    let prefixed: std::borrow::Cow<'_, str> =
+        if key.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+            format!("_{key}").into()
+        } else {
+            key.into()
+        };
+    prefixed
+        .encode_utf16()
+        .map(|unit| match char::from_u32(u32::from(unit)) {
+            Some(c) if c.is_ascii_alphanumeric() => c,
+            _ => '_',
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn consts(entries: &[(&str, EvalValue)]) -> EvalValue {
+        EvalValue::Obj(
+            entries
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), v.clone()))
+                .collect::<JsObjectMap>()
+                .into(),
+        )
+    }
+
+    #[test]
+    fn basic_output_matches_oracle() {
+        // Pinned via live-oracle probe 2026-08-27: tokens.stylex.ts under
+        // rootDir /fake/root, export name `colors`.
+        let options = ResolvedOptions::default();
+        let input = consts(&[
+            ("bg", EvalValue::Str("red".to_string())),
+            ("size", EvalValue::Num(12.0)),
+        ]);
+        let out = define_consts(&input, "tokens.stylex.ts", "colors", &options).unwrap();
+        assert_eq!(out.js_output.to_json(), input.to_json());
+        assert_eq!(out.rules.len(), 2);
+        assert_eq!(&*out.rules[0].class_name, "xjvywqn");
+        assert_eq!(out.rules[0].const_key.as_deref(), Some("xjvywqn"));
+        assert_eq!(out.rules[0].const_val, Some(serde_json::json!("red")));
+        assert_eq!(&*out.rules[0].ltr, "");
+        assert_eq!(out.rules[0].rtl, None);
+        assert!(out.rules[0].priority == 0.0);
+        assert_eq!(&*out.rules[1].class_name, "xont6ws");
+        assert_eq!(out.rules[1].const_val, Some(serde_json::json!(12)));
+    }
+
+    #[test]
+    fn custom_property_keys_skip_hashing() {
+        let options = ResolvedOptions::default();
+        let out = define_consts(
+            &consts(&[
+                ("--already", EvalValue::Str("x".to_string())),
+                ("--", EvalValue::Str("y".to_string())),
+            ]),
+            "tokens.stylex.ts",
+            "c",
+            &options,
+        )
+        .unwrap();
+        assert_eq!(&*out.rules[0].class_name, "already");
+        assert_eq!(&*out.rules[1].class_name, "");
+    }
+
+    #[test]
+    fn var_safe_key_rules() {
+        assert_eq!(var_safe_key("myColor"), "myColor");
+        assert_eq!(var_safe_key("2xl"), "_2xl");
+        assert_eq!(var_safe_key("foo-bar"), "foo_bar");
+        assert_eq!(var_safe_key("ké y"), "k__y");
+        assert_eq!(var_safe_key("a😀b"), "a__b");
+    }
+
+    #[test]
+    fn non_object_rejected_and_arrays_pass() {
+        let options = ResolvedOptions::default();
+        let err = define_consts(
+            &EvalValue::Str("x".to_string()),
+            "tokens.stylex.ts",
+            "c",
+            &options,
+        )
+        .unwrap_err();
+        assert_eq!(err.message, "defineConsts() can only accept an object.");
+        let out = define_consts(
+            &EvalValue::Arr(vec![
+                EvalValue::Str("a".to_string()),
+                EvalValue::Str("b".to_string()),
+            ]),
+            "t.stylex.ts",
+            "c",
+            &options,
+        )
+        .unwrap();
+        assert_eq!(out.js_output.keys().collect::<Vec<_>>(), vec!["0", "1"],);
+    }
+}

--- a/crates/stylex/src/shared/define_vars.rs
+++ b/crates/stylex/src/shared/define_vars.rs
@@ -1,0 +1,619 @@
+//! `stylex.defineVars` over an evaluated variables object.
+// parity: stylex-define-vars.js + stylex-vars-utils.js + its visitor (normalize)
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::errors::StylexError;
+use crate::eval::cross_file::VarGroupProxy;
+use crate::eval::functions::{DepTracker, arrow_info, register_self_reference};
+use crate::eval::value::{EvalValue, JsObjectMap, array_index};
+use crate::eval::{Callable, EvalOutcome, Evaluator, JsObj, JsValue};
+use crate::hash::hash;
+use crate::jsrt::{js_number_to_string, utf16_cmp};
+use crate::module_resolution::gen_file_based_identifier;
+use crate::options::ResolvedOptions;
+use crate::rules::StylexRule;
+use crate::shared::types::as_css_type_js;
+
+pub const SPLIT_TOKEN: &str = "__$$__";
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DefineVarsOutput {
+    /// Replaces the call: `{key: "var(--nameHash)", …, __varGroupHash__}`.
+    pub js_output: JsObjectMap,
+    /// `@property` rules (priority 0) then the grouped var rules (0.1 + n/10).
+    pub rules: Vec<StylexRule>,
+}
+
+/// ES OwnPropertyKeys order over the evaluator-local object representation.
+pub fn es_ordered_entries<'v>(obj: &'v JsObj) -> Vec<(&'v str, &'v JsValue)> {
+    let mut index: Vec<(u32, &'v str, &'v JsValue)> = Vec::new();
+    let mut named: Vec<(&'v str, &'v JsValue)> = Vec::new();
+    for (k, v) in obj.entries() {
+        match array_index(k) {
+            Some(n) => index.push((n, k, v)),
+            None => named.push((k, v)),
+        }
+    }
+    index.sort_by_key(|(n, _, _)| *n);
+    index
+        .into_iter()
+        .map(|(_, k, v)| (k, v))
+        .chain(named)
+        .collect()
+}
+
+/// `canonical_file_name` is the state-manager fileNameForHashing output; the
+/// caller maps a missing one to `cannot_generate_hash("defineVars")` first.
+pub fn define_vars<'a>(
+    ev: &mut Evaluator<'a, '_>,
+    value: &JsValue,
+    canonical_file_name: &str,
+    export_name: &str,
+) -> Result<DefineVarsOutput, StylexError> {
+    let entries: Vec<(String, JsValue)> = match value {
+        JsValue::Obj(obj) => es_ordered_entries(obj)
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect(),
+        JsValue::Arr(items) => items
+            .iter()
+            .enumerate()
+            .map(|(i, v)| (i.to_string(), v.clone()))
+            .collect(),
+        // Object.entries over the upstream proxy sees no own keys.
+        JsValue::Proxy(_) => Vec::new(),
+        _ => return Err(StylexError::non_style_object("defineVars")),
+    };
+    let options: &ResolvedOptions = ev.state.options;
+    let proxy = VarGroupProxy::new(
+        canonical_file_name.to_string(),
+        export_name.to_string(),
+        options,
+    );
+    register_self_reference(ev, export_name, proxy.clone());
+
+    let mut normalized: Vec<(String, JsValue)> = Vec::new();
+    let mut dep_map: Vec<(String, Vec<String>)> = Vec::new();
+    for (key, v) in &entries {
+        let mut deps = Vec::new();
+        let nv = normalize_value(ev, &proxy, v, key, &mut deps, true)?;
+        normalized.push((key.clone(), nv));
+        dep_map.push((key.clone(), deps));
+    }
+
+    let keys: BTreeSet<&str> = normalized.iter().map(|(k, _)| k.as_str()).collect();
+    for (key, deps) in &dep_map {
+        for dep in deps {
+            if dep != "__varGroupHash__" && !keys.contains(dep.as_str()) {
+                return Err(StylexError::unknown_define_vars_reference(key, dep));
+            }
+        }
+    }
+    assert_no_define_vars_cycles(&dep_map)?;
+
+    define_vars_core(&normalized, canonical_file_name, export_name, options)
+}
+
+// parity: visitors/stylex-define-vars.js normalizeDefineVarsValue.
+fn normalize_value<'a>(
+    ev: &mut Evaluator<'a, '_>,
+    self_proxy: &VarGroupProxy,
+    value: &JsValue,
+    root_key: &str,
+    deps: &mut Vec<String>,
+    allow_css_type: bool,
+) -> Result<JsValue, StylexError> {
+    match value {
+        JsValue::Callable(Callable::Arrow(key)) => {
+            evaluate_define_vars_function(ev, self_proxy, *key, root_key, deps)
+        }
+        // Injected callables carry fn.length >= 1 upstream.
+        JsValue::Callable(Callable::Stylex(_)) => {
+            Err(StylexError::invalid_define_vars_function_value())
+        }
+        // Opaque = shapes upstream deopts on before normalize; same message.
+        JsValue::Callable(Callable::Opaque) => Err(StylexError::non_static_value("defineVars")),
+        JsValue::Str(_) | JsValue::Num(_) | JsValue::Null => Ok(value.clone()),
+        JsValue::Arr(_) => Err(StylexError::array_in_define_vars()),
+        JsValue::Obj(_) if as_css_type_js(value).is_some() => {
+            if allow_css_type {
+                Ok(value.clone())
+            } else {
+                Err(StylexError::invalid_define_vars_function_value())
+            }
+        }
+        JsValue::Obj(obj) => {
+            if matches!(obj.get("default"), None | Some(JsValue::Undefined)) {
+                return Err(StylexError::missing_default_value(Some(root_key)));
+            }
+            let nested: Vec<(String, JsValue)> = es_ordered_entries(obj)
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v.clone()))
+                .collect();
+            let mut out = JsObj::default();
+            for (k, v) in nested {
+                out.insert(
+                    k,
+                    normalize_value(ev, self_proxy, &v, root_key, deps, false)?,
+                );
+            }
+            Ok(JsValue::object(out))
+        }
+        // The proxy's 'default' trap answers a var string; it has no own keys.
+        JsValue::Proxy(_) => Ok(JsValue::object(JsObj::default())),
+        JsValue::Undefined | JsValue::Bool(_) => Err(StylexError::invalid_define_vars_value()),
+    }
+}
+
+// parity: visitors/stylex-define-vars.js evaluateDefineVarsFunction — every
+// throw out of fn() is swallowed into nonStaticValue.
+fn evaluate_define_vars_function<'a>(
+    ev: &mut Evaluator<'a, '_>,
+    self_proxy: &VarGroupProxy,
+    arrow_key: u32,
+    root_key: &str,
+    deps: &mut Vec<String>,
+) -> Result<JsValue, StylexError> {
+    let Some((body, param_count)) = arrow_info(ev, arrow_key) else {
+        return Err(StylexError::non_static_value("defineVars"));
+    };
+    if param_count != 0 {
+        return Err(StylexError::invalid_define_vars_function_value());
+    }
+    let mut tracker = DepTracker::new(self_proxy);
+    let _ = tracker.walk(ev, body);
+    for dep in tracker.deps {
+        if !deps.contains(&dep) {
+            deps.push(dep);
+        }
+    }
+    let result = match ev.eval(body) {
+        Ok(EvalOutcome::Value(v)) => v,
+        Ok(EvalOutcome::NonStatic(_)) | Err(_) => {
+            return Err(StylexError::non_static_value("defineVars"));
+        }
+    };
+    if let JsValue::Callable(_) = result {
+        return Err(StylexError::invalid_define_vars_function_value());
+    }
+    if as_css_type_js(&result).is_some() {
+        return Ok(result);
+    }
+    normalize_value(ev, self_proxy, &result, root_key, deps, false)
+}
+
+// parity: visitors/stylex-define-vars.js assertNoDefineVarsCycles.
+fn assert_no_define_vars_cycles(dep_map: &[(String, Vec<String>)]) -> Result<(), StylexError> {
+    let map: BTreeMap<&str, &[String]> = dep_map
+        .iter()
+        .map(|(k, deps)| (k.as_str(), deps.as_slice()))
+        .collect();
+    let mut visited: BTreeSet<String> = BTreeSet::new();
+    let mut in_stack: BTreeSet<String> = BTreeSet::new();
+    let mut stack: Vec<String> = Vec::new();
+    fn visit(
+        key: &str,
+        map: &BTreeMap<&str, &[String]>,
+        visited: &mut BTreeSet<String>,
+        in_stack: &mut BTreeSet<String>,
+        stack: &mut Vec<String>,
+    ) -> Result<(), StylexError> {
+        if in_stack.contains(key) {
+            let start = stack.iter().position(|k| k == key).unwrap_or(0);
+            let mut parts: Vec<&str> = stack[start..].iter().map(String::as_str).collect();
+            parts.push(key);
+            return Err(StylexError::cyclic_define_vars_reference(
+                &parts.join(" -> "),
+            ));
+        }
+        if visited.contains(key) {
+            return Ok(());
+        }
+        visited.insert(key.to_string());
+        in_stack.insert(key.to_string());
+        stack.push(key.to_string());
+        if let Some(deps) = map.get(key) {
+            for dep in deps.iter() {
+                if map.contains_key(dep.as_str()) {
+                    visit(dep, map, visited, in_stack, stack)?;
+                }
+            }
+        }
+        stack.pop();
+        in_stack.remove(key);
+        Ok(())
+    }
+    for (key, _) in dep_map {
+        visit(key, &map, &mut visited, &mut in_stack, &mut stack)?;
+    }
+    Ok(())
+}
+
+/// Shared-core defineVars over pre-normalized entries (the nested wrapper feeds
+/// flattened dot-keys). parity: shared/stylex-define-vars.js styleXDefineVars.
+pub fn define_vars_core(
+    normalized: &[(String, JsValue)],
+    canonical_file_name: &str,
+    export_name: &str,
+    options: &ResolvedOptions,
+) -> Result<DefineVarsOutput, StylexError> {
+    let export_id = gen_file_based_identifier(canonical_file_name, export_name, None);
+    let var_group_hash = format!("{}{}", options.class_name_prefix, hash(&export_id));
+    let debug_names = options.debug && options.enable_debug_class_names;
+
+    let mut js_output = JsObjectMap::new();
+    let mut typed: EsKeyedMap<(Option<String>, String)> = EsKeyedMap::new();
+    let mut css_entries: Vec<(String, String, JsValue)> = Vec::new();
+    for (key, value) in normalized {
+        let name_hash = if let Some(rest) = key.strip_prefix("--") {
+            rest.to_string()
+        } else {
+            let hashed = hash(&gen_file_based_identifier(
+                canonical_file_name,
+                export_name,
+                Some(key),
+            ));
+            if debug_names {
+                format!(
+                    "{}-{}{hashed}",
+                    var_safe_key(key),
+                    options.class_name_prefix
+                )
+            } else {
+                format!("{}{hashed}", options.class_name_prefix)
+            }
+        };
+        let css_value = match as_css_type_js(value) {
+            Some((syntax, inner)) => {
+                typed.insert(&name_hash, (get_default_value(&inner)?, syntax));
+                inner
+            }
+            None => value.clone(),
+        };
+        js_output.insert(key.clone(), EvalValue::Str(format!("var(--{name_hash})")));
+        css_entries.push((key.clone(), name_hash, css_value));
+    }
+    js_output.insert("__varGroupHash__", EvalValue::Str(var_group_hash.clone()));
+
+    let mut collection: Vec<(String, Vec<String>)> = Vec::new();
+    for (key, name_hash, value) in &css_entries {
+        collect_vars_by_at_rule(key, name_hash, value, &mut collection, &[])?;
+    }
+
+    // parity: `{...injectableTypes, ...injectableStyles}` — an ES keyed object,
+    // so a colliding group-rule key overwrites the @property rule in place.
+    let mut merged: EsKeyedMap<StylexRule> = EsKeyedMap::new();
+    for (name_hash, (initial, syntax)) in typed.entries() {
+        let initial_part = initial
+            .as_ref()
+            .map(|iv| format!(" initial-value: {iv}"))
+            .unwrap_or_default();
+        merged.insert(
+            &name_hash,
+            StylexRule {
+                class_name: name_hash.as_str().into(),
+                ltr: format!(
+                    "@property --{name_hash} {{ syntax: \"{syntax}\"; inherits: true;{initial_part} }}"
+                )
+                .into(),
+                rtl: None,
+                const_key: None,
+                const_val: None,
+                priority: 0.0,
+            },
+        );
+    }
+    // Object.entries(rulesByAtRule) enumerates numeric at-rule keys first.
+    for (at_key, decls) in es_keyed_order(&collection) {
+        let body = format!(":root, .{var_group_hash}{{{}}}", decls.join(""));
+        let (ltr, suffix) = if at_key == "default" {
+            (body, String::new())
+        } else {
+            (
+                wrap_with_at_rules(&body, at_key),
+                format!("-{}", hash(at_key)),
+            )
+        };
+        let class_name = format!("{var_group_hash}{suffix}");
+        merged.insert(
+            &class_name.clone(),
+            StylexRule {
+                class_name: class_name.into(),
+                ltr: ltr.into(),
+                rtl: None,
+                const_key: None,
+                const_val: None,
+                priority: priority_for_at_rule(at_key) / 10.0,
+            },
+        );
+    }
+    let rules = merged.into_values();
+    Ok(DefineVarsOutput { js_output, rules })
+}
+
+/// ES keyed-object stand-in for the upstream rule maps: canonical index keys
+/// ascending first, insertion order after, overwrite keeps the key's position.
+struct EsKeyedMap<V> {
+    index_entries: Vec<(u32, V)>,
+    named_entries: Vec<(String, V)>,
+}
+
+impl<V> EsKeyedMap<V> {
+    fn new() -> Self {
+        Self {
+            index_entries: Vec::new(),
+            named_entries: Vec::new(),
+        }
+    }
+
+    fn insert(&mut self, key: &str, value: V) {
+        // parity: `obj[key] = v` — a "__proto__" key hits the prototype
+        // setter and creates no own entry (typedVariables, r5#7).
+        if key == "__proto__" {
+            return;
+        }
+        if let Some(n) = array_index(key) {
+            match self.index_entries.binary_search_by_key(&n, |e| e.0) {
+                Ok(i) => self.index_entries[i].1 = value,
+                Err(i) => self.index_entries.insert(i, (n, value)),
+            }
+        } else if let Some(entry) = self.named_entries.iter_mut().find(|(k, _)| k == key) {
+            entry.1 = value;
+        } else {
+            self.named_entries.push((key.to_string(), value));
+        }
+    }
+
+    fn entries(&self) -> impl Iterator<Item = (String, &V)> {
+        self.index_entries
+            .iter()
+            .map(|(n, v)| (n.to_string(), v))
+            .chain(self.named_entries.iter().map(|(k, v)| (k.clone(), v)))
+    }
+
+    fn into_values(self) -> Vec<V> {
+        self.index_entries
+            .into_iter()
+            .map(|(_, v)| v)
+            .chain(self.named_entries.into_iter().map(|(_, v)| v))
+            .collect()
+    }
+}
+
+/// Object.entries order over the insertion-ordered at-rule collection.
+fn es_keyed_order(collection: &[(String, Vec<String>)]) -> Vec<(&str, &Vec<String>)> {
+    let mut index: Vec<(u32, &str, &Vec<String>)> = Vec::new();
+    let mut named: Vec<(&str, &Vec<String>)> = Vec::new();
+    for (k, v) in collection {
+        match array_index(k) {
+            Some(n) => index.push((n, k, v)),
+            None => named.push((k, v)),
+        }
+    }
+    index.sort_by_key(|(n, _, _)| *n);
+    index
+        .into_iter()
+        .map(|(_, k, v)| (k, v))
+        .chain(named)
+        .collect()
+}
+
+// parity: stylex-vars-utils.js collectVarsByAtRule (booleans, functions and
+// undefined fall through every branch and drop silently).
+pub fn collect_vars_by_at_rule(
+    key: &str,
+    name_hash: &str,
+    value: &JsValue,
+    collection: &mut Vec<(String, Vec<String>)>,
+    at_rules: &[String],
+) -> Result<(), StylexError> {
+    let leaf = match value {
+        JsValue::Str(s) => Some(s.clone()),
+        JsValue::Num(n) => Some(js_number_to_string(*n)),
+        _ => None,
+    };
+    if let Some(val) = leaf {
+        let combo = if at_rules.is_empty() {
+            "default".to_string()
+        } else {
+            let mut sorted = at_rules.to_vec();
+            sorted.sort_by(|a, b| utf16_cmp(a, b));
+            sorted.join(SPLIT_TOKEN)
+        };
+        let decl = format!("--{name_hash}:{val};");
+        if let Some((_, decls)) = collection.iter_mut().find(|(k, _)| *k == combo) {
+            decls.push(decl);
+        } else {
+            collection.push((combo, vec![decl]));
+        }
+        return Ok(());
+    }
+    match value {
+        JsValue::Null => Ok(()),
+        JsValue::Arr(_) => Err(StylexError::array_in_define_vars()),
+        JsValue::Obj(obj) => {
+            if matches!(obj.get("default"), None | Some(JsValue::Undefined)) {
+                return Err(StylexError::missing_default_value(Some(key)));
+            }
+            let nested: Vec<(String, JsValue)> = es_ordered_entries(obj)
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v.clone()))
+                .collect();
+            for (at_rule, v) in nested {
+                if at_rule == "default" {
+                    collect_vars_by_at_rule(key, name_hash, &v, collection, at_rules)?;
+                } else {
+                    let mut extended = at_rules.to_vec();
+                    extended.push(at_rule);
+                    collect_vars_by_at_rule(key, name_hash, &v, collection, &extended)?;
+                }
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
+// parity: stylex-vars-utils.js wrapWithAtRules — later split parts wrap outside.
+pub fn wrap_with_at_rules(ltr: &str, at_rule_key: &str) -> String {
+    at_rule_key
+        .split(SPLIT_TOKEN)
+        .fold(ltr.to_string(), |acc, at_rule| {
+            format!("{at_rule}{{{acc}}}")
+        })
+}
+
+pub fn priority_for_at_rule(at_rule_key: &str) -> f64 {
+    if at_rule_key == "default" {
+        1.0
+    } else {
+        1.0 + at_rule_key.split(SPLIT_TOKEN).count() as f64
+    }
+}
+
+// parity: stylex-vars-utils.js getDefaultValue (keyless error message).
+pub fn get_default_value(value: &JsValue) -> Result<Option<String>, StylexError> {
+    match value {
+        JsValue::Str(s) => Ok(Some(s.clone())),
+        JsValue::Num(n) => Ok(Some(js_number_to_string(*n))),
+        JsValue::Null | JsValue::Undefined => Ok(None),
+        JsValue::Arr(_) => Err(StylexError::array_in_define_vars()),
+        JsValue::Obj(obj) => match obj.get("default") {
+            None | Some(JsValue::Undefined) => Err(StylexError::missing_default_value(None)),
+            Some(inner) => {
+                let inner = inner.clone();
+                get_default_value(&inner)
+            }
+        },
+        JsValue::Proxy(proxy) => {
+            let resolved = proxy.resolve_key("default");
+            Ok(Some(resolved))
+        }
+        JsValue::Bool(_) | JsValue::Callable(_) => Err(StylexError::invalid_define_vars_value()),
+    }
+}
+
+// parity: `(key[0] in 0-9 ? '_'+key : key).replace(/[^a-zA-Z0-9]/g, '_')`.
+fn var_safe_key(key: &str) -> String {
+    let prefixed: std::borrow::Cow<'_, str> =
+        if key.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+            format!("_{key}").into()
+        } else {
+            key.into()
+        };
+    prefixed
+        .encode_utf16()
+        .map(|unit| match char::from_u32(u32::from(unit)) {
+            Some(c) if c.is_ascii_alphanumeric() => c,
+            _ => '_',
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn at_rule_grouping_helpers_match_oracle() {
+        // Pinned via live-oracle probe 2026-08-28 (probe1 "basic multi-atrule").
+        assert_eq!(
+            wrap_with_at_rules(
+                ":root, .x{--a:1;}",
+                "@media (max-width: 600px)__$$__@supports (display: grid)"
+            ),
+            "@supports (display: grid){@media (max-width: 600px){:root, .x{--a:1;}}}"
+        );
+        assert!(priority_for_at_rule("default") == 1.0);
+        assert!(priority_for_at_rule("@media print") == 2.0);
+        assert!(priority_for_at_rule("@media a__$$__@supports b") == 3.0);
+    }
+
+    #[test]
+    fn collect_skips_null_and_opaque_values() {
+        let mut collection = Vec::new();
+        collect_vars_by_at_rule("a", "xh", &JsValue::Null, &mut collection, &[]).unwrap();
+        collect_vars_by_at_rule("a", "xh", &JsValue::Bool(true), &mut collection, &[]).unwrap();
+        collect_vars_by_at_rule("a", "xh", &JsValue::Undefined, &mut collection, &[]).unwrap();
+        collect_vars_by_at_rule(
+            "a",
+            "xh",
+            &JsValue::Callable(Callable::Opaque),
+            &mut collection,
+            &[],
+        )
+        .unwrap();
+        assert!(collection.is_empty());
+        let err = collect_vars_by_at_rule("a", "xh", &JsValue::array(vec![]), &mut collection, &[])
+            .unwrap_err();
+        assert_eq!(err.message, "Array is not supported in defineVars");
+    }
+
+    #[test]
+    fn missing_default_messages() {
+        let mut obj = JsObj::default();
+        obj.insert("@media print".to_string(), JsValue::Str("x".to_string()));
+        let mut collection = Vec::new();
+        let err = collect_vars_by_at_rule(
+            "gap",
+            "xh",
+            &JsValue::object(obj.clone()),
+            &mut collection,
+            &[],
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.message,
+            "Default value is not defined for gap variable."
+        );
+        let err = get_default_value(&JsValue::object(obj)).unwrap_err();
+        assert_eq!(err.message, "Default value is not defined for variable.");
+        assert_eq!(get_default_value(&JsValue::Null).unwrap(), None);
+        assert_eq!(
+            get_default_value(&JsValue::Num(4.0)).unwrap().as_deref(),
+            Some("4")
+        );
+        let err = get_default_value(&JsValue::Bool(true)).unwrap_err();
+        assert_eq!(err.message, "Invalid value in defineVars");
+    }
+
+    #[test]
+    fn cycle_error_text_matches_oracle() {
+        // Pinned via live-oracle probe 2026-08-28 (probe2 cycle shapes).
+        let dep_map = vec![
+            ("a".to_string(), vec!["b".to_string()]),
+            ("b".to_string(), vec!["c".to_string()]),
+            ("c".to_string(), vec!["a".to_string()]),
+        ];
+        let err = assert_no_define_vars_cycles(&dep_map).unwrap_err();
+        assert_eq!(
+            err.message,
+            "Cyclic same-group references in defineVars() are not allowed: a -> b -> c -> a."
+        );
+        let self_cycle = vec![("a".to_string(), vec!["a".to_string()])];
+        let err = assert_no_define_vars_cycles(&self_cycle).unwrap_err();
+        assert_eq!(
+            err.message,
+            "Cyclic same-group references in defineVars() are not allowed: a -> a."
+        );
+        let ok = vec![
+            ("x".to_string(), vec!["y".to_string()]),
+            ("y".to_string(), vec![]),
+        ];
+        assert!(assert_no_define_vars_cycles(&ok).is_ok());
+    }
+
+    #[test]
+    fn es_ordered_entries_reorders_index_keys() {
+        let mut obj = JsObj::default();
+        obj.insert("b".to_string(), JsValue::Str("1".into()));
+        obj.insert("2".to_string(), JsValue::Str("2".into()));
+        obj.insert("05".to_string(), JsValue::Str("3".into()));
+        let keys: Vec<&str> = es_ordered_entries(&obj)
+            .into_iter()
+            .map(|(k, _)| k)
+            .collect();
+        assert_eq!(keys, vec!["2", "b", "05"]);
+    }
+}

--- a/crates/stylex/src/shared/dev_naming.rs
+++ b/crates/stylex/src/shared/dev_naming.rs
@@ -1,0 +1,282 @@
+//! Dev class names, test-mode replacement, and `$$css` debug source strings.
+// parity: babel-plugin src/utils/{dev-classname,add-sourcemap-data}.js
+
+use crate::eval::value::{EvalValue, JsObjectMap};
+use crate::shared::dashify::sanitize_dev_class_name;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+/// Filesystem-derived inputs wave 3 computes; upstream's package.json walk
+/// starts at dirname, so a package.json in cwd itself is skipped.
+#[derive(Debug, Clone, Default)]
+pub struct DebugPathInfo {
+    /// Nearest package.json walking up from dirname(filename): (name, dir).
+    pub file_package: Option<(String, String)>,
+    /// Name of the nearest package.json walking up from dirname(cwd).
+    pub cwd_package_name: Option<String>,
+    /// unstable_moduleResolution commonJS rootDir, when configured.
+    pub root_dir: Option<String>,
+    pub is_haste: bool,
+}
+
+/// The `{basename}__{varName.}` prefix shared by every namespace of one call.
+fn dev_class_prefix(var_name: Option<&str>, filename: &str) -> String {
+    let basename = path_basename(filename)
+        .split('.')
+        .next()
+        .unwrap_or_default();
+    match var_name {
+        Some(v) => format!("{basename}__{v}."),
+        None => format!("{basename}__"),
+    }
+}
+
+// parity: dev-classname.js namespaceToDevClassName
+pub fn namespace_to_dev_class_name(
+    namespace: &str,
+    var_name: Option<&str>,
+    filename: &str,
+) -> String {
+    sanitize_dev_class_name(&format!(
+        "{}{namespace}",
+        dev_class_prefix(var_name, filename)
+    ))
+}
+
+/// Prepends the self-mapping dev-classname key to every compiled namespace.
+pub fn inject_dev_class_names(
+    compiled: Arc<JsObjectMap>,
+    var_name: Option<&str>,
+    filename: Option<&str>,
+) -> Arc<JsObjectMap> {
+    let prefix = dev_class_prefix(var_name, filename.unwrap_or("UnknownFile"));
+    let mut result = JsObjectMap::new();
+    for (namespace, value) in compiled.entries() {
+        let dev_class = sanitize_dev_class_name(&format!("{prefix}{namespace}"));
+        let mut obj = JsObjectMap::new();
+        obj.insert(dev_class.clone(), EvalValue::Str(dev_class));
+        if let EvalValue::Obj(inner) = value {
+            for (k, v) in inner.entries() {
+                obj.insert(k.to_string(), v.clone());
+            }
+        }
+        result.insert(namespace.to_string(), EvalValue::Obj(Arc::new(obj)));
+    }
+    Arc::new(result)
+}
+
+// parity: dev-classname.js convertToTestStyles
+pub fn convert_to_test_styles(
+    compiled: &Arc<JsObjectMap>,
+    var_name: Option<&str>,
+    filename: Option<&str>,
+) -> Arc<JsObjectMap> {
+    let prefix = dev_class_prefix(var_name, filename.unwrap_or("UnknownFile"));
+    let mut result = JsObjectMap::new();
+    for (namespace, _) in compiled.entries() {
+        let dev_class = sanitize_dev_class_name(&format!("{prefix}{namespace}"));
+        let mut obj = JsObjectMap::new();
+        obj.insert(dev_class.clone(), EvalValue::Str(dev_class));
+        obj.insert("$$css", EvalValue::Bool(true));
+        result.insert(namespace.to_string(), EvalValue::Obj(Arc::new(obj)));
+    }
+    Arc::new(result)
+}
+
+/// Replaces `$$css: true` with `"<shortFilename>:<line>"` per namespace whose
+/// source line is known (upstream skips namespaces it cannot find in the AST).
+pub fn add_source_map_data(
+    compiled: Arc<JsObjectMap>,
+    namespace_lines: Option<&BTreeMap<String, u32>>,
+    filename: Option<&str>,
+    info: &DebugPathInfo,
+) -> Arc<JsObjectMap> {
+    let mut short: Option<String> = None;
+    let mut result = JsObjectMap::new();
+    for (namespace, value) in compiled.entries() {
+        let line = namespace_lines
+            .and_then(|lines| lines.get(namespace))
+            .copied();
+        match (line, filename) {
+            (Some(line), Some(filename)) if line > 0 => {
+                let mut obj = match value {
+                    EvalValue::Obj(inner) => (**inner).clone(),
+                    other => {
+                        result.insert(namespace.to_string(), other.clone());
+                        continue;
+                    }
+                };
+                let short = short.get_or_insert_with(|| create_short_filename(filename, info));
+                let css_value = if short.is_empty() {
+                    EvalValue::Bool(true)
+                } else {
+                    EvalValue::Str(format!("{short}:{line}"))
+                };
+                obj.insert("$$css", css_value);
+                result.insert(namespace.to_string(), EvalValue::Obj(Arc::new(obj)));
+            }
+            _ => {
+                result.insert(namespace.to_string(), value.clone());
+            }
+        }
+    }
+    Arc::new(result)
+}
+
+// parity: add-sourcemap-data.js createShortFilename (debugFilePath unsupported)
+pub fn create_short_filename(filename: &str, info: &DebugPathInfo) -> String {
+    if let Some((name, dir)) = &info.file_package {
+        let relative = path_relative(dir, filename);
+        if info.cwd_package_name.as_deref() == Some(name.as_str()) {
+            return relative;
+        }
+        return format!("{name}:{relative}");
+    }
+    if let Some(prefix) = package_prefix(filename) {
+        return format!("{prefix}:{}", short_path(filename, info));
+    }
+    if info.is_haste {
+        return path_basename(filename).to_string();
+    }
+    short_path(filename, info)
+}
+
+// parity: add-sourcemap-data.js getShortPath
+fn short_path(filename: &str, info: &DebugPathInfo) -> String {
+    if let Some(root_dir) = &info.root_dir {
+        return path_relative(root_dir, filename);
+    }
+    let segments: Vec<&str> = filename.split('/').collect();
+    let start = segments.len().saturating_sub(2);
+    segments[start..].join("/")
+}
+
+// parity: add-sourcemap-data.js getPackagePrefix ('' prefix is falsy upstream)
+fn package_prefix(filename: &str) -> Option<String> {
+    let idx = filename.find("node_modules")?;
+    let rest = filename.get(idx + "node_modules".len() + 1..)?;
+    let prefix = rest.split('/').next().unwrap_or_default();
+    (!prefix.is_empty()).then(|| prefix.to_string())
+}
+
+fn path_basename(path: &str) -> &str {
+    path.rsplit('/').next().unwrap_or(path)
+}
+
+/// `path.relative` over already-normalized absolute '/'-separated paths.
+fn path_relative(from: &str, to: &str) -> String {
+    let from_parts: Vec<&str> = from.split('/').filter(|s| !s.is_empty()).collect();
+    let to_parts: Vec<&str> = to.split('/').filter(|s| !s.is_empty()).collect();
+    let common = from_parts
+        .iter()
+        .zip(to_parts.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+    let mut parts: Vec<&str> = vec![".."; from_parts.len() - common];
+    parts.extend(&to_parts[common..]);
+    parts.join("/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dev_class_names() {
+        assert_eq!(
+            namespace_to_dev_class_name("root", Some("styles"), "/fake/root/pins.ts"),
+            "pins__styles.root"
+        );
+        assert_eq!(
+            namespace_to_dev_class_name("a", None, "/fake/root/pins.ts"),
+            "pins__a"
+        );
+        assert_eq!(
+            namespace_to_dev_class_name("weird ns$!name", Some("styles"), "/fake/root/pins.ts"),
+            "pins__styles.weirdnsname"
+        );
+        assert_eq!(
+            namespace_to_dev_class_name("0", Some("styles"), "/fake/root/pins.ts"),
+            "pins__styles.0"
+        );
+    }
+
+    #[test]
+    fn short_filename_branches() {
+        // Pinned via probes 2026-08-27 against @stylexjs/babel-plugin 0.19.0.
+        let plain = DebugPathInfo::default();
+        assert_eq!(
+            create_short_filename("/fake/root/pins.ts", &plain),
+            "root/pins.ts"
+        );
+        assert_eq!(create_short_filename("pins.ts", &plain), "pins.ts");
+
+        let rooted = DebugPathInfo {
+            root_dir: Some("/fake".to_string()),
+            ..DebugPathInfo::default()
+        };
+        assert_eq!(
+            create_short_filename("/fake/deep/nested/dir/pins.ts", &rooted),
+            "deep/nested/dir/pins.ts"
+        );
+        let rooted_outside = DebugPathInfo {
+            root_dir: Some("/fake/other".to_string()),
+            ..DebugPathInfo::default()
+        };
+        assert_eq!(
+            create_short_filename("/fake/deep/pins.ts", &rooted_outside),
+            "../deep/pins.ts"
+        );
+
+        let pkg = DebugPathInfo {
+            file_package: Some(("fixture-pkg".to_string(), "/tmp/x/fixture-pkg".to_string())),
+            ..DebugPathInfo::default()
+        };
+        assert_eq!(
+            create_short_filename("/tmp/x/fixture-pkg/src/thing.ts", &pkg),
+            "fixture-pkg:src/thing.ts"
+        );
+        let same_pkg = DebugPathInfo {
+            cwd_package_name: Some("fixture-pkg".to_string()),
+            ..pkg
+        };
+        assert_eq!(
+            create_short_filename("/tmp/x/fixture-pkg/src/thing.ts", &same_pkg),
+            "src/thing.ts"
+        );
+
+        assert_eq!(
+            create_short_filename("/fake/proj/node_modules/some-lib/dist/x.ts", &plain),
+            "some-lib:dist/x.ts"
+        );
+        let rooted = DebugPathInfo {
+            root_dir: Some("/fake".to_string()),
+            ..DebugPathInfo::default()
+        };
+        assert_eq!(
+            create_short_filename("/fake/proj/node_modules/some-lib/dist/x.ts", &rooted),
+            "some-lib:proj/node_modules/some-lib/dist/x.ts"
+        );
+    }
+
+    #[test]
+    fn short_filename_haste_arm() {
+        // Last resort only: a package or node_modules ancestor still wins.
+        let haste = DebugPathInfo {
+            is_haste: true,
+            ..DebugPathInfo::default()
+        };
+        assert_eq!(
+            create_short_filename("/html/js/components/Foo.react.js", &haste),
+            "Foo.react.js"
+        );
+        let in_package = DebugPathInfo {
+            file_package: Some(("fixture-pkg".to_string(), "/tmp/x/fixture-pkg".to_string())),
+            ..haste
+        };
+        assert_eq!(
+            create_short_filename("/tmp/x/fixture-pkg/src/Foo.js", &in_package),
+            "fixture-pkg:src/Foo.js"
+        );
+    }
+}

--- a/crates/stylex/src/shared/dev_naming.rs
+++ b/crates/stylex/src/shared/dev_naming.rs
@@ -3,7 +3,6 @@
 
 use crate::eval::value::{EvalValue, JsObjectMap};
 use crate::shared::dashify::sanitize_dev_class_name;
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 /// Filesystem-derived inputs wave 3 computes; upstream's package.json walk
@@ -20,7 +19,7 @@ pub struct DebugPathInfo {
 }
 
 /// The `{basename}__{varName.}` prefix shared by every namespace of one call.
-fn dev_class_prefix(var_name: Option<&str>, filename: &str) -> String {
+pub(crate) fn dev_class_prefix(var_name: Option<&str>, filename: &str) -> String {
     let basename = path_basename(filename)
         .split('.')
         .next()
@@ -43,28 +42,6 @@ pub fn namespace_to_dev_class_name(
     ))
 }
 
-/// Prepends the self-mapping dev-classname key to every compiled namespace.
-pub fn inject_dev_class_names(
-    compiled: Arc<JsObjectMap>,
-    var_name: Option<&str>,
-    filename: Option<&str>,
-) -> Arc<JsObjectMap> {
-    let prefix = dev_class_prefix(var_name, filename.unwrap_or("UnknownFile"));
-    let mut result = JsObjectMap::new();
-    for (namespace, value) in compiled.entries() {
-        let dev_class = sanitize_dev_class_name(&format!("{prefix}{namespace}"));
-        let mut obj = JsObjectMap::new();
-        obj.insert(dev_class.clone(), EvalValue::Str(dev_class));
-        if let EvalValue::Obj(inner) = value {
-            for (k, v) in inner.entries() {
-                obj.insert(k.to_string(), v.clone());
-            }
-        }
-        result.insert(namespace.to_string(), EvalValue::Obj(Arc::new(obj)));
-    }
-    Arc::new(result)
-}
-
 // parity: dev-classname.js convertToTestStyles
 pub fn convert_to_test_styles(
     compiled: &Arc<JsObjectMap>,
@@ -79,46 +56,6 @@ pub fn convert_to_test_styles(
         obj.insert(dev_class.clone(), EvalValue::Str(dev_class));
         obj.insert("$$css", EvalValue::Bool(true));
         result.insert(namespace.to_string(), EvalValue::Obj(Arc::new(obj)));
-    }
-    Arc::new(result)
-}
-
-/// Replaces `$$css: true` with `"<shortFilename>:<line>"` per namespace whose
-/// source line is known (upstream skips namespaces it cannot find in the AST).
-pub fn add_source_map_data(
-    compiled: Arc<JsObjectMap>,
-    namespace_lines: Option<&BTreeMap<String, u32>>,
-    filename: Option<&str>,
-    info: &DebugPathInfo,
-) -> Arc<JsObjectMap> {
-    let mut short: Option<String> = None;
-    let mut result = JsObjectMap::new();
-    for (namespace, value) in compiled.entries() {
-        let line = namespace_lines
-            .and_then(|lines| lines.get(namespace))
-            .copied();
-        match (line, filename) {
-            (Some(line), Some(filename)) if line > 0 => {
-                let mut obj = match value {
-                    EvalValue::Obj(inner) => (**inner).clone(),
-                    other => {
-                        result.insert(namespace.to_string(), other.clone());
-                        continue;
-                    }
-                };
-                let short = short.get_or_insert_with(|| create_short_filename(filename, info));
-                let css_value = if short.is_empty() {
-                    EvalValue::Bool(true)
-                } else {
-                    EvalValue::Str(format!("{short}:{line}"))
-                };
-                obj.insert("$$css", css_value);
-                result.insert(namespace.to_string(), EvalValue::Obj(Arc::new(obj)));
-            }
-            _ => {
-                result.insert(namespace.to_string(), value.clone());
-            }
-        }
     }
     Arc::new(result)
 }

--- a/crates/stylex/src/shared/dynamic.rs
+++ b/crates/stylex/src/shared/dynamic.rs
@@ -1,0 +1,624 @@
+//! Function-valued namespaces -> CSS-variable rules + a structured arrow value.
+// parity: visitors/parse-stylex-create-arg.js + stylex-create.js:228-485
+
+use oxc_ast::ast::Expression;
+use oxc_span::{GetSpan, Span};
+
+use crate::eval::unwrap_parens;
+use crate::eval::value::{EvalValue, JsObjectMap};
+use crate::hash::hash;
+use crate::options::{ResolvedOptions, StyleResolution};
+use crate::rules::StylexRule;
+use crate::shared::flatten::StyleScalar;
+use crate::shared::resolution::flat_map_expanded_shorthands;
+use crate::shared::transform_value::get_number_suffix;
+
+/// One CSS-variable-backed dynamic leaf, recorded during create-arg evaluation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InlineStyle {
+    pub key_path: Vec<String>,
+    /// Span of the original (paren-unwrapped) leaf expression in the source.
+    pub span: Span,
+    /// "" ⇒ plain `expr != null ? expr : undefined`; else the
+    /// `((val) => typeof val === "number" ? val + "<unit>" : …)(expr)` coercion.
+    pub unit: String,
+    pub has_nullish_fallback: bool,
+    pub safe_to_skip_null_check: bool,
+}
+
+/// The `fns[namespace]` payload of parse-stylex-create-arg.js.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct DynamicFn {
+    pub params: Vec<String>,
+    /// varName → leaf; insertion-ordered, re-writes keep the first position.
+    pub inline_styles: Vec<(String, InlineStyle)>,
+}
+
+impl DynamicFn {
+    pub fn insert_inline(&mut self, var_name: String, style: InlineStyle) {
+        match self.inline_styles.iter_mut().find(|(n, _)| *n == var_name) {
+            Some(slot) => slot.1 = style,
+            None => self.inline_styles.push((var_name, style)),
+        }
+    }
+}
+
+/// Builds the var name + metadata for one non-static leaf.
+// parity: parse-stylex-create-arg.js:181-248
+pub fn inline_style_for_leaf(
+    expr: &Expression<'_>,
+    key_path: &[String],
+    key: &str,
+) -> (String, InlineStyle) {
+    let expr = unwrap_parens(expr);
+    let mut full_key_path: Vec<String> = key_path.to_vec();
+    full_key_path.push(key.to_string());
+    let var_name = if key_path.is_empty() {
+        format!("--x-{key}")
+    } else {
+        format!("--x-{}", hash(&full_key_path.join("_")))
+    };
+    let prop_name = full_key_path
+        .iter()
+        .find(|k| !k.starts_with(':') && !k.starts_with('@') && *k != "default")
+        .map(String::as_str)
+        .unwrap_or(key);
+    let unit = if is_time_unit_prop(prop_name) || is_length_unit_prop(prop_name) {
+        get_number_suffix(prop_name)
+    } else {
+        ""
+    };
+    let style = InlineStyle {
+        key_path: full_key_path,
+        span: expr.span(),
+        unit: unit.to_string(),
+        has_nullish_fallback: has_explicit_nullish_fallback(expr),
+        safe_to_skip_null_check: is_safe_to_skip_null_check(expr),
+    };
+    (var_name, style)
+}
+
+// parity: stylex-create.js isSafeToSkipNullCheck (babel ASTs carry no parens).
+fn is_safe_to_skip_null_check(expr: &Expression<'_>) -> bool {
+    match unwrap_parens(expr) {
+        Expression::TemplateLiteral(_)
+        | Expression::StringLiteral(_)
+        | Expression::NumericLiteral(_)
+        | Expression::BooleanLiteral(_) => true,
+        Expression::BinaryExpression(bin) => {
+            matches!(bin.operator.as_str(), "+" | "-" | "*" | "/" | "%" | "**")
+        }
+        Expression::UnaryExpression(unary) => matches!(unary.operator.as_str(), "-" | "+"),
+        Expression::ConditionalExpression(cond) => {
+            is_safe_to_skip_null_check(&cond.consequent)
+                && is_safe_to_skip_null_check(&cond.alternate)
+        }
+        Expression::LogicalExpression(logical) => match logical.operator.as_str() {
+            "??" | "||" => {
+                is_safe_to_skip_null_check(&logical.left)
+                    || is_safe_to_skip_null_check(&logical.right)
+            }
+            "&&" => {
+                is_safe_to_skip_null_check(&logical.left)
+                    && is_safe_to_skip_null_check(&logical.right)
+            }
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+// parity: stylex-create.js hasExplicitNullishFallback
+fn has_explicit_nullish_fallback(expr: &Expression<'_>) -> bool {
+    match unwrap_parens(expr) {
+        Expression::NullLiteral(_) => true,
+        Expression::Identifier(id) => id.name == "undefined",
+        Expression::UnaryExpression(unary) => unary.operator.as_str() == "void",
+        Expression::ConditionalExpression(cond) => {
+            has_explicit_nullish_fallback(&cond.consequent)
+                || has_explicit_nullish_fallback(&cond.alternate)
+        }
+        Expression::LogicalExpression(logical) => {
+            has_explicit_nullish_fallback(&logical.left)
+                || has_explicit_nullish_fallback(&logical.right)
+        }
+        _ => false,
+    }
+}
+
+/// One piece of a rewritten class-string concatenation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ClassPart {
+    /// String-literal chunk (class name plus trailing space when not last).
+    Lit(String),
+    /// `<expr> != null ? "<lit>" : <expr>` — expr printed from its span.
+    Guarded { lit: String, expr: Span },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct InlineVar {
+    pub var_name: String,
+    /// "" ⇒ nullish wrapper, else the typeof-number unit-coercion wrapper.
+    pub unit: String,
+    pub expr: Span,
+}
+
+/// Compiled arrow: `(params) => [staticObj?, conditionalObj?, vars]` (bare vars
+/// when both partitions empty); `$$css` keys carry `css_tag`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DynamicCompiled {
+    pub params: Vec<String>,
+    /// key → string-literal segments; empty vec prints/evaluates as "".
+    pub static_props: Vec<(String, Vec<String>)>,
+    pub conditional_props: Vec<(String, Vec<ClassPart>)>,
+    pub css_tag: EvalValue,
+    pub inline_vars: Vec<InlineVar>,
+}
+
+impl DynamicCompiled {
+    /// False only for namespaces with no compiled props: the arrow returns the
+    /// bare vars object and the `$$css` tag is dropped entirely (upstream).
+    pub fn has_container(&self) -> bool {
+        !self.static_props.is_empty() || !self.conditional_props.is_empty()
+    }
+}
+
+/// Compiled namespace -> arrow value; `injected_lookup` mirrors the visitor's
+/// merged injectedStyles map. parity: stylex-create.js:294-485 fns branch.
+pub fn compile_dynamic_namespace(
+    compiled_ns: &JsObjectMap,
+    class_paths: &[(String, Vec<String>)],
+    fn_def: &DynamicFn,
+    injected_lookup: &[StylexRule],
+    options: &ResolvedOptions,
+) -> DynamicCompiled {
+    let orig_class_paths: Vec<(&str, String)> = class_paths
+        .iter()
+        .map(|(class_name, path)| (class_name.as_str(), path.join("_")))
+        .collect();
+    let dynamic_styles: Vec<(String, &InlineStyle)> =
+        if options.style_resolution == StyleResolution::LegacyExpandShorthands {
+            legacy_expand_dynamic_styles(fn_def, options)
+        } else {
+            fn_def
+                .inline_styles
+                .iter()
+                .map(|(_, style)| (style.key_path.join("_"), style))
+                .collect()
+        };
+    let nullish_vars: Vec<(&str, &InlineStyle)> = fn_def
+        .inline_styles
+        .iter()
+        .filter(|(_, style)| style.has_nullish_fallback)
+        .map(|(name, style)| (name.as_str(), style))
+        .collect();
+
+    let mut css_tag = EvalValue::Bool(true);
+    let mut static_props: Vec<(String, Vec<String>)> = Vec::new();
+    let mut conditional_props: Vec<(String, Vec<ClassPart>)> = Vec::new();
+
+    for (key, value) in compiled_ns.entries() {
+        if key == "$$css" {
+            css_tag = value.clone();
+            continue;
+        }
+        // JS "".split(' ') is [""]; both roads end at a static "" prop.
+        let class_list: Vec<&str> = match value {
+            EvalValue::Str(s) => s.split(' ').collect(),
+            _ => Vec::new(),
+        };
+        let mut is_static = true;
+        let mut parts: Vec<ClassPart> = Vec::new();
+        for (index, cls) in class_list.iter().enumerate() {
+            let mut expr: Option<&InlineStyle> = orig_class_paths
+                .iter()
+                .find(|(name, _)| name == cls)
+                .and_then(|(_, path)| {
+                    dynamic_styles
+                        .iter()
+                        .find(|(p, _)| p == path)
+                        .map(|(_, style)| *style)
+                });
+            if expr.is_none() && !nullish_vars.is_empty() {
+                expr = injected_lookup
+                    .iter()
+                    .find(|rule| &*rule.class_name == *cls)
+                    .and_then(|rule| {
+                        placeholder_var_names(&rule.ltr).into_iter().find_map(|v| {
+                            nullish_vars
+                                .iter()
+                                .find(|(name, _)| *name == v)
+                                .map(|(_, style)| *style)
+                        })
+                    });
+            }
+            let is_last = index == class_list.len() - 1;
+            let lit = if is_last {
+                (*cls).to_string()
+            } else {
+                format!("{cls} ")
+            };
+            match expr {
+                Some(style) if !style.safe_to_skip_null_check => {
+                    is_static = false;
+                    parts.push(ClassPart::Guarded {
+                        lit,
+                        expr: style.span,
+                    });
+                }
+                _ => parts.push(ClassPart::Lit(lit)),
+            }
+        }
+        if is_static {
+            let segments = parts
+                .into_iter()
+                .map(|part| match part {
+                    ClassPart::Lit(lit) => lit,
+                    ClassPart::Guarded { .. } => unreachable!("static props hold literals only"),
+                })
+                .collect();
+            static_props.push((key.to_string(), segments));
+        } else {
+            conditional_props.push((key.to_string(), parts));
+        }
+    }
+
+    DynamicCompiled {
+        params: fn_def.params.clone(),
+        static_props,
+        conditional_props,
+        css_tag,
+        inline_vars: fn_def
+            .inline_styles
+            .iter()
+            .map(|(var_name, style)| InlineVar {
+                var_name: var_name.clone(),
+                unit: style.unit.clone(),
+                expr: style.span,
+            })
+            .collect(),
+    }
+}
+
+/// The path each leaf is looked up by: everything up to and including the
+/// first segment that is not a pseudo/at-rule condition.
+fn truncated_key(key_path: &[String]) -> String {
+    let end = key_path
+        .iter()
+        .position(|k| !k.starts_with(':') && !k.starts_with('@'))
+        .map_or(key_path.len(), |i| i + 1);
+    key_path[..end].join("_")
+}
+
+/// One entry per expanded longhand, key and path rewritten; nulls drop out.
+// parity: visitors/stylex-create.js:333 legacyExpandShorthands
+fn legacy_expand_dynamic_styles<'a>(
+    fn_def: &'a DynamicFn,
+    options: &ResolvedOptions,
+) -> Vec<(String, &'a InlineStyle)> {
+    let mut out = Vec::with_capacity(fn_def.inline_styles.len());
+    for (index, (_, style)) in fn_def.inline_styles.iter().enumerate() {
+        let key = truncated_key(&style.key_path);
+        let path = style.key_path.join("_");
+        let placeholder = StyleScalar::Str(std::borrow::Cow::Owned(format!("p{index}")));
+        let Ok(pairs) = flat_map_expanded_shorthands(
+            std::borrow::Cow::Borrowed(key.as_str()),
+            Some(placeholder),
+            false,
+            options,
+        ) else {
+            continue;
+        };
+        for (new_key, value) in pairs {
+            if !matches!(value, Some(StyleScalar::Str(_))) {
+                continue;
+            }
+            let new_path = if path == key {
+                new_key.into_owned()
+            } else if let Some(rest) = path.strip_prefix(&format!("{key}_")) {
+                format!("{new_key}_{rest}")
+            } else {
+                path.replacen(&format!("_{key}"), &format!("_{new_key}"), 1)
+            };
+            out.push((new_path, style));
+        }
+    }
+    out
+}
+
+/// The `/var\((--x-[^,)]+)[^)]*\)/g` capture list over one rule body.
+fn placeholder_var_names(rule: &str) -> Vec<&str> {
+    let mut names = Vec::new();
+    let mut search = 0;
+    while let Some(pos) = rule[search..].find("var(") {
+        let after = search + pos + 4;
+        let rest = &rule[after..];
+        if rest.starts_with("--x-") {
+            let name_len = rest.find([',', ')']).unwrap_or(rest.len());
+            if name_len > 4
+                && let Some(close) = rest.find(')')
+                && close >= name_len
+            {
+                names.push(&rest[..name_len]);
+                search = after + close + 1;
+                continue;
+            }
+        }
+        search = after;
+    }
+    names
+}
+
+/// Per-variable `@property` rules (priority 0), deduped first-seen/last-wins.
+// parity: stylex-create.js:228-248 injectedInheritStyles
+pub fn inherit_rules(fns: &[(String, DynamicFn)]) -> Vec<StylexRule> {
+    let mut rules: Vec<StylexRule> = Vec::new();
+    for (_, fn_def) in fns {
+        for (var_name, style) in &fn_def.inline_styles {
+            // Pseudo-elements can only access css vars via inheritance.
+            let inherits = style.key_path.iter().any(|k| k.starts_with("::"));
+            let rule = StylexRule {
+                class_name: var_name.as_str().into(),
+                ltr: format!("@property {var_name} {{ syntax: \"*\"; inherits: {inherits};}}")
+                    .into(),
+                rtl: None,
+                const_key: None,
+                const_val: None,
+                priority: 0.0,
+            };
+            match rules.iter_mut().find(|r| &*r.class_name == var_name) {
+                Some(slot) => *slot = rule,
+                None => rules.push(rule),
+            }
+        }
+    }
+    rules
+}
+
+fn is_time_unit_prop(key: &str) -> bool {
+    matches!(
+        key,
+        "animationDelay"
+            | "animationDuration"
+            | "transitionDelay"
+            | "transitionDuration"
+            | "voiceDuration"
+    )
+}
+
+// parity: transform-value.js lengthUnits (verbatim, duplicates and all)
+fn is_length_unit_prop(key: &str) -> bool {
+    matches!(
+        key,
+        "backgroundPositionX"
+            | "backgroundPositionY"
+            | "blockSize"
+            | "borderBlockEndWidth"
+            | "borderBlockStartWidth"
+            | "borderBlockWidth"
+            | "borderVerticalWidth"
+            | "borderBottomLeftRadius"
+            | "borderBottomRightRadius"
+            | "borderBottomWidth"
+            | "borderEndEndRadius"
+            | "borderEndStartRadius"
+            | "borderInlineEndWidth"
+            | "borderEndWidth"
+            | "borderInlineStartWidth"
+            | "borderStartWidth"
+            | "borderInlineWidth"
+            | "borderHorizontalWidth"
+            | "borderLeftWidth"
+            | "borderRightWidth"
+            | "borderSpacing"
+            | "borderStartEndRadius"
+            | "borderStartStartRadius"
+            | "borderTopLeftRadius"
+            | "borderTopRightRadius"
+            | "borderTopWidth"
+            | "bottom"
+            | "columnGap"
+            | "columnRuleWidth"
+            | "columnWidth"
+            | "containIntrinsicBlockSize"
+            | "containIntrinsicHeight"
+            | "containIntrinsicInlineSize"
+            | "containIntrinsicWidth"
+            | "flexBasis"
+            | "fontSize"
+            | "fontSmooth"
+            | "height"
+            | "inlineSize"
+            | "insetBlockEnd"
+            | "insetBlockStart"
+            | "insetInlineEnd"
+            | "insetInlineStart"
+            | "left"
+            | "letterSpacing"
+            | "marginBlockEnd"
+            | "marginBlockStart"
+            | "marginBottom"
+            | "marginInlineEnd"
+            | "marginEnd"
+            | "marginInlineStart"
+            | "marginStart"
+            | "marginLeft"
+            | "marginRight"
+            | "marginTop"
+            | "maxBlockSize"
+            | "maxHeight"
+            | "maxInlineSize"
+            | "maxWidth"
+            | "minBlockSize"
+            | "minHeight"
+            | "minInlineSize"
+            | "minWidth"
+            | "offsetDistance"
+            | "outlineOffset"
+            | "outlineWidth"
+            | "overflowClipMargin"
+            | "paddingBlockEnd"
+            | "paddingBlockStart"
+            | "paddingBottom"
+            | "paddingInlineEnd"
+            | "paddingEnd"
+            | "paddingInlineStart"
+            | "paddingStart"
+            | "paddingLeft"
+            | "paddingRight"
+            | "paddingTop"
+            | "perspective"
+            | "right"
+            | "rowGap"
+            | "scrollMarginBlockEnd"
+            | "scrollMarginBlockStart"
+            | "scrollMarginBottom"
+            | "scrollMarginInlineEnd"
+            | "scrollMarginInlineStart"
+            | "scrollMarginLeft"
+            | "scrollMarginRight"
+            | "scrollMarginTop"
+            | "scrollPaddingBlockEnd"
+            | "scrollPaddingBlockStart"
+            | "scrollPaddingBottom"
+            | "scrollPaddingInlineEnd"
+            | "scrollPaddingInlineStart"
+            | "scrollPaddingLeft"
+            | "scrollPaddingRight"
+            | "scrollPaddingTop"
+            | "scrollSnapMarginBottom"
+            | "scrollSnapMarginLeft"
+            | "scrollSnapMarginRight"
+            | "scrollSnapMarginTop"
+            | "shapeMargin"
+            | "tabSize"
+            | "textDecorationThickness"
+            | "textIndent"
+            | "textUnderlineOffset"
+            | "top"
+            | "transformOrigin"
+            | "translate"
+            | "verticalAlign"
+            | "width"
+            | "wordSpacing"
+            | "border"
+            | "borderBlock"
+            | "borderBlockEnd"
+            | "borderBlockStart"
+            | "borderBottom"
+            | "borderLeft"
+            | "borderRadius"
+            | "borderRight"
+            | "borderTop"
+            | "borderWidth"
+            | "columnRule"
+            | "containIntrinsicSize"
+            | "gap"
+            | "inset"
+            | "insetBlock"
+            | "insetInline"
+            | "margin"
+            | "marginBlock"
+            | "marginVertical"
+            | "marginInline"
+            | "marginHorizontal"
+            | "offset"
+            | "outline"
+            | "padding"
+            | "paddingBlock"
+            | "paddingVertical"
+            | "paddingInline"
+            | "paddingHorizontal"
+            | "scrollMargin"
+            | "scrollMarginBlock"
+            | "scrollMarginInline"
+            | "scrollPadding"
+            | "scrollPaddingBlock"
+            | "scrollPaddingInline"
+            | "scrollSnapMargin"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wrapper_unit_pins() {
+        // width: length prop → px; tabSize: length ∩ unitless → "" wrapper;
+        // opacity/color: not in either set → nullish wrapper.
+        let unit = |prop: &str| {
+            if is_time_unit_prop(prop) || is_length_unit_prop(prop) {
+                get_number_suffix(prop)
+            } else {
+                ""
+            }
+        };
+        assert_eq!(unit("width"), "px");
+        assert_eq!(unit("animationDuration"), "ms");
+        assert_eq!(unit("tabSize"), "");
+        assert_eq!(unit("opacity"), "");
+        assert_eq!(unit("color"), "");
+        assert_eq!(unit("strokeWidth"), "");
+    }
+
+    #[test]
+    fn placeholder_var_name_scan_matches_regex() {
+        assert_eq!(
+            placeholder_var_names(".x{width:var(--x-width)}"),
+            vec!["--x-width"]
+        );
+        assert_eq!(
+            placeholder_var_names(".x{width:var(--x-a, 10px)}"),
+            vec!["--x-a"]
+        );
+        assert_eq!(
+            placeholder_var_names(".x{margin:var(--x-a) var(--x-b)}"),
+            vec!["--x-a", "--x-b"]
+        );
+        // Non-placeholder vars and the bare prefix do not match.
+        assert!(placeholder_var_names(".x{color:var(--other)}").is_empty());
+        assert!(placeholder_var_names(".x{color:var(--x-)}").is_empty());
+    }
+
+    #[test]
+    fn inherit_rules_dedupe_and_pseudo_element_inherit() {
+        let style = |path: &[&str]| InlineStyle {
+            key_path: path.iter().map(|s| s.to_string()).collect(),
+            span: Span::default(),
+            unit: String::new(),
+            has_nullish_fallback: false,
+            safe_to_skip_null_check: false,
+        };
+        let fns = vec![
+            (
+                "a".to_string(),
+                DynamicFn {
+                    params: vec!["w".to_string()],
+                    inline_styles: vec![("--x-width".to_string(), style(&["width"]))],
+                },
+            ),
+            (
+                "b".to_string(),
+                DynamicFn {
+                    params: vec!["w".to_string()],
+                    inline_styles: vec![
+                        ("--x-width".to_string(), style(&["width"])),
+                        ("--x-abc".to_string(), style(&["::before", "width"])),
+                    ],
+                },
+            ),
+        ];
+        let rules = inherit_rules(&fns);
+        assert_eq!(rules.len(), 2);
+        assert_eq!(
+            &*rules[0].ltr,
+            "@property --x-width { syntax: \"*\"; inherits: false;}"
+        );
+        assert_eq!(
+            &*rules[1].ltr,
+            "@property --x-abc { syntax: \"*\"; inherits: true;}"
+        );
+        assert!(rules.iter().all(|r| r.priority == 0.0));
+    }
+}

--- a/crates/stylex/src/shared/fallbacks.rs
+++ b/crates/stylex/src/shared/fallbacks.rs
@@ -1,0 +1,100 @@
+//! Fallback arrays: contiguous `var()` runs collapse into nested `var(a, var(b, …))`.
+// parity: babel-plugin src/shared/utils/convert-to-className.js:85-121
+
+use crate::errors::StylexError;
+
+fn is_var(value: &str) -> bool {
+    value.starts_with("var(") && value.ends_with(')')
+}
+
+pub fn has_var_fallback(values: &[String]) -> bool {
+    values.iter().any(|v| is_var(v))
+}
+
+/// Errors with `NON_CONTIGUOUS_VARS` when a non-var value sits between vars.
+pub fn variable_fallbacks(values: &[String]) -> Result<Vec<String>, StylexError> {
+    let first_var = values.iter().position(|v| is_var(v));
+    let last_var = values.iter().rposition(|v| is_var(v));
+    let (Some(first_var), Some(last_var)) = (first_var, last_var) else {
+        // Unreachable via convertStyleToClassName (caller pre-checks has_var_fallback).
+        return Ok(values.to_vec());
+    };
+
+    let values_before = &values[..first_var];
+    let mut var_values: Vec<&String> = values[first_var..=last_var].iter().collect();
+    var_values.reverse();
+    let values_after = &values[last_var + 1..];
+
+    if var_values.iter().any(|v| !is_var(v)) {
+        return Err(StylexError::non_contiguous_vars());
+    }
+    let var_names: Vec<&str> = var_values.iter().map(|v| &v[4..v.len() - 1]).collect();
+
+    let mut out = Vec::new();
+    if values_before.is_empty() {
+        out.push(compose_vars(&var_names));
+    } else {
+        for val in values_before {
+            let mut args = var_names.clone();
+            args.push(val);
+            out.push(compose_vars(&args));
+        }
+    }
+    out.extend(values_after.iter().cloned());
+    Ok(out)
+}
+
+// parity: convert-to-className.js composeVars
+fn compose_vars(args: &[&str]) -> String {
+    match args {
+        [] => unreachable!("compose_vars is never called with zero args"),
+        [first] if first.starts_with("--") => format!("var({first})"),
+        [first] => (*first).to_string(),
+        [first, rest @ ..] => format!("var({first},{})", compose_vars(rest)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::errors::ErrorCode;
+
+    fn v(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn oracle_pinned_shapes() {
+        // Pinned via probes 2026-08-27 against @stylexjs/babel-plugin 0.19.0.
+        assert_eq!(
+            variable_fallbacks(&v(&["var(--a)", "red"])).unwrap(),
+            v(&["var(--a)", "red"])
+        );
+        assert_eq!(
+            variable_fallbacks(&v(&["red", "var(--a)", "var(--b)", "blue"])).unwrap(),
+            v(&["var(--b,var(--a,red))", "blue"])
+        );
+        assert_eq!(
+            variable_fallbacks(&v(&["red", "blue", "var(--a)", "var(--b)"])).unwrap(),
+            v(&["var(--b,var(--a,red))", "var(--b,var(--a,blue))"])
+        );
+        assert_eq!(
+            variable_fallbacks(&v(&["var(--a)", "var(--b)"])).unwrap(),
+            v(&["var(--b,var(--a))"])
+        );
+        assert_eq!(
+            variable_fallbacks(&v(&["var(--a)"])).unwrap(),
+            v(&["var(--a)"])
+        );
+    }
+
+    #[test]
+    fn non_contiguous_vars_throw() {
+        let err = variable_fallbacks(&v(&["var(--a)", "red", "var(--b)"])).unwrap_err();
+        assert_eq!(err.code, ErrorCode::NonContiguousVars);
+        assert_eq!(
+            err.message,
+            "All variables passed to firstThatWorks() must be contiguous."
+        );
+    }
+}

--- a/crates/stylex/src/shared/flatten.rs
+++ b/crates/stylex/src/shared/flatten.rs
@@ -36,23 +36,24 @@ pub enum PreRule<'a> {
     Set(Vec<PreRule<'a>>),
 }
 
-/// One compiled slot: `None` mirrors upstream's `null` ComputedStyle; the
-/// second element is the classesToOriginalPath keyPath for that class.
-pub type ComputedStyle<'a, 'b> = Option<(CompiledDecl, &'b [Cow<'a, str>])>;
-
 /// The property-value branch's per-property (condition, rule) groupings.
 type ConditionGroups<'a> = Vec<(Cow<'a, str>, Vec<(&'a str, PreRule<'a>)>)>;
 
 impl<'a> PreRule<'a> {
     // parity: PreRule.js PreRuleSet.create
     fn create_set(rules: Vec<PreRule<'a>>) -> PreRule<'a> {
-        let mut flat: Vec<PreRule> = Vec::with_capacity(rules.len());
-        for rule in rules {
-            match rule {
-                PreRule::Set(inner) => flat.extend(inner),
-                other => flat.push(other),
+        let flat = if rules.iter().any(|rule| matches!(rule, PreRule::Set(_))) {
+            let mut flat: Vec<PreRule> = Vec::with_capacity(rules.len());
+            for rule in rules {
+                match rule {
+                    PreRule::Set(inner) => flat.extend(inner),
+                    other => flat.push(other),
+                }
             }
-        }
+            flat
+        } else {
+            rules
+        };
         match flat.len() {
             0 => PreRule::Null,
             1 => flat.into_iter().next().expect("len checked"),
@@ -60,54 +61,29 @@ impl<'a> PreRule<'a> {
         }
     }
 
-    pub fn compiled(
+    /// Visits the compiled declarations in upstream's ComputedStyle order with
+    /// each one's classesToOriginalPath keyPath; `null` slots are skipped.
+    pub fn for_each_compiled(
         &self,
         options: &ResolvedOptions,
-    ) -> Result<Vec<ComputedStyle<'a, '_>>, StylexError> {
+        f: &mut dyn FnMut(CompiledDecl, &[Cow<'a, str>]),
+    ) -> Result<(), StylexError> {
         match self {
-            PreRule::Null => Ok(vec![None]),
+            PreRule::Null => Ok(()),
             PreRule::Rule {
                 property,
                 value,
                 key_path,
             } => {
-                // Condition lists stay in keyPath order; the sorted orders are
-                // derived inside the conversion, on its memo-miss path only.
-                let pseudos: Vec<&str> = key_path
-                    .iter()
-                    .filter(|k| k.starts_with(':') || k.starts_with('['))
-                    .map(Cow::as_ref)
-                    .collect();
-                let at_rules: Vec<&str> = key_path
-                    .iter()
-                    .filter(|k| k.starts_with('@'))
-                    .map(Cow::as_ref)
-                    .collect();
-                let const_rules: Vec<&str> = key_path
-                    .iter()
-                    .filter(|k| k.starts_with("var(--"))
-                    .map(Cow::as_ref)
-                    .collect();
-                let decl = convert_style_to_class_name(
-                    property,
-                    value,
-                    &pseudos,
-                    &at_rules,
-                    &const_rules,
-                    options,
-                )?;
-                Ok(vec![Some((decl, key_path.as_slice()))])
+                let decl = convert_style_to_class_name(property, value, key_path, options)?;
+                f(decl, key_path);
+                Ok(())
             }
             PreRule::Set(rules) => {
-                let mut tuples: Vec<ComputedStyle<'a, '_>> = Vec::new();
                 for rule in rules {
-                    tuples.extend(rule.compiled(options)?.into_iter().flatten().map(Some));
+                    rule.for_each_compiled(options, f)?;
                 }
-                if tuples.is_empty() {
-                    Ok(vec![None])
-                } else {
-                    Ok(tuples)
-                }
+                Ok(())
             }
         }
     }
@@ -115,60 +91,85 @@ impl<'a> PreRule<'a> {
 
 // Upstream copies via `obj[key]=value`, so "__proto__" is a [[Set]]: primitives
 // vanish, objects become the prototype, array/null protos break isPlainObject.
-struct ProtoSplit<'a> {
-    own: Vec<(&'a str, &'a EvalValue)>,
-    proto: Option<&'a JsObjectMap>,
-    non_plain: bool,
+fn is_plain(obj: &JsObjectMap) -> bool {
+    match obj.get("__proto__") {
+        None => true,
+        Some(EvalValue::Obj(proto)) => is_plain(proto),
+        Some(EvalValue::Null | EvalValue::Arr(_)) => false,
+        Some(_) => true,
+    }
 }
 
-fn proto_split(obj: &JsObjectMap) -> ProtoSplit<'_> {
-    let mut split = ProtoSplit {
-        own: Vec::with_capacity(obj.len()),
-        proto: None,
-        non_plain: false,
-    };
-    for (key, val) in obj.entries() {
-        if key == "__proto__" {
-            match val {
-                EvalValue::Obj(p) => split.proto = Some(p),
-                EvalValue::Null | EvalValue::Arr(_) => split.non_plain = true,
-                _ => {}
-            }
-        } else {
-            split.own.push((key, val));
+enum ForIn<'a, I> {
+    Own(I),
+    Chain(std::vec::IntoIter<(&'a str, &'a EvalValue)>),
+}
+
+impl<'a, I: Iterator<Item = (&'a str, &'a EvalValue)>> Iterator for ForIn<'a, I> {
+    type Item = (&'a str, &'a EvalValue);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            ForIn::Own(own) => own.next(),
+            ForIn::Chain(chain) => chain.next(),
         }
     }
-    // a non-plain link anywhere up the chain breaks the constructor lookup
-    if let Some(p) = split.proto
-        && proto_split(p).non_plain
-    {
-        split.non_plain = true;
-    }
-    split
 }
 
-// for..in order: own keys, then unshadowed prototype-chain keys.
-fn for_in_entries(obj: &JsObjectMap) -> Vec<(&str, &EvalValue)> {
+// for..in order: own keys, then unshadowed prototype-chain keys — which is the
+// map's own order, iterated in place, unless a "__proto__" key is present.
+fn for_in_entries(obj: &JsObjectMap) -> impl Iterator<Item = (&str, &EvalValue)> {
+    if obj.get("__proto__").is_none() {
+        ForIn::Own(obj.entries())
+    } else {
+        ForIn::Chain(for_in_chain(obj).into_iter())
+    }
+}
+
+fn for_in_chain(obj: &JsObjectMap) -> Vec<(&str, &EvalValue)> {
     let mut entries = Vec::new();
     let mut cursor = Some(obj);
     while let Some(map) = cursor {
-        let split = proto_split(map);
-        for (key, val) in split.own {
-            if !entries.iter().any(|(k, _)| *k == key) {
+        cursor = None;
+        for (key, val) in map.entries() {
+            if key == "__proto__" {
+                if let EvalValue::Obj(proto) = val {
+                    cursor = Some(proto);
+                }
+            } else if !entries.iter().any(|(k, _)| *k == key) {
                 entries.push((key, val));
             }
         }
-        cursor = split.proto;
     }
     entries
 }
 
-fn is_plain(obj: &JsObjectMap) -> bool {
-    !proto_split(obj).non_plain
+/// Enclosing condition keys, innermost first, linked through the call stack.
+struct Conditions<'p> {
+    key: &'p str,
+    outer: Option<&'p Conditions<'p>>,
+}
+
+fn is_enclosing_condition(conditions: Option<&Conditions<'_>>, key: &str) -> bool {
+    let mut cursor = conditions;
+    while let Some(condition) = cursor {
+        if condition.key == key {
+            return true;
+        }
+        cursor = condition.outer;
+    }
+    false
 }
 
 // parity: basic-validation.js validateNamespace
-pub fn validate_namespace(namespace: &EvalValue, conditions: &[String]) -> Result<(), StylexError> {
+pub fn validate_namespace(namespace: &EvalValue) -> Result<(), StylexError> {
+    validate_namespace_in(namespace, None)
+}
+
+fn validate_namespace_in(
+    namespace: &EvalValue,
+    conditions: Option<&Conditions<'_>>,
+) -> Result<(), StylexError> {
     let EvalValue::Obj(ns) = namespace else {
         return Err(StylexError::illegal_namespace_value());
     };
@@ -190,14 +191,16 @@ pub fn validate_namespace(namespace: &EvalValue, conditions: &[String]) -> Resul
             // through to ILLEGAL_PROP_VALUE exactly as upstream's last throw.
             EvalValue::Obj(inner) if is_plain(inner) => {
                 if key.starts_with('@') || key.starts_with(':') || key.starts_with('[') {
-                    if conditions.iter().any(|c| c == key) {
+                    if is_enclosing_condition(conditions, key) {
                         return Err(StylexError::duplicate_conditional());
                     }
-                    let mut nested = conditions.to_vec();
-                    nested.push(key.to_string());
-                    validate_namespace(val, &nested)?;
+                    let nested = Conditions {
+                        key,
+                        outer: conditions,
+                    };
+                    validate_namespace_in(val, Some(&nested))?;
                 } else {
-                    validate_conditional_styles(val, &[])?;
+                    validate_conditional_styles(val, None)?;
                 }
             }
             EvalValue::Obj(_) | EvalValue::Undefined | EvalValue::Bool(_) => {
@@ -209,7 +212,10 @@ pub fn validate_namespace(namespace: &EvalValue, conditions: &[String]) -> Resul
 }
 
 // parity: basic-validation.js validateConditionalStyles
-fn validate_conditional_styles(val: &EvalValue, conditions: &[String]) -> Result<(), StylexError> {
+fn validate_conditional_styles(
+    val: &EvalValue,
+    conditions: Option<&Conditions<'_>>,
+) -> Result<(), StylexError> {
     let EvalValue::Obj(obj) = val else {
         unreachable!("callers only pass objects");
     };
@@ -222,7 +228,7 @@ fn validate_conditional_styles(val: &EvalValue, conditions: &[String]) -> Result
         {
             return Err(StylexError::invalid_pseudo_or_at_rule());
         }
-        if conditions.iter().any(|c| c == key) {
+        if is_enclosing_condition(conditions, key) {
             return Err(StylexError::duplicate_conditional());
         }
         match v {
@@ -238,9 +244,11 @@ fn validate_conditional_styles(val: &EvalValue, conditions: &[String]) -> Result
                 }
             }
             EvalValue::Obj(inner) if is_plain(inner) => {
-                let mut nested = conditions.to_vec();
-                nested.push(key.to_string());
-                validate_conditional_styles(v, &nested)?;
+                let nested = Conditions {
+                    key,
+                    outer: conditions,
+                };
+                validate_conditional_styles(v, Some(&nested))?;
             }
             EvalValue::Obj(_) | EvalValue::Undefined | EvalValue::Bool(_) => {
                 return Err(StylexError::illegal_prop_value());
@@ -285,12 +293,14 @@ fn dfs_can_change(obj: &JsObjectMap, depth: usize) -> bool {
 // delete+reinsert moves every rewritten @media key to the end of its siblings.
 // Map-in skips a redundant top-level deep clone the EvalValue wrapper needed.
 fn dfs_process_map(obj: &JsObjectMap, depth: usize) -> Result<JsObjectMap, StylexError> {
-    let mut result = JsObjectMap::new();
+    let mut result = JsObjectMap::with_capacity(obj.len());
     // Object.entries-style clone: own keys only — a "__proto__"-carried
     // prototype (and its inherited entries) is stripped here, before flatten.
-    for (key, val) in proto_split(obj).own {
+    for (key, val) in obj.entries().filter(|(key, _)| *key != "__proto__") {
         let processed = match val {
-            EvalValue::Obj(inner) => EvalValue::Obj(Arc::new(dfs_process_map(inner, depth + 1)?)),
+            EvalValue::Obj(inner) if dfs_can_change(inner, depth + 1) => {
+                EvalValue::Obj(Arc::new(dfs_process_map(inner, depth + 1)?))
+            }
             other => other.clone(),
         };
         result.insert(key, processed);
@@ -382,7 +392,8 @@ fn rule_key_path<'a>(
             })
             .collect()
     } else {
-        let mut path = key_path.to_vec();
+        let mut path = Vec::with_capacity(key_path.len() + 1);
+        path.extend_from_slice(key_path);
         path.push(property);
         path
     }
@@ -393,7 +404,7 @@ fn flatten_inner<'a>(
     key_path: &[Cow<'a, str>],
     options: &ResolvedOptions,
 ) -> Result<Vec<(Cow<'a, str>, PreRule<'a>)>, StylexError> {
-    let mut flattened: Vec<(Cow<'a, str>, PreRule<'a>)> = Vec::new();
+    let mut flattened: Vec<(Cow<'a, str>, PreRule<'a>)> = Vec::with_capacity(style.len());
     // for..in reach: prototype entries planted by "__proto__" keys stay
     // visible here unless the media-query clone above already stripped them.
     for (raw_key, value) in for_in_entries(style) {
@@ -471,17 +482,25 @@ fn flatten_inner<'a>(
             {
                 // Property-value objects, e.g. color: { default, ':hover' }.
                 let mut equivalent: ConditionGroups<'a> = Vec::new();
+                let mut leaf = Vec::new();
                 for (condition, inner_value) in for_in_entries(obj) {
                     let nested_path: Vec<Cow<'a, str>> = if key_path.is_empty() {
                         vec![key.clone(), Cow::Borrowed(condition)]
                     } else {
-                        let mut p = key_path.to_vec();
+                        let mut p = Vec::with_capacity(key_path.len() + 1);
+                        p.extend_from_slice(key_path);
                         p.push(Cow::Borrowed(condition));
                         p
                     };
-                    for (property, pre_rule) in
-                        flatten_value_as_property(&key, inner_value, &nested_path, options)?
-                    {
+                    leaf.clear();
+                    flatten_value_as_property(
+                        key.clone(),
+                        inner_value,
+                        &nested_path,
+                        options,
+                        &mut leaf,
+                    )?;
+                    for (property, pre_rule) in leaf.drain(..) {
                         match equivalent.iter_mut().find(|(p, _)| *p == property) {
                             Some((_, conds)) => {
                                 match conds.iter_mut().find(|(c, _)| *c == condition) {
@@ -500,10 +519,15 @@ fn flatten_inner<'a>(
             }
             EvalValue::Obj(obj) => {
                 // Pseudo / at-rule / attribute objects, e.g. ':hover': { … }.
-                let mut nested_path = key_path.to_vec();
+                let mut nested_path = Vec::with_capacity(key_path.len() + 1);
+                nested_path.extend_from_slice(key_path);
                 nested_path.push(Cow::Borrowed(raw_key));
                 for (property, pre_rule) in flatten_inner(obj, &nested_path, options)? {
-                    flattened.push((Cow::Owned(format!("{key}_{property}")), pre_rule));
+                    let mut joined = String::with_capacity(key.len() + 1 + property.len());
+                    joined.push_str(&key);
+                    joined.push('_');
+                    joined.push_str(&property);
+                    flattened.push((Cow::Owned(joined), pre_rule));
                 }
             }
             // Upstream's flatten silently skips other types (validation ran first).
@@ -516,22 +540,22 @@ fn flatten_inner<'a>(
 /// The property-value-object recursion, without upstream's intermediate
 /// `{key: value}` object: identical to flatten_inner on that single-key map.
 fn flatten_value_as_property<'a>(
-    key: &Cow<'a, str>,
+    key: Cow<'a, str>,
     value: &'a EvalValue,
     nested_path: &[Cow<'a, str>],
     options: &ResolvedOptions,
-) -> Result<Vec<(Cow<'a, str>, PreRule<'a>)>, StylexError> {
+    out: &mut Vec<(Cow<'a, str>, PreRule<'a>)>,
+) -> Result<(), StylexError> {
     match value {
         EvalValue::Null | EvalValue::Str(_) | EvalValue::Num(_) => {
             let scalar = scalar_of(value);
-            let mut out = Vec::new();
             for (property, expanded) in
                 flat_map_expanded_shorthands(key.clone(), scalar, false, options)?
             {
                 match expanded {
                     None => out.push((property, PreRule::Null)),
                     Some(expanded) => {
-                        let path = rule_key_path(nested_path, key, property.clone());
+                        let path = rule_key_path(nested_path, &key, property.clone());
                         out.push((
                             property.clone(),
                             PreRule::Rule {
@@ -543,7 +567,7 @@ fn flatten_value_as_property<'a>(
                     }
                 }
             }
-            Ok(out)
+            Ok(())
         }
         EvalValue::Arr(items) => {
             let mut equivalent: Vec<(Cow<'a, str>, Vec<StyleScalar<'a>>)> = Vec::new();
@@ -564,7 +588,6 @@ fn flatten_value_as_property<'a>(
                     }
                 }
             }
-            let mut out = Vec::new();
             for (property, values) in equivalent {
                 let mut deduped: Vec<StyleScalar> = Vec::new();
                 for value in values {
@@ -577,28 +600,31 @@ fn flatten_value_as_property<'a>(
                     1 => PreRule::Rule {
                         property: property.clone(),
                         value: PreRuleValue::Single(deduped.into_iter().next().expect("len 1")),
-                        key_path: rule_key_path(nested_path, key, property.clone()),
+                        key_path: rule_key_path(nested_path, &key, property.clone()),
                     },
                     _ => PreRule::Rule {
                         property: property.clone(),
                         value: PreRuleValue::Multi(deduped),
-                        key_path: rule_key_path(nested_path, key, property.clone()),
+                        key_path: rule_key_path(nested_path, &key, property.clone()),
                     },
                 };
                 out.push((property, pre_rule));
             }
-            Ok(out)
+            Ok(())
         }
         // Deeper nesting (condition inside a property-value object): group by
         // property and condition into per-property sets, exactly the
         // property-value branch's shape one level down.
         EvalValue::Obj(obj) => {
-            let mut out = Vec::new();
             let mut equivalent: ConditionGroups<'a> = Vec::new();
+            let mut leaf = Vec::new();
             for (condition, inner) in for_in_entries(obj) {
-                let mut p = nested_path.to_vec();
+                let mut p = Vec::with_capacity(nested_path.len() + 1);
+                p.extend_from_slice(nested_path);
                 p.push(Cow::Borrowed(condition));
-                for (property, pre_rule) in flatten_value_as_property(key, inner, &p, options)? {
+                leaf.clear();
+                flatten_value_as_property(key.clone(), inner, &p, options, &mut leaf)?;
+                for (property, pre_rule) in leaf.drain(..) {
                     match equivalent.iter_mut().find(|(pr, _)| *pr == property) {
                         Some((_, conds)) => match conds.iter_mut().find(|(c, _)| *c == condition) {
                             Some((_, slot)) => *slot = pre_rule,
@@ -612,15 +638,109 @@ fn flatten_value_as_property<'a>(
                 let rules: Vec<PreRule> = conds.into_iter().map(|(_, r)| r).collect();
                 out.push((property, PreRule::create_set(rules)));
             }
-            Ok(out)
+            Ok(())
         }
-        EvalValue::Undefined | EvalValue::Bool(_) => Ok(Vec::new()),
+        EvalValue::Undefined | EvalValue::Bool(_) => Ok(()),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn s(v: &str) -> EvalValue {
+        EvalValue::Str(v.to_string())
+    }
+
+    fn obj(entries: Vec<(&str, EvalValue)>) -> Arc<JsObjectMap> {
+        let mut map = JsObjectMap::new();
+        for (key, val) in entries {
+            map.insert(key, val);
+        }
+        Arc::new(map)
+    }
+
+    // the pre-sharing rebuild: every level copied, every scalar cloned
+    fn deep_rebuild(map: &JsObjectMap, depth: usize) -> JsObjectMap {
+        let mut result = JsObjectMap::new();
+        for (key, val) in map.entries().filter(|(key, _)| *key != "__proto__") {
+            let processed = match val {
+                EvalValue::Obj(inner) => EvalValue::Obj(Arc::new(deep_rebuild(inner, depth + 1))),
+                other => other.clone(),
+            };
+            result.insert(key, processed);
+        }
+        if depth >= 1 {
+            let media_keys: Vec<String> = result
+                .keys()
+                .filter(|k| is_media_key(k))
+                .map(str::to_string)
+                .collect();
+            if !media_keys.is_empty() {
+                let rewritten =
+                    last_media_query_wins_transform(&media_keys).expect("valid fixture");
+                for (old_key, new_key) in media_keys.iter().zip(rewritten) {
+                    let value = result.remove(old_key).expect("collected from map");
+                    result.insert(new_key, value);
+                }
+            }
+        }
+        result
+    }
+
+    #[test]
+    fn dfs_process_map_shares_unchangeable_subtrees() {
+        let hover = obj(vec![
+            ("color", s("blue")),
+            (":focus", EvalValue::Obj(obj(vec![("color", s("green"))]))),
+        ]);
+        let media = obj(vec![
+            ("color", s("a")),
+            (
+                "@media (min-width: 900px)",
+                EvalValue::Obj(obj(vec![("color", s("b"))])),
+            ),
+            (
+                "@media (min-width: 700px)",
+                EvalValue::Obj(obj(vec![("color", s("c"))])),
+            ),
+            (
+                "__proto__",
+                EvalValue::Obj(obj(vec![("inherited", s("x"))])),
+            ),
+        ]);
+        let root = obj(vec![
+            ("color", s("red")),
+            (":hover", EvalValue::Obj(Arc::clone(&hover))),
+            (
+                "@media (min-width: 600px)",
+                EvalValue::Obj(Arc::clone(&media)),
+            ),
+            (
+                "__proto__",
+                EvalValue::Obj(obj(vec![("inherited", s("y"))])),
+            ),
+        ]);
+        assert!(dfs_can_change(&root, 0));
+        let processed = dfs_process_map(&root, 0).expect("fixture transforms");
+        assert_eq!(processed, deep_rebuild(&root, 0));
+        assert!(!processed.contains_key("__proto__"));
+
+        let Some(EvalValue::Obj(shared)) = processed.get(":hover") else {
+            panic!(":hover survives");
+        };
+        assert!(Arc::ptr_eq(shared, &hover));
+
+        let Some(EvalValue::Obj(rebuilt)) = processed.get("@media (min-width: 600px)") else {
+            panic!("depth-0 media key stays verbatim");
+        };
+        assert!(!Arc::ptr_eq(rebuilt, &media));
+        assert!(!rebuilt.contains_key("__proto__"));
+        assert_eq!(
+            rebuilt.keys().collect::<Vec<_>>(),
+            vec!["color", "@media not all", "@media (min-width: 700px)"]
+        );
+    }
 
     #[test]
     fn unwrap_var_key_matches_upstream_regex() {

--- a/crates/stylex/src/shared/flatten.rs
+++ b/crates/stylex/src/shared/flatten.rs
@@ -1,0 +1,643 @@
+//! Raw style namespace → flat `[key, PreRule]` entries, plus basic validation.
+// parity: babel-plugin src/shared/preprocess-rules/{flatten-raw-style-obj,basic-validation,PreRule}.js
+
+use crate::errors::StylexError;
+use crate::eval::value::{EvalValue, JsObjectMap};
+use crate::options::ResolvedOptions;
+use crate::shared::generate_rule::{CompiledDecl, convert_style_to_class_name};
+use crate::shared::media_query::{MediaQueryError, is_media_key, last_media_query_wins_transform};
+use crate::shared::resolution::flat_map_expanded_shorthands;
+use std::borrow::Cow;
+use std::sync::Arc;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum StyleScalar<'a> {
+    Str(Cow<'a, str>),
+    Num(f64),
+    /// A legacy shorthand whose split produced no part for this side; it
+    /// renders as an empty declaration instead of throwing on an empty value.
+    Undefined,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum PreRuleValue<'a> {
+    Single(StyleScalar<'a>),
+    Multi(Vec<StyleScalar<'a>>),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum PreRule<'a> {
+    Null,
+    Rule {
+        property: Cow<'a, str>,
+        value: PreRuleValue<'a>,
+        key_path: Vec<Cow<'a, str>>,
+    },
+    Set(Vec<PreRule<'a>>),
+}
+
+/// One compiled slot: `None` mirrors upstream's `null` ComputedStyle; the
+/// second element is the classesToOriginalPath keyPath for that class.
+pub type ComputedStyle<'a, 'b> = Option<(CompiledDecl, &'b [Cow<'a, str>])>;
+
+/// The property-value branch's per-property (condition, rule) groupings.
+type ConditionGroups<'a> = Vec<(Cow<'a, str>, Vec<(&'a str, PreRule<'a>)>)>;
+
+impl<'a> PreRule<'a> {
+    // parity: PreRule.js PreRuleSet.create
+    fn create_set(rules: Vec<PreRule<'a>>) -> PreRule<'a> {
+        let mut flat: Vec<PreRule> = Vec::with_capacity(rules.len());
+        for rule in rules {
+            match rule {
+                PreRule::Set(inner) => flat.extend(inner),
+                other => flat.push(other),
+            }
+        }
+        match flat.len() {
+            0 => PreRule::Null,
+            1 => flat.into_iter().next().expect("len checked"),
+            _ => PreRule::Set(flat),
+        }
+    }
+
+    pub fn compiled(
+        &self,
+        options: &ResolvedOptions,
+    ) -> Result<Vec<ComputedStyle<'a, '_>>, StylexError> {
+        match self {
+            PreRule::Null => Ok(vec![None]),
+            PreRule::Rule {
+                property,
+                value,
+                key_path,
+            } => {
+                // Condition lists stay in keyPath order; the sorted orders are
+                // derived inside the conversion, on its memo-miss path only.
+                let pseudos: Vec<&str> = key_path
+                    .iter()
+                    .filter(|k| k.starts_with(':') || k.starts_with('['))
+                    .map(Cow::as_ref)
+                    .collect();
+                let at_rules: Vec<&str> = key_path
+                    .iter()
+                    .filter(|k| k.starts_with('@'))
+                    .map(Cow::as_ref)
+                    .collect();
+                let const_rules: Vec<&str> = key_path
+                    .iter()
+                    .filter(|k| k.starts_with("var(--"))
+                    .map(Cow::as_ref)
+                    .collect();
+                let decl = convert_style_to_class_name(
+                    property,
+                    value,
+                    &pseudos,
+                    &at_rules,
+                    &const_rules,
+                    options,
+                )?;
+                Ok(vec![Some((decl, key_path.as_slice()))])
+            }
+            PreRule::Set(rules) => {
+                let mut tuples: Vec<ComputedStyle<'a, '_>> = Vec::new();
+                for rule in rules {
+                    tuples.extend(rule.compiled(options)?.into_iter().flatten().map(Some));
+                }
+                if tuples.is_empty() {
+                    Ok(vec![None])
+                } else {
+                    Ok(tuples)
+                }
+            }
+        }
+    }
+}
+
+// Upstream copies via `obj[key]=value`, so "__proto__" is a [[Set]]: primitives
+// vanish, objects become the prototype, array/null protos break isPlainObject.
+struct ProtoSplit<'a> {
+    own: Vec<(&'a str, &'a EvalValue)>,
+    proto: Option<&'a JsObjectMap>,
+    non_plain: bool,
+}
+
+fn proto_split(obj: &JsObjectMap) -> ProtoSplit<'_> {
+    let mut split = ProtoSplit {
+        own: Vec::with_capacity(obj.len()),
+        proto: None,
+        non_plain: false,
+    };
+    for (key, val) in obj.entries() {
+        if key == "__proto__" {
+            match val {
+                EvalValue::Obj(p) => split.proto = Some(p),
+                EvalValue::Null | EvalValue::Arr(_) => split.non_plain = true,
+                _ => {}
+            }
+        } else {
+            split.own.push((key, val));
+        }
+    }
+    // a non-plain link anywhere up the chain breaks the constructor lookup
+    if let Some(p) = split.proto
+        && proto_split(p).non_plain
+    {
+        split.non_plain = true;
+    }
+    split
+}
+
+// for..in order: own keys, then unshadowed prototype-chain keys.
+fn for_in_entries(obj: &JsObjectMap) -> Vec<(&str, &EvalValue)> {
+    let mut entries = Vec::new();
+    let mut cursor = Some(obj);
+    while let Some(map) = cursor {
+        let split = proto_split(map);
+        for (key, val) in split.own {
+            if !entries.iter().any(|(k, _)| *k == key) {
+                entries.push((key, val));
+            }
+        }
+        cursor = split.proto;
+    }
+    entries
+}
+
+fn is_plain(obj: &JsObjectMap) -> bool {
+    !proto_split(obj).non_plain
+}
+
+// parity: basic-validation.js validateNamespace
+pub fn validate_namespace(namespace: &EvalValue, conditions: &[String]) -> Result<(), StylexError> {
+    let EvalValue::Obj(ns) = namespace else {
+        return Err(StylexError::illegal_namespace_value());
+    };
+    if !is_plain(ns) {
+        return Err(StylexError::illegal_namespace_value());
+    }
+    for (key, val) in for_in_entries(ns) {
+        match val {
+            EvalValue::Null | EvalValue::Str(_) | EvalValue::Num(_) => {}
+            EvalValue::Arr(items) => {
+                for item in items {
+                    match item {
+                        EvalValue::Null | EvalValue::Str(_) | EvalValue::Num(_) => {}
+                        _ => return Err(StylexError::illegal_prop_array_value()),
+                    }
+                }
+            }
+            // isPlainObject gates the object branches; non-plain values fall
+            // through to ILLEGAL_PROP_VALUE exactly as upstream's last throw.
+            EvalValue::Obj(inner) if is_plain(inner) => {
+                if key.starts_with('@') || key.starts_with(':') || key.starts_with('[') {
+                    if conditions.iter().any(|c| c == key) {
+                        return Err(StylexError::duplicate_conditional());
+                    }
+                    let mut nested = conditions.to_vec();
+                    nested.push(key.to_string());
+                    validate_namespace(val, &nested)?;
+                } else {
+                    validate_conditional_styles(val, &[])?;
+                }
+            }
+            EvalValue::Obj(_) | EvalValue::Undefined | EvalValue::Bool(_) => {
+                return Err(StylexError::illegal_prop_value());
+            }
+        }
+    }
+    Ok(())
+}
+
+// parity: basic-validation.js validateConditionalStyles
+fn validate_conditional_styles(val: &EvalValue, conditions: &[String]) -> Result<(), StylexError> {
+    let EvalValue::Obj(obj) = val else {
+        unreachable!("callers only pass objects");
+    };
+    for (key, v) in for_in_entries(obj) {
+        if !(key.starts_with('@')
+            || key.starts_with(':')
+            || key.starts_with('[')
+            || key.starts_with("var(--")
+            || key == "default")
+        {
+            return Err(StylexError::invalid_pseudo_or_at_rule());
+        }
+        if conditions.iter().any(|c| c == key) {
+            return Err(StylexError::duplicate_conditional());
+        }
+        match v {
+            EvalValue::Null | EvalValue::Str(_) | EvalValue::Num(_) => {}
+            EvalValue::Arr(items) => {
+                // parity quirk: arrays inside conditions report ILLEGAL_PROP_VALUE,
+                // not ILLEGAL_PROP_ARRAY_VALUE.
+                for item in items {
+                    match item {
+                        EvalValue::Null | EvalValue::Str(_) | EvalValue::Num(_) => {}
+                        _ => return Err(StylexError::illegal_prop_value()),
+                    }
+                }
+            }
+            EvalValue::Obj(inner) if is_plain(inner) => {
+                let mut nested = conditions.to_vec();
+                nested.push(key.to_string());
+                validate_conditional_styles(v, &nested)?;
+            }
+            EvalValue::Obj(_) | EvalValue::Undefined | EvalValue::Bool(_) => {
+                return Err(StylexError::illegal_prop_value());
+            }
+        }
+    }
+    Ok(())
+}
+
+/// The `enableMediaQueryOrder` pre-pass: `Some(rebuilt)` when anything can
+/// change, so the caller can hold the rebuild and flatten borrows either way.
+pub fn media_order_transform(
+    style: &JsObjectMap,
+    options: &ResolvedOptions,
+) -> Result<Option<JsObjectMap>, StylexError> {
+    if options.enable_media_query_order && dfs_can_change(style, 0) {
+        Ok(Some(dfs_process_map(style, 0)?))
+    } else {
+        Ok(None)
+    }
+}
+
+pub fn flatten_raw_style_object<'a>(
+    style: &'a JsObjectMap,
+    options: &ResolvedOptions,
+) -> Result<Vec<(Cow<'a, str>, PreRule<'a>)>, StylexError> {
+    flatten_inner(style, &[], options)
+}
+
+/// Anything that would make `dfs_process_queries` differ from its input: a
+/// rewritable media key, a "__proto__" entry, or a CSSType brand it would drop.
+fn dfs_can_change(obj: &JsObjectMap, depth: usize) -> bool {
+    obj.css_type().is_some()
+        || obj.entries().any(|(key, val)| {
+            key == "__proto__"
+                || (depth >= 1 && is_media_key(key))
+                || matches!(val, EvalValue::Obj(inner) if dfs_can_change(inner, depth + 1))
+        })
+}
+
+// parity: style-value-parser media-query-transform.js dfsProcessQueries; the
+// delete+reinsert moves every rewritten @media key to the end of its siblings.
+// Map-in skips a redundant top-level deep clone the EvalValue wrapper needed.
+fn dfs_process_map(obj: &JsObjectMap, depth: usize) -> Result<JsObjectMap, StylexError> {
+    let mut result = JsObjectMap::new();
+    // Object.entries-style clone: own keys only — a "__proto__"-carried
+    // prototype (and its inherited entries) is stripped here, before flatten.
+    for (key, val) in proto_split(obj).own {
+        let processed = match val {
+            EvalValue::Obj(inner) => EvalValue::Obj(Arc::new(dfs_process_map(inner, depth + 1)?)),
+            other => other.clone(),
+        };
+        result.insert(key, processed);
+    }
+    if depth >= 1 {
+        let media_keys: Vec<String> = result
+            .keys()
+            .filter(|k| is_media_key(k))
+            .map(str::to_string)
+            .collect();
+        if !media_keys.is_empty() {
+            let rewritten = last_media_query_wins_transform(&media_keys).map_err(|e| match e {
+                MediaQueryError::Syntax(err) => err,
+                // Never claim upstream's syntax error for a form we cannot verify.
+                MediaQueryError::Unverified { input } => StylexError::unsupported_api(&format!(
+                    "media query `{input}` (unverified tokenizer form)"
+                )),
+            })?;
+            for (old_key, new_key) in media_keys.iter().zip(rewritten) {
+                let value = result.remove(old_key).expect("key collected from map");
+                result.insert(new_key, value);
+            }
+        }
+    }
+    Ok(result)
+}
+
+/// The unanchored `/var\(--[a-z0-9]+\)/` key unwrap in flatten-raw-style-obj.js:
+/// any key CONTAINING that pattern is sliced `[4..len-1]` wholesale.
+fn unwrap_var_key(key: &str) -> Cow<'_, str> {
+    let bytes = key.as_bytes();
+    let mut search = 0;
+    while let Some(pos) = key[search..].find("var(--") {
+        let start = search + pos;
+        let mut i = start + 6;
+        while i < bytes.len() && (bytes[i].is_ascii_lowercase() || bytes[i].is_ascii_digit()) {
+            i += 1;
+        }
+        if i > start + 6 && i < bytes.len() && bytes[i] == b')' {
+            // Upstream does key.slice(4, -1) in UTF-16 units regardless of
+            // where the match sits; byte slicing panics on multibyte keys.
+            return Cow::Owned(crate::jsrt::js_slice_utf16(key, 4, -1));
+        }
+        search = start + 1;
+    }
+    Cow::Borrowed(key)
+}
+
+fn js_truthy(scalar: &StyleScalar) -> bool {
+    match scalar {
+        StyleScalar::Str(s) => !s.is_empty(),
+        StyleScalar::Num(n) => *n != 0.0 && !n.is_nan(),
+        StyleScalar::Undefined => false,
+    }
+}
+
+fn same_value_zero(a: &StyleScalar, b: &StyleScalar) -> bool {
+    match (a, b) {
+        (StyleScalar::Str(x), StyleScalar::Str(y)) => x == y,
+        (StyleScalar::Num(x), StyleScalar::Num(y)) => x == y || (x.is_nan() && y.is_nan()),
+        (StyleScalar::Undefined, StyleScalar::Undefined) => true,
+        _ => false,
+    }
+}
+
+/// `None` is JS `null`; validation rejected every other non-scalar already.
+fn scalar_of<'a>(value: &'a EvalValue) -> Option<StyleScalar<'a>> {
+    match value {
+        EvalValue::Str(s) => Some(StyleScalar::Str(Cow::Borrowed(s))),
+        EvalValue::Num(n) => Some(StyleScalar::Num(*n)),
+        _ => None,
+    }
+}
+
+fn rule_key_path<'a>(
+    key_path: &[Cow<'a, str>],
+    includes_key: &str,
+    property: Cow<'a, str>,
+) -> Vec<Cow<'a, str>> {
+    if key_path.iter().any(|k| k == includes_key) {
+        key_path
+            .iter()
+            .map(|k| {
+                if k == includes_key {
+                    property.clone()
+                } else {
+                    k.clone()
+                }
+            })
+            .collect()
+    } else {
+        let mut path = key_path.to_vec();
+        path.push(property);
+        path
+    }
+}
+
+fn flatten_inner<'a>(
+    style: &'a JsObjectMap,
+    key_path: &[Cow<'a, str>],
+    options: &ResolvedOptions,
+) -> Result<Vec<(Cow<'a, str>, PreRule<'a>)>, StylexError> {
+    let mut flattened: Vec<(Cow<'a, str>, PreRule<'a>)> = Vec::new();
+    // for..in reach: prototype entries planted by "__proto__" keys stay
+    // visible here unless the media-query clone above already stripped them.
+    for (raw_key, value) in for_in_entries(style) {
+        let key: Cow<'a, str> = unwrap_var_key(raw_key);
+
+        match value {
+            EvalValue::Null | EvalValue::Str(_) | EvalValue::Num(_) => {
+                let scalar = scalar_of(value);
+                for (property, expanded) in
+                    flat_map_expanded_shorthands(key.clone(), scalar, false, options)?
+                {
+                    match expanded {
+                        None => flattened.push((property, PreRule::Null)),
+                        Some(expanded) => {
+                            let path = rule_key_path(key_path, &key, property.clone());
+                            flattened.push((
+                                property.clone(),
+                                PreRule::Rule {
+                                    property,
+                                    value: PreRuleValue::Single(expanded),
+                                    key_path: path,
+                                },
+                            ));
+                        }
+                    }
+                }
+            }
+            EvalValue::Arr(items) => {
+                // Fallback arrays: each element expands on its own, then the
+                // per-property value lists are merged in first-seen order.
+                let mut equivalent: Vec<(Cow<'a, str>, Vec<StyleScalar<'a>>)> = Vec::new();
+                for item in items {
+                    let scalar = scalar_of(item);
+                    for (property, expanded) in
+                        flat_map_expanded_shorthands(key.clone(), scalar, false, options)?
+                    {
+                        let slot = match equivalent.iter_mut().find(|(p, _)| *p == property) {
+                            Some(slot) => &mut slot.1,
+                            None => {
+                                equivalent.push((property, Vec::new()));
+                                &mut equivalent.last_mut().expect("just pushed").1
+                            }
+                        };
+                        if let Some(value) = expanded {
+                            slot.push(value);
+                        }
+                    }
+                }
+                for (property, values) in equivalent {
+                    let mut deduped: Vec<StyleScalar> = Vec::new();
+                    for value in values {
+                        if js_truthy(&value) && !deduped.iter().any(|d| same_value_zero(d, &value))
+                        {
+                            deduped.push(value);
+                        }
+                    }
+                    let pre_rule = match deduped.len() {
+                        0 => PreRule::Null,
+                        1 => PreRule::Rule {
+                            property: property.clone(),
+                            value: PreRuleValue::Single(deduped.into_iter().next().expect("len 1")),
+                            key_path: rule_key_path(key_path, raw_key, property.clone()),
+                        },
+                        _ => PreRule::Rule {
+                            property: property.clone(),
+                            value: PreRuleValue::Multi(deduped),
+                            key_path: rule_key_path(key_path, raw_key, property.clone()),
+                        },
+                    };
+                    flattened.push((property, pre_rule));
+                }
+            }
+            EvalValue::Obj(obj)
+                if !key.starts_with(':') && !key.starts_with('@') && !key.starts_with('[') =>
+            {
+                // Property-value objects, e.g. color: { default, ':hover' }.
+                let mut equivalent: ConditionGroups<'a> = Vec::new();
+                for (condition, inner_value) in for_in_entries(obj) {
+                    let nested_path: Vec<Cow<'a, str>> = if key_path.is_empty() {
+                        vec![key.clone(), Cow::Borrowed(condition)]
+                    } else {
+                        let mut p = key_path.to_vec();
+                        p.push(Cow::Borrowed(condition));
+                        p
+                    };
+                    for (property, pre_rule) in
+                        flatten_value_as_property(&key, inner_value, &nested_path, options)?
+                    {
+                        match equivalent.iter_mut().find(|(p, _)| *p == property) {
+                            Some((_, conds)) => {
+                                match conds.iter_mut().find(|(c, _)| *c == condition) {
+                                    Some((_, slot)) => *slot = pre_rule,
+                                    None => conds.push((condition, pre_rule)),
+                                }
+                            }
+                            None => equivalent.push((property, vec![(condition, pre_rule)])),
+                        }
+                    }
+                }
+                for (property, conds) in equivalent {
+                    let rules: Vec<PreRule> = conds.into_iter().map(|(_, r)| r).collect();
+                    flattened.push((property, PreRule::create_set(rules)));
+                }
+            }
+            EvalValue::Obj(obj) => {
+                // Pseudo / at-rule / attribute objects, e.g. ':hover': { … }.
+                let mut nested_path = key_path.to_vec();
+                nested_path.push(Cow::Borrowed(raw_key));
+                for (property, pre_rule) in flatten_inner(obj, &nested_path, options)? {
+                    flattened.push((Cow::Owned(format!("{key}_{property}")), pre_rule));
+                }
+            }
+            // Upstream's flatten silently skips other types (validation ran first).
+            EvalValue::Undefined | EvalValue::Bool(_) => {}
+        }
+    }
+    Ok(flattened)
+}
+
+/// The property-value-object recursion, without upstream's intermediate
+/// `{key: value}` object: identical to flatten_inner on that single-key map.
+fn flatten_value_as_property<'a>(
+    key: &Cow<'a, str>,
+    value: &'a EvalValue,
+    nested_path: &[Cow<'a, str>],
+    options: &ResolvedOptions,
+) -> Result<Vec<(Cow<'a, str>, PreRule<'a>)>, StylexError> {
+    match value {
+        EvalValue::Null | EvalValue::Str(_) | EvalValue::Num(_) => {
+            let scalar = scalar_of(value);
+            let mut out = Vec::new();
+            for (property, expanded) in
+                flat_map_expanded_shorthands(key.clone(), scalar, false, options)?
+            {
+                match expanded {
+                    None => out.push((property, PreRule::Null)),
+                    Some(expanded) => {
+                        let path = rule_key_path(nested_path, key, property.clone());
+                        out.push((
+                            property.clone(),
+                            PreRule::Rule {
+                                property,
+                                value: PreRuleValue::Single(expanded),
+                                key_path: path,
+                            },
+                        ));
+                    }
+                }
+            }
+            Ok(out)
+        }
+        EvalValue::Arr(items) => {
+            let mut equivalent: Vec<(Cow<'a, str>, Vec<StyleScalar<'a>>)> = Vec::new();
+            for item in items {
+                let scalar = scalar_of(item);
+                for (property, expanded) in
+                    flat_map_expanded_shorthands(key.clone(), scalar, false, options)?
+                {
+                    let slot = match equivalent.iter_mut().find(|(p, _)| *p == property) {
+                        Some(slot) => &mut slot.1,
+                        None => {
+                            equivalent.push((property, Vec::new()));
+                            &mut equivalent.last_mut().expect("just pushed").1
+                        }
+                    };
+                    if let Some(value) = expanded {
+                        slot.push(value);
+                    }
+                }
+            }
+            let mut out = Vec::new();
+            for (property, values) in equivalent {
+                let mut deduped: Vec<StyleScalar> = Vec::new();
+                for value in values {
+                    if js_truthy(&value) && !deduped.iter().any(|d| same_value_zero(d, &value)) {
+                        deduped.push(value);
+                    }
+                }
+                let pre_rule = match deduped.len() {
+                    0 => PreRule::Null,
+                    1 => PreRule::Rule {
+                        property: property.clone(),
+                        value: PreRuleValue::Single(deduped.into_iter().next().expect("len 1")),
+                        key_path: rule_key_path(nested_path, key, property.clone()),
+                    },
+                    _ => PreRule::Rule {
+                        property: property.clone(),
+                        value: PreRuleValue::Multi(deduped),
+                        key_path: rule_key_path(nested_path, key, property.clone()),
+                    },
+                };
+                out.push((property, pre_rule));
+            }
+            Ok(out)
+        }
+        // Deeper nesting (condition inside a property-value object): group by
+        // property and condition into per-property sets, exactly the
+        // property-value branch's shape one level down.
+        EvalValue::Obj(obj) => {
+            let mut out = Vec::new();
+            let mut equivalent: ConditionGroups<'a> = Vec::new();
+            for (condition, inner) in for_in_entries(obj) {
+                let mut p = nested_path.to_vec();
+                p.push(Cow::Borrowed(condition));
+                for (property, pre_rule) in flatten_value_as_property(key, inner, &p, options)? {
+                    match equivalent.iter_mut().find(|(pr, _)| *pr == property) {
+                        Some((_, conds)) => match conds.iter_mut().find(|(c, _)| *c == condition) {
+                            Some((_, slot)) => *slot = pre_rule,
+                            None => conds.push((condition, pre_rule)),
+                        },
+                        None => equivalent.push((property, vec![(condition, pre_rule)])),
+                    }
+                }
+            }
+            for (property, conds) in equivalent {
+                let rules: Vec<PreRule> = conds.into_iter().map(|(_, r)| r).collect();
+                out.push((property, PreRule::create_set(rules)));
+            }
+            Ok(out)
+        }
+        EvalValue::Undefined | EvalValue::Bool(_) => Ok(Vec::new()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unwrap_var_key_matches_upstream_regex() {
+        assert_eq!(unwrap_var_key("var(--abc)"), Cow::Borrowed("--abc"));
+        assert_eq!(unwrap_var_key("var(--abc123)"), Cow::Borrowed("--abc123"));
+        // Uppercase var names do not match the flatten-level regex.
+        assert_eq!(
+            unwrap_var_key("var(--myVar)"),
+            Cow::Borrowed("var(--myVar)")
+        );
+        assert_eq!(unwrap_var_key("var(--abc"), Cow::Borrowed("var(--abc"));
+        assert_eq!(unwrap_var_key("var(--)"), Cow::Borrowed("var(--)"));
+        // Unanchored match slices the whole key.
+        assert_eq!(
+            unwrap_var_key("xxvar(--ab)yy"),
+            Cow::<str>::Owned("r(--ab)y".to_string())
+        );
+        assert_eq!(unwrap_var_key("color"), Cow::Borrowed("color"));
+    }
+}

--- a/crates/stylex/src/shared/flatten.rs
+++ b/crates/stylex/src/shared/flatten.rs
@@ -31,7 +31,7 @@ pub enum PreRule<'a> {
     Rule {
         property: Cow<'a, str>,
         value: PreRuleValue<'a>,
-        key_path: Vec<Cow<'a, str>>,
+        key_path: Option<Box<[Cow<'a, str>]>>,
     },
     Set(Vec<PreRule<'a>>),
 }
@@ -75,6 +75,9 @@ impl<'a> PreRule<'a> {
                 value,
                 key_path,
             } => {
+                let key_path = key_path
+                    .as_deref()
+                    .unwrap_or_else(|| std::slice::from_ref(property));
                 let decl = convert_style_to_class_name(property, value, key_path, options)?;
                 f(decl, key_path);
                 Ok(())
@@ -379,8 +382,11 @@ fn rule_key_path<'a>(
     key_path: &[Cow<'a, str>],
     includes_key: &str,
     property: Cow<'a, str>,
-) -> Vec<Cow<'a, str>> {
-    if key_path.iter().any(|k| k == includes_key) {
+) -> Option<Box<[Cow<'a, str>]>> {
+    if key_path.is_empty() {
+        return None;
+    }
+    Some(if key_path.iter().any(|k| k == includes_key) {
         key_path
             .iter()
             .map(|k| {
@@ -395,8 +401,8 @@ fn rule_key_path<'a>(
         let mut path = Vec::with_capacity(key_path.len() + 1);
         path.extend_from_slice(key_path);
         path.push(property);
-        path
-    }
+        path.into_boxed_slice()
+    })
 }
 
 fn flatten_inner<'a>(

--- a/crates/stylex/src/shared/generate_rule.rs
+++ b/crates/stylex/src/shared/generate_rule.rs
@@ -1,0 +1,482 @@
+//! Style entry → className + injectable CSS rule.
+// parity: babel-plugin src/shared/utils/{convert-to-className,generate-css-rule}.js
+
+use crate::errors::StylexError;
+use crate::fxhash::FxHashMap;
+use crate::hash::hash;
+use crate::options::ResolvedOptions;
+use crate::rules::StylexRule;
+use crate::shared::dashify::dashed_key;
+use crate::shared::fallbacks::{has_var_fallback, variable_fallbacks};
+use crate::shared::flatten::{PreRuleValue, StyleScalar};
+use crate::shared::normalize_value::CssValueError;
+use crate::shared::priorities::get_priority;
+use crate::shared::pseudo_sort::{sort_at_rules, sort_pseudos};
+use crate::shared::rtl::{RtlContext, generate_ltr, generate_rtl};
+use crate::shared::transform_value::{transform_value_num, transform_value_str};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+fn css_value_error(e: CssValueError) -> StylexError {
+    match e {
+        CssValueError::UnclosedFunction => StylexError::unclosed_function(),
+        CssValueError::UnclosedString => StylexError::unclosed_string(),
+        CssValueError::EmptyValue => StylexError::empty_value(),
+    }
+}
+
+fn transform_scalar(
+    key: &str,
+    scalar: &StyleScalar,
+    font_size_px_to_rem: bool,
+) -> Result<String, StylexError> {
+    match scalar {
+        StyleScalar::Str(s) => {
+            transform_value_str(key, s.as_ref(), font_size_px_to_rem).map_err(css_value_error)
+        }
+        StyleScalar::Num(n) => {
+            transform_value_num(key, *n, font_size_px_to_rem).map_err(css_value_error)
+        }
+        // normalizeValue short-circuits on nullish, so the declaration is empty.
+        StyleScalar::Undefined => Ok(String::new()),
+    }
+}
+
+/// One compiled declaration, memo-shared behind `Rc`: a hit is a refcount bump.
+pub type CompiledDecl = Rc<StylexRule>;
+
+struct ConvertMemo {
+    key: String,
+    map: FxHashMap<String, CompiledDecl>,
+}
+
+thread_local! {
+    static CONVERT_MEMO: RefCell<ConvertMemo> = RefCell::new(ConvertMemo {
+        key: String::new(),
+        map: FxHashMap::default(),
+    });
+}
+
+const CONVERT_MEMO_CAP: usize = 1 << 16;
+
+/// Length-prefixed segments with fixed `|` section breaks: injective, so equal
+/// keys mean equal inputs.
+fn push_memo_part(key: &mut String, part: &str) {
+    let mut buf = [0u8; 20];
+    let mut n = part.len();
+    let mut i = buf.len();
+    loop {
+        i -= 1;
+        buf[i] = b'0' + (n % 10) as u8;
+        n /= 10;
+        if n == 0 {
+            break;
+        }
+    }
+    key.push_str(str::from_utf8(&buf[i..]).expect("ascii digits"));
+    key.push(':');
+    key.push_str(part);
+}
+
+fn push_memo_scalar(key: &mut String, scalar: &StyleScalar) {
+    match scalar {
+        StyleScalar::Str(s) => {
+            key.push('s');
+            push_memo_part(key, s);
+        }
+        StyleScalar::Num(n) => {
+            const HEX: &[u8; 16] = b"0123456789abcdef";
+            let bits = n.to_bits();
+            let mut buf = [0u8; 16];
+            for (j, b) in buf.iter_mut().enumerate() {
+                *b = HEX[((bits >> (60 - j * 4)) & 0xf) as usize];
+            }
+            key.push('n');
+            key.push_str(str::from_utf8(&buf).expect("ascii digits"));
+        }
+        StyleScalar::Undefined => key.push('u'),
+    }
+}
+
+// The fingerprint covers every option the uncached path reads: px-to-rem,
+// debug class names + prefix, and the three RtlContext fields.
+fn encode_memo_key(
+    key: &mut String,
+    property: &str,
+    value: &PreRuleValue<'_>,
+    pseudos: &[&str],
+    at_rules: &[&str],
+    const_rules: &[&str],
+    options: &ResolvedOptions,
+) {
+    key.push(if options.enable_font_size_px_to_rem {
+        'R'
+    } else {
+        'r'
+    });
+    key.push(if options.debug && options.enable_debug_class_names {
+        'D'
+    } else {
+        'd'
+    });
+    key.push(match options.style_resolution {
+        crate::options::StyleResolution::PropertySpecificity => 'p',
+        crate::options::StyleResolution::ApplicationOrder => 'a',
+        crate::options::StyleResolution::LegacyExpandShorthands => 'l',
+    });
+    key.push(if options.enable_logical_styles_polyfill {
+        'L'
+    } else {
+        'g'
+    });
+    key.push(if options.enable_legacy_value_flipping {
+        'F'
+    } else {
+        'f'
+    });
+    push_memo_part(key, &options.class_name_prefix);
+    key.push('|');
+    push_memo_part(key, property);
+    key.push('|');
+    match value {
+        PreRuleValue::Single(scalar) => {
+            key.push('S');
+            push_memo_scalar(key, scalar);
+        }
+        PreRuleValue::Multi(scalars) => {
+            key.push('M');
+            for scalar in scalars {
+                push_memo_scalar(key, scalar);
+            }
+        }
+    }
+    for list in [pseudos, at_rules, const_rules] {
+        key.push('|');
+        for item in list {
+            push_memo_part(key, item);
+        }
+    }
+}
+
+/// `pseudos`/`at_rules`/`const_rules` arrive in keyPath order; sorting for the
+/// hash input and selector happens here, on the miss path only.
+pub fn convert_style_to_class_name(
+    property: &str,
+    value: &PreRuleValue<'_>,
+    pseudos: &[&str],
+    at_rules: &[&str],
+    const_rules: &[&str],
+    options: &ResolvedOptions,
+) -> Result<CompiledDecl, StylexError> {
+    CONVERT_MEMO.with(|memo| {
+        let mut memo = memo.borrow_mut();
+        let ConvertMemo { key, map } = &mut *memo;
+        key.clear();
+        encode_memo_key(
+            key,
+            property,
+            value,
+            pseudos,
+            at_rules,
+            const_rules,
+            options,
+        );
+        if let Some(hit) = map.get(key.as_str()) {
+            return Ok(Rc::clone(hit));
+        }
+        let computed = Rc::new(convert_style_to_class_name_uncached(
+            property,
+            value,
+            pseudos,
+            at_rules,
+            const_rules,
+            options,
+        )?);
+        if map.len() >= CONVERT_MEMO_CAP {
+            map.clear();
+        }
+        map.insert(key.clone(), Rc::clone(&computed));
+        Ok(computed)
+    })
+}
+
+fn convert_style_to_class_name_uncached(
+    property: &str,
+    value: &PreRuleValue<'_>,
+    pseudos: &[&str],
+    at_rules: &[&str],
+    const_rules: &[&str],
+    options: &ResolvedOptions,
+) -> Result<StylexRule, StylexError> {
+    // Upstream evaluates the sorting PreRule.pseudos/atRules getters as call
+    // arguments, so a collation error precedes any value-normalization error.
+    let sorted_pseudos = sort_pseudos(pseudos)?;
+    let sorted_at_rules = sort_at_rules(at_rules);
+    let mut at_and_const = sorted_at_rules.clone();
+    at_and_const.extend(const_rules.iter().copied());
+    let sorted_at_and_const = sort_at_rules(&at_and_const);
+
+    let dashed = dashed_key(property);
+
+    let px_to_rem = options.enable_font_size_px_to_rem;
+    let (values, is_array) = match value {
+        PreRuleValue::Single(scalar) => {
+            (vec![transform_scalar(property, scalar, px_to_rem)?], false)
+        }
+        PreRuleValue::Multi(scalars) => (
+            scalars
+                .iter()
+                .map(|s| transform_scalar(property, s, px_to_rem))
+                .collect::<Result<Vec<_>, _>>()?,
+            true,
+        ),
+    };
+    let values = if is_array && has_var_fallback(&values) {
+        variable_fallbacks(&values)?
+    } else {
+        values
+    };
+
+    // The hash concatenates with `+` (so a JS `undefined` stringifies) while
+    // the declaration is built with `Array.join`, which renders it empty.
+    let hash_values: Vec<&str> = match value {
+        PreRuleValue::Single(StyleScalar::Undefined) => vec!["undefined"],
+        _ => values.iter().map(String::as_str).collect(),
+    };
+
+    // parity: the '<>' prefix and 'null' modifier keep upstream hashes stable;
+    // built in place, byte-for-byte `<>{dashed}{values.join(", ")}{modifier}`.
+    let modifier_len: usize = sorted_pseudos.iter().map(|s| s.len()).sum::<usize>()
+        + sorted_at_and_const.iter().map(|s| s.len()).sum::<usize>();
+    let mut hash_input = String::with_capacity(
+        2 + dashed.len()
+            + hash_values.iter().map(|v| v.len() + 2).sum::<usize>()
+            + modifier_len.max(4),
+    );
+    hash_input.push_str("<>");
+    hash_input.push_str(&dashed);
+    for (i, v) in hash_values.iter().enumerate() {
+        if i > 0 {
+            hash_input.push_str(", ");
+        }
+        hash_input.push_str(v);
+    }
+    if modifier_len == 0 {
+        hash_input.push_str("null");
+    } else {
+        for p in &sorted_pseudos {
+            hash_input.push_str(p);
+        }
+        for a in &sorted_at_and_const {
+            hash_input.push_str(a);
+        }
+    }
+    let hashed = hash(&hash_input);
+    let class_name: std::sync::Arc<str> = if options.debug && options.enable_debug_class_names {
+        format!("{property}-{}{hashed}", options.class_name_prefix).into()
+    } else {
+        format!("{}{hashed}", options.class_name_prefix).into()
+    };
+
+    let rule = generate_css_rule(
+        &class_name,
+        &dashed,
+        &values,
+        &sorted_pseudos,
+        &sorted_at_rules,
+        const_rules,
+        RtlContext::of(options),
+    );
+    Ok(rule)
+}
+
+pub fn generate_css_rule(
+    class_name: &str,
+    key: &str,
+    values: &[String],
+    pseudos: &[&str],
+    at_rules: &[&str],
+    const_rules: &[&str],
+    ctx: RtlContext,
+) -> StylexRule {
+    let mut ltr_decls = String::with_capacity(
+        values
+            .iter()
+            .map(|v| key.len() + v.len() + 2)
+            .sum::<usize>(),
+    );
+    for (i, v) in values.iter().enumerate() {
+        if i > 0 {
+            ltr_decls.push(';');
+        }
+        let (k, v) = generate_ltr(key, v, ctx);
+        ltr_decls.push_str(&k);
+        ltr_decls.push(':');
+        ltr_decls.push_str(&v);
+    }
+    let mut rtl_decls = String::new();
+    for v in values {
+        if let Some((k, v)) = generate_rtl(key, v, ctx) {
+            if !rtl_decls.is_empty() {
+                rtl_decls.push(';');
+            }
+            rtl_decls.push_str(&k);
+            rtl_decls.push(':');
+            rtl_decls.push_str(&v);
+        }
+    }
+
+    let ltr = build_nested_css_rule(class_name, &ltr_decls, pseudos, at_rules, const_rules);
+    let rtl = if rtl_decls.is_empty() {
+        None
+    } else {
+        Some(build_nested_css_rule(
+            class_name,
+            &rtl_decls,
+            pseudos,
+            at_rules,
+            const_rules,
+        ))
+    };
+
+    let priority = get_priority(key)
+        + pseudos.iter().map(|p| get_priority(p)).sum::<f64>()
+        + at_rules.iter().map(|a| get_priority(a)).sum::<f64>()
+        + const_rules.iter().map(|c| get_priority(c)).sum::<f64>();
+
+    StylexRule {
+        class_name: class_name.into(),
+        ltr: ltr.into(),
+        rtl: rtl.map(Into::into),
+        const_key: None,
+        const_val: None,
+        priority,
+    }
+}
+
+const THUMB_VARIANTS: [&str; 3] = [
+    "::-webkit-slider-thumb",
+    "::-moz-range-thumb",
+    "::-ms-thumb",
+];
+
+// parity: generate-css-rule.js buildNestedCSSRule
+fn build_nested_css_rule(
+    class_name: &str,
+    decls: &str,
+    pseudos: &[&str],
+    at_rules: &[&str],
+    const_rules: &[&str],
+) -> String {
+    // Pseudo-classes before pseudo-elements, insertion order within each —
+    // the two-buffer concat of upstream, built as one string in two passes.
+    let mut pseudo = String::new();
+    for p in pseudos {
+        if *p != "::thumb" && !p.starts_with("::") {
+            pseudo.push_str(p);
+        }
+    }
+    for p in pseudos {
+        if *p != "::thumb" && p.starts_with("::") {
+            pseudo.push_str(p);
+        }
+    }
+    let combined_len = at_rules.len() + const_rules.len();
+
+    let class_copies = 1 + usize::from(pseudo.contains(":where(")) + combined_len;
+    let mut selector = String::with_capacity(class_copies * (class_name.len() + 1) + pseudo.len());
+    for _ in 0..class_copies {
+        selector.push('.');
+        selector.push_str(class_name);
+    }
+    selector.push_str(&pseudo);
+    if pseudos.contains(&"::thumb") {
+        selector = THUMB_VARIANTS
+            .iter()
+            .map(|suffix| format!("{selector}{suffix}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+    }
+
+    // Nesting parity: iterating at_rules then const_rules and wrapping each
+    // time leaves the last-iterated outermost; emit them reversed in one pass.
+    let wrappers = at_rules.iter().chain(const_rules.iter());
+    let mut rule = String::with_capacity(
+        selector.len() + decls.len() + 2 + wrappers.clone().map(|w| w.len() + 2).sum::<usize>(),
+    );
+    for at_rule in wrappers.rev() {
+        rule.push_str(at_rule);
+        rule.push('{');
+    }
+    rule.push_str(&selector);
+    rule.push('{');
+    rule.push_str(decls);
+    rule.push('}');
+    for _ in 0..combined_len {
+        rule.push('}');
+    }
+    rule
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn defaults() -> ResolvedOptions {
+        ResolvedOptions::default()
+    }
+
+    #[test]
+    fn known_answer_color_red() {
+        let decl = convert_style_to_class_name(
+            "color",
+            &PreRuleValue::Single(StyleScalar::Str(std::borrow::Cow::Borrowed("red"))),
+            &[],
+            &[],
+            &[],
+            &defaults(),
+        )
+        .unwrap();
+        assert_eq!(&*decl.class_name, "x1e2nbdu");
+        assert_eq!(&*decl.ltr, ".x1e2nbdu{color:red}");
+        assert_eq!(decl.rtl, None);
+        assert_eq!(decl.priority, 3000.0);
+    }
+
+    #[test]
+    fn thumb_and_where_selector_shapes() {
+        let decl = convert_style_to_class_name(
+            "width",
+            &PreRuleValue::Single(StyleScalar::Num(16.0)),
+            &[":hover", "::thumb"],
+            &[],
+            &[],
+            &defaults(),
+        )
+        .unwrap();
+        assert_eq!(
+            &*decl.ltr,
+            format!(
+                ".{c}:hover::-webkit-slider-thumb, .{c}:hover::-moz-range-thumb, .{c}:hover::-ms-thumb{{width:16px}}",
+                c = decl.class_name
+            )
+        );
+        assert_eq!(decl.priority, 9130.0);
+
+        let decl = convert_style_to_class_name(
+            "color",
+            &PreRuleValue::Single(StyleScalar::Str(std::borrow::Cow::Borrowed("blue"))),
+            &[":where(.x-default-marker:hover *)"],
+            &[],
+            &[],
+            &defaults(),
+        )
+        .unwrap();
+        assert_eq!(&*decl.class_name, "xobp4yc");
+        assert_eq!(
+            &*decl.ltr,
+            ".xobp4yc.xobp4yc:where(.x-default-marker:hover *){color:blue}"
+        );
+        assert_eq!(decl.priority, 3011.3);
+    }
+}

--- a/crates/stylex/src/shared/generate_rule.rs
+++ b/crates/stylex/src/shared/generate_rule.rs
@@ -14,8 +14,11 @@ use crate::shared::priorities::get_priority;
 use crate::shared::pseudo_sort::{sort_at_rules, sort_pseudos};
 use crate::shared::rtl::{RtlContext, generate_ltr, generate_rtl};
 use crate::shared::transform_value::{transform_value_num, transform_value_str};
+use std::borrow::Cow;
 use std::cell::RefCell;
+use std::hash::{BuildHasher, BuildHasherDefault};
 use std::rc::Rc;
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
 fn css_value_error(e: CssValueError) -> StylexError {
     match e {
@@ -47,7 +50,7 @@ pub type CompiledDecl = Rc<StylexRule>;
 
 struct ConvertMemo {
     key: String,
-    map: FxHashMap<String, CompiledDecl>,
+    map: FxHashMap<Arc<str>, CompiledDecl>,
 }
 
 thread_local! {
@@ -58,6 +61,35 @@ thread_local! {
 }
 
 const CONVERT_MEMO_CAP: usize = 1 << 16;
+const SHARD_COUNT: usize = 64;
+const SHARD_CAP: usize = CONVERT_MEMO_CAP / SHARD_COUNT;
+
+type SharedMemo = FxHashMap<Arc<str>, StylexRule>;
+
+// Second level behind the thread-local memo: worker pools (batch threads, oj's
+// blocking pool) otherwise recompute every declaration once per thread.
+static SHARED_MEMO: [Mutex<SharedMemo>; SHARD_COUNT] =
+    [const { Mutex::new(FxHashMap::with_hasher(BuildHasherDefault::new())) }; SHARD_COUNT];
+
+// Threads never share a rule's `Arc<str>`s: every registry clone/drop would
+// then bounce the refcount line between cores (+20% create time at 18 threads).
+fn private_copy(rule: &StylexRule) -> StylexRule {
+    StylexRule {
+        class_name: Arc::from(&*rule.class_name),
+        ltr: Arc::from(&*rule.ltr),
+        rtl: rule.rtl.as_deref().map(Arc::from),
+        const_key: rule.const_key.as_deref().map(Arc::from),
+        const_val: rule.const_val.clone(),
+        priority: rule.priority,
+    }
+}
+
+fn shard_for(key: &str) -> MutexGuard<'static, SharedMemo> {
+    let hash = BuildHasherDefault::<crate::fxhash::FxHasher>::new().hash_one(key);
+    SHARED_MEMO[(hash >> (64 - SHARD_COUNT.trailing_zeros())) as usize]
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+}
 
 /// Length-prefixed segments with fixed `|` section breaks: injective, so equal
 /// keys mean equal inputs.
@@ -98,15 +130,36 @@ fn push_memo_scalar(key: &mut String, scalar: &StyleScalar) {
     }
 }
 
+// The keyPath carries the property too; the three condition classes are
+// disjoint prefix families, so each list is a filter over the same slice.
+fn pseudos_of<'k>(key_path: &'k [Cow<'_, str>]) -> impl Iterator<Item = &'k str> {
+    key_path
+        .iter()
+        .map(Cow::as_ref)
+        .filter(|k| k.starts_with(':') || k.starts_with('['))
+}
+
+fn at_rules_of<'k>(key_path: &'k [Cow<'_, str>]) -> impl Iterator<Item = &'k str> {
+    key_path
+        .iter()
+        .map(Cow::as_ref)
+        .filter(|k| k.starts_with('@'))
+}
+
+fn const_rules_of<'k>(key_path: &'k [Cow<'_, str>]) -> impl Iterator<Item = &'k str> {
+    key_path
+        .iter()
+        .map(Cow::as_ref)
+        .filter(|k| k.starts_with("var(--"))
+}
+
 // The fingerprint covers every option the uncached path reads: px-to-rem,
 // debug class names + prefix, and the three RtlContext fields.
 fn encode_memo_key(
     key: &mut String,
     property: &str,
     value: &PreRuleValue<'_>,
-    pseudos: &[&str],
-    at_rules: &[&str],
-    const_rules: &[&str],
+    key_path: &[Cow<'_, str>],
     options: &ResolvedOptions,
 ) {
     key.push(if options.enable_font_size_px_to_rem {
@@ -150,52 +203,69 @@ fn encode_memo_key(
             }
         }
     }
-    for list in [pseudos, at_rules, const_rules] {
-        key.push('|');
-        for item in list {
-            push_memo_part(key, item);
-        }
+    key.push('|');
+    for item in pseudos_of(key_path) {
+        push_memo_part(key, item);
+    }
+    key.push('|');
+    for item in at_rules_of(key_path) {
+        push_memo_part(key, item);
+    }
+    key.push('|');
+    for item in const_rules_of(key_path) {
+        push_memo_part(key, item);
     }
 }
 
-/// `pseudos`/`at_rules`/`const_rules` arrive in keyPath order; sorting for the
-/// hash input and selector happens here, on the miss path only.
+/// Conditions are read from `key_path` in keyPath order; sorting for the hash
+/// input and selector happens here, on the miss path only.
 pub fn convert_style_to_class_name(
     property: &str,
     value: &PreRuleValue<'_>,
-    pseudos: &[&str],
-    at_rules: &[&str],
-    const_rules: &[&str],
+    key_path: &[Cow<'_, str>],
     options: &ResolvedOptions,
 ) -> Result<CompiledDecl, StylexError> {
     CONVERT_MEMO.with(|memo| {
         let mut memo = memo.borrow_mut();
         let ConvertMemo { key, map } = &mut *memo;
         key.clear();
-        encode_memo_key(
-            key,
-            property,
-            value,
-            pseudos,
-            at_rules,
-            const_rules,
-            options,
-        );
+        encode_memo_key(key, property, value, key_path, options);
         if let Some(hit) = map.get(key.as_str()) {
             return Ok(Rc::clone(hit));
         }
-        let computed = Rc::new(convert_style_to_class_name_uncached(
-            property,
-            value,
-            pseudos,
-            at_rules,
-            const_rules,
-            options,
-        )?);
+        let shared = shard_for(key)
+            .get_key_value(key.as_str())
+            .map(|(k, v)| (Arc::clone(k), private_copy(v)));
+        let (shared_key, rule) = match shared {
+            Some(hit) => hit,
+            None => {
+                let pseudos: Vec<&str> = pseudos_of(key_path).collect();
+                let at_rules: Vec<&str> = at_rules_of(key_path).collect();
+                let const_rules: Vec<&str> = const_rules_of(key_path).collect();
+                let rule = convert_style_to_class_name_uncached(
+                    property,
+                    value,
+                    &pseudos,
+                    &at_rules,
+                    &const_rules,
+                    options,
+                )?;
+                let shared_key: Arc<str> = Arc::from(key.as_str());
+                let mut shard = shard_for(key);
+                if shard.len() >= SHARD_CAP {
+                    shard.clear();
+                }
+                shard
+                    .entry(Arc::clone(&shared_key))
+                    .or_insert_with(|| private_copy(&rule));
+                (shared_key, rule)
+            }
+        };
+        let computed = Rc::new(rule);
         if map.len() >= CONVERT_MEMO_CAP {
             map.clear();
         }
-        map.insert(key.clone(), Rc::clone(&computed));
+        map.insert(shared_key, Rc::clone(&computed));
         Ok(computed)
     })
 }
@@ -430,9 +500,7 @@ mod tests {
     fn known_answer_color_red() {
         let decl = convert_style_to_class_name(
             "color",
-            &PreRuleValue::Single(StyleScalar::Str(std::borrow::Cow::Borrowed("red"))),
-            &[],
-            &[],
+            &PreRuleValue::Single(StyleScalar::Str(Cow::Borrowed("red"))),
             &[],
             &defaults(),
         )
@@ -448,9 +516,7 @@ mod tests {
         let decl = convert_style_to_class_name(
             "width",
             &PreRuleValue::Single(StyleScalar::Num(16.0)),
-            &[":hover", "::thumb"],
-            &[],
-            &[],
+            &[Cow::Borrowed(":hover"), Cow::Borrowed("::thumb")],
             &defaults(),
         )
         .unwrap();
@@ -465,10 +531,8 @@ mod tests {
 
         let decl = convert_style_to_class_name(
             "color",
-            &PreRuleValue::Single(StyleScalar::Str(std::borrow::Cow::Borrowed("blue"))),
-            &[":where(.x-default-marker:hover *)"],
-            &[],
-            &[],
+            &PreRuleValue::Single(StyleScalar::Str(Cow::Borrowed("blue"))),
+            &[Cow::Borrowed(":where(.x-default-marker:hover *)")],
             &defaults(),
         )
         .unwrap();

--- a/crates/stylex/src/shared/generate_rule.rs
+++ b/crates/stylex/src/shared/generate_rule.rs
@@ -239,6 +239,7 @@ pub fn convert_style_to_class_name(
         let (shared_key, rule) = match shared {
             Some(hit) => hit,
             None => {
+                let _t = crate::timings::start(crate::timings::Stage::CreateMiss);
                 let pseudos: Vec<&str> = pseudos_of(key_path).collect();
                 let at_rules: Vec<&str> = at_rules_of(key_path).collect();
                 let const_rules: Vec<&str> = const_rules_of(key_path).collect();
@@ -282,54 +283,65 @@ fn convert_style_to_class_name_uncached(
     // arguments, so a collation error precedes any value-normalization error.
     let sorted_pseudos = sort_pseudos(pseudos)?;
     let sorted_at_rules = sort_at_rules(at_rules);
-    let mut at_and_const = sorted_at_rules.clone();
-    at_and_const.extend(const_rules.iter().copied());
-    let sorted_at_and_const = sort_at_rules(&at_and_const);
+    // A stable sort of an already sorted list is that list: the const-free
+    // case reads the at-rule order as is.
+    let sorted_at_and_const: Cow<[&str]> = if const_rules.is_empty() {
+        Cow::Borrowed(&sorted_at_rules)
+    } else {
+        let mut at_and_const = sorted_at_rules.clone();
+        at_and_const.extend(const_rules.iter().copied());
+        Cow::Owned(sort_at_rules(&at_and_const))
+    };
 
     let dashed = dashed_key(property);
 
     let px_to_rem = options.enable_font_size_px_to_rem;
-    let (values, is_array) = match value {
+    let single;
+    let multi;
+    let mut values: &[String] = match value {
         PreRuleValue::Single(scalar) => {
-            (vec![transform_scalar(property, scalar, px_to_rem)?], false)
+            single = transform_scalar(property, scalar, px_to_rem)?;
+            std::slice::from_ref(&single)
         }
-        PreRuleValue::Multi(scalars) => (
-            scalars
+        PreRuleValue::Multi(scalars) => {
+            multi = scalars
                 .iter()
                 .map(|s| transform_scalar(property, s, px_to_rem))
-                .collect::<Result<Vec<_>, _>>()?,
-            true,
-        ),
+                .collect::<Result<Vec<_>, _>>()?;
+            &multi
+        }
     };
-    let values = if is_array && has_var_fallback(&values) {
-        variable_fallbacks(&values)?
-    } else {
-        values
-    };
+    let fallbacks;
+    if matches!(value, PreRuleValue::Multi(_)) && has_var_fallback(values) {
+        fallbacks = variable_fallbacks(values)?;
+        values = &fallbacks;
+    }
 
     // The hash concatenates with `+` (so a JS `undefined` stringifies) while
     // the declaration is built with `Array.join`, which renders it empty.
-    let hash_values: Vec<&str> = match value {
-        PreRuleValue::Single(StyleScalar::Undefined) => vec!["undefined"],
-        _ => values.iter().map(String::as_str).collect(),
+    let undefined_single = matches!(value, PreRuleValue::Single(StyleScalar::Undefined));
+    let values_len: usize = if undefined_single {
+        "undefined".len()
+    } else {
+        values.iter().map(|v| v.len() + 2).sum()
     };
 
     // parity: the '<>' prefix and 'null' modifier keep upstream hashes stable;
     // built in place, byte-for-byte `<>{dashed}{values.join(", ")}{modifier}`.
     let modifier_len: usize = sorted_pseudos.iter().map(|s| s.len()).sum::<usize>()
         + sorted_at_and_const.iter().map(|s| s.len()).sum::<usize>();
-    let mut hash_input = String::with_capacity(
-        2 + dashed.len()
-            + hash_values.iter().map(|v| v.len() + 2).sum::<usize>()
-            + modifier_len.max(4),
-    );
+    let mut hash_input = String::with_capacity(2 + dashed.len() + values_len + modifier_len.max(4));
     hash_input.push_str("<>");
     hash_input.push_str(&dashed);
-    for (i, v) in hash_values.iter().enumerate() {
-        if i > 0 {
-            hash_input.push_str(", ");
+    if undefined_single {
+        hash_input.push_str("undefined");
+    } else {
+        for (i, v) in values.iter().enumerate() {
+            if i > 0 {
+                hash_input.push_str(", ");
+            }
+            hash_input.push_str(v);
         }
-        hash_input.push_str(v);
     }
     if modifier_len == 0 {
         hash_input.push_str("null");
@@ -337,21 +349,28 @@ fn convert_style_to_class_name_uncached(
         for p in &sorted_pseudos {
             hash_input.push_str(p);
         }
-        for a in &sorted_at_and_const {
+        for a in sorted_at_and_const.iter() {
             hash_input.push_str(a);
         }
     }
     let hashed = hash(&hash_input);
-    let class_name: std::sync::Arc<str> = if options.debug && options.enable_debug_class_names {
-        format!("{property}-{}{hashed}", options.class_name_prefix).into()
-    } else {
-        format!("{}{hashed}", options.class_name_prefix).into()
-    };
+    let debug_name = options.debug && options.enable_debug_class_names;
+    let mut class_name = String::with_capacity(
+        options.class_name_prefix.len()
+            + hashed.len()
+            + if debug_name { property.len() + 1 } else { 0 },
+    );
+    if debug_name {
+        class_name.push_str(property);
+        class_name.push('-');
+    }
+    class_name.push_str(&options.class_name_prefix);
+    class_name.push_str(&hashed);
 
     let rule = generate_css_rule(
         &class_name,
         &dashed,
-        &values,
+        values,
         &sorted_pseudos,
         &sorted_at_rules,
         const_rules,

--- a/crates/stylex/src/shared/keyframes.rs
+++ b/crates/stylex/src/shared/keyframes.rs
@@ -39,12 +39,14 @@ pub fn keyframes(
                 unreachable!("transform stage only stores strings");
             };
             let (lk, lv) = generate_ltr(key, value, ctx);
-            ltr.insert(lk, EvalValue::Str(lv));
-            let (rk, rv) =
-                generate_rtl(key, value, ctx).unwrap_or_else(|| (key.to_string(), value.clone()));
+            ltr.insert(lk, EvalValue::Str(lv.into_owned()));
+            let (rk, rv) = generate_rtl(key, value, ctx).map_or_else(
+                || (key.to_string(), value.clone()),
+                |(k, v)| (k.into_owned(), v.into_owned()),
+            );
             rtl.insert(rk, EvalValue::Str(rv));
             let (sk, sv) = generate_ltr(key, value, RtlContext::DEFAULTS);
-            stable.insert(sk, EvalValue::Str(sv));
+            stable.insert(sk, EvalValue::Str(sv.into_owned()));
         }
         ltr_frames.push((frame_name.to_string(), ltr));
         rtl_frames.push((frame_name.to_string(), rtl));

--- a/crates/stylex/src/shared/keyframes.rs
+++ b/crates/stylex/src/shared/keyframes.rs
@@ -1,0 +1,243 @@
+//! `stylex.keyframes` over an already-evaluated frames object.
+// parity: babel-plugin src/shared/stylex-keyframes.js + visitors/stylex-keyframes.js
+
+use crate::errors::StylexError;
+use crate::eval::value::{EvalValue, JsObjectMap};
+use crate::hash::hash;
+use crate::options::ResolvedOptions;
+use crate::rules::StylexRule;
+use crate::shared::dashify::dashify;
+use crate::shared::flatten::StyleScalar;
+use crate::shared::normalize_value::CssValueError;
+use crate::shared::resolution::flat_map_expanded_shorthands;
+use crate::shared::rtl::{RtlContext, generate_ltr, generate_rtl};
+use crate::shared::transform_value::{transform_value_num, transform_value_str};
+
+/// Returns the animation name and its single injectable rule (priority 0).
+pub fn keyframes(
+    frames: &EvalValue,
+    options: &ResolvedOptions,
+) -> Result<(String, StylexRule), StylexError> {
+    let frames = assert_valid_keyframes(frames)?;
+
+    let ctx = RtlContext::of(options);
+    let mut ltr_frames: Vec<(String, JsObjectMap)> = Vec::new();
+    let mut rtl_frames: Vec<(String, JsObjectMap)> = Vec::new();
+    let mut stable_frames: Vec<(String, JsObjectMap)> = Vec::new();
+    for (frame_name, frame_value) in frames.entries() {
+        let EvalValue::Obj(frame) = frame_value else {
+            // Validation admits `null` frames (typeof null is 'object'); upstream
+            // then crashes in Object.keys.
+            return Err(StylexError::upstream_type_crash("a null keyframes frame"));
+        };
+        let transformed = expand_dashify_transform(frame, options)?;
+        let mut ltr = JsObjectMap::new();
+        let mut rtl = JsObjectMap::new();
+        let mut stable = JsObjectMap::new();
+        for (key, value) in transformed.entries() {
+            let EvalValue::Str(value) = value else {
+                unreachable!("transform stage only stores strings");
+            };
+            let (lk, lv) = generate_ltr(key, value, ctx);
+            ltr.insert(lk, EvalValue::Str(lv));
+            let (rk, rv) =
+                generate_rtl(key, value, ctx).unwrap_or_else(|| (key.to_string(), value.clone()));
+            rtl.insert(rk, EvalValue::Str(rv));
+            let (sk, sv) = generate_ltr(key, value, RtlContext::DEFAULTS);
+            stable.insert(sk, EvalValue::Str(sv));
+        }
+        ltr_frames.push((frame_name.to_string(), ltr));
+        rtl_frames.push((frame_name.to_string(), rtl));
+        stable_frames.push((frame_name.to_string(), stable));
+    }
+
+    let ltr_string = construct_keyframes_string(&ltr_frames);
+    let rtl_string = construct_keyframes_string(&rtl_frames);
+    // The name hashes a third serialization built with DEFAULT options, so it
+    // is direction- and option-agnostic (`objMapEntry(frame, generateLtr)`).
+    let stable_string = construct_keyframes_string(&stable_frames);
+    let animation_name = format!(
+        "{}{}-B",
+        options.class_name_prefix,
+        hash(&format!("<>{stable_string}"))
+    );
+
+    let ltr = format!("@keyframes {animation_name}{{{ltr_string}}}");
+    let rtl =
+        (ltr_string != rtl_string).then(|| format!("@keyframes {animation_name}{{{rtl_string}}}"));
+
+    let rule = StylexRule {
+        class_name: animation_name.as_str().into(),
+        ltr: ltr.into(),
+        rtl: rtl.map(Into::into),
+        const_key: None,
+        const_val: None,
+        priority: 0.0,
+    };
+    Ok((animation_name, rule))
+}
+
+// parity: visitors/stylex-keyframes.js assertValidKeyframes
+fn assert_valid_keyframes(frames: &EvalValue) -> Result<&JsObjectMap, StylexError> {
+    let EvalValue::Obj(map) = frames else {
+        return Err(StylexError::non_style_object("keyframes"));
+    };
+    for (_key, value) in map.entries() {
+        // `typeof value === 'object' && !Array.isArray(value)`: null passes.
+        match value {
+            EvalValue::Obj(_) | EvalValue::Null => {}
+            _ => return Err(StylexError::non_object_keyframe()),
+        }
+    }
+    Ok(map)
+}
+
+// parity: stylex-keyframes.js expand+dashify+transformValue pipe; each stage
+// rebuilds the object, so duplicate keys collapse first-position last-value.
+fn expand_dashify_transform(
+    frame: &JsObjectMap,
+    options: &ResolvedOptions,
+) -> Result<JsObjectMap, StylexError> {
+    let mut expanded = JsObjectMap::new();
+    for (key, value) in frame.entries() {
+        let value_is_array = matches!(value, EvalValue::Arr(_));
+        let scalar = match value {
+            EvalValue::Str(s) => Some(StyleScalar::Str(std::borrow::Cow::Borrowed(s.as_str()))),
+            EvalValue::Num(n) => Some(StyleScalar::Num(*n)),
+            _ => None,
+        };
+        // Only string/number values survive; arrays, nulls, and objects drop.
+        for (property, expanded_value) in flat_map_expanded_shorthands(
+            std::borrow::Cow::Borrowed(key),
+            scalar,
+            value_is_array,
+            options,
+        )? {
+            match expanded_value {
+                Some(StyleScalar::Str(s)) => {
+                    expanded.insert(property.to_string(), EvalValue::Str(s.into_owned()));
+                }
+                Some(StyleScalar::Num(n)) => {
+                    expanded.insert(property, EvalValue::Num(n));
+                }
+                Some(StyleScalar::Undefined) | None => {}
+            }
+        }
+    }
+    let mut dashed = JsObjectMap::new();
+    for (key, value) in expanded.entries() {
+        dashed.insert(dashify(key), value.clone());
+    }
+    let mut transformed = JsObjectMap::new();
+    for (key, value) in dashed.entries() {
+        // transformValue sees the already-dashed key: dashed forms miss the
+        // camelCase ms-suffix and unitless tables (e.g. transition-duration: 500px).
+        let out = match value {
+            EvalValue::Str(s) => transform_value_str(key, s, options.enable_font_size_px_to_rem),
+            EvalValue::Num(n) => transform_value_num(key, *n, options.enable_font_size_px_to_rem),
+            _ => unreachable!("expand stage only stores scalars"),
+        }
+        .map_err(css_value_error)?;
+        transformed.insert(key, EvalValue::Str(out));
+    }
+    Ok(transformed)
+}
+
+fn construct_keyframes_string(frames: &[(String, JsObjectMap)]) -> String {
+    let mut out = String::new();
+    for (name, decls) in frames {
+        out.push_str(name);
+        out.push('{');
+        for (k, v) in decls.entries() {
+            let EvalValue::Str(v) = v else {
+                unreachable!("frames hold string declarations");
+            };
+            out.push_str(k);
+            out.push(':');
+            out.push_str(v);
+            out.push(';');
+        }
+        out.push('}');
+    }
+    out
+}
+
+fn css_value_error(e: CssValueError) -> StylexError {
+    match e {
+        CssValueError::UnclosedFunction => StylexError::unclosed_function(),
+        CssValueError::UnclosedString => StylexError::unclosed_string(),
+        CssValueError::EmptyValue => StylexError::empty_value(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn obj(entries: &[(&str, EvalValue)]) -> EvalValue {
+        EvalValue::Obj(
+            entries
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), v.clone()))
+                .collect::<JsObjectMap>()
+                .into(),
+        )
+    }
+
+    #[test]
+    fn basic_frames_match_oracle() {
+        // Pinned via live-oracle probe 2026-08-27.
+        let frames = obj(&[
+            ("from", obj(&[("opacity", EvalValue::Num(0.0))])),
+            ("to", obj(&[("opacity", EvalValue::Num(1.0))])),
+        ]);
+        let options = ResolvedOptions::default();
+        let (name, rule) = keyframes(&frames, &options).unwrap();
+        assert_eq!(name, "x18re5ia-B");
+        assert_eq!(
+            &*rule.ltr,
+            "@keyframes x18re5ia-B{from{opacity:0;}to{opacity:1;}}"
+        );
+        assert_eq!(rule.rtl, None);
+        assert!(rule.priority == 0.0);
+    }
+
+    #[test]
+    fn rtl_emitted_only_when_different() {
+        let options = ResolvedOptions::default();
+        let frames = obj(&[
+            (
+                "from",
+                obj(&[("float", EvalValue::Str("inline-start".to_string()))]),
+            ),
+            (
+                "to",
+                obj(&[("float", EvalValue::Str("inline-end".to_string()))]),
+            ),
+        ]);
+        let (_, rule) = keyframes(&frames, &options).unwrap();
+        assert_eq!(
+            &*rule.ltr,
+            "@keyframes x1uod70n-B{from{float:left;}to{float:right;}}"
+        );
+        assert_eq!(
+            rule.rtl.as_deref(),
+            Some("@keyframes x1uod70n-B{from{float:right;}to{float:left;}}")
+        );
+    }
+
+    #[test]
+    fn frame_validation() {
+        let options = ResolvedOptions::default();
+        let err = keyframes(&EvalValue::Str("x".to_string()), &options).unwrap_err();
+        assert_eq!(err.message, "keyframes() can only accept an object.");
+        let err =
+            keyframes(&obj(&[("from", EvalValue::Str("x".to_string()))]), &options).unwrap_err();
+        assert_eq!(
+            err.message,
+            "Every frame within a keyframes() call must be an object."
+        );
+        let err = keyframes(&obj(&[("from", EvalValue::Null)]), &options).unwrap_err();
+        assert_eq!(err.code, crate::errors::ErrorCode::UpstreamTypeError);
+    }
+}

--- a/crates/stylex/src/shared/markers.rs
+++ b/crates/stylex/src/shared/markers.rs
@@ -1,0 +1,74 @@
+//! `stylex.defaultMarker` / `stylex.defineMarker` compiled objects.
+// parity: shared/stylex-defaultMarker.js + visitors/stylex-define-marker.js
+
+use crate::eval::value::{EvalValue, JsObjectMap};
+use crate::hash::hash;
+use crate::options::ResolvedOptions;
+
+/// `{prefix}-default-marker`; ResolvedOptions always carries a prefix, so the
+/// upstream `classNamePrefix == null` no-dash branch is unreachable here.
+pub fn default_marker_class_name(options: &ResolvedOptions) -> String {
+    format!("{}-default-marker", options.class_name_prefix)
+}
+
+pub fn default_marker_object(options: &ResolvedOptions) -> JsObjectMap {
+    self_map_object(default_marker_class_name(options))
+}
+
+pub fn define_marker_id(
+    canonical_file_name: &str,
+    export_name: &str,
+    options: &ResolvedOptions,
+) -> String {
+    format!(
+        "{}{}",
+        options.class_name_prefix,
+        hash(&format!("{canonical_file_name}//{export_name}"))
+    )
+}
+
+/// `canonical_file_name` is state-manager fileNameForHashing output; callers
+/// map a missing one to `cannot_generate_hash("defineMarker")` first.
+pub fn define_marker_object(
+    canonical_file_name: &str,
+    export_name: &str,
+    options: &ResolvedOptions,
+) -> JsObjectMap {
+    self_map_object(define_marker_id(canonical_file_name, export_name, options))
+}
+
+fn self_map_object(id: String) -> JsObjectMap {
+    let mut obj = JsObjectMap::new();
+    obj.insert(id.clone(), EvalValue::Str(id));
+    obj.insert("$$css", EvalValue::Bool(true));
+    obj
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn oracle_pinned_objects() {
+        // Pinned via live-oracle probe 2026-08-27.
+        let options = ResolvedOptions::default();
+        assert_eq!(
+            default_marker_object(&options).to_json(),
+            serde_json::json!({ "x-default-marker": "x-default-marker", "$$css": true })
+        );
+        let prefixed = ResolvedOptions {
+            class_name_prefix: "pfx".to_string(),
+            ..ResolvedOptions::default()
+        };
+        assert_eq!(default_marker_class_name(&prefixed), "pfx-default-marker");
+        // tokens.stylex.ts under rootDir /fake/root, export name `marker`.
+        assert_eq!(
+            define_marker_object("tokens.stylex.ts", "marker", &options).to_json(),
+            serde_json::json!({ "xleysvp": "xleysvp", "$$css": true })
+        );
+        assert_eq!(
+            define_marker_id("tokens.stylex.ts", "marker", &prefixed),
+            "pfxleysvp"
+        );
+    }
+}

--- a/crates/stylex/src/shared/media_query.rs
+++ b/crates/stylex/src/shared/media_query.rs
@@ -2,7 +2,9 @@
 // toString) and media-query-transform.js (last-media-query-wins), both at 0.19.0.
 
 use crate::errors::StylexError;
+use crate::fxhash::FxHashMap;
 use crate::jsrt::js_number_to_string;
+use std::cell::RefCell;
 use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
@@ -85,11 +87,35 @@ impl fmt::Display for MediaQuery {
     }
 }
 
+thread_local! {
+    // The rewrite is a pure function of the sibling list, and a design-system
+    // corpus repeats the same few breakpoint sets in every file.
+    static TRANSFORM_MEMO: RefCell<FxHashMap<Vec<String>, Vec<String>>> =
+        RefCell::new(FxHashMap::default());
+}
+
+const TRANSFORM_MEMO_CAP: usize = 1 << 16;
+
 /// Depth>=1 sibling `@media` rewrite: earlier keys gain ANDed not-clauses of
 /// later siblings; every key (last included) re-serializes via normalize.
 pub fn last_media_query_wins_transform(
     sibling_keys: &[String],
 ) -> Result<Vec<String>, MediaQueryError> {
+    if let Some(hit) = TRANSFORM_MEMO.with(|memo| memo.borrow().get(sibling_keys).cloned()) {
+        return Ok(hit);
+    }
+    let out = transform_uncached(sibling_keys)?;
+    TRANSFORM_MEMO.with(|memo| {
+        let mut memo = memo.borrow_mut();
+        if memo.len() >= TRANSFORM_MEMO_CAP {
+            memo.clear();
+        }
+        memo.insert(sibling_keys.to_vec(), out.clone());
+    });
+    Ok(out)
+}
+
+fn transform_uncached(sibling_keys: &[String]) -> Result<Vec<String>, MediaQueryError> {
     let queries = sibling_keys
         .iter()
         .map(|key| MediaQuery::parse(key))

--- a/crates/stylex/src/shared/media_query.rs
+++ b/crates/stylex/src/shared/media_query.rs
@@ -1,0 +1,1246 @@
+// parity: style-value-parser/src/at-queries/media-query.js (parser, normalize,
+// toString) and media-query-transform.js (last-media-query-wins), both at 0.19.0.
+
+use crate::errors::StylexError;
+use crate::jsrt::js_number_to_string;
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum MediaQueryError {
+    #[error("{0}")]
+    Syntax(StylexError),
+    // Forms our tokenizer cannot faithfully replicate (escapes, non-ASCII):
+    // refusing beats guessing a serialization no oracle pin covers.
+    #[error("unverified media query form: {input}")]
+    Unverified { input: String },
+}
+
+impl MediaQueryError {
+    fn syntax() -> Self {
+        MediaQueryError::Syntax(StylexError::invalid_media_query_syntax())
+    }
+}
+
+/// The exact key filter `lastMediaQueryWinsTransform` applies to style-object
+/// siblings: `'@media\t…'` and bare `'@media'` pass through verbatim.
+pub fn is_media_key(key: &str) -> bool {
+    key.starts_with("@media ")
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MediaRuleValue {
+    Length { value: f64, unit: String },
+    Number(f64),
+    // idents and calc() expressions both live as plain strings upstream
+    Str(String),
+    Fraction(f64, f64),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MediaQueryRule {
+    Keyword { key: String, not: bool, only: bool },
+    WordRule(String),
+    Pair { key: String, value: MediaRuleValue },
+    Not(Box<MediaQueryRule>),
+    And(Vec<MediaQueryRule>),
+    Or(Vec<MediaQueryRule>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MediaQuery {
+    pub queries: MediaQueryRule,
+}
+
+impl MediaQuery {
+    pub fn new(rule: MediaQueryRule) -> Self {
+        MediaQuery {
+            queries: normalize(rule),
+        }
+    }
+
+    pub fn parse(input: &str) -> Result<Self, MediaQueryError> {
+        if input.bytes().any(|b| b >= 0x80 || b == b'\\' || b == b'\0') {
+            return Err(MediaQueryError::Unverified {
+                input: input.to_string(),
+            });
+        }
+        let tokens = tokenize(input);
+        let mut parser = Parser {
+            tokens: &tokens,
+            pos: 0,
+        };
+        let Some(rule) = parser.media_query() else {
+            return Err(MediaQueryError::syntax());
+        };
+        if parser.pos != tokens.len() {
+            return Err(MediaQueryError::syntax());
+        }
+        Ok(MediaQuery::new(rule))
+    }
+}
+
+impl fmt::Display for MediaQuery {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "@media {}", rule_to_string(&self.queries, true))
+    }
+}
+
+/// Depth>=1 sibling `@media` rewrite: earlier keys gain ANDed not-clauses of
+/// later siblings; every key (last included) re-serializes via normalize.
+pub fn last_media_query_wins_transform(
+    sibling_keys: &[String],
+) -> Result<Vec<String>, MediaQueryError> {
+    let queries = sibling_keys
+        .iter()
+        .map(|key| MediaQuery::parse(key))
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut out = Vec::with_capacity(queries.len());
+    for (i, current) in queries.iter().enumerate() {
+        let negations: Vec<MediaQueryRule> = queries[i + 1..]
+            .iter()
+            .map(|q| MediaQueryRule::Not(Box::new(q.queries.clone())))
+            .collect();
+        if negations.is_empty() {
+            out.push(current.to_string());
+            continue;
+        }
+        let combined = match &current.queries {
+            MediaQueryRule::Or(rules) => MediaQueryRule::Or(
+                rules
+                    .iter()
+                    .map(|rule| {
+                        let mut branch = vec![rule.clone()];
+                        branch.extend(negations.iter().cloned());
+                        MediaQueryRule::And(branch)
+                    })
+                    .collect(),
+            ),
+            other => {
+                let mut rules = vec![other.clone()];
+                rules.extend(negations);
+                MediaQueryRule::And(rules)
+            }
+        };
+        out.push(MediaQuery::new(combined).to_string());
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// serialization
+
+fn rule_to_string(rule: &MediaQueryRule, is_top_level: bool) -> String {
+    match rule {
+        MediaQueryRule::Keyword { key, not, only } => {
+            let prefix = if *not {
+                "not "
+            } else if *only {
+                "only "
+            } else {
+                ""
+            };
+            let is_typed = *not || *only;
+            if is_top_level || is_typed {
+                format!("{prefix}{key}")
+            } else {
+                format!("({key})")
+            }
+        }
+        MediaQueryRule::WordRule(key) => format!("({key})"),
+        MediaQueryRule::Pair { key, value } => match value {
+            MediaRuleValue::Fraction(a, b) => {
+                format!(
+                    "({key}: {} / {})",
+                    js_number_to_string(*a),
+                    js_number_to_string(*b)
+                )
+            }
+            MediaRuleValue::Str(s) => format!("({key}: {s})"),
+            MediaRuleValue::Length { value, unit } => {
+                format!("({key}: {}{unit})", js_number_to_string(*value))
+            }
+            MediaRuleValue::Number(n) => format!("({key}: {})", js_number_to_string(*n)),
+        },
+        MediaQueryRule::Not(inner) => match **inner {
+            MediaQueryRule::And(_) | MediaQueryRule::Or(_) | MediaQueryRule::Not(_) => {
+                format!("(not ({}))", rule_to_string(inner, false))
+            }
+            _ => format!("(not {})", rule_to_string(inner, false)),
+        },
+        MediaQueryRule::And(rules) => rules
+            .iter()
+            .map(|r| rule_to_string(r, false))
+            .collect::<Vec<_>>()
+            .join(" and "),
+        MediaQueryRule::Or(rules) => {
+            let valid: Vec<&MediaQueryRule> = rules
+                .iter()
+                .filter(|r| !matches!(r, MediaQueryRule::Or(inner) if inner.is_empty()))
+                .collect();
+            if valid.is_empty() {
+                return "not all".to_string();
+            }
+            if valid.len() == 1 {
+                return rule_to_string(valid[0], is_top_level);
+            }
+            let formatted: Vec<String> = valid
+                .iter()
+                .map(|r| match r {
+                    MediaQueryRule::And(_) | MediaQueryRule::Or(_) => {
+                        let inner = rule_to_string(r, false);
+                        if is_top_level {
+                            inner
+                        } else {
+                            format!("({inner})")
+                        }
+                    }
+                    _ => rule_to_string(r, false),
+                })
+                .collect();
+            formatted.join(if is_top_level { ", " } else { " or " })
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// normalization
+
+fn normalize(rule: MediaQueryRule) -> MediaQueryRule {
+    match rule {
+        MediaQueryRule::And(rules) => {
+            let mut flattened = Vec::new();
+            for r in rules {
+                match normalize(r) {
+                    MediaQueryRule::And(inner) => flattened.extend(inner),
+                    other => flattened.push(other),
+                }
+            }
+            let merged = merge_intervals_for_and(&flattened);
+            if merged.is_empty() {
+                MediaQueryRule::Keyword {
+                    key: "all".to_string(),
+                    not: true,
+                    only: false,
+                }
+            } else {
+                MediaQueryRule::And(merged)
+            }
+        }
+        MediaQueryRule::Or(rules) => MediaQueryRule::Or(rules.into_iter().map(normalize).collect()),
+        MediaQueryRule::Not(inner) => {
+            let operand = normalize(*inner);
+            if let MediaQueryRule::Keyword { key, not: true, .. } = &operand
+                && key == "all"
+            {
+                return MediaQueryRule::Keyword {
+                    key: "all".to_string(),
+                    not: false,
+                    only: false,
+                };
+            }
+            if let MediaQueryRule::Not(inner2) = operand {
+                return normalize(*inner2);
+            }
+            MediaQueryRule::Not(Box::new(operand))
+        }
+        other => other,
+    }
+}
+
+fn as_numeric_minmax(rule: &MediaQueryRule) -> Option<(&str, f64, &str)> {
+    if let MediaQueryRule::Pair {
+        key,
+        value: MediaRuleValue::Length { value, unit },
+    } = rule
+        && (key == "min-width" || key == "max-width" || key == "min-height" || key == "max-height")
+    {
+        Some((key.as_str(), *value, unit.as_str()))
+    } else {
+        None
+    }
+}
+
+const MERGE_EPSILON: f64 = 0.01;
+
+fn merge_intervals_for_and(rules: &[MediaQueryRule]) -> Vec<MediaQueryRule> {
+    // (not (A and B)) with exactly two operands distributes into an OR of the
+    // two negated branches before any interval math happens.
+    for (idx, rule) in rules.iter().enumerate() {
+        if let MediaQueryRule::Not(inner) = rule
+            && let MediaQueryRule::And(inner_rules) = &**inner
+            && inner_rules.len() == 2
+        {
+            let others: Vec<MediaQueryRule> = rules
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| *i != idx)
+                .map(|(_, r)| r.clone())
+                .collect();
+            let branches: Vec<Vec<MediaQueryRule>> = inner_rules
+                .iter()
+                .map(|negated| {
+                    let mut input = others.clone();
+                    input.push(MediaQueryRule::Not(Box::new(negated.clone())));
+                    merge_intervals_for_and(&input)
+                })
+                .collect();
+            return vec![MediaQueryRule::Or(
+                branches
+                    .into_iter()
+                    .filter(|branch| !branch.is_empty())
+                    .map(|branch| {
+                        if branch.len() == 1 {
+                            branch.into_iter().next().expect("len checked")
+                        } else {
+                            MediaQueryRule::And(branch)
+                        }
+                    })
+                    .collect(),
+            )];
+        }
+    }
+
+    let dims = ["width", "height"];
+    let mut intervals: [Vec<(f64, f64)>; 2] = [Vec::new(), Vec::new()];
+    let mut units: [Option<String>; 2] = [None, None];
+    let mut has_unit_conflict = false;
+
+    for rule in rules {
+        let mut matched = false;
+        for (d, dim) in dims.iter().enumerate() {
+            let min_key = format!("min-{dim}");
+            let max_key = format!("max-{dim}");
+            if let Some((key, value, unit)) = as_numeric_minmax(rule)
+                && (key == min_key || key == max_key)
+            {
+                match &units[d] {
+                    None if intervals[d].is_empty() => units[d] = Some(unit.to_string()),
+                    Some(u) if u != unit => has_unit_conflict = true,
+                    _ => {}
+                }
+                intervals[d].push(if key == min_key {
+                    (value, f64::INFINITY)
+                } else {
+                    (f64::NEG_INFINITY, value)
+                });
+                matched = true;
+                break;
+            }
+            if let MediaQueryRule::Not(inner) = rule
+                && let Some((key, value, unit)) = as_numeric_minmax(inner)
+                && (key == min_key || key == max_key)
+            {
+                match &units[d] {
+                    None if intervals[d].is_empty() => units[d] = Some(unit.to_string()),
+                    Some(u) if u != unit => has_unit_conflict = true,
+                    _ => {}
+                }
+                intervals[d].push(if key == min_key {
+                    (f64::NEG_INFINITY, value - MERGE_EPSILON)
+                } else {
+                    (value + MERGE_EPSILON, f64::INFINITY)
+                });
+                matched = true;
+                break;
+            }
+        }
+        if !matched {
+            // any rule that is not a numeric min/max pair (or its negation)
+            // disables merging for the whole conjunction
+            return rules.to_vec();
+        }
+    }
+
+    if has_unit_conflict {
+        return rules.to_vec();
+    }
+
+    let mut result = Vec::new();
+    for (d, dim) in dims.iter().enumerate() {
+        if intervals[d].is_empty() {
+            continue;
+        }
+        let mut lower = f64::NEG_INFINITY;
+        let mut upper = f64::INFINITY;
+        for (l, u) in &intervals[d] {
+            if *l > lower {
+                lower = *l;
+            }
+            if *u < upper {
+                upper = *u;
+            }
+        }
+        if lower > upper {
+            return Vec::new();
+        }
+        let unit = units[d].clone().unwrap_or_default();
+        if lower != f64::NEG_INFINITY {
+            result.push(MediaQueryRule::Pair {
+                key: format!("min-{dim}"),
+                value: MediaRuleValue::Length {
+                    value: lower,
+                    unit: unit.clone(),
+                },
+            });
+        }
+        if upper != f64::INFINITY {
+            result.push(MediaQueryRule::Pair {
+                key: format!("max-{dim}"),
+                value: MediaRuleValue::Length { value: upper, unit },
+            });
+        }
+    }
+    if result.is_empty() {
+        rules.to_vec()
+    } else {
+        result
+    }
+}
+
+// ---------------------------------------------------------------------------
+// tokenizer (CSS Syntax 3 subset; escapes/non-ASCII are gated in parse())
+
+#[derive(Debug, Clone, PartialEq)]
+enum Tok {
+    Whitespace,
+    Ident(String),
+    AtKeyword(String),
+    Function(String),
+    Number(f64),
+    Percentage(f64),
+    Dimension { value: f64, unit: String },
+    Colon,
+    Comma,
+    OpenParen,
+    CloseParen,
+    Delim(u8),
+    // strings, brackets, semicolons, comments, CDO/CDC: tokens the media query
+    // grammar can never match, so one opaque variant preserves the rejection
+    Unsupported,
+}
+
+fn is_ws(b: u8) -> bool {
+    matches!(b, b' ' | b'\t' | b'\n' | b'\r' | 0x0C)
+}
+
+fn is_ident_start(b: u8) -> bool {
+    b.is_ascii_alphabetic() || b == b'_'
+}
+
+fn is_ident_char(b: u8) -> bool {
+    is_ident_start(b) || b.is_ascii_digit() || b == b'-'
+}
+
+fn would_start_ident(bytes: &[u8], i: usize) -> bool {
+    match bytes.get(i) {
+        Some(b'-') => matches!(bytes.get(i + 1), Some(&b) if is_ident_start(b) || b == b'-'),
+        Some(&b) => is_ident_start(b),
+        None => false,
+    }
+}
+
+fn would_start_number(bytes: &[u8], i: usize) -> bool {
+    match bytes.get(i) {
+        Some(b'+') | Some(b'-') => match bytes.get(i + 1) {
+            Some(b'.') => matches!(bytes.get(i + 2), Some(b) if b.is_ascii_digit()),
+            Some(b) => b.is_ascii_digit(),
+            None => false,
+        },
+        Some(b'.') => matches!(bytes.get(i + 1), Some(b) if b.is_ascii_digit()),
+        Some(b) => b.is_ascii_digit(),
+        None => false,
+    }
+}
+
+fn consume_ident(bytes: &[u8], i: &mut usize) -> String {
+    let start = *i;
+    while *i < bytes.len() && is_ident_char(bytes[*i]) {
+        *i += 1;
+    }
+    String::from_utf8_lossy(&bytes[start..*i]).into_owned()
+}
+
+fn consume_number(bytes: &[u8], i: &mut usize) -> f64 {
+    let start = *i;
+    if matches!(bytes.get(*i), Some(b'+') | Some(b'-')) {
+        *i += 1;
+    }
+    while matches!(bytes.get(*i), Some(b) if b.is_ascii_digit()) {
+        *i += 1;
+    }
+    if bytes.get(*i) == Some(&b'.') && matches!(bytes.get(*i + 1), Some(b) if b.is_ascii_digit()) {
+        *i += 2;
+        while matches!(bytes.get(*i), Some(b) if b.is_ascii_digit()) {
+            *i += 1;
+        }
+    }
+    if matches!(bytes.get(*i), Some(b'e') | Some(b'E')) {
+        let mut j = *i + 1;
+        if matches!(bytes.get(j), Some(b'+') | Some(b'-')) {
+            j += 1;
+        }
+        if matches!(bytes.get(j), Some(b) if b.is_ascii_digit()) {
+            *i = j;
+            while matches!(bytes.get(*i), Some(b) if b.is_ascii_digit()) {
+                *i += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&bytes[start..*i])
+        .parse::<f64>()
+        .unwrap_or(f64::NAN)
+}
+
+fn tokenize(input: &str) -> Vec<Tok> {
+    let bytes = input.as_bytes();
+    let mut tokens = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if is_ws(b) {
+            while i < bytes.len() && is_ws(bytes[i]) {
+                i += 1;
+            }
+            tokens.push(Tok::Whitespace);
+        } else if b == b'/' && bytes.get(i + 1) == Some(&b'*') {
+            i += 2;
+            while i < bytes.len() && !(bytes[i] == b'*' && bytes.get(i + 1) == Some(&b'/')) {
+                i += 1;
+            }
+            i = (i + 2).min(bytes.len());
+            tokens.push(Tok::Unsupported);
+        } else if would_start_number(bytes, i) {
+            let value = consume_number(bytes, &mut i);
+            if would_start_ident(bytes, i) {
+                let unit = consume_ident(bytes, &mut i);
+                tokens.push(Tok::Dimension { value, unit });
+            } else if bytes.get(i) == Some(&b'%') {
+                i += 1;
+                tokens.push(Tok::Percentage(value));
+            } else {
+                tokens.push(Tok::Number(value));
+            }
+        } else if b == b'-' && bytes.get(i..i + 3) == Some(b"-->") {
+            i += 3;
+            tokens.push(Tok::Unsupported);
+        } else if b == b'<' && bytes.get(i..i + 4) == Some(b"<!--") {
+            i += 4;
+            tokens.push(Tok::Unsupported);
+        } else if would_start_ident(bytes, i) {
+            let name = consume_ident(bytes, &mut i);
+            if bytes.get(i) == Some(&b'(') {
+                i += 1;
+                tokens.push(Tok::Function(name));
+            } else {
+                tokens.push(Tok::Ident(name));
+            }
+        } else if b == b'@' && would_start_ident(bytes, i + 1) {
+            i += 1;
+            let name = consume_ident(bytes, &mut i);
+            tokens.push(Tok::AtKeyword(name));
+        } else {
+            i += 1;
+            tokens.push(match b {
+                b'(' => Tok::OpenParen,
+                b')' => Tok::CloseParen,
+                b':' => Tok::Colon,
+                b',' => Tok::Comma,
+                b'"' | b'\'' | b'[' | b']' | b'{' | b'}' | b';' => Tok::Unsupported,
+                _ => Tok::Delim(b),
+            });
+        }
+    }
+    tokens
+}
+
+// Parser ports the upstream TokenParser grammar: alternatives in upstream
+// order; every helper resets `pos` when it returns None.
+
+struct Parser<'a> {
+    tokens: &'a [Tok],
+    pos: usize,
+}
+
+impl Parser<'_> {
+    fn peek(&self) -> Option<&Tok> {
+        self.tokens.get(self.pos)
+    }
+
+    fn ws(&mut self) -> Option<()> {
+        if matches!(self.peek(), Some(Tok::Whitespace)) {
+            self.pos += 1;
+            Some(())
+        } else {
+            None
+        }
+    }
+
+    fn ws_opt(&mut self) {
+        if matches!(self.peek(), Some(Tok::Whitespace)) {
+            self.pos += 1;
+        }
+    }
+
+    fn ident(&mut self) -> Option<String> {
+        if let Some(Tok::Ident(name)) = self.peek() {
+            let name = name.clone();
+            self.pos += 1;
+            Some(name)
+        } else {
+            None
+        }
+    }
+
+    fn ident_eq(&mut self, expected: &str) -> Option<()> {
+        if matches!(self.peek(), Some(Tok::Ident(name)) if name == expected) {
+            self.pos += 1;
+            Some(())
+        } else {
+            None
+        }
+    }
+
+    fn delim(&mut self, expected: u8) -> Option<()> {
+        if matches!(self.peek(), Some(Tok::Delim(b)) if *b == expected) {
+            self.pos += 1;
+            Some(())
+        } else {
+            None
+        }
+    }
+
+    fn delim_in(&mut self, set: &[u8]) -> Option<u8> {
+        if let Some(Tok::Delim(b)) = self.peek()
+            && set.contains(b)
+        {
+            let b = *b;
+            self.pos += 1;
+            Some(b)
+        } else {
+            None
+        }
+    }
+
+    fn open(&mut self) -> Option<()> {
+        if matches!(self.peek(), Some(Tok::OpenParen)) {
+            self.pos += 1;
+            Some(())
+        } else {
+            None
+        }
+    }
+
+    fn close(&mut self) -> Option<()> {
+        if matches!(self.peek(), Some(Tok::CloseParen)) {
+            self.pos += 1;
+            Some(())
+        } else {
+            None
+        }
+    }
+
+    fn colon(&mut self) -> Option<()> {
+        if matches!(self.peek(), Some(Tok::Colon)) {
+            self.pos += 1;
+            Some(())
+        } else {
+            None
+        }
+    }
+
+    fn comma(&mut self) -> Option<()> {
+        if matches!(self.peek(), Some(Tok::Comma)) {
+            self.pos += 1;
+            Some(())
+        } else {
+            None
+        }
+    }
+
+    fn number(&mut self) -> Option<f64> {
+        if let Some(Tok::Number(v)) = self.peek() {
+            let v = *v;
+            self.pos += 1;
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    fn percentage(&mut self) -> Option<f64> {
+        if let Some(Tok::Percentage(v)) = self.peek() {
+            let v = *v;
+            self.pos += 1;
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    fn dimension(&mut self) -> Option<(f64, String)> {
+        if let Some(Tok::Dimension { value, unit }) = self.peek() {
+            let out = (*value, unit.clone());
+            self.pos += 1;
+            Some(out)
+        } else {
+            None
+        }
+    }
+
+    fn function_eq(&mut self, expected: &str) -> Option<()> {
+        if matches!(self.peek(), Some(Tok::Function(name)) if name == expected) {
+            self.pos += 1;
+            Some(())
+        } else {
+            None
+        }
+    }
+
+    // --- grammar rules ---
+
+    fn basic_media_type(&mut self) -> Option<String> {
+        let start = self.pos;
+        let name = self.ident()?;
+        if name == "screen" || name == "print" || name == "all" {
+            Some(name)
+        } else {
+            self.pos = start;
+            None
+        }
+    }
+
+    // sequence(not?, only?, type).separatedBy(Whitespace): a separator is
+    // required before an element only once earlier elements consumed input
+    fn media_keyword(&mut self) -> Option<MediaQueryRule> {
+        let start = self.pos;
+        let not = self.ident_eq("not").is_some();
+        let only = if self.pos > start {
+            let save = self.pos;
+            let matched = self.ws().is_some() && self.ident_eq("only").is_some();
+            if !matched {
+                self.pos = save;
+            }
+            matched
+        } else {
+            self.ident_eq("only").is_some()
+        };
+        if self.pos > start && self.ws().is_none() {
+            self.pos = start;
+            return None;
+        }
+        let Some(key) = self.basic_media_type() else {
+            self.pos = start;
+            return None;
+        };
+        Some(MediaQueryRule::Keyword { key, not, only })
+    }
+
+    fn word_rule(&mut self) -> Option<MediaQueryRule> {
+        let start = self.pos;
+        let matched = (|| {
+            self.open()?;
+            let key = self.ident()?;
+            self.close()?;
+            if key == "color" || key == "monochrome" || key == "grid" || key == "color-index" {
+                Some(MediaQueryRule::WordRule(key))
+            } else {
+                None
+            }
+        })();
+        if matched.is_none() {
+            self.pos = start;
+        }
+        matched
+    }
+
+    fn calc_value(&mut self) -> Option<String> {
+        for constant in ["pi", "e", "infinity", "-infinity", "NaN"] {
+            if self.ident_eq(constant).is_some() {
+                return Some(constant.to_string());
+            }
+        }
+        if let Some(n) = self.number() {
+            return Some(js_number_to_string(n));
+        }
+        if let Some((value, unit)) = self.dimension() {
+            return Some(format!("{}{unit}", js_number_to_string(value)));
+        }
+        if let Some(p) = self.percentage() {
+            return Some(format!("{}%", js_number_to_string(p)));
+        }
+        None
+    }
+
+    fn calc_group(&mut self) -> Option<String> {
+        let start = self.pos;
+        let matched = (|| {
+            self.open()?;
+            self.ws_opt();
+            let inner = self.calc_operations()?;
+            self.ws_opt();
+            self.close()?;
+            Some(format!("({inner})"))
+        })();
+        if matched.is_none() {
+            self.pos = start;
+        }
+        matched
+    }
+
+    fn calc_operand(&mut self) -> Option<String> {
+        self.calc_value().or_else(|| self.calc_group())
+    }
+
+    fn calc_operations(&mut self) -> Option<String> {
+        let first = self.calc_operand()?;
+        let mut parts = vec![first];
+        self.ws_opt();
+        let mut first_item = true;
+        loop {
+            let save = self.pos;
+            if !first_item {
+                self.ws_opt();
+            }
+            let item = (|| {
+                let op = self.delim_in(b"*/+-")?;
+                self.ws_opt();
+                let operand = self.calc_operand()?;
+                Some((op, operand))
+            })();
+            match item {
+                Some((op, operand)) => {
+                    parts.push((op as char).to_string());
+                    parts.push(operand);
+                    first_item = false;
+                }
+                None => {
+                    self.pos = save;
+                    break;
+                }
+            }
+        }
+        Some(parts.join(" "))
+    }
+
+    fn calc(&mut self) -> Option<String> {
+        let start = self.pos;
+        let matched = (|| {
+            self.function_eq("calc")?;
+            self.ws_opt();
+            let body = self.calc_operations()?;
+            self.ws_opt();
+            self.close()?;
+            Some(format!("calc({body})"))
+        })();
+        if matched.is_none() {
+            self.pos = start;
+        }
+        matched
+    }
+
+    fn media_rule_value(&mut self) -> Option<MediaRuleValue> {
+        if let Some(calc) = self.calc() {
+            return Some(MediaRuleValue::Str(calc));
+        }
+        if let Some((value, unit)) = self.dimension() {
+            return Some(MediaRuleValue::Length { value, unit });
+        }
+        if let Some(name) = self.ident() {
+            return Some(MediaRuleValue::Str(name));
+        }
+        let start = self.pos;
+        let fraction = (|| {
+            let a = self.number()?;
+            self.ws_opt();
+            self.delim(b'/')?;
+            self.ws_opt();
+            let b = self.number()?;
+            Some(MediaRuleValue::Fraction(a, b))
+        })();
+        if fraction.is_some() {
+            return fraction;
+        }
+        self.pos = start;
+        self.number().map(MediaRuleValue::Number)
+    }
+
+    fn simple_pair(&mut self) -> Option<MediaQueryRule> {
+        let start = self.pos;
+        let matched = (|| {
+            self.open()?;
+            self.ws_opt();
+            let key = self.ident()?;
+            self.ws_opt();
+            self.colon()?;
+            self.ws_opt();
+            let value = self.media_rule_value()?;
+            self.ws_opt();
+            self.close()?;
+            Some(MediaQueryRule::Pair { key, value })
+        })();
+        if matched.is_none() {
+            self.pos = start;
+        }
+        matched
+    }
+
+    fn width_or_height(&mut self) -> Option<String> {
+        let start = self.pos;
+        let name = self.ident()?;
+        if name == "width" || name == "height" {
+            Some(name)
+        } else {
+            self.pos = start;
+            None
+        }
+    }
+
+    fn ineq_op(&mut self) -> Option<u8> {
+        self.delim_in(b"><")
+    }
+
+    // optional('=') with the sequence's optional-whitespace separator folded in
+    fn ineq_eq(&mut self) -> bool {
+        let save = self.pos;
+        self.ws_opt();
+        if self.delim(b'=').is_some() {
+            true
+        } else {
+            self.pos = save;
+            false
+        }
+    }
+
+    fn adjust(value: f64, eq: bool, is_max: bool) -> f64 {
+        if eq {
+            value
+        } else if is_max {
+            value - MERGE_EPSILON
+        } else {
+            value + MERGE_EPSILON
+        }
+    }
+
+    fn ineq_forward(&mut self) -> Option<MediaQueryRule> {
+        let start = self.pos;
+        let matched = (|| {
+            self.open()?;
+            self.ws_opt();
+            let key = self.width_or_height()?;
+            self.ws_opt();
+            let op = self.ineq_op()?;
+            let eq = self.ineq_eq();
+            self.ws_opt();
+            let (value, unit) = self.dimension()?;
+            self.ws_opt();
+            self.close()?;
+            let final_key = if op == b'>' {
+                format!("min-{key}")
+            } else {
+                format!("max-{key}")
+            };
+            let is_max = final_key.starts_with("max-");
+            Some(MediaQueryRule::Pair {
+                key: final_key,
+                value: MediaRuleValue::Length {
+                    value: Self::adjust(value, eq, is_max),
+                    unit,
+                },
+            })
+        })();
+        if matched.is_none() {
+            self.pos = start;
+        }
+        matched
+    }
+
+    fn ineq_reversed(&mut self) -> Option<MediaQueryRule> {
+        let start = self.pos;
+        let matched = (|| {
+            self.open()?;
+            self.ws_opt();
+            let (value, unit) = self.dimension()?;
+            self.ws_opt();
+            let op = self.ineq_op()?;
+            let eq = self.ineq_eq();
+            self.ws_opt();
+            let key = self.width_or_height()?;
+            self.ws_opt();
+            self.close()?;
+            let final_key = if op == b'>' {
+                format!("max-{key}")
+            } else {
+                format!("min-{key}")
+            };
+            let is_max = final_key.starts_with("max-");
+            Some(MediaQueryRule::Pair {
+                key: final_key,
+                value: MediaRuleValue::Length {
+                    value: Self::adjust(value, eq, is_max),
+                    unit,
+                },
+            })
+        })();
+        if matched.is_none() {
+            self.pos = start;
+        }
+        matched
+    }
+
+    fn combined_inequality(&mut self) -> Option<MediaQueryRule> {
+        self.ineq_forward().or_else(|| self.ineq_reversed())
+    }
+
+    fn double_inequality(&mut self) -> Option<MediaQueryRule> {
+        let start = self.pos;
+        let matched = (|| {
+            self.open()?;
+            self.ws_opt();
+            let (lower, lower_unit) = self.dimension()?;
+            self.ws_opt();
+            let op = self.ineq_op()?;
+            let eq = self.ineq_eq();
+            self.ws_opt();
+            let key = self.width_or_height()?;
+            self.ws_opt();
+            let op2 = self.ineq_op()?;
+            let eq2 = self.ineq_eq();
+            self.ws_opt();
+            let (upper, upper_unit) = self.dimension()?;
+            self.ws_opt();
+            self.close()?;
+            let lower_key = if op == b'>' {
+                format!("max-{key}")
+            } else {
+                format!("min-{key}")
+            };
+            let upper_key = if op2 == b'>' {
+                format!("min-{key}")
+            } else {
+                format!("max-{key}")
+            };
+            let lower_is_max = lower_key.starts_with("max-");
+            let upper_is_max = upper_key.starts_with("max-");
+            Some(MediaQueryRule::And(vec![
+                MediaQueryRule::Pair {
+                    key: lower_key,
+                    value: MediaRuleValue::Length {
+                        value: Self::adjust(lower, eq, lower_is_max),
+                        unit: lower_unit,
+                    },
+                },
+                MediaQueryRule::Pair {
+                    key: upper_key,
+                    value: MediaRuleValue::Length {
+                        value: Self::adjust(upper, eq2, upper_is_max),
+                        unit: upper_unit,
+                    },
+                },
+            ]))
+        })();
+        if matched.is_none() {
+            self.pos = start;
+        }
+        matched
+    }
+
+    fn or_in_parens(&mut self) -> Option<MediaQueryRule> {
+        let start = self.pos;
+        let matched = (|| {
+            self.open()?;
+            let rule = self.or_rules()?;
+            self.close()?;
+            Some(rule)
+        })();
+        if matched.is_none() {
+            self.pos = start;
+        }
+        matched
+    }
+
+    fn and_in_parens(&mut self) -> Option<MediaQueryRule> {
+        let start = self.pos;
+        let matched = (|| {
+            self.open()?;
+            let rule = self.and_rules()?;
+            self.close()?;
+            Some(rule)
+        })();
+        if matched.is_none() {
+            self.pos = start;
+        }
+        matched
+    }
+
+    fn and_or_element(&mut self) -> Option<MediaQueryRule> {
+        self.media_keyword()
+            .or_else(|| self.or_in_parens())
+            .or_else(|| self.and_in_parens())
+            .or_else(|| self.not_parser())
+            .or_else(|| self.double_inequality())
+            .or_else(|| self.combined_inequality())
+            .or_else(|| self.simple_pair())
+            .or_else(|| self.word_rule())
+    }
+
+    fn combinator_rules(&mut self, word: &str) -> Option<Vec<MediaQueryRule>> {
+        let start = self.pos;
+        let Some(first) = self.and_or_element() else {
+            self.pos = start;
+            return None;
+        };
+        let mut items = vec![first];
+        loop {
+            let sep_save = self.pos;
+            let sep = (|| {
+                self.ws()?;
+                self.ident_eq(word)?;
+                self.ws()
+            })();
+            if sep.is_none() {
+                self.pos = sep_save;
+                break;
+            }
+            // upstream keeps a consumed separator when the next element fails
+            match self.and_or_element() {
+                Some(rule) => items.push(rule),
+                None => break,
+            }
+        }
+        if items.len() > 1 {
+            Some(items)
+        } else {
+            self.pos = start;
+            None
+        }
+    }
+
+    fn and_rules(&mut self) -> Option<MediaQueryRule> {
+        self.combinator_rules("and").map(MediaQueryRule::And)
+    }
+
+    fn or_rules(&mut self) -> Option<MediaQueryRule> {
+        self.combinator_rules("or").map(MediaQueryRule::Or)
+    }
+
+    fn paren_keyword(&mut self) -> Option<MediaQueryRule> {
+        let start = self.pos;
+        let matched = (|| {
+            self.open()?;
+            let key = self.basic_media_type()?;
+            self.close()?;
+            Some(MediaQueryRule::Keyword {
+                key,
+                not: false,
+                only: false,
+            })
+        })();
+        if matched.is_none() {
+            self.pos = start;
+        }
+        matched
+    }
+
+    // parity: getNormalRuleParser() — the rule set allowed inside `(not …)`;
+    // inequality forms are deliberately absent there upstream
+    fn normal_rule_for_not(&mut self) -> Option<MediaQueryRule> {
+        let rule = self
+            .paren_keyword()
+            .or_else(|| self.and_rules())
+            .or_else(|| self.or_rules())
+            .or_else(|| self.simple_pair())
+            .or_else(|| self.word_rule())
+            .or_else(|| self.not_parser())
+            .or_else(|| self.or_in_parens())
+            .or_else(|| self.and_in_parens())?;
+        self.ws_opt();
+        Some(rule)
+    }
+
+    fn not_parser(&mut self) -> Option<MediaQueryRule> {
+        let start = self.pos;
+        let matched = (|| {
+            self.open()?;
+            self.ident_eq("not")?;
+            self.ws()?;
+            let rule = self.normal_rule_for_not()?;
+            self.close()?;
+            Some(MediaQueryRule::Not(Box::new(rule)))
+        })();
+        if matched.is_none() {
+            self.pos = start;
+        }
+        matched
+    }
+
+    fn leading_not(&mut self) -> Option<MediaQueryRule> {
+        let start = self.pos;
+        let matched = (|| {
+            self.ident_eq("not")?;
+            self.ws()?;
+            let rule = self
+                .or_in_parens()
+                .or_else(|| self.and_in_parens())
+                .or_else(|| self.not_parser())
+                .or_else(|| self.combined_inequality())
+                .or_else(|| self.simple_pair())
+                .or_else(|| self.word_rule())?;
+            Some(MediaQueryRule::Not(Box::new(rule)))
+        })();
+        if matched.is_none() {
+            self.pos = start;
+        }
+        matched
+    }
+
+    fn normal_rule(&mut self) -> Option<MediaQueryRule> {
+        self.and_rules()
+            .or_else(|| self.or_rules())
+            .or_else(|| self.media_keyword())
+            .or_else(|| self.not_parser())
+            .or_else(|| self.double_inequality())
+            .or_else(|| self.combined_inequality())
+            .or_else(|| self.simple_pair())
+            .or_else(|| self.word_rule())
+            .or_else(|| self.or_in_parens())
+            .or_else(|| self.and_in_parens())
+    }
+
+    fn query(&mut self) -> Option<MediaQueryRule> {
+        self.leading_not().or_else(|| self.normal_rule())
+    }
+
+    fn media_query(&mut self) -> Option<MediaQueryRule> {
+        let start = self.pos;
+        let matched = (|| {
+            if !matches!(self.peek(), Some(Tok::AtKeyword(name)) if name == "media") {
+                return None;
+            }
+            self.pos += 1;
+            self.ws()?;
+            let mut sets = vec![self.query()?];
+            loop {
+                let sep_save = self.pos;
+                self.ws_opt();
+                if self.comma().is_none() {
+                    self.pos = sep_save;
+                    break;
+                }
+                self.ws_opt();
+                match self.query() {
+                    Some(q) => sets.push(q),
+                    None => break,
+                }
+            }
+            Some(if sets.len() > 1 {
+                MediaQueryRule::Or(sets)
+            } else {
+                sets.pop().expect("one query set parsed")
+            })
+        })();
+        if matched.is_none() {
+            self.pos = start;
+        }
+        matched
+    }
+}

--- a/crates/stylex/src/shared/nested.rs
+++ b/crates/stylex/src/shared/nested.rs
@@ -1,0 +1,734 @@
+//! Nested-to-flat token transforms for the `unstable_*Nested` APIs.
+// parity: babel-plugin src/shared/stylex-nested-utils.js + the *-nested wrappers
+
+use crate::fxhash::FxHashMap;
+use std::sync::Arc;
+
+use crate::errors::StylexError;
+use crate::eval::functions::StylexCallable;
+use crate::eval::value::{EvalValue, JsObjectMap, array_index};
+use crate::eval::{Callable, JsObj, JsValue, to_eval_value};
+use crate::jsrt::js_number_to_string;
+use crate::options::ResolvedOptions;
+use crate::shared::define_consts::{DefineConstsOutput, define_consts};
+use crate::shared::define_vars::es_ordered_entries;
+use crate::shared::types::{as_css_type_js, types_member_source};
+use crate::shared::view_transition::object_entries_js;
+
+pub const NESTED_KEY_SEPARATOR: char = '.';
+
+/// `String(fn)` of the closure the oracle's evaluator wraps every evaluatable
+/// arrow in (pinned from the 0.19.0 dist; identical for every user arrow).
+pub const EVALUATED_FN_SOURCE: &str = "(...args) => {\n        const identifierEntries = identParams.map((ident, index) => [ident, args[index]]);\n        const identifiersObj = Object.fromEntries(identifierEntries);\n        const result = evaluate(evaluatedExpr, state.traversalState, {\n          ...state.functions,\n          identifiers: {\n            ...state.functions.identifiers,\n            ...identifiersObj\n          }\n        });\n        if (!result.confident) {\n          throw new Error(result.reason ?? NON_CONSTANT);\n        }\n        return result.value;\n      }";
+
+enum LeafKind {
+    Strings,
+    Consts,
+}
+
+/// unstable_createThemeNested themeVars flatten: only strings are leaves.
+pub fn flatten_nested_string_config(value: &EvalValue) -> Result<JsObjectMap, StylexError> {
+    flatten(value, &LeafKind::Strings)
+}
+
+/// unstable_defineConstsNested flatten: strings and numbers are leaves, every
+/// object (even one with a `default` key) is a namespace.
+pub fn flatten_nested_consts_config(value: &EvalValue) -> Result<JsObjectMap, StylexError> {
+    flatten(value, &LeafKind::Consts)
+}
+
+fn flatten(value: &EvalValue, kind: &LeafKind) -> Result<JsObjectMap, StylexError> {
+    let entries = object_entries_js(value, "Object.keys of a nullish nested config")?;
+    let mut result = JsObjectMap::new();
+    flatten_impl(&entries, "", &mut result, kind)?;
+    Ok(result)
+}
+
+fn flatten_impl(
+    obj: &JsObjectMap,
+    prefix: &str,
+    result: &mut JsObjectMap,
+    kind: &LeafKind,
+) -> Result<(), StylexError> {
+    for (key, value) in obj.entries() {
+        // The oracle's evaluator builds objects with `obj[key]=` [[Set]]s, so
+        // an own "__proto__" never reaches its flatten (r4#7).
+        if key == "__proto__" {
+            continue;
+        }
+        if key.contains(NESTED_KEY_SEPARATOR) {
+            return Err(StylexError::nested_key_contains_separator(key));
+        }
+        let full_key = if prefix.is_empty() {
+            key.to_string()
+        } else {
+            format!("{prefix}{NESTED_KEY_SEPARATOR}{key}")
+        };
+        let is_leaf = match kind {
+            LeafKind::Strings => matches!(value, EvalValue::Str(_)),
+            LeafKind::Consts => matches!(value, EvalValue::Str(_) | EvalValue::Num(_)),
+        };
+        if is_leaf {
+            result.insert(full_key, value.clone());
+        } else if let EvalValue::Obj(map) = value {
+            flatten_impl(map, &full_key, result, kind)?;
+        }
+    }
+    Ok(())
+}
+
+// Vars/overrides flatten over the evaluator model: callables must survive to
+// conditional leaves, where the oracle String()s them (r4#8).
+
+/// unstable_defineVarsNested flatten: strings, CSSTypes, and conditional
+/// `{default, '@…'}` objects are leaves; other objects are namespaces.
+pub fn flatten_nested_vars_config(value: &JsValue) -> Result<JsObjectMap, StylexError> {
+    flatten_js(value, false, "unstable_defineVarsNested")
+}
+
+/// unstable_createThemeNested overrides flatten: vars leaves, CSSTypes unwrapped.
+pub fn flatten_nested_overrides_config(value: &JsValue) -> Result<JsObjectMap, StylexError> {
+    flatten_js(value, true, "unstable_createThemeNested")
+}
+
+fn flatten_js(
+    value: &JsValue,
+    unwrap_css_types: bool,
+    api: &str,
+) -> Result<JsObjectMap, StylexError> {
+    let mut result = JsObjectMap::new();
+    match value {
+        JsValue::Obj(obj) => flatten_js_impl(obj, "", &mut result, unwrap_css_types, api)?,
+        JsValue::Arr(items) => {
+            for (i, item) in items.iter().enumerate() {
+                flatten_js_entry(&i.to_string(), item, "", &mut result, unwrap_css_types, api)?;
+            }
+        }
+        // Object.keys over the upstream proxy sees no own keys.
+        JsValue::Proxy(_) => {}
+        _ => return Err(StylexError::non_style_object(api)),
+    }
+    Ok(result)
+}
+
+fn flatten_js_impl(
+    obj: &JsObj,
+    prefix: &str,
+    result: &mut JsObjectMap,
+    unwrap_css_types: bool,
+    api: &str,
+) -> Result<(), StylexError> {
+    for (key, value) in es_ordered_entries(obj) {
+        flatten_js_entry(key, value, prefix, result, unwrap_css_types, api)?;
+    }
+    Ok(())
+}
+
+fn flatten_js_entry(
+    key: &str,
+    value: &JsValue,
+    prefix: &str,
+    result: &mut JsObjectMap,
+    unwrap_css_types: bool,
+    api: &str,
+) -> Result<(), StylexError> {
+    // parity: an own "__proto__" cannot survive the oracle's evaluation (r4#7).
+    if key == "__proto__" {
+        return Ok(());
+    }
+    if key.contains(NESTED_KEY_SEPARATOR) {
+        return Err(StylexError::nested_key_contains_separator(key));
+    }
+    let full_key = if prefix.is_empty() {
+        key.to_string()
+    } else {
+        format!("{prefix}{NESTED_KEY_SEPARATOR}{key}")
+    };
+    if undefined_like(value) {
+        return Ok(());
+    }
+    if is_vars_leaf_js(value) {
+        let leaf = if let JsValue::Str(_) = value {
+            to_eval_value(value)
+        } else if let Some((_, inner)) = as_css_type_js(value) {
+            if unwrap_css_types {
+                to_vars_config_value_js(&inner, api)?
+            } else {
+                to_eval_value(value)
+            }
+        } else {
+            to_vars_config_value_js(value, api)?
+        };
+        result.insert(full_key, leaf);
+    } else if let JsValue::Obj(obj) = value {
+        flatten_js_impl(obj, &full_key, result, unwrap_css_types, api)?;
+    }
+    Ok(())
+}
+
+/// Callables the oracle's evaluator resolves to `undefined` (uninvoked
+/// keyframes/positionTry/… wrappers) behave as undefined everywhere here.
+fn undefined_like(value: &JsValue) -> bool {
+    match value {
+        JsValue::Undefined => true,
+        JsValue::Callable(Callable::Stylex(callee)) => !matches!(callee, StylexCallable::Types(_)),
+        _ => false,
+    }
+}
+
+// parity: stylex-nested-utils.js isVarsLeaf
+fn is_vars_leaf_js(value: &JsValue) -> bool {
+    if matches!(value, JsValue::Str(_)) || as_css_type_js(value).is_some() {
+        return true;
+    }
+    let JsValue::Obj(obj) = value else {
+        return false;
+    };
+    // `value.default === undefined` → namespace; else a conditional leaf only
+    // when every other key is an @-rule.
+    match obj.get("default") {
+        None => false,
+        Some(v) if undefined_like(v) => false,
+        Some(_) => es_ordered_entries(obj)
+            .into_iter()
+            .all(|(k, _)| k == "default" || k == "__proto__" || k.starts_with('@')),
+    }
+}
+
+// parity: stylex-nested-utils.js toVarsConfigValue — note the object branch
+// seeds `default: ''` first, so `default` always sorts to the front.
+fn to_vars_config_value_js(value: &JsValue, api: &str) -> Result<EvalValue, StylexError> {
+    if undefined_like(value) {
+        return Ok(EvalValue::Str(String::new()));
+    }
+    Ok(match value {
+        JsValue::Str(s) => EvalValue::Str(s.clone()),
+        JsValue::Obj(obj) => {
+            let mut out = JsObjectMap::new();
+            out.insert("default", EvalValue::Str(String::new()));
+            for (k, v) in es_ordered_entries(obj) {
+                if k == "__proto__" {
+                    continue;
+                }
+                out.insert(k, to_vars_config_value_js(v, api)?);
+            }
+            EvalValue::Obj(Arc::new(out))
+        }
+        JsValue::Proxy(_) => {
+            let mut out = JsObjectMap::new();
+            out.insert("default", EvalValue::Str(String::new()));
+            EvalValue::Obj(Arc::new(out))
+        }
+        // `String(value ?? '')`
+        JsValue::Null => EvalValue::Str(String::new()),
+        other => EvalValue::Str(js_coerce_string(other, api)?),
+    })
+}
+
+// parity: JS String() coercion for the non-object leaves reachable above.
+fn js_coerce_string(value: &JsValue, api: &str) -> Result<String, StylexError> {
+    Ok(match value {
+        JsValue::Str(s) => s.clone(),
+        JsValue::Num(n) => js_number_to_string(*n),
+        JsValue::Bool(b) => b.to_string(),
+        JsValue::Null => "null".to_string(),
+        JsValue::Undefined => "undefined".to_string(),
+        JsValue::Obj(_) | JsValue::Proxy(_) => "[object Object]".to_string(),
+        JsValue::Arr(items) => {
+            let mut parts = Vec::with_capacity(items.len());
+            for item in items.iter() {
+                parts.push(match item {
+                    JsValue::Null => String::new(),
+                    v if undefined_like(v) => String::new(),
+                    other => js_coerce_string(other, api)?,
+                });
+            }
+            parts.join(",")
+        }
+        JsValue::Callable(Callable::Arrow(_)) => EVALUATED_FN_SOURCE.to_string(),
+        JsValue::Callable(Callable::Stylex(StylexCallable::Types(kind))) => {
+            types_member_source(kind)
+                .ok_or_else(|| StylexError::non_static_value(api))?
+                .to_string()
+        }
+        // The oracle's evaluator deopts wherever ours manufactures these.
+        JsValue::Callable(_) => return Err(StylexError::non_static_value(api)),
+    })
+}
+
+// parity: stylex-nested-utils.js SPECIAL_KEYS
+const SPECIAL_KEYS: [&str; 2] = ["__varGroupHash__", "$$css"];
+
+/// Rebuilds a nested object from dot-separated flat keys, including the
+/// upstream conflict quirks (a scalar written over a namespace detaches it).
+pub fn unflatten_object(flat: &JsObjectMap) -> JsObjectMap {
+    let mut nodes: Vec<NodeMap> = vec![NodeMap::default()];
+    let mut intermediates: FxHashMap<String, usize> = FxHashMap::default();
+    for (key, value) in flat.entries() {
+        if SPECIAL_KEYS.contains(&key) || !key.contains(NESTED_KEY_SEPARATOR) {
+            nodes[0].insert(key, Slot::Value(value.clone()));
+            continue;
+        }
+        let parts: Vec<&str> = key.split(NESTED_KEY_SEPARATOR).collect();
+        let mut path_so_far = String::new();
+        let mut current = 0usize;
+        for part in &parts[..parts.len() - 1] {
+            let next_path = if path_so_far.is_empty() {
+                (*part).to_string()
+            } else {
+                format!("{path_so_far}{NESTED_KEY_SEPARATOR}{part}")
+            };
+            if let Some(&existing) = intermediates.get(&next_path) {
+                current = existing;
+            } else {
+                let id = nodes.len();
+                nodes.push(NodeMap::default());
+                nodes[current].insert(part, Slot::Child(id));
+                intermediates.insert(next_path.clone(), id);
+                current = id;
+            }
+            path_so_far = next_path;
+        }
+        nodes[current].insert(parts[parts.len() - 1], Slot::Value(value.clone()));
+    }
+    materialize(&nodes, 0)
+}
+
+/// defineVarsNested JS-output shape: unflatten the flat var refs and re-append
+/// `__varGroupHash__` last (`define_vars` itself is the theming slice's).
+pub fn nest_define_vars_js_output(flat_result: &JsObjectMap) -> JsObjectMap {
+    let mut refs = JsObjectMap::new();
+    let mut hash = None;
+    for (k, v) in flat_result.entries() {
+        if k == "__varGroupHash__" {
+            hash = Some(v.clone());
+        } else {
+            refs.insert(k, v.clone());
+        }
+    }
+    let mut out = unflatten_object(&refs);
+    if let Some(hash) = hash {
+        out.insert("__varGroupHash__", hash);
+    }
+    out
+}
+
+/// unstable_defineConstsNested: flatten → the landed flat defineConsts → unflatten.
+// parity: stylex-define-consts-nested.js + its visitor
+pub fn define_consts_nested(
+    constants: &EvalValue,
+    canonical_file_name: &str,
+    export_name: &str,
+    options: &ResolvedOptions,
+) -> Result<DefineConstsOutput, StylexError> {
+    // parity: the visitor's `typeof value !== 'object' || value == null` gate.
+    if !matches!(constants, EvalValue::Obj(_) | EvalValue::Arr(_)) {
+        return Err(StylexError::non_style_object("unstable_defineConstsNested"));
+    }
+    let flat = flatten_nested_consts_config(constants)?;
+    let out = define_consts(
+        &EvalValue::Obj(Arc::new(flat)),
+        canonical_file_name,
+        export_name,
+        options,
+    )?;
+    Ok(DefineConstsOutput {
+        js_output: unflatten_object(&out.js_output),
+        rules: out.rules,
+    })
+}
+
+enum Slot {
+    Value(EvalValue),
+    Child(usize),
+}
+
+/// Arena node with JS ownPropertyKeys ordering (index keys ascending first);
+/// writing a "__proto__" key is the ordinary-object [[Set]]: no own entry.
+#[derive(Default)]
+struct NodeMap {
+    index_entries: Vec<(u32, String, Slot)>,
+    named_entries: Vec<(String, Slot)>,
+}
+
+impl NodeMap {
+    fn insert(&mut self, key: &str, slot: Slot) {
+        if key == "__proto__" {
+            return;
+        }
+        if let Some(n) = array_index(key) {
+            match self.index_entries.binary_search_by_key(&n, |e| e.0) {
+                Ok(i) => self.index_entries[i].2 = slot,
+                Err(i) => self.index_entries.insert(i, (n, key.to_string(), slot)),
+            }
+        } else if let Some(entry) = self.named_entries.iter_mut().find(|(k, _)| k == key) {
+            entry.1 = slot;
+        } else {
+            self.named_entries.push((key.to_string(), slot));
+        }
+    }
+
+    fn entries(&self) -> impl Iterator<Item = (&str, &Slot)> {
+        self.index_entries
+            .iter()
+            .map(|(_, k, v)| (k.as_str(), v))
+            .chain(self.named_entries.iter().map(|(k, v)| (k.as_str(), v)))
+    }
+}
+
+fn materialize(nodes: &[NodeMap], id: usize) -> JsObjectMap {
+    let mut out = JsObjectMap::new();
+    for (key, slot) in nodes[id].entries() {
+        match slot {
+            Slot::Value(v) => out.insert(key, v.clone()),
+            Slot::Child(child) => {
+                out.insert(key, EvalValue::Obj(Arc::new(materialize(nodes, *child))))
+            }
+        };
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shared::types::create_css_type;
+
+    fn obj(entries: &[(&str, EvalValue)]) -> EvalValue {
+        EvalValue::Obj(map(entries).into())
+    }
+
+    fn map(entries: &[(&str, EvalValue)]) -> JsObjectMap {
+        entries
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), v.clone()))
+            .collect()
+    }
+
+    fn jobj(entries: &[(&str, JsValue)]) -> JsValue {
+        let mut out = JsObj::default();
+        for (k, v) in entries {
+            out.insert((*k).to_string(), v.clone());
+        }
+        JsValue::object(out)
+    }
+
+    fn s(v: &str) -> EvalValue {
+        EvalValue::Str(v.to_string())
+    }
+
+    fn js(v: &str) -> JsValue {
+        JsValue::Str(v.to_string())
+    }
+
+    fn flat_pairs(map: &JsObjectMap) -> Vec<(String, EvalValue)> {
+        map.entries()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn consts_flatten_drops_non_scalars_and_recurses_default_groups() {
+        let input = obj(&[(
+            "a",
+            obj(&[
+                ("b", EvalValue::Null),
+                ("c", EvalValue::Bool(true)),
+                ("d", EvalValue::Arr(vec![s("x")])),
+                ("e", s("kept")),
+                ("f", EvalValue::Num(5.0)),
+                ("g", obj(&[("default", s("x")), ("hovered", s("y"))])),
+            ]),
+        )]);
+        let flat = flatten_nested_consts_config(&input).unwrap();
+        assert_eq!(
+            flat_pairs(&flat),
+            vec![
+                ("a.e".to_string(), s("kept")),
+                ("a.f".to_string(), EvalValue::Num(5.0)),
+                ("a.g.default".to_string(), s("x")),
+                ("a.g.hovered".to_string(), s("y")),
+            ]
+        );
+    }
+
+    #[test]
+    fn vars_flatten_leaf_detection() {
+        let cond = jobj(&[("default", js("blue")), ("@media x", js("dark"))]);
+        let input = jobj(&[
+            ("num", JsValue::Num(5.0)),
+            ("b", jobj(&[("c", cond.clone())])),
+            // default present but sibling key not @-prefixed → namespace
+            ("mixed", jobj(&[("default", js("a")), ("hovered", js("b"))])),
+            // default: undefined → namespace
+            (
+                "und",
+                jobj(&[("default", JsValue::Undefined), ("x", js("y"))]),
+            ),
+        ]);
+        let flat = flatten_nested_vars_config(&input).unwrap();
+        assert_eq!(
+            flat_pairs(&flat),
+            vec![
+                (
+                    "b.c".to_string(),
+                    obj(&[("default", s("blue")), ("@media x", s("dark"))])
+                ),
+                ("mixed.default".to_string(), s("a")),
+                ("mixed.hovered".to_string(), s("b")),
+                ("und.x".to_string(), s("y")),
+            ]
+        );
+    }
+
+    #[test]
+    fn to_vars_config_value_reorders_default_first_and_string_coerces() {
+        let leaf = jobj(&[
+            ("@media x", JsValue::array(vec![JsValue::Num(1.0), js("x")])),
+            ("default", JsValue::Num(5.0)),
+        ]);
+        let flat = flatten_nested_vars_config(&jobj(&[("c", leaf)])).unwrap();
+        assert_eq!(
+            flat.get("c"),
+            Some(&obj(&[("default", s("5")), ("@media x", s("1,x"))]))
+        );
+    }
+
+    #[test]
+    fn dot_keys_are_rejected_at_any_depth() {
+        let err = flatten_nested_consts_config(&obj(&[("a.b", s("x"))])).unwrap_err();
+        assert_eq!(
+            err.message,
+            "Key \"a.b\" must not contain the \".\" character. Use nested objects instead of dots in key names. See: https://www.designtokens.org/tr/drafts/format/#character-restrictions"
+        );
+        let err =
+            flatten_nested_vars_config(&jobj(&[("a", jobj(&[("b.c", js("x"))]))])).unwrap_err();
+        assert!(err.message.starts_with("Key \"b.c\""));
+        // The key check fires even when the value would be dropped.
+        let err = flatten_nested_consts_config(&obj(&[("a.b", EvalValue::Null)])).unwrap_err();
+        assert_eq!(err.code, crate::errors::ErrorCode::NestedKeySeparator);
+    }
+
+    #[test]
+    fn unflatten_rebuilds_and_keeps_special_keys() {
+        let flat = map(&[
+            ("button.primary.bg", s("var(--x1)")),
+            ("button.secondary.bg", s("var(--x2)")),
+            ("flat", s("var(--x3)")),
+            ("__varGroupHash__", s("xh")),
+        ]);
+        let nested = unflatten_object(&flat);
+        assert_eq!(
+            flat_pairs(&nested),
+            vec![
+                (
+                    "button".to_string(),
+                    obj(&[
+                        ("primary", obj(&[("bg", s("var(--x1)"))])),
+                        ("secondary", obj(&[("bg", s("var(--x2)"))])),
+                    ])
+                ),
+                ("flat".to_string(), s("var(--x3)")),
+                ("__varGroupHash__".to_string(), s("xh")),
+            ]
+        );
+    }
+
+    #[test]
+    fn unflatten_conflict_quirks_mirror_upstream() {
+        // "a.b" then "a": the scalar clobbers the namespace, and later "a.c"
+        // writes land in the detached object (lost) — upstream-exact.
+        let flat = map(&[("a.b", s("1")), ("a", s("2")), ("a.c", s("3"))]);
+        let nested = unflatten_object(&flat);
+        assert_eq!(flat_pairs(&nested), vec![("a".to_string(), s("2"))]);
+        // "a" then "a.b": the namespace clobbers the scalar.
+        let flat = map(&[("a", s("1")), ("a.b", s("2"))]);
+        let nested = unflatten_object(&flat);
+        assert_eq!(
+            flat_pairs(&nested),
+            vec![("a".to_string(), obj(&[("b", s("2"))]))]
+        );
+    }
+
+    #[test]
+    fn nest_define_vars_js_output_appends_hash_last() {
+        let flat = map(&[("__varGroupHash__", s("xh")), ("a.b", s("var(--x1)"))]);
+        let nested = nest_define_vars_js_output(&flat);
+        assert_eq!(
+            flat_pairs(&nested),
+            vec![
+                ("a".to_string(), obj(&[("b", s("var(--x1)"))])),
+                ("__varGroupHash__".to_string(), s("xh")),
+            ]
+        );
+    }
+
+    fn live_css_type(kind: &str, value: JsValue) -> JsValue {
+        let created = create_css_type(kind, &[to_eval_value(&value)]).unwrap();
+        crate::eval::from_eval_value(&created)
+    }
+
+    #[test]
+    fn css_type_leaves_keep_or_unwrap_by_variant() {
+        let css = live_css_type("color", js("red"));
+        let flat =
+            flatten_nested_vars_config(&jobj(&[("a", jobj(&[("b", css.clone())]))])).unwrap();
+        assert_eq!(
+            flat_pairs(&flat),
+            vec![("a.b".to_string(), to_eval_value(&css))]
+        );
+        let flat = flatten_nested_overrides_config(&jobj(&[("a", css)])).unwrap();
+        assert_eq!(flat_pairs(&flat), vec![("a".to_string(), s("red"))]);
+    }
+
+    #[test]
+    fn css_type_in_conditional_leaf_never_leaks_the_brand() {
+        // Pinned via live-oracle probe 2026-08-28 (r4#6): the instance
+        // enumerates as {default:'', value, syntax} — no marker key.
+        let leaf = jobj(&[
+            ("default", js("blue")),
+            ("@media print", live_css_type("length", JsValue::Num(4.0))),
+        ]);
+        let flat = flatten_nested_vars_config(&jobj(&[("c", leaf)])).unwrap();
+        assert_eq!(
+            flat.get("c"),
+            Some(&obj(&[
+                ("default", s("blue")),
+                (
+                    "@media print",
+                    obj(&[
+                        ("default", s("")),
+                        ("value", s("4px")),
+                        ("syntax", s("<length>")),
+                    ])
+                ),
+            ]))
+        );
+    }
+
+    #[test]
+    fn proto_keys_drop_like_the_oracle_evaluator() {
+        // Pinned via live-oracle probe 2026-08-28 (r4#7): every shape drops.
+        let flat =
+            flatten_nested_vars_config(&jobj(&[("__proto__", js("red")), ("ok", js("blue"))]))
+                .unwrap();
+        assert_eq!(flat_pairs(&flat), vec![("ok".to_string(), s("blue"))]);
+        let flat = flatten_nested_vars_config(&jobj(&[
+            ("__proto__", jobj(&[("x", js("red"))])),
+            ("ok", js("blue")),
+        ]))
+        .unwrap();
+        assert_eq!(flat_pairs(&flat), vec![("ok".to_string(), s("blue"))]);
+        let flat = flatten_nested_vars_config(&jobj(&[
+            ("a", jobj(&[("__proto__", jobj(&[("b", js("red"))]))])),
+            ("ok", js("blue")),
+        ]))
+        .unwrap();
+        assert_eq!(flat_pairs(&flat), vec![("ok".to_string(), s("blue"))]);
+        // conditional leaves ignore a __proto__ sibling and skip it on convert
+        let leaf = jobj(&[
+            ("default", JsValue::Num(1.0)),
+            ("__proto__", js("x")),
+            ("@media print", js("y")),
+        ]);
+        let flat = flatten_nested_vars_config(&jobj(&[("c", leaf)])).unwrap();
+        assert_eq!(
+            flat.get("c"),
+            Some(&obj(&[("default", s("1")), ("@media print", s("y"))]))
+        );
+        let flat =
+            flatten_nested_consts_config(&obj(&[("__proto__", s("red")), ("ok", s("blue"))]))
+                .unwrap();
+        assert_eq!(flat_pairs(&flat), vec![("ok".to_string(), s("blue"))]);
+        let flat =
+            flatten_nested_string_config(&obj(&[("__proto__", s("v")), ("ok", s("w"))])).unwrap();
+        assert_eq!(flat_pairs(&flat), vec![("ok".to_string(), s("w"))]);
+    }
+
+    #[test]
+    fn unflatten_proto_writes_are_ordinary_object_sets() {
+        // Root leaf, root intermediate, and deep intermediate all vanish while
+        // later writes land in the detached node — upstream Map bookkeeping.
+        let flat = map(&[("__proto__", s("1")), ("ok", s("2"))]);
+        assert_eq!(
+            flat_pairs(&unflatten_object(&flat)),
+            vec![("ok".to_string(), s("2"))]
+        );
+        let flat = map(&[("__proto__.x", s("1")), ("ok", s("2"))]);
+        assert_eq!(
+            flat_pairs(&unflatten_object(&flat)),
+            vec![("ok".to_string(), s("2"))]
+        );
+        let flat = map(&[("a.__proto__.b", s("1")), ("a.c", s("2"))]);
+        assert_eq!(
+            flat_pairs(&unflatten_object(&flat)),
+            vec![("a".to_string(), obj(&[("c", s("2"))]))]
+        );
+    }
+
+    #[test]
+    fn callable_leaves_string_coerce_like_the_oracle() {
+        // Pinned via live-oracle probe 2026-08-28 (r4#8): the oracle wraps
+        // every evaluatable arrow in one closure and String()s that.
+        let arrow = JsValue::Callable(Callable::Arrow(0));
+        let leaf = jobj(&[("default", arrow.clone()), ("@media print", js("blue"))]);
+        let flat = flatten_nested_vars_config(&jobj(&[("c", leaf)])).unwrap();
+        assert_eq!(
+            flat.get("c"),
+            Some(&obj(&[
+                ("default", s(EVALUATED_FN_SOURCE)),
+                ("@media print", s("blue")),
+            ]))
+        );
+        // top-level callables are neither leaves nor namespaces → dropped
+        let flat =
+            flatten_nested_vars_config(&jobj(&[("c", arrow.clone()), ("ok", js("blue"))])).unwrap();
+        assert_eq!(flat_pairs(&flat), vec![("ok".to_string(), s("blue"))]);
+        // array elements coerce through the same String()
+        let leaf = jobj(&[(
+            "default",
+            JsValue::array(vec![JsValue::Num(1.0), arrow.clone()]),
+        )]);
+        let flat = flatten_nested_vars_config(&jobj(&[("c", leaf)])).unwrap();
+        assert_eq!(
+            flat.get("c"),
+            Some(&obj(&[("default", s(&format!("1,{EVALUATED_FN_SOURCE}")))]))
+        );
+        // overrides flatten shares the coercion
+        let leaf = jobj(&[("default", arrow), ("@media print", js("x"))]);
+        let flat = flatten_nested_overrides_config(&jobj(&[("c", leaf)])).unwrap();
+        assert_eq!(
+            flat.get("c"),
+            Some(&obj(&[
+                ("default", s(EVALUATED_FN_SOURCE)),
+                ("@media print", s("x")),
+            ]))
+        );
+    }
+
+    #[test]
+    fn stylex_callables_split_types_texts_from_undefined() {
+        // Live-oracle pinned: uninvoked types.* members String() to the dist
+        // source; keyframes resolves undefined, so the leaf lacks a default.
+        let color = JsValue::Callable(Callable::Stylex(StylexCallable::Types("color".into())));
+        let leaf = jobj(&[("default", color), ("@media print", js("blue"))]);
+        let flat = flatten_nested_vars_config(&jobj(&[("c", leaf)])).unwrap();
+        assert_eq!(
+            flat.get("c"),
+            Some(&obj(&[
+                (
+                    "default",
+                    s("create(value) {\n    return new Color(value);\n  }")
+                ),
+                ("@media print", s("blue")),
+            ]))
+        );
+        let kf = JsValue::Callable(Callable::Stylex(StylexCallable::Keyframes));
+        let leaf = jobj(&[("default", kf), ("@media print", js("blue"))]);
+        let flat = flatten_nested_vars_config(&jobj(&[("c", leaf)])).unwrap();
+        assert_eq!(
+            flat_pairs(&flat),
+            vec![("c.@media print".to_string(), s("blue"))]
+        );
+    }
+}

--- a/crates/stylex/src/shared/normalize_value.rs
+++ b/crates/stylex/src/shared/normalize_value.rs
@@ -1,0 +1,467 @@
+//! Value normalization pipeline.
+// parity: babel-plugin/src/shared/utils/normalize-value.js (+ normalizers/*)
+
+use crate::jsrt::js_number_to_string;
+use crate::shared::css_value::{Kind, Node, parse, stringify, unit, walk};
+use crate::shared::dashify::dashify;
+
+// Local until errors.rs lands a shared error surface; Display strings for the
+// two unclosed variants byte-match upstream messages.js LINT_* constants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CssValueError {
+    UnclosedFunction,
+    UnclosedString,
+    // Upstream crashes with the same TypeError on empty/whitespace-only values
+    // and on mid-value '!important'; we surface one structured error for both.
+    EmptyValue,
+}
+
+impl std::fmt::Display for CssValueError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CssValueError::UnclosedFunction => f.write_str("Rule contains an unclosed function"),
+            CssValueError::UnclosedString => f.write_str("Rule contains an unclosed string"),
+            CssValueError::EmptyValue => f.write_str("Cannot normalize an empty value"),
+        }
+    }
+}
+
+impl std::error::Error for CssValueError {}
+
+pub fn normalize_value(
+    value: &str,
+    key: &str,
+    font_size_px_to_rem: bool,
+) -> Result<String, CssValueError> {
+    let mut nodes = parse(value);
+    detect_unclosed(&nodes, Kind::Func, CssValueError::UnclosedFunction)?;
+    detect_unclosed(&nodes, Kind::Str, CssValueError::UnclosedString)?;
+    normalize_whitespace(&mut nodes)?;
+    normalize_timings(&mut nodes);
+    normalize_zero_dimensions(&mut nodes, key);
+    normalize_leading_zero(&mut nodes);
+    normalize_quotes(&mut nodes);
+    convert_camel_case_values(&mut nodes, key);
+    if font_size_px_to_rem {
+        convert_font_size_to_rem(&mut nodes, key);
+    }
+    Ok(stringify(&nodes))
+}
+
+fn detect_unclosed(nodes: &[Node], kind: Kind, err: CssValueError) -> Result<(), CssValueError> {
+    for node in nodes {
+        if node.kind == kind && node.unclosed {
+            return Err(err);
+        }
+        if node.kind == Kind::Func {
+            detect_unclosed(&node.nodes, kind, err)?;
+        }
+    }
+    Ok(())
+}
+
+// parity: normalizers/whitespace.js
+fn normalize_whitespace(nodes: &mut Vec<Node>) -> Result<(), CssValueError> {
+    // Upstream indexes nodes[0]/nodes[last] unguarded; empty input crashes there.
+    if nodes.first().ok_or(CssValueError::EmptyValue)?.kind == Kind::Space {
+        nodes.remove(0);
+    }
+    if nodes.last().ok_or(CssValueError::EmptyValue)?.kind == Kind::Space {
+        nodes.pop();
+    }
+    let max = nodes.len();
+    for i in 0..max {
+        if i >= nodes.len() {
+            // Upstream's stale-length walk reads undefined here and throws
+            // (mid-value '!important'); reproduce the compile failure.
+            return Err(CssValueError::EmptyValue);
+        }
+        match nodes[i].kind {
+            Kind::Space => nodes[i].value = " ".to_string(),
+            Kind::Div => normalize_div_spacing(&mut nodes[i]),
+            Kind::Func => {
+                nodes[i].before.clear();
+                nodes[i].after.clear();
+                whitespace_walk_nested(&mut nodes[i].nodes);
+            }
+            Kind::Word
+                if nodes[i].value == "!important" && i > 0 && nodes[i - 1].kind == Kind::Space =>
+            {
+                nodes.remove(i - 1);
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn normalize_div_spacing(node: &mut Node) {
+    if node.value == "," {
+        node.before.clear();
+        node.after.clear();
+    } else {
+        node.before = " ".to_string();
+        node.after = " ".to_string();
+    }
+}
+
+fn whitespace_walk_nested(nodes: &mut [Node]) {
+    for node in nodes.iter_mut() {
+        match node.kind {
+            Kind::Space => node.value = " ".to_string(),
+            Kind::Div => normalize_div_spacing(node),
+            Kind::Func => {
+                node.before.clear();
+                node.after.clear();
+                whitespace_walk_nested(&mut node.nodes);
+            }
+            // Nested '!important' upstream splices the TOP-level node list (a
+            // latent bug never hit by valid CSS); we deliberately skip it.
+            _ => {}
+        }
+    }
+}
+
+// parity: normalizers/timings.js — ms >= 10 becomes seconds
+fn normalize_timings(nodes: &mut [Node]) {
+    walk(nodes, &mut |node| {
+        if node.kind != Kind::Word {
+            return;
+        }
+        let Some(value) = js_parse_float(&node.value) else {
+            return;
+        };
+        let Some(dimension) = unit(&node.value) else {
+            return;
+        };
+        if dimension.unit != "ms" || value < 10.0 {
+            return;
+        }
+        node.value = js_number_to_string(value / 1000.0) + "s";
+    });
+}
+
+// parity: normalizers/zero-dimensions.js, including its one-live-function
+// endFunction bookkeeping (later sibling functions lose zero-unit protection).
+fn normalize_zero_dimensions(nodes: &mut [Node], key: &str) {
+    if key.starts_with("--") {
+        return;
+    }
+    let mut end_function: usize = 0;
+    walk(nodes, &mut |node| {
+        if node.kind == Kind::Func && end_function == 0 {
+            end_function = node.source_end_index;
+        }
+        if end_function > 0 && node.source_index > end_function {
+            end_function = 0;
+        }
+        if node.kind != Kind::Word {
+            return;
+        }
+        let Some(dimension) = unit(&node.value) else {
+            return;
+        };
+        if dimension.number != "0" {
+            return;
+        }
+        let unit_str = dimension.unit.as_str();
+        if matches!(unit_str, "deg" | "grad" | "turn" | "rad") {
+            node.value = "0deg".to_string();
+        } else if matches!(unit_str, "ms" | "s") {
+            node.value = "0s".to_string();
+        } else if unit_str == "fr" {
+            node.value = "0fr".to_string();
+        } else if unit_str == "%" {
+            node.value = "0%".to_string();
+        } else if end_function == 0 {
+            node.value = "0".to_string();
+        }
+    });
+}
+
+// parity: normalizers/leading-zero.js
+fn normalize_leading_zero(nodes: &mut [Node]) {
+    walk(nodes, &mut |node| {
+        if node.kind != Kind::Word {
+            return;
+        }
+        let Some(value) = js_parse_float(&node.value) else {
+            return;
+        };
+        if (0.0..1.0).contains(&value) {
+            let unit_str = unit(&node.value).map(|d| d.unit).unwrap_or_default();
+            node.value = js_number_to_string(value).replacen("0.", ".", 1) + &unit_str;
+        }
+    });
+}
+
+// parity: normalizers/quotes.js — empty strings get double quotes
+fn normalize_quotes(nodes: &mut [Node]) {
+    walk(nodes, &mut |node| {
+        if node.kind == Kind::Str && node.value.is_empty() {
+            node.quote = b'"';
+        }
+    });
+}
+
+// parity: normalizers/convert-camel-case-values.js — top-level words only
+fn convert_camel_case_values(nodes: &mut [Node], key: &str) {
+    if key != "transitionProperty" && key != "willChange" {
+        return;
+    }
+    for node in nodes.iter_mut() {
+        if node.kind == Kind::Word && !node.value.starts_with("--") {
+            node.value = dashify(&node.value);
+        }
+    }
+}
+
+// parity: normalizers/font-size-px-to-rem.js — appended last, so leading zeros
+// are already stripped ('.5px' → '.03125rem') and '0px' already collapsed to '0'.
+fn convert_font_size_to_rem(nodes: &mut [Node], key: &str) {
+    if key != "fontSize" {
+        return;
+    }
+    walk(nodes, &mut |node| {
+        if node.kind != Kind::Word {
+            return;
+        }
+        let Some(dimension) = unit(&node.value) else {
+            return;
+        };
+        if dimension.unit != "px" {
+            return;
+        }
+        let number = js_parse_float(&dimension.number).unwrap_or(f64::NAN);
+        node.value = js_number_to_string(number / 16.0) + "rem";
+    });
+}
+
+// JS Number.parseFloat over a word token: longest valid decimal-literal
+// prefix, or None for what JS reports as NaN.
+pub(crate) fn js_parse_float(s: &str) -> Option<f64> {
+    let b = s.as_bytes();
+    let mut end = 0;
+    if matches!(b.first(), Some(b'+') | Some(b'-')) {
+        end = 1;
+    }
+    if s[end..].starts_with("Infinity") {
+        let inf = if b[0] == b'-' {
+            f64::NEG_INFINITY
+        } else {
+            f64::INFINITY
+        };
+        return Some(inf);
+    }
+    let int_start = end;
+    while b.get(end).is_some_and(|c| c.is_ascii_digit()) {
+        end += 1;
+    }
+    if int_start == end {
+        // '.' must be followed by at least one digit when there is no int part
+        if b.get(end) != Some(&b'.') || !b.get(end + 1).is_some_and(|c| c.is_ascii_digit()) {
+            return None;
+        }
+        end += 1;
+        while b.get(end).is_some_and(|c| c.is_ascii_digit()) {
+            end += 1;
+        }
+    } else if b.get(end) == Some(&b'.') {
+        end += 1;
+        while b.get(end).is_some_and(|c| c.is_ascii_digit()) {
+            end += 1;
+        }
+    }
+    if matches!(b.get(end), Some(b'e') | Some(b'E')) {
+        let mut k = end + 1;
+        if matches!(b.get(k), Some(b'+') | Some(b'-')) {
+            k += 1;
+        }
+        let exp_start = k;
+        while b.get(k).is_some_and(|c| c.is_ascii_digit()) {
+            k += 1;
+        }
+        if k > exp_start {
+            end = k;
+        }
+    }
+    s[..end].parse::<f64>().ok()
+}
+
+// Also exercised end-to-end by tests/values.rs against oracle pins.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_messages_match_upstream() {
+        assert_eq!(
+            normalize_value("calc(", "width", false),
+            Err(CssValueError::UnclosedFunction)
+        );
+        assert_eq!(
+            normalize_value("\"abc", "width", false),
+            Err(CssValueError::UnclosedString)
+        );
+        assert_eq!(
+            CssValueError::UnclosedFunction.to_string(),
+            "Rule contains an unclosed function"
+        );
+        assert_eq!(
+            CssValueError::UnclosedString.to_string(),
+            "Rule contains an unclosed string"
+        );
+    }
+
+    #[test]
+    fn mid_value_important_reproduces_upstream_throw() {
+        assert_eq!(
+            normalize_value("a !important b", "width", false),
+            Err(CssValueError::EmptyValue)
+        );
+        assert_eq!(
+            normalize_value("1px !important 2px", "margin", false),
+            Err(CssValueError::EmptyValue)
+        );
+        assert_eq!(
+            normalize_value("1px !important !important", "width", false),
+            Err(CssValueError::EmptyValue)
+        );
+        // trailing '!important' stays legal, space removed
+        assert_eq!(
+            normalize_value("1px !important", "margin", false).unwrap(),
+            "1px!important"
+        );
+        assert_eq!(
+            normalize_value("!important 1px", "width", false).unwrap(),
+            "!important 1px"
+        );
+    }
+
+    #[test]
+    fn empty_and_whitespace_only_error() {
+        assert_eq!(
+            normalize_value("", "width", false),
+            Err(CssValueError::EmptyValue)
+        );
+        assert_eq!(
+            normalize_value(" ", "width", false),
+            Err(CssValueError::EmptyValue)
+        );
+    }
+
+    #[test]
+    fn js_parse_float_prefix_semantics() {
+        assert_eq!(js_parse_float("500ms"), Some(500.0));
+        assert_eq!(js_parse_float(".5em"), Some(0.5));
+        assert_eq!(js_parse_float("+.5"), Some(0.5));
+        assert_eq!(js_parse_float("-0px"), Some(-0.0));
+        assert!(js_parse_float("-0px").unwrap().is_sign_negative());
+        assert_eq!(js_parse_float("5.e3"), Some(5000.0));
+        assert_eq!(js_parse_float("5e"), Some(5.0));
+        assert_eq!(js_parse_float("5e+"), Some(5.0));
+        assert_eq!(js_parse_float("1e-7px"), Some(1e-7));
+        assert_eq!(js_parse_float("Infinityms"), Some(f64::INFINITY));
+        assert_eq!(js_parse_float("-Infinity"), Some(f64::NEG_INFINITY));
+        assert_eq!(js_parse_float("solid"), None);
+        assert_eq!(js_parse_float(".e3"), None);
+        assert_eq!(js_parse_float("0x10"), Some(0.0));
+    }
+
+    fn rem(value: &str) -> String {
+        normalize_value(value, "fontSize", true).unwrap()
+    }
+
+    #[test]
+    fn font_size_px_to_rem_divides_by_sixteen() {
+        assert_eq!(rem("24px"), "1.5rem");
+        assert_eq!(rem("+24px"), "1.5rem");
+        assert_eq!(rem("-24px"), "-1.5rem");
+        assert_eq!(rem("24px 12px"), "1.5rem 0.75rem");
+        assert_eq!(rem("1.25rem"), "1.25rem");
+        assert_eq!(rem("inherit"), "inherit");
+        // Off by default, and gated on the exact camelCase key.
+        assert_eq!(normalize_value("24px", "fontSize", false).unwrap(), "24px");
+        for key in ["font-size", "fontSizeAdjust", "--fontSize", "font"] {
+            assert_eq!(normalize_value("24px", key, true).unwrap(), "24px", "{key}");
+        }
+    }
+
+    #[test]
+    fn font_size_px_to_rem_runs_after_the_other_normalizers() {
+        // leading-zero already stripped: the rem result keeps the '0.' form.
+        assert_eq!(rem("0.5px"), "0.03125rem");
+        // zero-dimensions already collapsed '0px' to a unitless word.
+        assert_eq!(rem("0px"), "0");
+        assert_eq!(normalize_value("0", "fontSize", true).unwrap(), "0");
+        assert_eq!(rem("0x10px"), "0");
+    }
+
+    #[test]
+    fn font_size_px_to_rem_number_formatting_matches_js() {
+        assert_eq!(rem("-0px"), "0rem");
+        assert_eq!(rem("5e-324px"), "0rem");
+        assert_eq!(rem("1e-7px"), "6.25e-9rem");
+        assert_eq!(rem("1.6e-6px"), "1e-7rem");
+        assert_eq!(rem("1e-6px"), "6.25e-8rem");
+        assert_eq!(rem("0.000001px"), "6.25e-8rem");
+        assert_eq!(rem("0.0000001px"), "6.25e-9rem");
+        assert_eq!(rem("1e21px"), "62500000000000000000rem");
+        assert_eq!(rem("1e300px"), "6.25e+298rem");
+        assert_eq!(
+            rem("1.7976931348623157e308px"),
+            "1.1235582092889473e+307rem"
+        );
+        assert_eq!(
+            rem("123456789012345678901234567890px"),
+            "7.716049313271605e+27rem"
+        );
+        assert_eq!(rem("0.30000000000000004px"), "0.018750000000000003rem");
+    }
+
+    #[test]
+    fn font_size_px_to_rem_walks_functions_and_skips_non_px_words() {
+        assert_eq!(rem("calc(100% - 24px)"), "calc(100% - 1.5rem)");
+        assert_eq!(rem("clamp(12px, 2vw, 24px)"), "clamp(0.75rem,2vw,1.5rem)");
+        assert_eq!(rem("url(24px)"), "url(1.5rem)");
+        assert_eq!(rem("attr(24px)"), "attr(1.5rem)");
+        assert_eq!(rem("'24px'"), "'24px'");
+        // Unit match is exact and lowercase; malformed words have no unit().
+        for value in [
+            "1PX",
+            "1Px",
+            "px",
+            "-px",
+            ".px",
+            "1.px",
+            "--24px",
+            "24pxx",
+            "24 px",
+            "Infinitypx",
+            "NaNpx",
+            "24px!important",
+        ] {
+            assert_eq!(rem(value), value, "{value}");
+        }
+    }
+
+    #[test]
+    fn camel_case_values_dashify_for_gated_keys_only() {
+        assert_eq!(
+            normalize_value("marginTop, opacity", "transitionProperty", false).unwrap(),
+            "margin-top,opacity"
+        );
+        assert_eq!(
+            normalize_value("WebkitFilter", "willChange", false).unwrap(),
+            "-webkit-filter"
+        );
+        assert_eq!(
+            normalize_value("--customProp", "willChange", false).unwrap(),
+            "--customProp"
+        );
+        assert_eq!(
+            normalize_value("marginTop", "color", false).unwrap(),
+            "marginTop"
+        );
+    }
+}

--- a/crates/stylex/src/shared/normalize_value.rs
+++ b/crates/stylex/src/shared/normalize_value.rs
@@ -77,7 +77,7 @@ fn normalize_whitespace(nodes: &mut Vec<Node>) -> Result<(), CssValueError> {
             return Err(CssValueError::EmptyValue);
         }
         match nodes[i].kind {
-            Kind::Space => nodes[i].value = " ".to_string(),
+            Kind::Space => set_single_space(&mut nodes[i].value),
             Kind::Div => normalize_div_spacing(&mut nodes[i]),
             Kind::Func => {
                 nodes[i].before.clear();
@@ -100,15 +100,22 @@ fn normalize_div_spacing(node: &mut Node) {
         node.before.clear();
         node.after.clear();
     } else {
-        node.before = " ".to_string();
-        node.after = " ".to_string();
+        set_single_space(&mut node.before);
+        set_single_space(&mut node.after);
+    }
+}
+
+fn set_single_space(s: &mut String) {
+    if s != " " {
+        s.clear();
+        s.push(' ');
     }
 }
 
 fn whitespace_walk_nested(nodes: &mut [Node]) {
     for node in nodes.iter_mut() {
         match node.kind {
-            Kind::Space => node.value = " ".to_string(),
+            Kind::Space => set_single_space(&mut node.value),
             Kind::Div => normalize_div_spacing(node),
             Kind::Func => {
                 node.before.clear();
@@ -164,7 +171,7 @@ fn normalize_zero_dimensions(nodes: &mut [Node], key: &str) {
         if dimension.number != "0" {
             return;
         }
-        let unit_str = dimension.unit.as_str();
+        let unit_str = dimension.unit;
         if matches!(unit_str, "deg" | "grad" | "turn" | "rad") {
             node.value = "0deg".to_string();
         } else if matches!(unit_str, "ms" | "s") {
@@ -190,7 +197,7 @@ fn normalize_leading_zero(nodes: &mut [Node]) {
         };
         if (0.0..1.0).contains(&value) {
             let unit_str = unit(&node.value).map(|d| d.unit).unwrap_or_default();
-            node.value = js_number_to_string(value).replacen("0.", ".", 1) + &unit_str;
+            node.value = js_number_to_string(value).replacen("0.", ".", 1) + unit_str;
         }
     });
 }
@@ -232,7 +239,7 @@ fn convert_font_size_to_rem(nodes: &mut [Node], key: &str) {
         if dimension.unit != "px" {
             return;
         }
-        let number = js_parse_float(&dimension.number).unwrap_or(f64::NAN);
+        let number = js_parse_float(dimension.number).unwrap_or(f64::NAN);
         node.value = js_number_to_string(number / 16.0) + "rem";
     });
 }

--- a/crates/stylex/src/shared/position_try.rs
+++ b/crates/stylex/src/shared/position_try.rs
@@ -1,0 +1,279 @@
+//! `stylex.positionTry` over an already-evaluated styles object.
+// parity: babel-plugin src/shared/stylex-position-try.js + visitors/stylex-position-try.js
+
+use crate::errors::StylexError;
+use crate::eval::value::{EvalValue, JsObjectMap};
+use crate::hash::hash;
+use crate::jsrt::utf16_cmp;
+use crate::options::ResolvedOptions;
+use crate::rules::StylexRule;
+use crate::shared::dashify::dashify;
+use crate::shared::flatten::StyleScalar;
+use crate::shared::normalize_value::CssValueError;
+use crate::shared::resolution::flat_map_expanded_shorthands;
+use crate::shared::rtl::{RtlContext, generate_ltr, generate_rtl};
+use crate::shared::transform_value::{transform_value_num, transform_value_str};
+
+// parity: visitors/stylex-position-try.js VALID_POSITION_TRY_PROPERTIES
+const VALID_POSITION_TRY_PROPERTIES: [&str; 40] = [
+    "anchorName",
+    "positionAnchor",
+    "positionArea",
+    "top",
+    "right",
+    "bottom",
+    "left",
+    "inset",
+    "insetBlock",
+    "insetBlockEnd",
+    "insetBlockStart",
+    "insetInline",
+    "insetInlineEnd",
+    "insetInlineStart",
+    "margin",
+    "marginBlock",
+    "marginBlockEnd",
+    "marginBlockStart",
+    "marginInline",
+    "marginInlineEnd",
+    "marginInlineStart",
+    "marginTop",
+    "marginBottom",
+    "marginLeft",
+    "marginRight",
+    "width",
+    "height",
+    "minWidth",
+    "minHeight",
+    "maxWidth",
+    "maxHeight",
+    "blockSize",
+    "inlineSize",
+    "minBlockSize",
+    "minInlineSize",
+    "maxBlockSize",
+    "maxInlineSize",
+    "alignSelf",
+    "justifySelf",
+    "placeSelf",
+];
+
+/// Returns the `--`-prefixed name and its single injectable rule (priority 0).
+pub fn position_try(
+    styles: &EvalValue,
+    options: &ResolvedOptions,
+) -> Result<(String, StylexRule), StylexError> {
+    let styles = assert_valid_position_try(styles)?;
+    assert_valid_properties(styles)?;
+    position_try_impl(styles, options)
+}
+
+/// The callable path (create/defineVars/createTheme FunctionConfig closures):
+/// shared fn only — Object.entries coercion, no property validation.
+pub fn position_try_shared(
+    styles: &EvalValue,
+    options: &ResolvedOptions,
+) -> Result<(String, StylexRule), StylexError> {
+    let entries = crate::shared::view_transition::object_entries_js(
+        styles,
+        "a nullish positionTry() argument",
+    )?;
+    position_try_impl(&entries, options)
+}
+
+fn position_try_impl(
+    styles: &JsObjectMap,
+    options: &ResolvedOptions,
+) -> Result<(String, StylexRule), StylexError> {
+    let expanded = expand_dashify_transform(styles, options)?;
+    let mut keys: Vec<&str> = expanded.keys().collect();
+    keys.sort_by(|a, b| utf16_cmp(a, b));
+
+    // Upstream stores the whole generateLtr PAIR as the value, so each ltr decl
+    // doubles into `k:ltrKey;k:ltrValue;` (and rtl too, when a flip fires).
+    let mut ltr_string = String::new();
+    let mut rtl_string = String::new();
+    for key in keys {
+        let Some(EvalValue::Str(value)) = expanded.get(key) else {
+            unreachable!("transform stage only stores strings");
+        };
+        // Upstream passes no options here, so both sides see defaultOptions.
+        let (lk, lv) = generate_ltr(key, value, RtlContext::DEFAULTS);
+        ltr_string.push_str(&format!("{key}:{lk};{key}:{lv};"));
+        match generate_rtl(key, value, RtlContext::DEFAULTS) {
+            Some((rk, rv)) => rtl_string.push_str(&format!("{key}:{rk};{key}:{rv};")),
+            None => rtl_string.push_str(&format!("{key}:{value};")),
+        }
+    }
+
+    let name = format!("--{}{}", options.class_name_prefix, hash(&ltr_string));
+    let ltr = format!("@position-try {name} {{{ltr_string}}}");
+    let rtl = (ltr_string != rtl_string).then(|| format!("@position-try {name} {{{rtl_string}}}"));
+
+    let rule = StylexRule {
+        class_name: name.as_str().into(),
+        ltr: ltr.into(),
+        rtl: rtl.map(Into::into),
+        const_key: None,
+        const_val: None,
+        priority: 0.0,
+    };
+    Ok((name, rule))
+}
+
+// parity: visitors/stylex-position-try.js assertValidPositionTry
+fn assert_valid_position_try(styles: &EvalValue) -> Result<&JsObjectMap, StylexError> {
+    match styles {
+        EvalValue::Obj(map) => Ok(map),
+        _ => Err(StylexError::non_style_object("positionTry")),
+    }
+}
+
+// parity: visitors/stylex-position-try.js assertValidProperties (original keys,
+// before any alias expansion or dashify).
+fn assert_valid_properties(styles: &JsObjectMap) -> Result<(), StylexError> {
+    if styles
+        .keys()
+        .any(|key| !VALID_POSITION_TRY_PROPERTIES.contains(&key))
+    {
+        return Err(StylexError::position_try_invalid_property());
+    }
+    Ok(())
+}
+
+// parity: stylex-position-try.js preprocessProperties + dashify + transformValue
+// pipe (same stage as stylex-keyframes.js; each stage rebuilds the object).
+pub(crate) fn expand_dashify_transform(
+    styles: &JsObjectMap,
+    options: &ResolvedOptions,
+) -> Result<JsObjectMap, StylexError> {
+    let mut expanded = JsObjectMap::new();
+    for (key, value) in styles.entries() {
+        let value_is_array = matches!(value, EvalValue::Arr(_));
+        let scalar = match value {
+            EvalValue::Str(s) => Some(StyleScalar::Str(std::borrow::Cow::Borrowed(s.as_str()))),
+            EvalValue::Num(n) => Some(StyleScalar::Num(*n)),
+            _ => None,
+        };
+        // Only string/number values survive; arrays, nulls, and objects drop.
+        for (property, expanded_value) in flat_map_expanded_shorthands(
+            std::borrow::Cow::Borrowed(key),
+            scalar,
+            value_is_array,
+            options,
+        )? {
+            match expanded_value {
+                Some(StyleScalar::Str(s)) => {
+                    expanded.insert(property.to_string(), EvalValue::Str(s.into_owned()));
+                }
+                Some(StyleScalar::Num(n)) => {
+                    expanded.insert(property, EvalValue::Num(n));
+                }
+                Some(StyleScalar::Undefined) | None => {}
+            }
+        }
+    }
+    let mut dashed = JsObjectMap::new();
+    for (key, value) in expanded.entries() {
+        dashed.insert(dashify(key), value.clone());
+    }
+    let mut transformed = JsObjectMap::new();
+    for (key, value) in dashed.entries() {
+        // transformValue sees the already-dashed key (the same camelCase-keyed
+        // suffix-table misses as keyframes: `transition-duration: 500` → 500px).
+        let out = match value {
+            EvalValue::Str(s) => transform_value_str(key, s, options.enable_font_size_px_to_rem),
+            EvalValue::Num(n) => transform_value_num(key, *n, options.enable_font_size_px_to_rem),
+            _ => unreachable!("expand stage only stores scalars"),
+        }
+        .map_err(css_value_error)?;
+        transformed.insert(key, EvalValue::Str(out));
+    }
+    Ok(transformed)
+}
+
+pub(crate) fn css_value_error(e: CssValueError) -> StylexError {
+    match e {
+        CssValueError::UnclosedFunction => StylexError::unclosed_function(),
+        CssValueError::UnclosedString => StylexError::unclosed_string(),
+        CssValueError::EmptyValue => StylexError::empty_value(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn obj(entries: &[(&str, EvalValue)]) -> EvalValue {
+        EvalValue::Obj(
+            entries
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), v.clone()))
+                .collect::<JsObjectMap>()
+                .into(),
+        )
+    }
+
+    #[test]
+    fn basic_output_matches_oracle() {
+        // Pinned via live-oracle probe 2026-08-28.
+        let options = ResolvedOptions::default();
+        let styles = obj(&[
+            ("width", EvalValue::Num(100.0)),
+            ("top", EvalValue::Num(0.0)),
+        ]);
+        let (name, rule) = position_try(&styles, &options).unwrap();
+        assert_eq!(name, "--x1cy0vnv");
+        assert_eq!(
+            &*rule.ltr,
+            "@position-try --x1cy0vnv {top:top;top:0;width:width;width:100px;}"
+        );
+        assert_eq!(
+            rule.rtl.as_deref(),
+            Some("@position-try --x1cy0vnv {top:0;width:100px;}")
+        );
+        assert!(rule.priority == 0.0);
+        assert_eq!(rule.const_key, None);
+    }
+
+    #[test]
+    fn empty_styles_have_no_rtl() {
+        let options = ResolvedOptions::default();
+        let (name, rule) = position_try(&obj(&[]), &options).unwrap();
+        assert_eq!(name, "--xph554m");
+        assert_eq!(&*rule.ltr, "@position-try --xph554m {}");
+        assert_eq!(rule.rtl, None);
+    }
+
+    #[test]
+    fn validation_errors() {
+        let options = ResolvedOptions::default();
+        let err = position_try(&EvalValue::Str("x".to_string()), &options).unwrap_err();
+        assert_eq!(err.message, "positionTry() can only accept an object.");
+        let err = position_try(
+            &EvalValue::Arr(vec![EvalValue::Str("x".to_string())]),
+            &options,
+        )
+        .unwrap_err();
+        assert_eq!(err.message, "positionTry() can only accept an object.");
+        let err = position_try(
+            &obj(&[("color", EvalValue::Str("red".to_string()))]),
+            &options,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.code,
+            crate::errors::ErrorCode::PositionTryInvalidProperty
+        );
+        // Dashed spellings of valid properties are rejected too.
+        let err = position_try(
+            &obj(&[("position-anchor", EvalValue::Str("--x".to_string()))]),
+            &options,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.code,
+            crate::errors::ErrorCode::PositionTryInvalidProperty
+        );
+    }
+}

--- a/crates/stylex/src/shared/priorities.rs
+++ b/crates/stylex/src/shared/priorities.rs
@@ -1,0 +1,832 @@
+//! Property/pseudo/at-rule priority tables.
+// parity: @stylexjs/shared src/utils/property-priorities.js
+
+/// Priority for one selector-path segment: a property key, a pseudo, an
+/// at-rule, or a `when.*` relational `:where(...)` selector.
+pub fn get_priority(key: &str) -> f64 {
+    if let Some(p) = at_rule_priority(key) {
+        return p;
+    }
+    if let Some(p) = compound_pseudo_priority(key) {
+        return p;
+    }
+    if let Some(p) = pseudo_element_priority(key) {
+        return p;
+    }
+    if let Some(p) = pseudo_class_priority(key) {
+        return p;
+    }
+    default_priority(key).unwrap_or(3000.0)
+}
+
+fn at_rule_priority(key: &str) -> Option<f64> {
+    if key.starts_with("--") {
+        return Some(1.0);
+    }
+    if key.starts_with("@supports") {
+        return Some(30.0);
+    }
+    if key.starts_with("@media") {
+        return Some(200.0);
+    }
+    if key.starts_with("@container") {
+        return Some(300.0);
+    }
+    None
+}
+
+fn pseudo_element_priority(key: &str) -> Option<f64> {
+    key.starts_with("::").then_some(5000.0)
+}
+
+fn pseudo_class_table(pseudo: &str) -> Option<f64> {
+    match pseudo {
+        ":is" => Some(40.0),
+        ":where" => Some(40.0),
+        ":not" => Some(40.0),
+        ":has" => Some(45.0),
+        ":dir" => Some(50.0),
+        ":lang" => Some(51.0),
+        ":first-child" => Some(52.0),
+        ":first-of-type" => Some(53.0),
+        ":last-child" => Some(54.0),
+        ":last-of-type" => Some(55.0),
+        ":only-child" => Some(56.0),
+        ":only-of-type" => Some(57.0),
+        ":nth-child" => Some(60.0),
+        ":nth-last-child" => Some(61.0),
+        ":nth-of-type" => Some(62.0),
+        ":nth-last-of-type" => Some(63.0),
+        ":empty" => Some(70.0),
+        ":link" => Some(80.0),
+        ":any-link" => Some(81.0),
+        ":local-link" => Some(82.0),
+        ":target-within" => Some(83.0),
+        ":target" => Some(84.0),
+        ":visited" => Some(85.0),
+        ":enabled" => Some(91.0),
+        ":disabled" => Some(92.0),
+        ":required" => Some(93.0),
+        ":optional" => Some(94.0),
+        ":read-only" => Some(95.0),
+        ":read-write" => Some(96.0),
+        ":placeholder-shown" => Some(97.0),
+        ":in-range" => Some(98.0),
+        ":out-of-range" => Some(99.0),
+        ":default" => Some(100.0),
+        ":checked" => Some(101.0),
+        ":indeterminate" => Some(101.0),
+        ":blank" => Some(102.0),
+        ":valid" => Some(103.0),
+        ":invalid" => Some(104.0),
+        ":user-invalid" => Some(105.0),
+        ":autofill" => Some(110.0),
+        ":picture-in-picture" => Some(120.0),
+        ":modal" => Some(121.0),
+        ":fullscreen" => Some(122.0),
+        ":paused" => Some(123.0),
+        ":playing" => Some(124.0),
+        ":current" => Some(125.0),
+        ":past" => Some(126.0),
+        ":future" => Some(127.0),
+        ":hover" => Some(130.0),
+        ":focusWithin" => Some(140.0),
+        ":focus" => Some(150.0),
+        ":focusVisible" => Some(160.0),
+        ":active" => Some(170.0),
+        _ => None,
+    }
+}
+
+// Chains of simple pseudo-classes/elements only; any functional part opts out.
+fn compound_pseudo_priority(key: &str) -> Option<f64> {
+    let parts = pseudo_parts(key);
+    if parts.len() <= 1 || parts.iter().any(|p| p.contains('(')) {
+        return None;
+    }
+    let mut total = 0.0;
+    for part in parts {
+        total += if part.starts_with("::") {
+            5000.0
+        } else {
+            pseudo_class_table(part).unwrap_or(40.0)
+        };
+    }
+    Some(total)
+}
+
+// Equivalent of matching /::[a-zA-Z-]+|:[a-zA-Z-]+(?:\([^)]*\))?/g.
+fn pseudo_parts(key: &str) -> Vec<&str> {
+    let bytes = key.as_bytes();
+    let mut parts = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b':'
+            && let Some(end) = pseudo_part_end(bytes, i)
+        {
+            parts.push(&key[i..end]);
+            i = end;
+            continue;
+        }
+        i += 1;
+    }
+    parts
+}
+
+fn pseudo_part_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let is_name = |b: u8| b.is_ascii_alphabetic() || b == b'-';
+    if bytes.get(start + 1) == Some(&b':') {
+        let mut j = start + 2;
+        while bytes.get(j).is_some_and(|&b| is_name(b)) {
+            j += 1;
+        }
+        return (j > start + 2).then_some(j);
+    }
+    let mut j = start + 1;
+    while bytes.get(j).is_some_and(|&b| is_name(b)) {
+        j += 1;
+    }
+    if j == start + 1 {
+        return None;
+    }
+    if bytes.get(j) == Some(&b'(')
+        && let Some(rel) = bytes[j + 1..].iter().position(|&b| b == b')')
+    {
+        return Some(j + 1 + rel + 1);
+    }
+    Some(j)
+}
+
+fn pseudo_class_priority(key: &str) -> Option<f64> {
+    if !key.starts_with(':') {
+        return None;
+    }
+    let base = |p: &str| pseudo_class_table(p).unwrap_or(40.0) / 100.0;
+
+    // Every relational shape opens with this literal; plain keys and ordinary
+    // pseudos skip the five scanner allocations (hot per style entry).
+    if key.starts_with(":where(") {
+        if let Some(p) = match_relational(key, Relational::Ancestor) {
+            return Some(10.0 + base(p.0));
+        }
+        if let Some(p) = match_relational(key, Relational::Descendant) {
+            return Some(15.0 + base(p.0));
+        }
+        if let Some(p) = match_relational(key, Relational::AnySibling) {
+            return Some(20.0 + base(p.0).max(base(p.1.unwrap_or(p.0))));
+        }
+        if let Some(p) = match_relational(key, Relational::SiblingBefore) {
+            return Some(30.0 + base(p.0));
+        }
+        if let Some(p) = match_relational(key, Relational::SiblingAfter) {
+            return Some(40.0 + base(p.0));
+        }
+    }
+
+    let prop = key.split('(').next().unwrap_or(key);
+    Some(pseudo_class_table(prop).unwrap_or(40.0))
+}
+
+// The five `when.*` output shapes (property-priorities.js RELATIONAL_SELECTORS).
+enum Relational {
+    Ancestor,
+    Descendant,
+    SiblingBefore,
+    SiblingAfter,
+    AnySibling,
+}
+
+struct RelScanner<'a> {
+    chars: Vec<char>,
+    src: &'a str,
+    pos: usize,
+}
+
+impl<'a> RelScanner<'a> {
+    fn new(src: &'a str) -> Self {
+        Self {
+            chars: src.chars().collect(),
+            src,
+            pos: 0,
+        }
+    }
+
+    fn lit(&mut self, s: &str) -> bool {
+        for expected in s.chars() {
+            if self.chars.get(self.pos) != Some(&expected) {
+                return false;
+            }
+            self.pos += 1;
+        }
+        true
+    }
+
+    // \.[0-9a-zA-Z_-]+ — the marker class; ≥1 char
+    fn class_name(&mut self) -> bool {
+        if !self.lit(".") {
+            return false;
+        }
+        let start = self.pos;
+        while self
+            .chars
+            .get(self.pos)
+            .is_some_and(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
+        {
+            self.pos += 1;
+        }
+        self.pos > start
+    }
+
+    // (:[a-zA-Z-]+) — the captured pseudo; ≥1 name char
+    fn pseudo_capture(&mut self) -> Option<&'a str> {
+        if self.chars.get(self.pos) != Some(&':') {
+            return None;
+        }
+        let start = self.pos;
+        self.pos += 1;
+        while self
+            .chars
+            .get(self.pos)
+            .is_some_and(|c| c.is_ascii_alphabetic() || *c == '-')
+        {
+            self.pos += 1;
+        }
+        if self.pos == start + 1 {
+            return None;
+        }
+        let byte_start: usize = self.chars[..start].iter().map(|c| c.len_utf8()).sum();
+        let byte_len: usize = self.chars[start..self.pos]
+            .iter()
+            .map(|c| c.len_utf8())
+            .sum();
+        Some(&self.src[byte_start..byte_start + byte_len])
+    }
+
+    fn ws(&mut self, at_least_one: bool, at_most_one: bool) -> bool {
+        let start = self.pos;
+        while self.chars.get(self.pos).is_some_and(|c| is_js_ws(*c)) {
+            self.pos += 1;
+            if at_most_one {
+                break;
+            }
+        }
+        !at_least_one || self.pos > start
+    }
+
+    fn eof(&self) -> bool {
+        self.pos == self.chars.len()
+    }
+}
+
+// JS /\s/: ECMA-262 WhiteSpace + LineTerminator set.
+fn is_js_ws(c: char) -> bool {
+    matches!(
+        c,
+        '\t' | '\n' | '\u{000B}' | '\u{000C}' | '\r' | ' ' | '\u{00A0}' | '\u{1680}' | '\u{2000}'
+            ..='\u{200A}'
+                | '\u{2028}'
+                | '\u{2029}'
+                | '\u{202F}'
+                | '\u{205F}'
+                | '\u{3000}'
+                | '\u{FEFF}'
+    )
+}
+
+fn match_relational(key: &str, shape: Relational) -> Option<(&str, Option<&str>)> {
+    let mut s = RelScanner::new(key);
+    if !s.lit(":where(") {
+        return None;
+    }
+    match shape {
+        Relational::Ancestor => {
+            // :where(\.CLASS(:pseudo)\s+\*)
+            if !s.class_name() {
+                return None;
+            }
+            let p = s.pseudo_capture()?;
+            (s.ws(true, false) && s.lit("*)") && s.eof()).then_some((p, None))
+        }
+        Relational::Descendant => {
+            // :where(:has(\.CLASS(:pseudo)))
+            if !s.lit(":has(") || !s.class_name() {
+                return None;
+            }
+            let p = s.pseudo_capture()?;
+            (s.lit("))") && s.eof()).then_some((p, None))
+        }
+        Relational::SiblingBefore => {
+            // :where(\.CLASS(:pseudo)\s+~\s+\*)
+            if !s.class_name() {
+                return None;
+            }
+            let p = s.pseudo_capture()?;
+            (s.ws(true, false) && s.lit("~") && s.ws(true, false) && s.lit("*)") && s.eof())
+                .then_some((p, None))
+        }
+        Relational::SiblingAfter => {
+            // :where(:has(~\s\.CLASS(:pseudo)))
+            if !s.lit(":has(~") || !s.ws(true, true) || !s.class_name() {
+                return None;
+            }
+            let p = s.pseudo_capture()?;
+            (s.lit("))") && s.eof()).then_some((p, None))
+        }
+        Relational::AnySibling => {
+            // :where(\.CLASS(:p1)\s+~\s+\*,\s+:has(~\s\.CLASS(:p2)))
+            if !s.class_name() {
+                return None;
+            }
+            let p1 = s.pseudo_capture()?;
+            if !(s.ws(true, false) && s.lit("~") && s.ws(true, false) && s.lit("*,")) {
+                return None;
+            }
+            if !s.ws(true, false) || !s.lit(":has(~") || !s.ws(true, true) || !s.class_name() {
+                return None;
+            }
+            let p2 = s.pseudo_capture()?;
+            (s.lit("))") && s.eof()).then_some((p1, Some(p2)))
+        }
+    }
+}
+
+// Tier tables transcribed from property-priorities.js (MDN-derived data),
+// including upstream's literal 'border-block-stylex' entry.
+fn default_priority(key: &str) -> Option<f64> {
+    let tier = match key {
+        "animation" | "background" | "border" | "border-block" | "border-inline" | "margin"
+        | "padding" | "font" | "grid" | "grid-template" | "grid-area" | "all" | "inset"
+        | "scroll-margin" | "scroll-padding" => 1000.0,
+        "animation-range"
+        | "scroll-timeline"
+        | "view-timeline"
+        | "background-position"
+        | "border-color"
+        | "border-style"
+        | "border-width"
+        | "border-block-start"
+        | "border-top"
+        | "border-block-end"
+        | "border-bottom"
+        | "border-inline-color"
+        | "border-inline-style"
+        | "border-inline-width"
+        | "border-inline-start"
+        | "border-left"
+        | "border-inline-end"
+        | "border-right"
+        | "border-image"
+        | "border-radius"
+        | "corner-shape"
+        | "caret"
+        | "outline"
+        | "grid-gap"
+        | "gap"
+        | "place-content"
+        | "place-items"
+        | "place-self"
+        | "margin-block"
+        | "margin-inline"
+        | "overscroll-behavior"
+        | "padding-block"
+        | "padding-inline"
+        | "columns"
+        | "column-rule"
+        | "contain-intrinsic-size"
+        | "container"
+        | "flex"
+        | "flex-flow"
+        | "font-variant"
+        | "grid-template-areas"
+        | "grid-row"
+        | "grid-column"
+        | "list-style"
+        | "mask"
+        | "mask-border"
+        | "offset"
+        | "overflow"
+        | "inset-block"
+        | "inset-inline"
+        | "scroll-margin-block"
+        | "scroll-margin-inline"
+        | "scroll-padding-block"
+        | "scroll-padding-inline"
+        | "scroll-snap-type"
+        | "text-decoration"
+        | "text-emphasis"
+        | "transition" => 2000.0,
+        "background-blend-mode"
+        | "isolation"
+        | "mix-blend-mode"
+        | "animation-composition"
+        | "animation-delay"
+        | "animation-direction"
+        | "animation-duration"
+        | "animation-fill-mode"
+        | "animation-iteration-count"
+        | "animation-name"
+        | "animation-play-state"
+        | "animation-range-end"
+        | "animation-range-start"
+        | "animation-timing-function"
+        | "animation-timeline"
+        | "scroll-timeline-axis"
+        | "scroll-timeline-name"
+        | "timeline-scope"
+        | "view-timeline-axis"
+        | "view-timeline-inset"
+        | "view-timeline-name"
+        | "background-attachment"
+        | "background-clip"
+        | "background-color"
+        | "background-image"
+        | "background-origin"
+        | "background-repeat"
+        | "background-size"
+        | "background-position-x"
+        | "background-position-y"
+        | "border-block-color"
+        | "border-block-stylex"
+        | "border-block-width"
+        | "border-block-start-color"
+        | "border-block-start-style"
+        | "border-block-start-width"
+        | "border-block-end-color"
+        | "border-block-end-style"
+        | "border-block-end-width"
+        | "border-inline-start-color"
+        | "border-inline-start-style"
+        | "border-inline-start-width"
+        | "border-inline-end-color"
+        | "border-inline-end-style"
+        | "border-inline-end-width"
+        | "border-image-outset"
+        | "border-image-repeat"
+        | "border-image-slice"
+        | "border-image-source"
+        | "border-image-width"
+        | "border-start-end-radius"
+        | "border-start-start-radius"
+        | "border-end-end-radius"
+        | "border-end-start-radius"
+        | "corner-start-start-shape"
+        | "corner-start-end-shape"
+        | "corner-end-start-shape"
+        | "corner-end-end-shape"
+        | "box-shadow"
+        | "accent-color"
+        | "appearance"
+        | "aspect-ratio"
+        | "caret-color"
+        | "caret-shape"
+        | "cursor"
+        | "ime-mode"
+        | "input-security"
+        | "outline-color"
+        | "outline-offset"
+        | "outline-style"
+        | "outline-width"
+        | "pointer-events"
+        | "resize"
+        | "text-overflow"
+        | "user-select"
+        | "grid-row-gap"
+        | "row-gap"
+        | "grid-column-gap"
+        | "column-gap"
+        | "align-content"
+        | "justify-content"
+        | "align-items"
+        | "justify-items"
+        | "align-self"
+        | "justify-self"
+        | "box-sizing"
+        | "block-size"
+        | "inline-size"
+        | "max-block-size"
+        | "max-inline-size"
+        | "min-block-size"
+        | "min-inline-size"
+        | "margin-block-start"
+        | "margin-block-end"
+        | "margin-inline-start"
+        | "margin-inline-end"
+        | "margin-trim"
+        | "overscroll-behavior-block"
+        | "overscroll-behavior-inline"
+        | "padding-block-start"
+        | "padding-block-end"
+        | "padding-inline-start"
+        | "padding-inline-end"
+        | "visibility"
+        | "color"
+        | "color-scheme"
+        | "forced-color-adjust"
+        | "opacity"
+        | "print-color-adjust"
+        | "column-count"
+        | "column-width"
+        | "column-fill"
+        | "column-span"
+        | "column-rule-color"
+        | "column-rule-style"
+        | "column-rule-width"
+        | "contain"
+        | "contain-intrinsic-block-size"
+        | "contain-intrinsic-width"
+        | "contain-intrinsic-height"
+        | "contain-intrinsic-inline-size"
+        | "container-name"
+        | "container-type"
+        | "content-visibility"
+        | "counter-increment"
+        | "counter-reset"
+        | "counter-set"
+        | "display"
+        | "flex-basis"
+        | "flex-grow"
+        | "flex-shrink"
+        | "flex-direction"
+        | "flex-wrap"
+        | "order"
+        | "font-family"
+        | "font-size"
+        | "font-stretch"
+        | "font-style"
+        | "font-weight"
+        | "line-height"
+        | "font-variant-alternates"
+        | "font-variant-caps"
+        | "font-variant-east-asian"
+        | "font-variant-emoji"
+        | "font-variant-ligatures"
+        | "font-variant-numeric"
+        | "font-variant-position"
+        | "font-feature-settings"
+        | "font-kerning"
+        | "font-language-override"
+        | "font-optical-sizing"
+        | "font-palette"
+        | "font-variation-settings"
+        | "font-size-adjust"
+        | "font-smooth"
+        | "font-synthesis-position"
+        | "font-synthesis-small-caps"
+        | "font-synthesis-style"
+        | "font-synthesis-weight"
+        | "line-height-step"
+        | "box-decoration-break"
+        | "break-after"
+        | "break-before"
+        | "break-inside"
+        | "orphans"
+        | "widows"
+        | "content"
+        | "quotes"
+        | "grid-auto-flow"
+        | "grid-auto-rows"
+        | "grid-auto-columns"
+        | "grid-template-columns"
+        | "grid-template-rows"
+        | "grid-row-start"
+        | "grid-row-end"
+        | "grid-column-start"
+        | "grid-column-end"
+        | "align-tracks"
+        | "justify-tracks"
+        | "masonry-auto-flow"
+        | "image-orientation"
+        | "image-rendering"
+        | "image-resolution"
+        | "object-fit"
+        | "object-position"
+        | "initial-letter"
+        | "initial-letter-align"
+        | "list-style-image"
+        | "list-style-position"
+        | "list-style-type"
+        | "clip"
+        | "clip-path"
+        | "mask-clip"
+        | "mask-composite"
+        | "mask-image"
+        | "mask-mode"
+        | "mask-origin"
+        | "mask-position"
+        | "mask-repeat"
+        | "mask-size"
+        | "mask-type"
+        | "mask-border-mode"
+        | "mask-border-outset"
+        | "mask-border-repeat"
+        | "mask-border-slice"
+        | "mask-border-source"
+        | "mask-border-width"
+        | "text-rendering"
+        | "offset-anchor"
+        | "offset-distance"
+        | "offset-path"
+        | "offset-position"
+        | "offset-rotate"
+        | "-webkit-box-orient"
+        | "-webkit-line-clamp"
+        | "overflow-block"
+        | "overflow-inline"
+        | "overflow-clip-margin"
+        | "scroll-gutter"
+        | "scroll-behavior"
+        | "page"
+        | "page-break-after"
+        | "page-break-before"
+        | "page-break-inside"
+        | "inset-block-start"
+        | "inset-block-end"
+        | "inset-inline-start"
+        | "inset-inline-end"
+        | "clear"
+        | "float"
+        | "position"
+        | "z-index"
+        | "ruby-align"
+        | "ruby-merge"
+        | "ruby-position"
+        | "overflow-anchor"
+        | "scroll-margin-block-start"
+        | "scroll-margin-block-end"
+        | "scroll-margin-inline-start"
+        | "scroll-margin-inline-end"
+        | "scroll-padding-block-start"
+        | "scroll-padding-block-end"
+        | "scroll-padding-inline-start"
+        | "scroll-padding-inline-end"
+        | "scroll-snap-align"
+        | "scroll-snap-stop"
+        | "scrollbar-color"
+        | "scrollbar-width"
+        | "shape-image-threshold"
+        | "shape-margin"
+        | "shape-outside"
+        | "azimuth"
+        | "border-collapse"
+        | "border-spacing"
+        | "caption-side"
+        | "empty-cells"
+        | "table-layout"
+        | "vertical-align"
+        | "text-decoration-color"
+        | "text-decoration-line"
+        | "text-decoration-skip"
+        | "text-decoration-skip-ink"
+        | "text-decoration-style"
+        | "text-decoration-thickness"
+        | "text-emphasis-color"
+        | "text-emphasis-position"
+        | "text-emphasis-style"
+        | "text-shadow"
+        | "text-underline-offset"
+        | "text-underline-position"
+        | "hanging-punctuation"
+        | "hyphenate-character"
+        | "hyphenate-limit-chars"
+        | "hyphens"
+        | "letter-spacing"
+        | "line-break"
+        | "overflow-wrap"
+        | "paint-order"
+        | "tab-size"
+        | "text-align"
+        | "text-align-last"
+        | "text-indent"
+        | "text-justify"
+        | "text-size-adjust"
+        | "text-transform"
+        | "text-wrap"
+        | "white-space"
+        | "white-space-collapse"
+        | "word-break"
+        | "word-spacing"
+        | "word-wrap"
+        | "backface-visibility"
+        | "perspective"
+        | "perspective-origin"
+        | "rotate"
+        | "scale"
+        | "transform"
+        | "transform-box"
+        | "transform-origin"
+        | "transform-style"
+        | "translate"
+        | "transition-delay"
+        | "transition-duration"
+        | "transition-property"
+        | "transition-timing-function"
+        | "view-transition-name"
+        | "will-change"
+        | "direction"
+        | "text-combine-upright"
+        | "text-orientation"
+        | "unicode-bidi"
+        | "writing-mode"
+        | "backdrop-filter"
+        | "filter"
+        | "math-depth"
+        | "math-shift"
+        | "math-style"
+        | "touch-action" => 3000.0,
+        "border-top-color"
+        | "border-top-style"
+        | "border-top-width"
+        | "border-bottom-color"
+        | "border-bottom-style"
+        | "border-bottom-width"
+        | "border-left-color"
+        | "border-left-style"
+        | "border-left-width"
+        | "border-right-color"
+        | "border-right-style"
+        | "border-right-width"
+        | "border-top-left-radius"
+        | "border-top-right-radius"
+        | "border-bottom-left-radius"
+        | "border-bottom-right-radius"
+        | "corner-top-left-shape"
+        | "corner-top-right-shape"
+        | "corner-bottom-left-shape"
+        | "corner-bottom-right-shape"
+        | "height"
+        | "width"
+        | "max-height"
+        | "max-width"
+        | "min-height"
+        | "min-width"
+        | "margin-top"
+        | "margin-bottom"
+        | "margin-left"
+        | "margin-right"
+        | "overscroll-behavior-y"
+        | "overscroll-behavior-x"
+        | "padding-top"
+        | "padding-bottom"
+        | "padding-left"
+        | "padding-right"
+        | "overflow-y"
+        | "overflow-x"
+        | "top"
+        | "bottom"
+        | "left"
+        | "right"
+        | "scroll-margin-top"
+        | "scroll-margin-bottom"
+        | "scroll-margin-left"
+        | "scroll-margin-right"
+        | "scroll-padding-top"
+        | "scroll-padding-bottom"
+        | "scroll-padding-left"
+        | "scroll-padding-right" => 4000.0,
+        _ => return None,
+    };
+    Some(tier)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spot_values() {
+        assert_eq!(get_priority("--anything"), 1.0);
+        assert_eq!(get_priority("@supports (display: grid)"), 30.0);
+        assert_eq!(get_priority("@media (min-width: 600px)"), 200.0);
+        assert_eq!(get_priority("@container (min-width: 100px)"), 300.0);
+        assert_eq!(get_priority(":hover"), 130.0);
+        assert_eq!(get_priority(":focusWithin"), 140.0);
+        assert_eq!(get_priority(":focus-within"), 40.0);
+        assert_eq!(get_priority("::before"), 5000.0);
+        assert_eq!(get_priority(":hover:active"), 300.0);
+        assert_eq!(get_priority("::before:hover"), 5130.0);
+        assert_eq!(get_priority(":nth-child(2n)"), 60.0);
+        // functional part in a chain opts out of compound handling
+        assert_eq!(get_priority(":hover:nth-child(2n)"), 40.0);
+        assert_eq!(get_priority("[data-open]"), 3000.0);
+        assert_eq!(get_priority("margin"), 1000.0);
+        assert_eq!(get_priority("margin-inline"), 2000.0);
+        assert_eq!(get_priority("margin-inline-start"), 3000.0);
+        assert_eq!(get_priority("margin-top"), 4000.0);
+        assert_eq!(get_priority("unknown-prop"), 3000.0);
+    }
+
+    #[test]
+    fn relational_shapes() {
+        let m = "x-default-marker";
+        assert_eq!(get_priority(&format!(":where(.{m}:hover *)")), 11.3);
+        assert_eq!(get_priority(&format!(":where(:has(.{m}:checked))")), 16.01);
+        assert_eq!(get_priority(&format!(":where(.{m}:focus ~ *)")), 31.5);
+        assert_eq!(get_priority(&format!(":where(:has(~ .{m}:active))")), 41.7);
+        assert_eq!(
+            get_priority(&format!(":where(.{m}:hover ~ *, :has(~ .{m}:hover))")),
+            21.3
+        );
+        // attribute selectors do not match the relational shapes
+        assert_eq!(get_priority(&format!(":where(.{m}[data-open] *)")), 40.0);
+    }
+}

--- a/crates/stylex/src/shared/pseudo_sort.rs
+++ b/crates/stylex/src/shared/pseudo_sort.rs
@@ -1,0 +1,125 @@
+//! Deterministic ordering of pseudo selectors and at-rules before hashing.
+// parity: babel-plugin src/shared/utils/rule-utils.js
+
+use crate::errors::StylexError;
+use crate::jsrt::{locale_cmp, unverified_collation_char, utf16_cmp};
+use std::cmp::Ordering;
+
+/// Sorts consecutive runs of pseudo-classes (and `[attr]` selectors);
+/// pseudo-elements (`::`) are barriers. The result feeds the class-name hash.
+pub fn sort_pseudos<'s>(pseudos: &[&'s str]) -> Result<Vec<&'s str>, StylexError> {
+    if pseudos.len() < 2 {
+        return Ok(pseudos.to_vec());
+    }
+    let mut out: Vec<&'s str> = Vec::with_capacity(pseudos.len());
+    let mut run_start = 0;
+    let sort_run = |out: &mut Vec<&'s str>, start: usize, end: usize| {
+        let mut run = pseudos[start..end].to_vec();
+        // A comparator-sorted run with a char outside the pinned collation
+        // alphabet hard-errors instead of guessing an order (r4#4 policy).
+        if run.len() >= 2 {
+            for pseudo in &run {
+                if let Some(c) = unverified_collation_char(pseudo) {
+                    return Err(StylexError::new(
+                        crate::errors::ErrorCode::UnsupportedApi,
+                        format!(
+                            "cannot sort pseudo selector {pseudo:?}: {c:?} is outside the pinned collation alphabet and the order feeds the class-name hash"
+                        ),
+                    ));
+                }
+            }
+        }
+        run.sort_by(|a, b| string_comparator(a, b));
+        out.extend(run);
+        Ok(())
+    };
+    for (i, pseudo) in pseudos.iter().enumerate() {
+        if pseudo.starts_with("::") {
+            sort_run(&mut out, run_start, i)?;
+            out.push(pseudo);
+            run_start = i + 1;
+        }
+    }
+    sort_run(&mut out, run_start, pseudos.len())?;
+    Ok(out)
+}
+
+/// JS default `Array.prototype.sort` over strings: UTF-16 code-unit order.
+pub fn sort_at_rules<'s>(at_rules: &[&'s str]) -> Vec<&'s str> {
+    let mut sorted = at_rules.to_vec();
+    sorted.sort_by(|a, b| utf16_cmp(a, b));
+    sorted
+}
+
+// 'default' first, then verified localeCompare (unverified chars were
+// rejected before the sort — never the UTF-16 fallback on this hash path).
+fn string_comparator(a: &str, b: &str) -> Ordering {
+    if a == "default" {
+        return Ordering::Less;
+    }
+    if b == "default" {
+        return Ordering::Greater;
+    }
+    locale_cmp(a, b).expect("unverified chars rejected before sorting")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v<'a>(items: &[&'a str]) -> Vec<&'a str> {
+        items.to_vec()
+    }
+
+    #[test]
+    fn classes_sort_elements_are_barriers() {
+        assert_eq!(
+            sort_pseudos(&v(&[":hover", "::before", ":active"])).unwrap(),
+            v(&[":hover", "::before", ":active"])
+        );
+        assert_eq!(
+            sort_pseudos(&v(&[":hover", ":active"])).unwrap(),
+            v(&[":active", ":hover"])
+        );
+        assert_eq!(
+            sort_pseudos(&v(&[":b", ":a", "::x", ":d", ":c"])).unwrap(),
+            v(&[":a", ":b", "::x", ":c", ":d"])
+        );
+    }
+
+    #[test]
+    fn default_comes_first() {
+        assert_eq!(
+            sort_pseudos(&v(&[":hover", "default", ":active"])).unwrap(),
+            v(&["default", ":active", ":hover"])
+        );
+    }
+
+    #[test]
+    fn short_inputs_pass_through() {
+        assert_eq!(sort_pseudos(&[]).unwrap(), Vec::<String>::new());
+        assert_eq!(sort_pseudos(&v(&[":hover"])).unwrap(), v(&[":hover"]));
+    }
+
+    #[test]
+    fn unverified_chars_error_only_in_sorted_runs() {
+        // r5#2: the oracle emits x1ua4pqi here — rust refuses loudly instead
+        // of silently hashing a UTF-16-fallback order.
+        let err = sort_pseudos(&v(&["[data-a]", "[data-🐱]"])).unwrap_err();
+        assert!(err.to_string().contains("pinned collation alphabet"));
+        // A lone unverified pseudo is never comparator-sorted: exact parity.
+        assert_eq!(sort_pseudos(&v(&["[data-🐱]"])).unwrap(), v(&["[data-🐱]"]));
+        assert_eq!(
+            sort_pseudos(&v(&["[data-🐱]", "::before", ":hover"])).unwrap(),
+            v(&["[data-🐱]", "::before", ":hover"])
+        );
+    }
+
+    #[test]
+    fn at_rules_sort_by_code_unit() {
+        assert_eq!(
+            sort_at_rules(&v(&["@supports x", "@media y", "@Media z"])),
+            v(&["@Media z", "@media y", "@supports x"])
+        );
+    }
+}

--- a/crates/stylex/src/shared/resolution.rs
+++ b/crates/stylex/src/shared/resolution.rs
@@ -159,6 +159,18 @@ enum Expansion {
     Alias(&'static str),
 }
 
+pub(super) fn is_unexpanded_property(key: &str, resolution: StyleResolution) -> bool {
+    match resolution {
+        StyleResolution::PropertySpecificity => {
+            matches!(property_specificity_expansion(key), Expansion::None)
+        }
+        StyleResolution::ApplicationOrder => {
+            key != "all" && application_order_expansion(key).is_none()
+        }
+        StyleResolution::LegacyExpandShorthands => !legacy_has_expansion(key),
+    }
+}
+
 fn property_specificity_expansion(key: &str) -> Expansion {
     if crate::errors::banned_shorthand_message(key).is_some() {
         return Expansion::Banned;

--- a/crates/stylex/src/shared/resolution.rs
+++ b/crates/stylex/src/shared/resolution.rs
@@ -1,0 +1,1874 @@
+//! styleResolution dispatch: the three shorthand-expansion tables.
+// parity: babel-plugin src/shared/preprocess-rules/*.js
+
+use crate::errors::StylexError;
+use crate::options::{PropertyValidationMode, ResolvedOptions, StyleResolution};
+use crate::shared::flatten::StyleScalar;
+use crate::shared::split_css_value::split_value;
+use std::borrow::Cow;
+
+/// One expanded declaration: the resolved property and its value, where `None`
+/// is the `null` punch that stops an earlier longhand from leaking through.
+pub type ExpandedPair<'a> = (Cow<'a, str>, Option<StyleScalar<'a>>);
+
+const LOGICAL_START_VAR: &str = "var(--stylex-logical-start)";
+const LOGICAL_END_VAR: &str = "var(--stylex-logical-end)";
+
+/// `flatMapExpandedShorthands`: an empty result is the silent drop.
+pub fn flat_map_expanded_shorthands<'a>(
+    key: Cow<'a, str>,
+    value: Option<StyleScalar<'a>>,
+    value_is_array: bool,
+    options: &ResolvedOptions,
+) -> Result<Vec<ExpandedPair<'a>>, StylexError> {
+    let key: Cow<'a, str> = if key.starts_with("var(") && key.ends_with(')') {
+        match key {
+            Cow::Borrowed(k) => Cow::Borrowed(&k[4..k.len() - 1]),
+            Cow::Owned(k) => Cow::Owned(k[4..k.len() - 1].to_string()),
+        }
+    } else {
+        key
+    };
+    let identity = || Ok(vec![(key.clone(), value.clone())]);
+    match options.style_resolution {
+        StyleResolution::PropertySpecificity => {
+            let expansion = property_specificity_expansion(&key);
+            if matches!(expansion, Expansion::None) {
+                return identity();
+            }
+            if value_is_array {
+                return Err(StylexError::shorthand_fallback());
+            }
+            match expansion {
+                Expansion::Banned => banned(&key, options),
+                Expansion::Alias(target) => Ok(vec![(Cow::Borrowed(target), value)]),
+                Expansion::None => unreachable!("checked above"),
+            }
+        }
+        StyleResolution::ApplicationOrder => {
+            if key == "all" {
+                if value_is_array {
+                    return Err(StylexError::shorthand_fallback());
+                }
+                return banned(&key, options);
+            }
+            let Some(table) = application_order_expansion(&key) else {
+                return identity();
+            };
+            if value_is_array {
+                return Err(StylexError::shorthand_fallback());
+            }
+            let mut pairs = vec![(Cow::Borrowed(table[0]), value)];
+            pairs.extend(table[1..].iter().map(|k| (Cow::Borrowed(*k), None)));
+            Ok(pairs)
+        }
+        StyleResolution::LegacyExpandShorthands => {
+            if !legacy_has_expansion(&key) {
+                return identity();
+            }
+            if value_is_array {
+                return Err(StylexError::shorthand_fallback());
+            }
+            match legacy_expansion(&key, value) {
+                Ok(pairs) => Ok(pairs),
+                Err(error) => match options.property_validation_mode {
+                    PropertyValidationMode::Throw => Err(error),
+                    // Warn logs upstream, then drops just like silent.
+                    PropertyValidationMode::Silent | PropertyValidationMode::Warn => Ok(Vec::new()),
+                },
+            }
+        }
+    }
+}
+
+fn banned(key: &str, options: &ResolvedOptions) -> Result<Vec<ExpandedPair<'static>>, StylexError> {
+    match options.property_validation_mode {
+        PropertyValidationMode::Throw => Err(StylexError::banned_shorthand(key)
+            .expect("banned keys are in the banned-shorthand table")),
+        PropertyValidationMode::Silent | PropertyValidationMode::Warn => Ok(Vec::new()),
+    }
+}
+
+enum Expansion {
+    None,
+    Banned,
+    Alias(&'static str),
+}
+
+fn property_specificity_expansion(key: &str) -> Expansion {
+    if crate::errors::banned_shorthand_message(key).is_some() {
+        return Expansion::Banned;
+    }
+    alias_target(key).map_or(Expansion::None, Expansion::Alias)
+}
+
+// parity: property-specificity.js `aliases` (the non-throwing rewrites).
+fn alias_target(key: &str) -> Option<&'static str> {
+    Some(match key {
+        "blockSize" => "height",
+        "inlineSize" => "width",
+        "minBlockSize" => "minHeight",
+        "minInlineSize" => "minWidth",
+        "maxBlockSize" => "maxHeight",
+        "maxInlineSize" => "maxWidth",
+        "borderHorizontalWidth" => "borderInlineWidth",
+        "borderHorizontalStyle" => "borderInlineStyle",
+        "borderHorizontalColor" => "borderInlineColor",
+        "borderVerticalWidth" => "borderBlockWidth",
+        "borderVerticalStyle" => "borderBlockStyle",
+        "borderVerticalColor" => "borderBlockColor",
+        "borderBlockStartColor" => "borderTopColor",
+        "borderBlockEndColor" => "borderBottomColor",
+        "borderBlockStartStyle" => "borderTopStyle",
+        "borderBlockEndStyle" => "borderBottomStyle",
+        "borderBlockStartWidth" => "borderTopWidth",
+        "borderBlockEndWidth" => "borderBottomWidth",
+        "borderStartColor" => "borderInlineStartColor",
+        "borderEndColor" => "borderInlineEndColor",
+        "borderStartStyle" => "borderInlineStartStyle",
+        "borderEndStyle" => "borderInlineEndStyle",
+        "borderStartWidth" => "borderInlineStartWidth",
+        "borderEndWidth" => "borderInlineEndWidth",
+        "borderTopStartRadius" => "borderStartStartRadius",
+        "borderTopEndRadius" => "borderStartEndRadius",
+        "borderBottomStartRadius" => "borderEndStartRadius",
+        "borderBottomEndRadius" => "borderEndEndRadius",
+        "containIntrinsicBlockSize" => "containIntrinsicHeight",
+        "containIntrinsicInlineSize" => "containIntrinsicWidth",
+        "marginBlockStart" => "marginTop",
+        "marginBlockEnd" => "marginBottom",
+        "marginStart" => "marginInlineStart",
+        "marginEnd" => "marginInlineEnd",
+        "marginHorizontal" => "marginInline",
+        "marginVertical" => "marginBlock",
+        "overflowBlock" => "overflowY",
+        "overflowInline" => "overflowX",
+        "paddingBlockStart" => "paddingTop",
+        "paddingBlockEnd" => "paddingBottom",
+        "paddingStart" => "paddingInlineStart",
+        "paddingEnd" => "paddingInlineEnd",
+        "paddingHorizontal" => "paddingInline",
+        "paddingVertical" => "paddingBlock",
+        "scrollMarginBlockStart" => "scrollMarginTop",
+        "scrollMarginBlockEnd" => "scrollMarginBottom",
+        "insetBlockStart" => "top",
+        "insetBlockEnd" => "bottom",
+        "start" => "insetInlineStart",
+        "end" => "insetInlineEnd",
+        _ => return None,
+    })
+}
+
+/// application-order.js: element 0 is the property that keeps the value, the
+/// rest are the longhands it nulls out. `all` is the only banned key here.
+fn application_order_expansion(key: &str) -> Option<&'static [&'static str]> {
+    Some(match key {
+        "animation" => &[
+            "animation",
+            "animationComposition",
+            "animationName",
+            "animationDuration",
+            "animationTimingFunction",
+            "animationDelay",
+            "animationIterationCount",
+            "animationDirection",
+            "animationFillMode",
+            "animationPlayState",
+            "animationRange",
+            "animationRangeEnd",
+            "animationRangeStart",
+            "animationTimeline",
+        ],
+        "background" => &[
+            "background",
+            "backgroundAttachment",
+            "backgroundClip",
+            "backgroundColor",
+            "backgroundImage",
+            "backgroundOrigin",
+            "backgroundPosition",
+            "backgroundPositionX",
+            "backgroundPositionY",
+            "backgroundRepeat",
+            "backgroundSize",
+        ],
+        "border" => &[
+            "border",
+            "borderWidth",
+            "borderInlineWidth",
+            "borderInlineStartWidth",
+            "borderLeftWidth",
+            "borderInlineEndWidth",
+            "borderRightWidth",
+            "borderBlockWidth",
+            "borderTopWidth",
+            "borderBottomWidth",
+            "borderStyle",
+            "borderInlineStyle",
+            "borderInlineStartStyle",
+            "borderLeftStyle",
+            "borderInlineEndStyle",
+            "borderRightStyle",
+            "borderBlockStyle",
+            "borderTopStyle",
+            "borderBottomStyle",
+            "borderColor",
+            "borderInlineColor",
+            "borderInlineStartColor",
+            "borderLeftColor",
+            "borderInlineEndColor",
+            "borderRightColor",
+            "borderBlockColor",
+            "borderTopColor",
+            "borderBottomColor",
+        ],
+        "borderBlock" => &[
+            "borderBlock",
+            "borderBlockWidth",
+            "borderTopWidth",
+            "borderBottomWidth",
+            "borderBlockStyle",
+            "borderTopStyle",
+            "borderBottomStyle",
+            "borderBlockColor",
+            "borderTopColor",
+            "borderBottomColor",
+        ],
+        "borderInline" => &[
+            "borderInline",
+            "borderInlineWidth",
+            "borderInlineStartWidth",
+            "borderLeftWidth",
+            "borderInlineEndWidth",
+            "borderRightWidth",
+            "borderInlineStyle",
+            "borderInlineStartStyle",
+            "borderLeftStyle",
+            "borderInlineEndStyle",
+            "borderRightStyle",
+            "borderInlineColor",
+            "borderInlineStartColor",
+            "borderLeftColor",
+            "borderInlineEndColor",
+            "borderRightColor",
+        ],
+        "margin" => &[
+            "margin",
+            "marginInline",
+            "marginInlineStart",
+            "marginLeft",
+            "marginInlineEnd",
+            "marginRight",
+            "marginBlock",
+            "marginTop",
+            "marginBottom",
+        ],
+        "padding" => &[
+            "padding",
+            "paddingInline",
+            "paddingStart",
+            "paddingLeft",
+            "paddingEnd",
+            "paddingRight",
+            "paddingBlock",
+            "paddingTop",
+            "paddingBottom",
+        ],
+        "font" => &[
+            "font",
+            "fontFamily",
+            "fontSize",
+            "fontStretch",
+            "fontStyle",
+            "fontVariant",
+            "fontVariantAlternates",
+            "fontVariantCaps",
+            "fontVariantEastAsian",
+            "fontVariantEmoji",
+            "fontVariantLigatures",
+            "fontVariantNumeric",
+            "fontVariantPosition",
+            "fontWeight",
+            "lineHeight",
+        ],
+        "grid" => &[
+            "grid",
+            "gridTemplate",
+            "gridTemplateAreas",
+            "gridTemplateColumns",
+            "gridTemplateRows",
+            "gridAutoRows",
+            "gridAutoColumns",
+            "gridAutoFlow",
+        ],
+        "gridTemplate" => &[
+            "gridTemplate",
+            "gridTemplateAreas",
+            "gridTemplateColumns",
+            "gridTemplateRows",
+        ],
+        "gridArea" => &[
+            "gridArea",
+            "gridRow",
+            "gridRowStart",
+            "gridRowEnd",
+            "gridColumn",
+            "gridColumnStart",
+            "gridColumnEnd",
+        ],
+        "inset" => &[
+            "inset",
+            "insetInline",
+            "insetInlineStart",
+            "insetInlineEnd",
+            "left",
+            "right",
+            "insetBlock",
+            "top",
+            "bottom",
+        ],
+        "scrollMargin" => &[
+            "scrollMargin",
+            "scrollMarginBlock",
+            "scrollMarginTop",
+            "scrollMarginBottom",
+            "scrollMarginInline",
+            "scrollMarginInlineStart",
+            "scrollMarginInlineEnd",
+            "scrollMarginLeft",
+            "scrollMarginRight",
+        ],
+        "scrollPadding" => &[
+            "scrollPadding",
+            "scrollPaddingBlock",
+            "scrollPaddingTop",
+            "scrollPaddingBottom",
+            "scrollPaddingInline",
+            "scrollPaddingInlineStart",
+            "scrollPaddingInlineEnd",
+            "scrollPaddingLeft",
+            "scrollPaddingRight",
+        ],
+        "animationRange" => &["animationRange", "animationRangeEnd", "animationRangeStart"],
+        "scrollTimeline" => &["scrollTimeline", "scrollTimelineName", "scrollTimelineAxis"],
+        "backgroundPosition" => &[
+            "backgroundPosition",
+            "backgroundPositionX",
+            "backgroundPositionY",
+        ],
+        "borderColor" => &[
+            "borderColor",
+            "borderInlineColor",
+            "borderInlineStartColor",
+            "borderLeftColor",
+            "borderInlineEndColor",
+            "borderRightColor",
+            "borderBlockColor",
+            "borderTopColor",
+            "borderBottomColor",
+        ],
+        "borderStyle" => &[
+            "borderStyle",
+            "borderInlineStyle",
+            "borderInlineStartStyle",
+            "borderLeftStyle",
+            "borderInlineEndStyle",
+            "borderRightStyle",
+            "borderBlockStyle",
+            "borderTopStyle",
+            "borderBottomStyle",
+        ],
+        "borderWidth" => &[
+            "borderWidth",
+            "borderInlineWidth",
+            "borderInlineStartWidth",
+            "borderLeftWidth",
+            "borderInlineEndWidth",
+            "borderRightWidth",
+            "borderBlockWidth",
+            "borderTopWidth",
+            "borderBottomWidth",
+        ],
+        "borderBlockStart" => &[
+            "borderTop",
+            "borderTopWidth",
+            "borderTopStyle",
+            "borderTopColor",
+        ],
+        "borderTop" => &[
+            "borderTop",
+            "borderTopWidth",
+            "borderTopStyle",
+            "borderTopColor",
+        ],
+        "borderBlockEnd" => &[
+            "borderBottom",
+            "borderBottomWidth",
+            "borderBottomStyle",
+            "borderBottomColor",
+        ],
+        "borderBottom" => &[
+            "borderBottom",
+            "borderBottomWidth",
+            "borderBottomStyle",
+            "borderBottomColor",
+        ],
+        "borderInlineColor" => &[
+            "borderInlineColor",
+            "borderInlineStartColor",
+            "borderLeftColor",
+            "borderInlineEndColor",
+            "borderRightColor",
+        ],
+        "borderInlineStyle" => &[
+            "borderInlineStyle",
+            "borderInlineStartStyle",
+            "borderLeftStyle",
+            "borderInlineEndStyle",
+            "borderRightStyle",
+        ],
+        "borderInlineWidth" => &[
+            "borderInlineWidth",
+            "borderInlineStartWidth",
+            "borderLeftWidth",
+            "borderInlineEndWidth",
+            "borderRightWidth",
+        ],
+        "borderInlineStart" => &[
+            "borderInlineStart",
+            "borderInlineStartWidth",
+            "borderLeftWidth",
+            "borderRightWidth",
+            "borderInlineStartStyle",
+            "borderLeftStyle",
+            "borderRightStyle",
+            "borderInlineStartColor",
+            "borderLeftColor",
+            "borderRightColor",
+        ],
+        "borderLeft" => &[
+            "borderLeft",
+            "borderLeftWidth",
+            "borderInlineStartWidth",
+            "borderInlineEndWidth",
+            "borderLeftStyle",
+            "borderInlineStartStyle",
+            "borderInlineEndStyle",
+            "borderLeftColor",
+            "borderInlineStartColor",
+            "borderInlineEndColor",
+        ],
+        "borderInlineEnd" => &[
+            "borderInlineEnd",
+            "borderInlineEndWidth",
+            "borderLeftWidth",
+            "borderRightWidth",
+            "borderInlineEndStyle",
+            "borderLeftStyle",
+            "borderRightStyle",
+            "borderInlineEndColor",
+            "borderLeftColor",
+            "borderRightColor",
+        ],
+        "borderRight" => &[
+            "borderRight",
+            "borderRightWidth",
+            "borderInlineStartWidth",
+            "borderInlineEndWidth",
+            "borderRightStyle",
+            "borderInlineStartStyle",
+            "borderInlineEndStyle",
+            "borderRightColor",
+            "borderInlineStartColor",
+            "borderInlineEndColor",
+        ],
+        "borderImage" => &[
+            "borderImage",
+            "borderImageOutset",
+            "borderImageRepeat",
+            "borderImageSlice",
+            "borderImageSource",
+            "borderImageWidth",
+        ],
+        "borderRadius" => &[
+            "borderRadius",
+            "borderStartStartRadius",
+            "borderStartEndRadius",
+            "borderEndStartRadius",
+            "borderEndEndRadius",
+            "borderTopLeftRadius",
+            "borderTopRightRadius",
+            "borderBottomLeftRadius",
+            "borderBottomRightRadius",
+        ],
+        "cornerShape" => &[
+            "cornerShape",
+            "cornerStartStartShape",
+            "cornerStartEndShape",
+            "cornerEndStartShape",
+            "cornerEndEndShape",
+            "cornerTopLeftShape",
+            "cornerTopRightShape",
+            "cornerBottomLeftShape",
+            "cornerBottomRightShape",
+        ],
+        "outline" => &[
+            "outline",
+            "outlineColor",
+            "outlineOffset",
+            "outlineStyle",
+            "outlineWidth",
+        ],
+        "gridGap" => &["gap", "rowGap", "columnGap"],
+        "gap" => &["gap", "rowGap", "columnGap"],
+        "placeContent" => &["placeContent", "alignContent", "justifyContent"],
+        "placeItems" => &["placeItems", "alignItems", "justifyItems"],
+        "placeSelf" => &["placeSelf", "alignSelf", "justifySelf"],
+        "marginBlock" => &["marginBlock", "marginTop", "marginBottom"],
+        "marginInline" => &[
+            "marginInline",
+            "marginInlineStart",
+            "marginLeft",
+            "marginInlineEnd",
+            "marginRight",
+        ],
+        "paddingBlock" => &["paddingBlock", "paddingTop", "paddingBottom"],
+        "paddingInline" => &[
+            "paddingInline",
+            "paddingStart",
+            "paddingLeft",
+            "paddingEnd",
+            "paddingRight",
+        ],
+        "columns" => &["columns", "columnCount", "columnWidth"],
+        "columnRule" => &[
+            "columnRule",
+            "columnRuleColor",
+            "columnRuleStyle",
+            "columnRuleWidth",
+        ],
+        "containIntrinsicSize" => &[
+            "containIntrinsicSize",
+            "containIntrinsicWidth",
+            "containIntrinsicHeight",
+        ],
+        "container" => &["container", "containerName", "containerType"],
+        "flex" => &["flex", "flexGrow", "flexShrink", "flexBasis"],
+        "flexFlow" => &["flexFlow", "flexDirection", "flexWrap"],
+        "fontVariant" => &[
+            "fontVariant",
+            "fontVariantAlternates",
+            "fontVariantCaps",
+            "fontVariantEastAsian",
+            "fontVariantEmoji",
+            "fontVariantLigatures",
+            "fontVariantNumeric",
+            "fontVariantPosition",
+        ],
+        "gridRow" => &["gridRow", "gridRowStart", "gridRowEnd"],
+        "gridColumn" => &["gridColumn", "gridColumnStart", "gridColumnEnd"],
+        "listStyle" => &[
+            "listStyle",
+            "listStyleImage",
+            "listStylePosition",
+            "listStyleType",
+        ],
+        "mask" => &[
+            "mask",
+            "maskClip",
+            "maskComposite",
+            "maskImage",
+            "maskMode",
+            "maskOrigin",
+            "maskPosition",
+            "maskRepeat",
+            "maskSize",
+        ],
+        "maskBorder" => &[
+            "maskBorder",
+            "maskBorderMode",
+            "maskBorderOutset",
+            "maskBorderRepeat",
+            "maskBorderSlice",
+            "maskBorderSource",
+            "maskBorderWidth",
+        ],
+        "offset" => &[
+            "offset",
+            "offsetAnchor",
+            "offsetDistance",
+            "offsetPath",
+            "offsetPosition",
+            "offsetRotate",
+        ],
+        "overflow" => &["overflow", "overflowX", "overflowY"],
+        "insetBlock" => &["insetBlock", "top", "bottom"],
+        "insetInline" => &[
+            "insetInline",
+            "insetInlineStart",
+            "insetInlineEnd",
+            "left",
+            "right",
+        ],
+        "scrollMarginBlock" => &["scrollMarginBlock", "scrollMarginTop", "scrollMarginBottom"],
+        "scrollMarginInline" => &[
+            "scrollMarginInline",
+            "scrollMarginInlineStart",
+            "scrollMarginInlineEnd",
+            "scrollMarginLeft",
+            "scrollMarginRight",
+        ],
+        "scrollPaddingBlock" => &[
+            "scrollPaddingBlock",
+            "scrollPaddingTop",
+            "scrollPaddingBottom",
+        ],
+        "scrollPaddingInline" => &[
+            "scrollPaddingInline",
+            "scrollPaddingInlineStart",
+            "scrollPaddingInlineEnd",
+            "scrollPaddingLeft",
+            "scrollPaddingRight",
+        ],
+        "scrollSnapType" => &["scrollSnapType", "scrollSnapTypeX", "scrollSnapTypeY"],
+        "textDecoration" => &[
+            "textDecoration",
+            "textDecorationColor",
+            "textDecorationLine",
+            "textDecorationStyle",
+            "textDecorationThickness",
+        ],
+        "textEmphasis" => &["textEmphasis", "textEmphasisColor", "textEmphasisStyle"],
+        "transition" => &[
+            "transition",
+            "transitionBehavior",
+            "transitionDelay",
+            "transitionDuration",
+            "transitionProperty",
+            "transitionTimingFunction",
+        ],
+        "borderBlockColor" => &["borderBlockColor", "borderTopColor", "borderBottomColor"],
+        "borderBlockWidth" => &["borderBlockWidth", "borderTopWidth", "borderBottomWidth"],
+        "borderBlockStartColor" => &["borderTopColor"],
+        "borderBlockStartStyle" => &["borderTopStyle"],
+        "borderBlockStartWidth" => &["borderTopWidth"],
+        "borderBlockEndColor" => &["borderBottomColor"],
+        "borderBlockEndStyle" => &["borderBottomStyle"],
+        "borderBlockEndWidth" => &["borderBottomWidth"],
+        "borderInlineStartColor" => &[
+            "borderInlineStartColor",
+            "borderLeftColor",
+            "borderRightColor",
+        ],
+        "borderInlineStartStyle" => &[
+            "borderInlineStartStyle",
+            "borderLeftStyle",
+            "borderRightStyle",
+        ],
+        "borderInlineStartWidth" => &[
+            "borderInlineStartWidth",
+            "borderLeftWidth",
+            "borderRightWidth",
+        ],
+        "borderInlineEndColor" => &[
+            "borderInlineEndColor",
+            "borderLeftColor",
+            "borderRightColor",
+        ],
+        "borderInlineEndStyle" => &[
+            "borderInlineEndStyle",
+            "borderLeftStyle",
+            "borderRightStyle",
+        ],
+        "borderInlineEndWidth" => &[
+            "borderInlineEndWidth",
+            "borderLeftWidth",
+            "borderRightWidth",
+        ],
+        "borderStartEndRadius" => &[
+            "borderStartEndRadius",
+            "borderTopLeftRadius",
+            "borderTopRightRadius",
+        ],
+        "borderStartStartRadius" => &[
+            "borderStartStartRadius",
+            "borderTopLeftRadius",
+            "borderTopRightRadius",
+        ],
+        "borderEndEndRadius" => &[
+            "borderEndEndRadius",
+            "borderBottomLeftRadius",
+            "borderBottomRightRadius",
+        ],
+        "borderEndStartRadius" => &[
+            "borderEndStartRadius",
+            "borderBottomLeftRadius",
+            "borderBottomRightRadius",
+        ],
+        "cornerStartStartShape" => &[
+            "cornerStartStartShape",
+            "cornerTopLeftShape",
+            "cornerTopRightShape",
+        ],
+        "cornerStartEndShape" => &[
+            "cornerStartEndShape",
+            "cornerTopLeftShape",
+            "cornerTopRightShape",
+        ],
+        "cornerEndStartShape" => &[
+            "cornerEndStartShape",
+            "cornerBottomLeftShape",
+            "cornerBottomRightShape",
+        ],
+        "cornerEndEndShape" => &[
+            "cornerEndEndShape",
+            "cornerBottomLeftShape",
+            "cornerBottomRightShape",
+        ],
+        "gridRowGap" => &["rowGap"],
+        "gridColumnGap" => &["columnGap"],
+        "blockSize" => &["height"],
+        "inlineSize" => &["width"],
+        "maxBlockSize" => &["maxHeight"],
+        "maxInlineSize" => &["maxWidth"],
+        "minBlockSize" => &["minHeight"],
+        "minInlineSize" => &["minWidth"],
+        "marginBlockStart" => &["marginTop"],
+        "marginBlockEnd" => &["marginBottom"],
+        "marginInlineStart" => &["marginInlineStart", "marginLeft", "marginRight"],
+        "marginInlineEnd" => &["marginInlineEnd", "marginLeft", "marginRight"],
+        "paddingBlockStart" => &["paddingTop"],
+        "paddingBlockEnd" => &["paddingBottom"],
+        "paddingInlineStart" => &["paddingInlineStart", "paddingLeft", "paddingRight"],
+        "paddingInlineEnd" => &["paddingInlineEnd", "paddingLeft", "paddingRight"],
+        "containIntrinsicBlockSize" => &["containIntrinsicHeight"],
+        "containIntrinsicInlineSize" => &["containIntrinsicWidth"],
+        "overflowBlock" => &["overflowY"],
+        "overflowInline" => &["overflowX"],
+        "insetBlockStart" => &["top"],
+        "insetBlockEnd" => &["bottom"],
+        "insetInlineStart" => &["insetInlineStart", "left", "right"],
+        "insetInlineEnd" => &["insetInlineEnd", "left", "right"],
+        "scrollMarginBlockStart" => &["scrollMarginTop"],
+        "scrollMarginBlockEnd" => &["scrollMarginBottom"],
+        "scrollMarginInlineStart" => &[
+            "scrollMarginInlineStart",
+            "scrollMarginLeft",
+            "scrollMarginRight",
+        ],
+        "scrollMarginInlineEnd" => &[
+            "scrollMarginInlineEnd",
+            "scrollMarginLeft",
+            "scrollMarginRight",
+        ],
+        "scrollPaddingInlineStart" => &[
+            "scrollPaddingInlineStart",
+            "scrollPaddingLeft",
+            "scrollPaddingRight",
+        ],
+        "scrollPaddingInlineEnd" => &[
+            "scrollPaddingInlineEnd",
+            "scrollPaddingLeft",
+            "scrollPaddingRight",
+        ],
+        "borderLeftColor" => &[
+            "borderLeftColor",
+            "borderInlineStartColor",
+            "borderInlineEndColor",
+        ],
+        "borderLeftStyle" => &[
+            "borderLeftStyle",
+            "borderInlineStartStyle",
+            "borderInlineEndStyle",
+        ],
+        "borderLeftWidth" => &[
+            "borderLeftWidth",
+            "borderInlineStartWidth",
+            "borderInlineEndWidth",
+        ],
+        "borderRightColor" => &[
+            "borderRightColor",
+            "borderInlineStartColor",
+            "borderInlineEndColor",
+        ],
+        "borderRightStyle" => &[
+            "borderRightStyle",
+            "borderInlineStartStyle",
+            "borderInlineEndStyle",
+        ],
+        "borderRightWidth" => &[
+            "borderRightWidth",
+            "borderInlineStartWidth",
+            "borderInlineEndWidth",
+        ],
+        "borderTopLeftRadius" => &[
+            "borderTopLeftRadius",
+            "borderStartStartRadius",
+            "borderStartEndRadius",
+        ],
+        "borderTopRightRadius" => &[
+            "borderTopRightRadius",
+            "borderStartStartRadius",
+            "borderStartEndRadius",
+        ],
+        "borderBottomLeftRadius" => &[
+            "borderBottomLeftRadius",
+            "borderEndStartRadius",
+            "borderEndEndRadius",
+        ],
+        "borderBottomRightRadius" => &[
+            "borderBottomRightRadius",
+            "borderEndStartRadius",
+            "borderEndEndRadius",
+        ],
+        "cornerTopLeftShape" => &[
+            "cornerTopLeftShape",
+            "cornerStartStartShape",
+            "cornerStartEndShape",
+        ],
+        "cornerTopRightShape" => &[
+            "cornerTopRightShape",
+            "cornerStartStartShape",
+            "cornerStartEndShape",
+        ],
+        "cornerBottomLeftShape" => &[
+            "cornerBottomLeftShape",
+            "cornerEndStartShape",
+            "cornerEndEndShape",
+        ],
+        "cornerBottomRightShape" => &[
+            "cornerBottomRightShape",
+            "cornerEndStartShape",
+            "cornerEndEndShape",
+        ],
+        "marginLeft" => &["marginLeft", "marginInlineStart", "marginInlineEnd"],
+        "marginRight" => &["marginRight", "marginInlineStart", "marginInlineEnd"],
+        "paddingLeft" => &["paddingLeft", "paddingInlineStart", "paddingInlineEnd"],
+        "paddingRight" => &["paddingRight", "paddingInlineStart", "paddingInlineEnd"],
+        "left" => &["left", "insetInlineStart", "insetInlineEnd"],
+        "right" => &["right", "insetInlineStart", "insetInlineEnd"],
+        "scrollMarginLeft" => &[
+            "scrollMarginLeft",
+            "scrollMarginInlineStart",
+            "scrollMarginInlineEnd",
+        ],
+        "scrollMarginRight" => &[
+            "scrollMarginRight",
+            "scrollMarginInlineStart",
+            "scrollMarginInlineEnd",
+        ],
+        "scrollPaddingLeft" => &[
+            "scrollPaddingLeft",
+            "scrollPaddingInlineStart",
+            "scrollPaddingInlineEnd",
+        ],
+        "scrollPaddingRight" => &[
+            "scrollPaddingRight",
+            "scrollPaddingInlineStart",
+            "scrollPaddingInlineEnd",
+        ],
+        "borderHorizontal" => &[
+            "borderInline",
+            "borderInlineWidth",
+            "borderInlineStartWidth",
+            "borderLeftWidth",
+            "borderInlineEndWidth",
+            "borderRightWidth",
+            "borderInlineStyle",
+            "borderInlineStartStyle",
+            "borderLeftStyle",
+            "borderInlineEndStyle",
+            "borderRightStyle",
+            "borderInlineColor",
+            "borderInlineStartColor",
+            "borderLeftColor",
+            "borderInlineEndColor",
+            "borderRightColor",
+        ],
+        "borderVertical" => &[
+            "borderBlock",
+            "borderBlockWidth",
+            "borderTopWidth",
+            "borderBottomWidth",
+            "borderBlockStyle",
+            "borderTopStyle",
+            "borderBottomStyle",
+            "borderBlockColor",
+            "borderTopColor",
+            "borderBottomColor",
+        ],
+        "borderEnd" => &[
+            "borderInlineEnd",
+            "borderInlineEndWidth",
+            "borderLeftWidth",
+            "borderRightWidth",
+            "borderInlineEndStyle",
+            "borderLeftStyle",
+            "borderRightStyle",
+            "borderInlineEndColor",
+            "borderLeftColor",
+            "borderRightColor",
+        ],
+        "borderStart" => &[
+            "borderInlineStart",
+            "borderInlineStartWidth",
+            "borderLeftWidth",
+            "borderRightWidth",
+            "borderInlineStartStyle",
+            "borderLeftStyle",
+            "borderRightStyle",
+            "borderInlineStartColor",
+            "borderLeftColor",
+            "borderRightColor",
+        ],
+        "borderHorizontalWidth" => &[
+            "borderInlineWidth",
+            "borderInlineStartWidth",
+            "borderLeftWidth",
+            "borderInlineEndWidth",
+            "borderRightWidth",
+        ],
+        "borderHorizontalStyle" => &[
+            "borderInlineStyle",
+            "borderInlineStartStyle",
+            "borderLeftStyle",
+            "borderInlineEndStyle",
+            "borderRightStyle",
+        ],
+        "borderHorizontalColor" => &[
+            "borderInlineColor",
+            "borderInlineStartColor",
+            "borderLeftColor",
+            "borderInlineEndColor",
+            "borderRightColor",
+        ],
+        "borderVerticalWidth" => &["borderBlockWidth", "borderTopWidth", "borderBottomWidth"],
+        "borderVerticalStyle" => &["borderBlockStyle", "borderTopStyle", "borderBottomStyle"],
+        "borderVerticalColor" => &["borderBlockColor", "borderTopColor", "borderBottomColor"],
+        "borderStartColor" => &[
+            "borderInlineStartColor",
+            "borderLeftColor",
+            "borderRightColor",
+        ],
+        "borderEndColor" => &[
+            "borderInlineEndColor",
+            "borderLeftColor",
+            "borderRightColor",
+        ],
+        "borderStartStyle" => &[
+            "borderInlineStartStyle",
+            "borderLeftStyle",
+            "borderRightStyle",
+        ],
+        "borderEndStyle" => &[
+            "borderInlineEndStyle",
+            "borderLeftStyle",
+            "borderRightStyle",
+        ],
+        "borderStartWidth" => &[
+            "borderInlineStartWidth",
+            "borderLeftWidth",
+            "borderRightWidth",
+        ],
+        "borderEndWidth" => &[
+            "borderInlineEndWidth",
+            "borderLeftWidth",
+            "borderRightWidth",
+        ],
+        "borderTopStartRadius" => &["borderStartStartRadius"],
+        "borderTopEndRadius" => &["borderStartEndRadius"],
+        "borderBottomStartRadius" => &["borderEndStartRadius"],
+        "borderBottomEndRadius" => &["borderEndEndRadius"],
+        "marginStart" => &["marginInlineStart", "marginLeft", "marginRight"],
+        "marginEnd" => &["marginInlineEnd", "marginLeft", "marginRight"],
+        "marginHorizontal" => &[
+            "marginInline",
+            "marginInlineStart",
+            "marginLeft",
+            "marginInlineEnd",
+            "marginRight",
+        ],
+        "marginVertical" => &["marginBlock", "marginTop", "marginBottom"],
+        "paddingStart" => &["paddingInlineStart", "paddingLeft", "paddingRight"],
+        "paddingEnd" => &["paddingInlineEnd", "paddingLeft", "paddingRight"],
+        "paddingHorizontal" => &[
+            "paddingInline",
+            "paddingStart",
+            "paddingLeft",
+            "paddingEnd",
+            "paddingRight",
+        ],
+        "paddingVertical" => &["paddingBlock", "paddingTop", "paddingBottom"],
+        "start" => &["insetInlineStart", "left", "right"],
+        "end" => &["insetInlineEnd", "left", "right"],
+        "borderBlockStyle" => &["borderBlockStyle", "borderTopStyle", "borderBottomStyle"],
+        _ => return None,
+    })
+}
+
+fn legacy_has_expansion(key: &str) -> bool {
+    matches!(
+        key,
+        "border"
+            | "borderColor"
+            | "borderStyle"
+            | "borderWidth"
+            | "borderRadius"
+            | "borderHorizontal"
+            | "borderVertical"
+            | "borderHorizontalColor"
+            | "borderHorizontalStyle"
+            | "borderHorizontalWidth"
+            | "borderVerticalColor"
+            | "borderVerticalStyle"
+            | "borderVerticalWidth"
+            | "containIntrinsicSize"
+            | "inset"
+            | "insetInline"
+            | "insetBlock"
+            | "start"
+            | "end"
+            | "left"
+            | "right"
+            | "gap"
+            | "listStyle"
+            | "margin"
+            | "marginHorizontal"
+            | "marginStart"
+            | "marginEnd"
+            | "marginLeft"
+            | "marginRight"
+            | "marginVertical"
+            | "overflow"
+            | "padding"
+            | "paddingHorizontal"
+            | "paddingStart"
+            | "paddingEnd"
+            | "paddingLeft"
+            | "paddingRight"
+            | "paddingVertical"
+            | "insetBlockStart"
+            | "insetBlockEnd"
+            | "insetInlineStart"
+            | "insetInlineEnd"
+            | "blockSize"
+            | "inlineSize"
+            | "minBlockSize"
+            | "minInlineSize"
+            | "maxBlockSize"
+            | "maxInlineSize"
+            | "borderStart"
+            | "borderEnd"
+            | "borderBlockWidth"
+            | "borderBlockStyle"
+            | "borderBlockColor"
+            | "borderBlockStartWidth"
+            | "borderBlockStartStyle"
+            | "borderBlockStartColor"
+            | "borderBlockEndWidth"
+            | "borderBlockEndStyle"
+            | "borderBlockEndColor"
+            | "borderInlineWidth"
+            | "borderInlineStyle"
+            | "borderInlineColor"
+            | "borderTopStartRadius"
+            | "borderTopEndRadius"
+            | "borderBottomStartRadius"
+            | "borderBottomEndRadius"
+            | "gridGap"
+            | "gridRowGap"
+            | "gridColumnGap"
+            | "marginBlock"
+            | "marginBlockStart"
+            | "marginBlockEnd"
+            | "marginInline"
+            | "overflowBlock"
+            | "overflowInline"
+            | "paddingBlock"
+            | "paddingBlockStart"
+            | "paddingBlockEnd"
+            | "paddingInline"
+            | "scrollMarginBlockStart"
+            | "scrollMarginBlockEnd"
+            | "float"
+            | "clear"
+    )
+}
+
+fn one<'a>(key: &'static str, value: Option<StyleScalar<'a>>) -> Vec<ExpandedPair<'a>> {
+    vec![pair(key, value)]
+}
+
+fn pair<'a>(key: impl Into<Cow<'a, str>>, value: Option<StyleScalar<'a>>) -> ExpandedPair<'a> {
+    (key.into(), value)
+}
+
+/// JS array destructuring: a missing index reads as `undefined`, which the
+/// `= t` / `= r` defaults then replace.
+fn at<'a>(parts: &[Option<StyleScalar<'a>>], index: usize) -> Option<StyleScalar<'a>> {
+    parts
+        .get(index)
+        .cloned()
+        .unwrap_or(Some(StyleScalar::Undefined))
+}
+
+fn or<'a>(
+    value: Option<StyleScalar<'a>>,
+    fallback: &Option<StyleScalar<'a>>,
+) -> Option<StyleScalar<'a>> {
+    if value == Some(StyleScalar::Undefined) {
+        fallback.clone()
+    } else {
+        value
+    }
+}
+
+/// `[t, r = t, b = t, l = r]` over the split parts.
+fn box_sides<'a>(parts: &[Option<StyleScalar<'a>>]) -> [Option<StyleScalar<'a>>; 4] {
+    let t = at(parts, 0);
+    let r = or(at(parts, 1), &t);
+    let b = or(at(parts, 2), &t);
+    let l = or(at(parts, 3), &r);
+    [t, r, b, l]
+}
+
+/// `[a, b = a]` over the split parts.
+fn two_sides<'a>(parts: &[Option<StyleScalar<'a>>]) -> [Option<StyleScalar<'a>>; 2] {
+    let a = at(parts, 0);
+    let b = or(at(parts, 1), &a);
+    [a, b]
+}
+
+fn quad<'a>(keys: [&'static str; 4], parts: &[Option<StyleScalar<'a>>]) -> Vec<ExpandedPair<'a>> {
+    let [t, r, b, l] = box_sides(parts);
+    vec![
+        pair(keys[0], t),
+        pair(keys[1], r),
+        pair(keys[2], b),
+        pair(keys[3], l),
+    ]
+}
+
+fn duo<'a>(keys: [&'static str; 2], parts: &[Option<StyleScalar<'a>>]) -> Vec<ExpandedPair<'a>> {
+    let [a, b] = two_sides(parts);
+    vec![pair(keys[0], a), pair(keys[1], b)]
+}
+
+fn same<'a>(keys: [&'static str; 2], value: Option<StyleScalar<'a>>) -> Vec<ExpandedPair<'a>> {
+    vec![pair(keys[0], value.clone()), pair(keys[1], value)]
+}
+
+/// `key: v` plus the two physical longhands it must null out.
+fn punched<'a>(
+    key: &'static str,
+    value: Option<StyleScalar<'a>>,
+    nulls: [&'static str; 2],
+) -> Vec<ExpandedPair<'a>> {
+    vec![pair(key, value), pair(nulls[0], None), pair(nulls[1], None)]
+}
+
+// parity: legacy-expand-shorthands.js `shorthands` merged under `aliases`.
+fn legacy_expansion<'a>(
+    key: &Cow<'a, str>,
+    value: Option<StyleScalar<'a>>,
+) -> Result<Vec<ExpandedPair<'a>>, StylexError> {
+    let parts = || split_value(value.as_ref());
+    Ok(match key.as_ref() {
+        "border" => vec![
+            pair("borderTop", value.clone()),
+            pair("borderInlineEnd", value.clone()),
+            pair("borderBottom", value.clone()),
+            pair("borderInlineStart", value.clone()),
+        ],
+        "borderColor" => quad(
+            [
+                "borderTopColor",
+                "borderInlineEndColor",
+                "borderBottomColor",
+                "borderInlineStartColor",
+            ],
+            &parts(),
+        ),
+        "borderStyle" => quad(
+            [
+                "borderTopStyle",
+                "borderInlineEndStyle",
+                "borderBottomStyle",
+                "borderInlineStartStyle",
+            ],
+            &parts(),
+        ),
+        "borderWidth" => quad(
+            [
+                "borderTopWidth",
+                "borderInlineEndWidth",
+                "borderBottomWidth",
+                "borderInlineStartWidth",
+            ],
+            &parts(),
+        ),
+        "borderRadius" => quad(
+            [
+                "borderStartStartRadius",
+                "borderStartEndRadius",
+                "borderEndEndRadius",
+                "borderEndStartRadius",
+            ],
+            &parts(),
+        ),
+        "borderHorizontal" => same(["borderInlineStart", "borderInlineEnd"], value),
+        "borderVertical" => same(["borderTop", "borderBottom"], value),
+        "borderHorizontalColor" | "borderInlineColor" => {
+            same(["borderInlineStartColor", "borderInlineEndColor"], value)
+        }
+        "borderHorizontalStyle" | "borderInlineStyle" => {
+            same(["borderInlineStartStyle", "borderInlineEndStyle"], value)
+        }
+        "borderHorizontalWidth" | "borderInlineWidth" => {
+            same(["borderInlineStartWidth", "borderInlineEndWidth"], value)
+        }
+        "borderVerticalColor" | "borderBlockColor" => {
+            same(["borderTopColor", "borderBottomColor"], value)
+        }
+        "borderVerticalStyle" | "borderBlockStyle" => {
+            same(["borderTopStyle", "borderBottomStyle"], value)
+        }
+        "borderVerticalWidth" | "borderBlockWidth" => {
+            same(["borderTopWidth", "borderBottomWidth"], value)
+        }
+        "containIntrinsicSize" => contain_intrinsic_size(&parts()),
+        "inset" => quad(
+            ["top", "insetInlineEnd", "bottom", "insetInlineStart"],
+            &parts(),
+        ),
+        "insetInline" => {
+            let [s, e] = two_sides(&parts());
+            let mut out = legacy_start(s);
+            out.extend(legacy_end(e));
+            out
+        }
+        "insetBlock" => duo(["top", "bottom"], &parts()),
+        "start" | "insetInlineStart" => legacy_start(value.clone()),
+        "end" | "insetInlineEnd" => legacy_end(value.clone()),
+        "left" => punched("left", value, ["insetInlineStart", "insetInlineEnd"]),
+        "right" => punched("right", value, ["insetInlineStart", "insetInlineEnd"]),
+        "gap" | "gridGap" => duo(["rowGap", "columnGap"], &parts()),
+        "listStyle" => list_style(value)?,
+        "margin" => quad(
+            [
+                "marginTop",
+                "marginInlineEnd",
+                "marginBottom",
+                "marginInlineStart",
+            ],
+            &parts(),
+        ),
+        "marginHorizontal" | "marginInline" => {
+            let [s, e] = two_sides(&parts());
+            let mut out = punched_owned("marginInlineStart", s, ["marginLeft", "marginRight"]);
+            out.extend(punched_owned(
+                "marginInlineEnd",
+                e,
+                ["marginLeft", "marginRight"],
+            ));
+            out
+        }
+        "marginStart" => punched("marginInlineStart", value, ["marginLeft", "marginRight"]),
+        "marginEnd" => punched("marginInlineEnd", value, ["marginLeft", "marginRight"]),
+        "marginLeft" => punched(
+            "marginLeft",
+            value,
+            ["marginInlineStart", "marginInlineEnd"],
+        ),
+        "marginRight" => punched(
+            "marginRight",
+            value,
+            ["marginInlineStart", "marginInlineEnd"],
+        ),
+        "marginVertical" | "marginBlock" => duo(["marginTop", "marginBottom"], &parts()),
+        "overflow" => duo(["overflowX", "overflowY"], &parts()),
+        "padding" => quad(
+            [
+                "paddingTop",
+                "paddingInlineEnd",
+                "paddingBottom",
+                "paddingInlineStart",
+            ],
+            &parts(),
+        ),
+        "paddingHorizontal" | "paddingInline" => {
+            let [s, e] = two_sides(&parts());
+            let mut out = punched_owned("paddingInlineStart", s, ["paddingLeft", "paddingRight"]);
+            out.extend(punched_owned(
+                "paddingInlineEnd",
+                e,
+                ["paddingLeft", "paddingRight"],
+            ));
+            out
+        }
+        "paddingStart" => punched("paddingInlineStart", value, ["paddingLeft", "paddingRight"]),
+        "paddingEnd" => punched("paddingInlineEnd", value, ["paddingLeft", "paddingRight"]),
+        "paddingLeft" => punched(
+            "paddingLeft",
+            value,
+            ["paddingInlineStart", "paddingInlineEnd"],
+        ),
+        "paddingRight" => punched(
+            "paddingRight",
+            value,
+            ["paddingInlineStart", "paddingInlineEnd"],
+        ),
+        "paddingVertical" | "paddingBlock" => duo(["paddingTop", "paddingBottom"], &parts()),
+        "insetBlockStart" | "marginBlockStart" | "paddingBlockStart" => {
+            one(block_start_target(key), value)
+        }
+        "insetBlockEnd" | "marginBlockEnd" | "paddingBlockEnd" => one(block_end_target(key), value),
+        "blockSize" => one("height", value),
+        "inlineSize" => one("width", value),
+        "minBlockSize" => one("minHeight", value),
+        "minInlineSize" => one("minWidth", value),
+        "maxBlockSize" => one("maxHeight", value),
+        "maxInlineSize" => one("maxWidth", value),
+        "borderStart" => one("borderInlineStart", value),
+        "borderEnd" => one("borderInlineEnd", value),
+        "borderBlockStartWidth" => one("borderTopWidth", value),
+        "borderBlockStartStyle" => one("borderTopStyle", value),
+        "borderBlockStartColor" => one("borderTopColor", value),
+        "borderBlockEndWidth" => one("borderBottomWidth", value),
+        "borderBlockEndStyle" => one("borderBottomStyle", value),
+        "borderBlockEndColor" => one("borderBottomColor", value),
+        "borderTopStartRadius" => one("borderStartStartRadius", value),
+        "borderTopEndRadius" => one("borderStartEndRadius", value),
+        "borderBottomStartRadius" => one("borderEndStartRadius", value),
+        "borderBottomEndRadius" => one("borderEndEndRadius", value),
+        "gridRowGap" => one("rowGap", value),
+        "gridColumnGap" => one("columnGap", value),
+        "overflowBlock" => one("overflowY", value),
+        "overflowInline" => one("overflowX", value),
+        "scrollMarginBlockStart" => one("scrollMarginTop", value),
+        "scrollMarginBlockEnd" => one("scrollMarginBottom", value),
+        "float" | "clear" => vec![pair(key.clone(), logical_float_value(value.as_ref()))],
+        _ => unreachable!("legacy_has_expansion gates this match"),
+    })
+}
+
+fn block_start_target(key: &str) -> &'static str {
+    match key {
+        "insetBlockStart" => "top",
+        "marginBlockStart" => "marginTop",
+        _ => "paddingTop",
+    }
+}
+
+fn block_end_target(key: &str) -> &'static str {
+    match key {
+        "insetBlockEnd" => "bottom",
+        "marginBlockEnd" => "marginBottom",
+        _ => "paddingBottom",
+    }
+}
+
+fn punched_owned<'a>(
+    key: &'static str,
+    value: Option<StyleScalar<'a>>,
+    nulls: [&'static str; 2],
+) -> Vec<ExpandedPair<'a>> {
+    vec![pair(key, value), pair(nulls[0], None), pair(nulls[1], None)]
+}
+
+fn legacy_start(value: Option<StyleScalar>) -> Vec<ExpandedPair> {
+    punched_owned("insetInlineStart", value, ["left", "right"])
+}
+
+fn legacy_end(value: Option<StyleScalar>) -> Vec<ExpandedPair> {
+    punched_owned("insetInlineEnd", value, ["left", "right"])
+}
+
+fn logical_float_value<'a>(value: Option<&StyleScalar<'a>>) -> Option<StyleScalar<'a>> {
+    match value {
+        Some(StyleScalar::Str(s)) if s == "inline-start" || s == "start" => {
+            Some(StyleScalar::Str(Cow::Borrowed(LOGICAL_START_VAR)))
+        }
+        Some(StyleScalar::Str(s)) if s == "inline-end" || s == "end" => {
+            Some(StyleScalar::Str(Cow::Borrowed(LOGICAL_END_VAR)))
+        }
+        other => other.cloned(),
+    }
+}
+
+// parity: legacy-expand-shorthands.js containIntrinsicSize — an `auto` part
+// absorbs the part after it.
+fn contain_intrinsic_size<'a>(parts: &[Option<StyleScalar<'a>>]) -> Vec<ExpandedPair<'a>> {
+    let mut folded: Vec<Option<StyleScalar>> = Vec::with_capacity(parts.len());
+    for part in parts {
+        let absorbs = matches!(folded.last(), Some(Some(StyleScalar::Str(s))) if s == "auto")
+            && !matches!(part, None | Some(StyleScalar::Undefined));
+        if absorbs {
+            let joined = format!("auto {}", scalar_text(part.as_ref()));
+            folded.pop();
+            folded.push(Some(StyleScalar::Str(Cow::Owned(joined))));
+        } else {
+            folded.push(part.clone());
+        }
+    }
+    let [w, h] = two_sides(&folded);
+    vec![
+        pair("containIntrinsicWidth", w),
+        pair("containIntrinsicHeight", h),
+    ]
+}
+
+/// `${part}` template coercion.
+fn scalar_text(value: Option<&StyleScalar<'_>>) -> String {
+    match value {
+        Some(StyleScalar::Str(s)) => s.to_string(),
+        Some(StyleScalar::Num(n)) => crate::jsrt::js_number_to_string(*n),
+        Some(StyleScalar::Undefined) => "undefined".to_string(),
+        None => "null".to_string(),
+    }
+}
+
+const LIST_STYLE_GLOBALS: [&str; 4] = ["inherit", "initial", "revert", "unset"];
+
+// parity: legacy-expand-shorthands.js listStyle — the one throwing expansion.
+fn list_style<'a>(value: Option<StyleScalar<'a>>) -> Result<Vec<ExpandedPair<'a>>, StylexError> {
+    let nulls = || {
+        vec![
+            pair("listStyleType", None),
+            pair("listStylePosition", None),
+            pair("listStyleImage", None),
+        ]
+    };
+    let Some(value) = value else {
+        return Ok(nulls());
+    };
+    let parts = split_value(Some(&value));
+    let strings: Vec<Option<&str>> = parts
+        .iter()
+        .map(|p| match p {
+            Some(StyleScalar::Str(s)) => Some(s.as_ref()),
+            _ => None,
+        })
+        .collect();
+    if strings.len() == 1
+        && let Some(only) = strings[0]
+        && LIST_STYLE_GLOBALS.contains(&only)
+    {
+        return Ok(vec![
+            pair(
+                "listStyleType",
+                Some(StyleScalar::Str(Cow::Owned(only.to_string()))),
+            ),
+            pair(
+                "listStylePosition",
+                Some(StyleScalar::Str(Cow::Owned(only.to_string()))),
+            ),
+            pair(
+                "listStyleImage",
+                Some(StyleScalar::Str(Cow::Owned(only.to_string()))),
+            ),
+        ]);
+    }
+
+    let mut ty: Option<&str> = None;
+    let mut position: Option<&str> = None;
+    let mut image: Option<&str> = None;
+    let mut remaining: Vec<&str> = Vec::new();
+    for part in strings.iter().flatten() {
+        if LIST_STYLE_GLOBALS.contains(part) || part.contains("var(--") {
+            return Err(list_style_error(&value, true));
+        }
+        if *part == "inside" || *part == "outside" {
+            if position.is_some() {
+                return Err(list_style_error(&value, false));
+            }
+            position = Some(part);
+        } else if *part != "none" && is_list_style_type(part) {
+            if ty.is_some() {
+                return Err(list_style_error(&value, false));
+            }
+            ty = Some(part);
+        } else {
+            remaining.push(part);
+        }
+    }
+    for part in remaining {
+        if part == "none" && ty.is_none() {
+            ty = Some(part);
+        } else {
+            if image.is_some() {
+                return Err(list_style_error(&value, false));
+            }
+            image = Some(part);
+        }
+    }
+    let cell = |v: Option<&str>| v.map(|s| StyleScalar::Str(Cow::Owned(s.to_string())));
+    Ok(vec![
+        pair("listStyleType", cell(ty)),
+        pair("listStylePosition", cell(position)),
+        pair("listStyleImage", cell(image)),
+    ])
+}
+
+/// `/^([a-z-]+|".*?"|'.*?')$/` — `.` never matches a JS line terminator.
+fn is_list_style_type(part: &str) -> bool {
+    if !part.is_empty() && part.bytes().all(|b| b.is_ascii_lowercase() || b == b'-') {
+        return true;
+    }
+    let mut chars = part.chars();
+    let (Some(first), Some(last)) = (chars.next(), chars.next_back()) else {
+        return false;
+    };
+    (first == '"' || first == '\'')
+        && last == first
+        && !chars.any(|c| matches!(c, '\n' | '\r' | '\u{2028}' | '\u{2029}'))
+}
+
+// parity: the two message spellings differ only by an extra pair of quotes.
+fn list_style_error(value: &StyleScalar, doubled_quotes: bool) -> StylexError {
+    let json = match value {
+        StyleScalar::Str(s) => serde_json::to_string(s).unwrap_or_else(|_| format!("\"{s}\"")),
+        StyleScalar::Num(n) => crate::jsrt::js_number_to_string(*n),
+        StyleScalar::Undefined => "undefined".to_string(),
+    };
+    StylexError::invalid_list_style(&if doubled_quotes {
+        format!("\"{json}\"")
+    } else {
+        json
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::errors::ErrorCode;
+
+    fn s(v: &str) -> StyleScalar<'_> {
+        StyleScalar::Str(Cow::Owned(v.to_string()))
+    }
+
+    fn expand(key: &str, value: &str, options: &ResolvedOptions) -> Vec<(String, String)> {
+        flat_map_expanded_shorthands(Cow::Borrowed(key), Some(s(value)), false, options)
+            .unwrap()
+            .into_iter()
+            .map(|(k, v)| {
+                (
+                    k.into_owned(),
+                    match v {
+                        Some(StyleScalar::Str(text)) => text.into_owned(),
+                        Some(other) => format!("{other:?}"),
+                        None => "null".to_string(),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    fn legacy() -> ResolvedOptions {
+        ResolvedOptions {
+            style_resolution: StyleResolution::LegacyExpandShorthands,
+            ..ResolvedOptions::default()
+        }
+    }
+
+    fn application_order() -> ResolvedOptions {
+        ResolvedOptions {
+            style_resolution: StyleResolution::ApplicationOrder,
+            ..ResolvedOptions::default()
+        }
+    }
+
+    #[test]
+    fn aliases_rewrite_and_pass_value_through() {
+        let opts = ResolvedOptions::default();
+        assert_eq!(
+            expand("marginStart", "1px", &opts),
+            vec![("marginInlineStart".to_string(), "1px".to_string())]
+        );
+        assert_eq!(
+            expand("insetBlockStart", "1px", &opts),
+            vec![("top".to_string(), "1px".to_string())]
+        );
+        assert_eq!(
+            expand("color", "red", &opts),
+            vec![("color".to_string(), "red".to_string())]
+        );
+        assert_eq!(
+            expand("var(--myVar)", "1px", &opts),
+            vec![("--myVar".to_string(), "1px".to_string())]
+        );
+        assert_eq!(
+            expand("var(--abc", "1px", &opts),
+            vec![("var(--abc".to_string(), "1px".to_string())]
+        );
+    }
+
+    #[test]
+    fn banned_shorthands_drop_silently_and_throw_in_throw_mode() {
+        let silent = ResolvedOptions::default();
+        assert!(expand("border", "1px", &silent).is_empty());
+        let throw = ResolvedOptions {
+            property_validation_mode: PropertyValidationMode::Throw,
+            ..ResolvedOptions::default()
+        };
+        let err = flat_map_expanded_shorthands(
+            Cow::Borrowed("borderStart"),
+            Some(s("1px")),
+            false,
+            &throw,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, ErrorCode::BannedShorthand);
+        assert_eq!(
+            err.message,
+            "borderInlineStart is not supported. Use borderInlineStartWidth, borderInlineStartStyle and borderInlineStartColor instead."
+        );
+    }
+
+    #[test]
+    fn warn_mode_drops_exactly_like_silent() {
+        let warn = ResolvedOptions {
+            property_validation_mode: PropertyValidationMode::Warn,
+            ..ResolvedOptions::default()
+        };
+        let silent = ResolvedOptions::default();
+        for key in ["border", "borderStart", "all", "listStyle", "animation"] {
+            assert_eq!(
+                flat_map_expanded_shorthands(Cow::Borrowed(key), Some(s("1px")), false, &warn)
+                    .unwrap(),
+                flat_map_expanded_shorthands(Cow::Borrowed(key), Some(s("1px")), false, &silent)
+                    .unwrap(),
+                "key: {key}"
+            );
+        }
+        // The array-value throw is orthogonal to the mode.
+        assert_eq!(
+            flat_map_expanded_shorthands(Cow::Borrowed("marginStart"), Some(s("1px")), true, &warn)
+                .unwrap_err()
+                .code,
+            ErrorCode::ShorthandFallback
+        );
+    }
+
+    #[test]
+    fn shorthand_with_array_value_throws_regardless_of_mode() {
+        let opts = ResolvedOptions::default();
+        let err =
+            flat_map_expanded_shorthands(Cow::Borrowed("marginStart"), Some(s("1px")), true, &opts)
+                .unwrap_err();
+        assert_eq!(err.code, ErrorCode::ShorthandFallback);
+        assert_eq!(
+            flat_map_expanded_shorthands(Cow::Borrowed("color"), Some(s("red")), true, &opts)
+                .unwrap(),
+            vec![(Cow::Borrowed("color"), Some(s("red")))]
+        );
+    }
+
+    #[test]
+    fn application_order_keeps_the_shorthand_and_punches_the_longhands() {
+        let opts = application_order();
+        assert_eq!(
+            expand("gridGap", "1px", &opts),
+            vec![
+                ("gap".to_string(), "1px".to_string()),
+                ("rowGap".to_string(), "null".to_string()),
+                ("columnGap".to_string(), "null".to_string()),
+            ]
+        );
+        // Only `all` stays banned; every property-specificity ban passes through.
+        assert_eq!(
+            expand("border", "1px", &opts),
+            expand("border", "1px", &opts)
+        );
+        assert_eq!(expand("border", "1px", &opts)[0].0, "border");
+        assert!(expand("all", "initial", &opts).is_empty());
+        let throw = ResolvedOptions {
+            property_validation_mode: PropertyValidationMode::Throw,
+            ..application_order()
+        };
+        assert_eq!(
+            flat_map_expanded_shorthands(Cow::Borrowed("all"), Some(s("initial")), false, &throw)
+                .unwrap_err()
+                .code,
+            ErrorCode::BannedShorthand
+        );
+        assert_eq!(
+            flat_map_expanded_shorthands(
+                Cow::Borrowed("animation"),
+                Some(s("a 1s")),
+                false,
+                &throw
+            )
+            .unwrap()
+            .len(),
+            14
+        );
+    }
+
+    #[test]
+    fn legacy_splits_values_and_punches_nulls() {
+        let opts = legacy();
+        assert_eq!(
+            expand("margin", "1px 2px 3px 4px", &opts),
+            vec![
+                ("marginTop".to_string(), "1px".to_string()),
+                ("marginInlineEnd".to_string(), "2px".to_string()),
+                ("marginBottom".to_string(), "3px".to_string()),
+                ("marginInlineStart".to_string(), "4px".to_string()),
+            ]
+        );
+        assert_eq!(
+            expand("start", "1px", &opts),
+            vec![
+                ("insetInlineStart".to_string(), "1px".to_string()),
+                ("left".to_string(), "null".to_string()),
+                ("right".to_string(), "null".to_string()),
+            ]
+        );
+        // insetInline is start ++ end, so left/right appear twice before dedupe.
+        assert_eq!(expand("insetInline", "1px", &opts).len(), 6);
+        // The `/` is a div node, so a two-radius value fills all four corners.
+        assert_eq!(
+            expand("borderRadius", "10px / 20px", &opts),
+            vec![
+                ("borderStartStartRadius".to_string(), "10px".to_string()),
+                ("borderStartEndRadius".to_string(), "20px".to_string()),
+                ("borderEndEndRadius".to_string(), "10px".to_string()),
+                ("borderEndStartRadius".to_string(), "20px".to_string()),
+            ]
+        );
+        assert_eq!(
+            expand("float", "start", &opts),
+            vec![("float".to_string(), LOGICAL_START_VAR.to_string())]
+        );
+        assert_eq!(
+            expand("clear", "left", &opts),
+            vec![("clear".to_string(), "left".to_string())]
+        );
+        // No banned shorthands at all under legacy, even in throw mode.
+        let throw = ResolvedOptions {
+            property_validation_mode: PropertyValidationMode::Throw,
+            ..legacy()
+        };
+        assert_eq!(
+            expand("all", "initial", &throw),
+            vec![("all".to_string(), "initial".to_string())]
+        );
+        assert_eq!(expand("borderTop", "1px", &throw)[0].0, "borderTop");
+    }
+
+    #[test]
+    fn legacy_empty_value_yields_undefined_longhands() {
+        let opts = legacy();
+        let pairs =
+            flat_map_expanded_shorthands(Cow::Borrowed("margin"), Some(s("   ")), false, &opts)
+                .unwrap();
+        assert_eq!(pairs.len(), 4);
+        assert!(
+            pairs
+                .iter()
+                .all(|(_, v)| *v == Some(StyleScalar::Undefined))
+        );
+        let nulled =
+            flat_map_expanded_shorthands(Cow::Borrowed("margin"), None, false, &opts).unwrap();
+        assert!(nulled.iter().all(|(_, v)| v.is_none()));
+    }
+
+    #[test]
+    fn contain_intrinsic_size_folds_auto() {
+        let opts = legacy();
+        assert_eq!(
+            expand("containIntrinsicSize", "auto 10px auto 20px", &opts),
+            vec![
+                ("containIntrinsicWidth".to_string(), "auto 10px".to_string()),
+                (
+                    "containIntrinsicHeight".to_string(),
+                    "auto 20px".to_string()
+                ),
+            ]
+        );
+        assert_eq!(
+            expand("containIntrinsicSize", "10px auto 20px", &opts),
+            vec![
+                ("containIntrinsicWidth".to_string(), "10px".to_string()),
+                (
+                    "containIntrinsicHeight".to_string(),
+                    "auto 20px".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn list_style_parses_and_throws() {
+        let opts = legacy();
+        assert_eq!(
+            expand(
+                "listStyle",
+                "outside \"+\" linear-gradient(90deg, white 100%)",
+                &opts
+            ),
+            vec![
+                ("listStyleType".to_string(), "\"+\"".to_string()),
+                ("listStylePosition".to_string(), "outside".to_string()),
+                (
+                    "listStyleImage".to_string(),
+                    "linear-gradient(90deg,white 100%)".to_string()
+                ),
+            ]
+        );
+        assert_eq!(
+            expand("listStyle", "none none", &opts),
+            vec![
+                ("listStyleType".to_string(), "none".to_string()),
+                ("listStylePosition".to_string(), "null".to_string()),
+                ("listStyleImage".to_string(), "none".to_string()),
+            ]
+        );
+        assert_eq!(
+            expand("listStyle", "inherit", &opts),
+            vec![
+                ("listStyleType".to_string(), "inherit".to_string()),
+                ("listStylePosition".to_string(), "inherit".to_string()),
+                ("listStyleImage".to_string(), "inherit".to_string()),
+            ]
+        );
+        // Numbers are skipped by both passes, so every longhand comes back null.
+        let numeric = flat_map_expanded_shorthands(
+            Cow::Borrowed("listStyle"),
+            Some(StyleScalar::Num(5.0)),
+            false,
+            &opts,
+        )
+        .unwrap();
+        assert!(numeric.iter().all(|(_, v)| v.is_none()));
+        // Silent mode drops the property whole.
+        assert!(expand("listStyle", "none inherit", &opts).is_empty());
+        let throw = ResolvedOptions {
+            property_validation_mode: PropertyValidationMode::Throw,
+            ..legacy()
+        };
+        let err = flat_map_expanded_shorthands(
+            Cow::Borrowed("listStyle"),
+            Some(s("none inherit")),
+            false,
+            &throw,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.message,
+            "invalid \"listStyle\" value of \"\"none inherit\"\""
+        );
+        let err = flat_map_expanded_shorthands(
+            Cow::Borrowed("listStyle"),
+            Some(s("square circle")),
+            false,
+            &throw,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.message,
+            "invalid \"listStyle\" value of \"square circle\""
+        );
+    }
+}

--- a/crates/stylex/src/shared/resolution.rs
+++ b/crates/stylex/src/shared/resolution.rs
@@ -11,6 +11,68 @@ use std::borrow::Cow;
 /// is the `null` punch that stops an earlier longhand from leaking through.
 pub type ExpandedPair<'a> = (Cow<'a, str>, Option<StyleScalar<'a>>);
 
+/// The expansion result; the unexpanded (identity) case carries its pair inline.
+#[derive(Debug)]
+pub enum Expanded<'a> {
+    One(ExpandedPair<'a>),
+    Many(Vec<ExpandedPair<'a>>),
+}
+
+impl<'a> Expanded<'a> {
+    pub fn as_slice(&self) -> &[ExpandedPair<'a>] {
+        match self {
+            Expanded::One(pair) => std::slice::from_ref(pair),
+            Expanded::Many(pairs) => pairs,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.as_slice().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.as_slice().is_empty()
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, ExpandedPair<'a>> {
+        self.as_slice().iter()
+    }
+}
+
+impl PartialEq for Expanded<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+pub enum ExpandedIter<'a> {
+    One(Option<ExpandedPair<'a>>),
+    Many(std::vec::IntoIter<ExpandedPair<'a>>),
+}
+
+impl<'a> Iterator for ExpandedIter<'a> {
+    type Item = ExpandedPair<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            ExpandedIter::One(pair) => pair.take(),
+            ExpandedIter::Many(pairs) => pairs.next(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for Expanded<'a> {
+    type Item = ExpandedPair<'a>;
+    type IntoIter = ExpandedIter<'a>;
+
+    fn into_iter(self) -> ExpandedIter<'a> {
+        match self {
+            Expanded::One(pair) => ExpandedIter::One(Some(pair)),
+            Expanded::Many(pairs) => ExpandedIter::Many(pairs.into_iter()),
+        }
+    }
+}
+
 const LOGICAL_START_VAR: &str = "var(--stylex-logical-start)";
 const LOGICAL_END_VAR: &str = "var(--stylex-logical-end)";
 
@@ -20,7 +82,7 @@ pub fn flat_map_expanded_shorthands<'a>(
     value: Option<StyleScalar<'a>>,
     value_is_array: bool,
     options: &ResolvedOptions,
-) -> Result<Vec<ExpandedPair<'a>>, StylexError> {
+) -> Result<Expanded<'a>, StylexError> {
     let key: Cow<'a, str> = if key.starts_with("var(") && key.ends_with(')') {
         match key {
             Cow::Borrowed(k) => Cow::Borrowed(&k[4..k.len() - 1]),
@@ -29,19 +91,18 @@ pub fn flat_map_expanded_shorthands<'a>(
     } else {
         key
     };
-    let identity = || Ok(vec![(key.clone(), value.clone())]);
     match options.style_resolution {
         StyleResolution::PropertySpecificity => {
             let expansion = property_specificity_expansion(&key);
             if matches!(expansion, Expansion::None) {
-                return identity();
+                return Ok(Expanded::One((key, value)));
             }
             if value_is_array {
                 return Err(StylexError::shorthand_fallback());
             }
             match expansion {
-                Expansion::Banned => banned(&key, options),
-                Expansion::Alias(target) => Ok(vec![(Cow::Borrowed(target), value)]),
+                Expansion::Banned => banned(&key, options).map(Expanded::Many),
+                Expansion::Alias(target) => Ok(Expanded::One((Cow::Borrowed(target), value))),
                 Expansion::None => unreachable!("checked above"),
             }
         }
@@ -50,31 +111,34 @@ pub fn flat_map_expanded_shorthands<'a>(
                 if value_is_array {
                     return Err(StylexError::shorthand_fallback());
                 }
-                return banned(&key, options);
+                return banned(&key, options).map(Expanded::Many);
             }
             let Some(table) = application_order_expansion(&key) else {
-                return identity();
+                return Ok(Expanded::One((key, value)));
             };
             if value_is_array {
                 return Err(StylexError::shorthand_fallback());
             }
-            let mut pairs = vec![(Cow::Borrowed(table[0]), value)];
+            let mut pairs = Vec::with_capacity(table.len());
+            pairs.push((Cow::Borrowed(table[0]), value));
             pairs.extend(table[1..].iter().map(|k| (Cow::Borrowed(*k), None)));
-            Ok(pairs)
+            Ok(Expanded::Many(pairs))
         }
         StyleResolution::LegacyExpandShorthands => {
             if !legacy_has_expansion(&key) {
-                return identity();
+                return Ok(Expanded::One((key, value)));
             }
             if value_is_array {
                 return Err(StylexError::shorthand_fallback());
             }
             match legacy_expansion(&key, value) {
-                Ok(pairs) => Ok(pairs),
+                Ok(pairs) => Ok(Expanded::Many(pairs)),
                 Err(error) => match options.property_validation_mode {
                     PropertyValidationMode::Throw => Err(error),
                     // Warn logs upstream, then drops just like silent.
-                    PropertyValidationMode::Silent | PropertyValidationMode::Warn => Ok(Vec::new()),
+                    PropertyValidationMode::Silent | PropertyValidationMode::Warn => {
+                        Ok(Expanded::Many(Vec::new()))
+                    }
                 },
             }
         }
@@ -1660,7 +1724,7 @@ mod tests {
         assert_eq!(
             flat_map_expanded_shorthands(Cow::Borrowed("color"), Some(s("red")), true, &opts)
                 .unwrap(),
-            vec![(Cow::Borrowed("color"), Some(s("red")))]
+            Expanded::One((Cow::Borrowed("color"), Some(s("red"))))
         );
     }
 

--- a/crates/stylex/src/shared/rtl.rs
+++ b/crates/stylex/src/shared/rtl.rs
@@ -1,0 +1,495 @@
+//! Logical→physical declaration rewrites and the legacy RTL value flips.
+// parity: babel-plugin src/shared/physical-rtl/{generate-ltr,generate-rtl}.js
+
+use crate::options::{ResolvedOptions, StyleResolution};
+use crate::shared::css_value::{Kind, Node, parse, stringify, unit};
+
+/// The three options `generateLtr`/`generateRtl` read; upstream passes none
+/// from `positionTry` or the keyframes stable string, so those take DEFAULTS.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RtlContext {
+    pub style_resolution: StyleResolution,
+    pub enable_logical_styles_polyfill: bool,
+    pub enable_legacy_value_flipping: bool,
+}
+
+impl RtlContext {
+    pub const DEFAULTS: RtlContext = RtlContext {
+        style_resolution: StyleResolution::PropertySpecificity,
+        enable_logical_styles_polyfill: false,
+        enable_legacy_value_flipping: false,
+    };
+
+    pub fn of(options: &ResolvedOptions) -> RtlContext {
+        RtlContext {
+            style_resolution: options.style_resolution,
+            enable_logical_styles_polyfill: options.enable_logical_styles_polyfill,
+            enable_legacy_value_flipping: options.enable_legacy_value_flipping,
+        }
+    }
+
+    fn legacy(&self) -> bool {
+        self.style_resolution == StyleResolution::LegacyExpandShorthands
+    }
+}
+
+fn ltr_value(value: &str) -> Option<&'static str> {
+    match value {
+        "start" | "inline-start" => Some("left"),
+        "end" | "inline-end" => Some("right"),
+        _ => None,
+    }
+}
+
+fn rtl_value(value: &str) -> Option<&'static str> {
+    match value {
+        "start" | "inline-start" => Some("right"),
+        "end" | "inline-end" => Some("left"),
+        _ => None,
+    }
+}
+
+fn ltr_property(key: &str) -> Option<&'static str> {
+    Some(match key {
+        "margin-start" => "margin-left",
+        "margin-end" => "margin-right",
+        "padding-start" => "padding-left",
+        "padding-end" => "padding-right",
+        "border-start" => "border-left",
+        "border-end" => "border-right",
+        "border-start-width" => "border-left-width",
+        "border-end-width" => "border-right-width",
+        "border-start-color" => "border-left-color",
+        "border-end-color" => "border-right-color",
+        "border-start-style" => "border-left-style",
+        "border-end-style" => "border-right-style",
+        "border-top-start-radius" => "border-top-left-radius",
+        "border-bottom-start-radius" => "border-bottom-left-radius",
+        "border-top-end-radius" => "border-top-right-radius",
+        "border-bottom-end-radius" => "border-bottom-right-radius",
+        "start" => "left",
+        "end" => "right",
+        _ => return None,
+    })
+}
+
+fn rtl_property(key: &str) -> Option<&'static str> {
+    Some(match key {
+        "margin-start" => "margin-right",
+        "margin-end" => "margin-left",
+        "padding-start" => "padding-right",
+        "padding-end" => "padding-left",
+        "border-start" => "border-right",
+        "border-end" => "border-left",
+        "border-start-width" => "border-right-width",
+        "border-end-width" => "border-left-width",
+        "border-start-color" => "border-right-color",
+        "border-end-color" => "border-left-color",
+        "border-start-style" => "border-right-style",
+        "border-end-style" => "border-left-style",
+        "border-top-start-radius" => "border-top-right-radius",
+        "border-bottom-start-radius" => "border-bottom-right-radius",
+        "border-top-end-radius" => "border-top-left-radius",
+        "border-bottom-end-radius" => "border-bottom-left-radius",
+        "start" => "right",
+        "end" => "left",
+        _ => return None,
+    })
+}
+
+// parity: generate-ltr.js inlinePropertyToLTR — consulted only under
+// legacy-expand-shorthands with the polyfill on.
+fn inline_ltr_property(key: &str) -> Option<&'static str> {
+    Some(match key {
+        "margin-inline-start" => "margin-left",
+        "margin-inline-end" => "margin-right",
+        "padding-inline-start" => "padding-left",
+        "padding-inline-end" => "padding-right",
+        "border-inline-start" => "border-left",
+        "border-inline-end" => "border-right",
+        "border-inline-start-width" => "border-left-width",
+        "border-inline-end-width" => "border-right-width",
+        "border-inline-start-color" => "border-left-color",
+        "border-inline-end-color" => "border-right-color",
+        "border-inline-start-style" => "border-left-style",
+        "border-inline-end-style" => "border-right-style",
+        "border-start-start-radius" => "border-top-left-radius",
+        "border-start-end-radius" => "border-top-right-radius",
+        "border-end-start-radius" => "border-bottom-left-radius",
+        "border-end-end-radius" => "border-bottom-right-radius",
+        "inset-inline-start" => "left",
+        "inset-inline-end" => "right",
+        _ => return None,
+    })
+}
+
+fn inline_rtl_property(key: &str) -> Option<&'static str> {
+    Some(match key {
+        "margin-inline-start" => "margin-right",
+        "margin-inline-end" => "margin-left",
+        "padding-inline-start" => "padding-right",
+        "padding-inline-end" => "padding-left",
+        "border-inline-start" => "border-right",
+        "border-inline-end" => "border-left",
+        "border-inline-start-width" => "border-right-width",
+        "border-inline-end-width" => "border-left-width",
+        "border-inline-start-color" => "border-right-color",
+        "border-inline-end-color" => "border-left-color",
+        "border-inline-start-style" => "border-right-style",
+        "border-inline-end-style" => "border-left-style",
+        "border-start-start-radius" => "border-top-right-radius",
+        "border-start-end-radius" => "border-top-left-radius",
+        "border-end-start-radius" => "border-bottom-right-radius",
+        "border-end-end-radius" => "border-bottom-left-radius",
+        "inset-inline-start" => "right",
+        "inset-inline-end" => "left",
+        _ => return None,
+    })
+}
+
+fn map_background_position(value: &str, start_to: &str, end_to: &str) -> String {
+    value
+        .split(' ')
+        .map(|word| match word {
+            "start" | "insetInlineStart" => start_to,
+            "end" | "insetInlineEnd" => end_to,
+            other => other,
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// The ltr declaration for a `[dashed-key, value]` pair (identity when no
+/// rewrite applies).
+pub fn generate_ltr(key: &str, value: &str, ctx: RtlContext) -> (String, String) {
+    if ctx.legacy() {
+        if !ctx.enable_logical_styles_polyfill {
+            return (key.to_string(), value.to_string());
+        }
+        if let Some(mapped) = inline_ltr_property(key) {
+            return (mapped.to_string(), value.to_string());
+        }
+    }
+    if let Some(mapped) = ltr_property(key) {
+        return (mapped.to_string(), value.to_string());
+    }
+    match key {
+        "float" | "clear" => (
+            key.to_string(),
+            ltr_value(value).map_or_else(|| value.to_string(), str::to_string),
+        ),
+        "background-position" => (
+            key.to_string(),
+            map_background_position(value, "left", "right"),
+        ),
+        _ => (key.to_string(), value.to_string()),
+    }
+}
+
+/// The rtl declaration, or `None` when the pair does not flip.
+pub fn generate_rtl(key: &str, value: &str, ctx: RtlContext) -> Option<(String, String)> {
+    if ctx.legacy() {
+        // The polyfill gates every rtl rule, legacy value flipping included.
+        if !ctx.enable_logical_styles_polyfill {
+            return None;
+        }
+        if let Some(mapped) = inline_rtl_property(key) {
+            return Some((mapped.to_string(), value.to_string()));
+        }
+    }
+    if let Some(mapped) = rtl_property(key) {
+        return Some((mapped.to_string(), value.to_string()));
+    }
+    match key {
+        "float" | "clear" => rtl_value(value).map(|v| (key.to_string(), v.to_string())),
+        "background-position" => {
+            let words: Vec<&str> = value.split(' ').collect();
+            if !words.contains(&"start") && !words.contains(&"end") {
+                return None;
+            }
+            Some((
+                key.to_string(),
+                map_background_position(value, "right", "left"),
+            ))
+        }
+        "cursor" if ctx.enable_legacy_value_flipping => {
+            cursor_flip(value).map(|v| (key.to_string(), v.to_string()))
+        }
+        "box-shadow" | "text-shadow" if ctx.enable_legacy_value_flipping => {
+            flip_shadow(value).map(|v| (key.to_string(), v))
+        }
+        _ => None,
+    }
+}
+
+// parity: generate-rtl.js CURSOR_FLIP — whole-string, case-sensitive.
+fn cursor_flip(value: &str) -> Option<&'static str> {
+    Some(match value {
+        "e-resize" => "w-resize",
+        "w-resize" => "e-resize",
+        "ne-resize" => "nw-resize",
+        "nw-resize" => "ne-resize",
+        "se-resize" => "sw-resize",
+        "sw-resize" => "se-resize",
+        "nesw-resize" => "nwse-resize",
+        "nwse-resize" => "nesw-resize",
+        _ => return None,
+    })
+}
+
+/// Top-level `,` `/` `:` groups; empty groups drop and the join is always `,`.
+fn split_by_divisor(value: &str) -> Vec<String> {
+    let mut groups: Vec<String> = Vec::new();
+    let mut current: Vec<Node> = Vec::new();
+    for node in parse(value) {
+        if node.kind == Kind::Div {
+            if !current.is_empty() {
+                groups.push(stringify(&current));
+                current.clear();
+            }
+        } else {
+            current.push(node);
+        }
+    }
+    if !current.is_empty() {
+        groups.push(stringify(&current));
+    }
+    groups
+}
+
+// parity: generate-rtl.js flipShadow — naive space split, string-only surgery.
+fn flip_shadow(value: &str) -> Option<String> {
+    let flipped: Vec<String> = split_by_divisor(value)
+        .into_iter()
+        .map(|def| {
+            let mut parts: Vec<String> = def.split(' ').map(str::to_string).collect();
+            let index = usize::from(!starts_like_number(&parts[0]));
+            if index < parts.len() {
+                parts[index] = flip_sign(&parts[index]);
+            }
+            parts.join(" ")
+        })
+        .collect();
+    let rtl = flipped.join(",");
+    (rtl != value).then_some(rtl)
+}
+
+fn starts_like_number(part: &str) -> bool {
+    unit(part).is_some()
+}
+
+fn flip_sign(part: &str) -> String {
+    if part == "0" {
+        return part.to_string();
+    }
+    match part.strip_prefix('-') {
+        Some(rest) => rest.to_string(),
+        None => format!("-{part}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn legacy(polyfill: bool) -> RtlContext {
+        RtlContext {
+            style_resolution: StyleResolution::LegacyExpandShorthands,
+            enable_logical_styles_polyfill: polyfill,
+            enable_legacy_value_flipping: false,
+        }
+    }
+
+    fn flipping() -> RtlContext {
+        RtlContext {
+            enable_legacy_value_flipping: true,
+            ..RtlContext::DEFAULTS
+        }
+    }
+
+    #[test]
+    fn oracle_pinned_pairs() {
+        // Pinned via probes 2026-08-27 against @stylexjs/babel-plugin 0.19.0.
+        let d = RtlContext::DEFAULTS;
+        assert_eq!(
+            generate_ltr("margin-start", "10px", d),
+            ("margin-left".to_string(), "10px".to_string())
+        );
+        assert_eq!(
+            generate_rtl("margin-start", "10px", d),
+            Some(("margin-right".to_string(), "10px".to_string()))
+        );
+        assert_eq!(
+            generate_ltr("float", "inline-start", d),
+            ("float".to_string(), "left".to_string())
+        );
+        assert_eq!(
+            generate_rtl("float", "inline-start", d),
+            Some(("float".to_string(), "right".to_string()))
+        );
+        assert_eq!(
+            generate_ltr("float", "left", d),
+            ("float".to_string(), "left".to_string())
+        );
+        assert_eq!(generate_rtl("float", "left", d), None);
+        assert_eq!(
+            generate_ltr("background-position", "start top", d),
+            ("background-position".to_string(), "left top".to_string())
+        );
+        assert_eq!(
+            generate_rtl("background-position", "start top", d),
+            Some(("background-position".to_string(), "right top".to_string()))
+        );
+        assert_eq!(generate_rtl("background-position", "left top", d), None);
+        assert_eq!(generate_rtl("cursor", "e-resize", d), None);
+        assert_eq!(generate_rtl("margin-inline-start", "1px", d), None);
+        assert_eq!(
+            generate_ltr("margin-inline-start", "1px", d),
+            ("margin-inline-start".to_string(), "1px".to_string())
+        );
+    }
+
+    #[test]
+    fn legacy_polyfill_gates_every_rtl_rule() {
+        // polyfill off: ltr is identity for everything and there is no rtl.
+        assert_eq!(
+            generate_ltr("margin-inline-start", "1px", legacy(false)),
+            ("margin-inline-start".to_string(), "1px".to_string())
+        );
+        assert_eq!(
+            generate_rtl("margin-inline-start", "1px", legacy(false)),
+            None
+        );
+        assert_eq!(
+            generate_ltr("margin-start", "1px", legacy(false)),
+            ("margin-start".to_string(), "1px".to_string())
+        );
+        assert_eq!(generate_rtl("margin-start", "1px", legacy(false)), None);
+        assert_eq!(
+            generate_ltr("background-position", "start top", legacy(false)),
+            ("background-position".to_string(), "start top".to_string())
+        );
+
+        // polyfill on: the inline table fires first, then the normal one.
+        assert_eq!(
+            generate_ltr("border-start-start-radius", "1px", legacy(true)),
+            ("border-top-left-radius".to_string(), "1px".to_string())
+        );
+        assert_eq!(
+            generate_rtl("border-start-start-radius", "1px", legacy(true)),
+            Some(("border-top-right-radius".to_string(), "1px".to_string()))
+        );
+        assert_eq!(
+            generate_ltr("border-start-width", "1px", legacy(true)),
+            ("border-left-width".to_string(), "1px".to_string())
+        );
+        // camelCase background-position words map in ltr but never produce rtl.
+        assert_eq!(
+            generate_ltr("background-position", "insetInlineStart 0", legacy(true)),
+            ("background-position".to_string(), "left 0".to_string())
+        );
+        assert_eq!(
+            generate_rtl("background-position", "insetInlineStart 0", legacy(true)),
+            None
+        );
+    }
+
+    #[test]
+    fn legacy_value_flipping_is_gated_by_the_polyfill() {
+        let leg_flip = RtlContext {
+            enable_legacy_value_flipping: true,
+            ..legacy(false)
+        };
+        assert_eq!(generate_rtl("cursor", "e-resize", leg_flip), None);
+        let leg_flip_poly = RtlContext {
+            enable_logical_styles_polyfill: true,
+            ..leg_flip
+        };
+        assert_eq!(
+            generate_rtl("cursor", "e-resize", leg_flip_poly),
+            Some(("cursor".to_string(), "w-resize".to_string()))
+        );
+    }
+
+    #[test]
+    fn cursor_and_shadow_flips() {
+        let f = flipping();
+        let rtl = |k: &str, v: &str| generate_rtl(k, v, f).map(|(_, v)| v);
+        assert_eq!(rtl("cursor", "nesw-resize").as_deref(), Some("nwse-resize"));
+        assert_eq!(rtl("cursor", "n-resize"), None);
+        assert_eq!(rtl("cursor", "E-resize"), None);
+        assert_eq!(rtl("cursor", "url(a.png),e-resize"), None);
+        assert_eq!(generate_ltr("cursor", "e-resize", f).1, "e-resize");
+
+        assert_eq!(
+            rtl("box-shadow", "1px 1px #000").as_deref(),
+            Some("-1px 1px #000")
+        );
+        assert_eq!(
+            rtl("text-shadow", "1px 1px #000").as_deref(),
+            Some("-1px 1px #000")
+        );
+        assert_eq!(
+            rtl("box-shadow", "-1px -1px #000").as_deref(),
+            Some("1px -1px #000")
+        );
+        assert_eq!(
+            rtl("box-shadow", "inset 1px 1px #000").as_deref(),
+            Some("inset -1px 1px #000")
+        );
+        assert_eq!(rtl("box-shadow", "0 1px 2px #000"), None);
+        assert_eq!(
+            rtl("box-shadow", "0px 1px 2px #000").as_deref(),
+            Some("-0px 1px 2px #000")
+        );
+        assert_eq!(rtl("box-shadow", "none"), None);
+        assert_eq!(rtl("box-shadow", "var(--shadow)"), None);
+        // `/` and `:` are divisors too, and the join is always a comma.
+        assert_eq!(
+            rtl("box-shadow", "1px 1px / 2px 2px").as_deref(),
+            Some("-1px 1px,-2px 2px")
+        );
+        assert_eq!(rtl("box-shadow", "1px : 2px").as_deref(), Some("-1px,-2px"));
+        assert_eq!(
+            rtl("box-shadow", "1px 1px red,,").as_deref(),
+            Some("-1px 1px red")
+        );
+        assert_eq!(
+            rtl("box-shadow", "1px 1px #000,,2px 2px red").as_deref(),
+            Some("-1px 1px #000,-2px 2px red")
+        );
+        // Commas and slashes nested in a function are not divisors.
+        assert_eq!(
+            rtl("box-shadow", "1px 1px hsl(0 0% 0% / 50%)").as_deref(),
+            Some("-1px 1px hsl(0 0% 0% / 50%)")
+        );
+        assert_eq!(
+            rtl("box-shadow", "min(1px,2px) 1px red").as_deref(),
+            Some("min(1px,2px) -1px red")
+        );
+        // Upstream corrupts these; reproduce it.
+        assert_eq!(
+            rtl("box-shadow", "var(--a,1px 1px red)").as_deref(),
+            Some("var(--a,1px -1px red)")
+        );
+        assert_eq!(
+            rtl("box-shadow", "calc(1px + 2px) 1px red").as_deref(),
+            Some("calc(1px -+ 2px) 1px red")
+        );
+        assert_eq!(rtl("box-shadow", ".px 1px").as_deref(), Some(".px -1px"));
+        assert_eq!(
+            rtl("box-shadow", "- 1px 1px").as_deref(),
+            Some("- -1px 1px")
+        );
+        assert_eq!(rtl("box-shadow", "+1px 1px").as_deref(), Some("-+1px 1px"));
+        assert_eq!(rtl("box-shadow", ".5px 1px").as_deref(), Some("-.5px 1px"));
+        assert_eq!(
+            rtl("box-shadow", "1px 1px red /* c */").as_deref(),
+            Some("-1px 1px red /* c */")
+        );
+        assert_eq!(
+            rtl("box-shadow", "none,1px 1px red").as_deref(),
+            Some("none,-1px 1px red")
+        );
+    }
+}

--- a/crates/stylex/src/shared/rtl.rs
+++ b/crates/stylex/src/shared/rtl.rs
@@ -2,6 +2,8 @@
 // parity: babel-plugin src/shared/physical-rtl/{generate-ltr,generate-rtl}.js
 
 use crate::options::{ResolvedOptions, StyleResolution};
+use std::borrow::Cow;
+
 use crate::shared::css_value::{Kind, Node, parse, stringify, unit};
 
 /// The three options `generateLtr`/`generateRtl` read; upstream passes none
@@ -161,62 +163,70 @@ fn map_background_position(value: &str, start_to: &str, end_to: &str) -> String 
 
 /// The ltr declaration for a `[dashed-key, value]` pair (identity when no
 /// rewrite applies).
-pub fn generate_ltr(key: &str, value: &str, ctx: RtlContext) -> (String, String) {
+pub fn generate_ltr<'k, 'v>(
+    key: &'k str,
+    value: &'v str,
+    ctx: RtlContext,
+) -> (Cow<'k, str>, Cow<'v, str>) {
+    let identity = (Cow::Borrowed(key), Cow::Borrowed(value));
     if ctx.legacy() {
         if !ctx.enable_logical_styles_polyfill {
-            return (key.to_string(), value.to_string());
+            return identity;
         }
         if let Some(mapped) = inline_ltr_property(key) {
-            return (mapped.to_string(), value.to_string());
+            return (Cow::Borrowed(mapped), Cow::Borrowed(value));
         }
     }
     if let Some(mapped) = ltr_property(key) {
-        return (mapped.to_string(), value.to_string());
+        return (Cow::Borrowed(mapped), Cow::Borrowed(value));
     }
     match key {
         "float" | "clear" => (
-            key.to_string(),
-            ltr_value(value).map_or_else(|| value.to_string(), str::to_string),
+            Cow::Borrowed(key),
+            Cow::Borrowed(ltr_value(value).unwrap_or(value)),
         ),
         "background-position" => (
-            key.to_string(),
-            map_background_position(value, "left", "right"),
+            Cow::Borrowed(key),
+            Cow::Owned(map_background_position(value, "left", "right")),
         ),
-        _ => (key.to_string(), value.to_string()),
+        _ => identity,
     }
 }
 
 /// The rtl declaration, or `None` when the pair does not flip.
-pub fn generate_rtl(key: &str, value: &str, ctx: RtlContext) -> Option<(String, String)> {
+pub fn generate_rtl<'k, 'v>(
+    key: &'k str,
+    value: &'v str,
+    ctx: RtlContext,
+) -> Option<(Cow<'k, str>, Cow<'v, str>)> {
     if ctx.legacy() {
         // The polyfill gates every rtl rule, legacy value flipping included.
         if !ctx.enable_logical_styles_polyfill {
             return None;
         }
         if let Some(mapped) = inline_rtl_property(key) {
-            return Some((mapped.to_string(), value.to_string()));
+            return Some((Cow::Borrowed(mapped), Cow::Borrowed(value)));
         }
     }
     if let Some(mapped) = rtl_property(key) {
-        return Some((mapped.to_string(), value.to_string()));
+        return Some((Cow::Borrowed(mapped), Cow::Borrowed(value)));
     }
     match key {
-        "float" | "clear" => rtl_value(value).map(|v| (key.to_string(), v.to_string())),
+        "float" | "clear" => rtl_value(value).map(|v| (Cow::Borrowed(key), Cow::Borrowed(v))),
         "background-position" => {
-            let words: Vec<&str> = value.split(' ').collect();
-            if !words.contains(&"start") && !words.contains(&"end") {
+            if !value.split(' ').any(|w| w == "start" || w == "end") {
                 return None;
             }
             Some((
-                key.to_string(),
-                map_background_position(value, "right", "left"),
+                Cow::Borrowed(key),
+                Cow::Owned(map_background_position(value, "right", "left")),
             ))
         }
         "cursor" if ctx.enable_legacy_value_flipping => {
-            cursor_flip(value).map(|v| (key.to_string(), v.to_string()))
+            cursor_flip(value).map(|v| (Cow::Borrowed(key), Cow::Borrowed(v)))
         }
         "box-shadow" | "text-shadow" if ctx.enable_legacy_value_flipping => {
-            flip_shadow(value).map(|v| (key.to_string(), v))
+            flip_shadow(value).map(|v| (Cow::Borrowed(key), Cow::Owned(v)))
         }
         _ => None,
     }
@@ -292,6 +302,15 @@ fn flip_sign(part: &str) -> String {
 mod tests {
     use super::*;
 
+    fn ltr(key: &str, value: &str, ctx: RtlContext) -> (String, String) {
+        let (k, v) = generate_ltr(key, value, ctx);
+        (k.into_owned(), v.into_owned())
+    }
+
+    fn rtl(key: &str, value: &str, ctx: RtlContext) -> Option<(String, String)> {
+        generate_rtl(key, value, ctx).map(|(k, v)| (k.into_owned(), v.into_owned()))
+    }
+
     fn legacy(polyfill: bool) -> RtlContext {
         RtlContext {
             style_resolution: StyleResolution::LegacyExpandShorthands,
@@ -312,39 +331,39 @@ mod tests {
         // Pinned via probes 2026-08-27 against @stylexjs/babel-plugin 0.19.0.
         let d = RtlContext::DEFAULTS;
         assert_eq!(
-            generate_ltr("margin-start", "10px", d),
+            ltr("margin-start", "10px", d),
             ("margin-left".to_string(), "10px".to_string())
         );
         assert_eq!(
-            generate_rtl("margin-start", "10px", d),
+            rtl("margin-start", "10px", d),
             Some(("margin-right".to_string(), "10px".to_string()))
         );
         assert_eq!(
-            generate_ltr("float", "inline-start", d),
+            ltr("float", "inline-start", d),
             ("float".to_string(), "left".to_string())
         );
         assert_eq!(
-            generate_rtl("float", "inline-start", d),
+            rtl("float", "inline-start", d),
             Some(("float".to_string(), "right".to_string()))
         );
         assert_eq!(
-            generate_ltr("float", "left", d),
+            ltr("float", "left", d),
             ("float".to_string(), "left".to_string())
         );
-        assert_eq!(generate_rtl("float", "left", d), None);
+        assert_eq!(rtl("float", "left", d), None);
         assert_eq!(
-            generate_ltr("background-position", "start top", d),
+            ltr("background-position", "start top", d),
             ("background-position".to_string(), "left top".to_string())
         );
         assert_eq!(
-            generate_rtl("background-position", "start top", d),
+            rtl("background-position", "start top", d),
             Some(("background-position".to_string(), "right top".to_string()))
         );
-        assert_eq!(generate_rtl("background-position", "left top", d), None);
-        assert_eq!(generate_rtl("cursor", "e-resize", d), None);
-        assert_eq!(generate_rtl("margin-inline-start", "1px", d), None);
+        assert_eq!(rtl("background-position", "left top", d), None);
+        assert_eq!(rtl("cursor", "e-resize", d), None);
+        assert_eq!(rtl("margin-inline-start", "1px", d), None);
         assert_eq!(
-            generate_ltr("margin-inline-start", "1px", d),
+            ltr("margin-inline-start", "1px", d),
             ("margin-inline-start".to_string(), "1px".to_string())
         );
     }
@@ -353,43 +372,40 @@ mod tests {
     fn legacy_polyfill_gates_every_rtl_rule() {
         // polyfill off: ltr is identity for everything and there is no rtl.
         assert_eq!(
-            generate_ltr("margin-inline-start", "1px", legacy(false)),
+            ltr("margin-inline-start", "1px", legacy(false)),
             ("margin-inline-start".to_string(), "1px".to_string())
         );
+        assert_eq!(rtl("margin-inline-start", "1px", legacy(false)), None);
         assert_eq!(
-            generate_rtl("margin-inline-start", "1px", legacy(false)),
-            None
-        );
-        assert_eq!(
-            generate_ltr("margin-start", "1px", legacy(false)),
+            ltr("margin-start", "1px", legacy(false)),
             ("margin-start".to_string(), "1px".to_string())
         );
-        assert_eq!(generate_rtl("margin-start", "1px", legacy(false)), None);
+        assert_eq!(rtl("margin-start", "1px", legacy(false)), None);
         assert_eq!(
-            generate_ltr("background-position", "start top", legacy(false)),
+            ltr("background-position", "start top", legacy(false)),
             ("background-position".to_string(), "start top".to_string())
         );
 
         // polyfill on: the inline table fires first, then the normal one.
         assert_eq!(
-            generate_ltr("border-start-start-radius", "1px", legacy(true)),
+            ltr("border-start-start-radius", "1px", legacy(true)),
             ("border-top-left-radius".to_string(), "1px".to_string())
         );
         assert_eq!(
-            generate_rtl("border-start-start-radius", "1px", legacy(true)),
+            rtl("border-start-start-radius", "1px", legacy(true)),
             Some(("border-top-right-radius".to_string(), "1px".to_string()))
         );
         assert_eq!(
-            generate_ltr("border-start-width", "1px", legacy(true)),
+            ltr("border-start-width", "1px", legacy(true)),
             ("border-left-width".to_string(), "1px".to_string())
         );
         // camelCase background-position words map in ltr but never produce rtl.
         assert_eq!(
-            generate_ltr("background-position", "insetInlineStart 0", legacy(true)),
+            ltr("background-position", "insetInlineStart 0", legacy(true)),
             ("background-position".to_string(), "left 0".to_string())
         );
         assert_eq!(
-            generate_rtl("background-position", "insetInlineStart 0", legacy(true)),
+            rtl("background-position", "insetInlineStart 0", legacy(true)),
             None
         );
     }
@@ -400,13 +416,13 @@ mod tests {
             enable_legacy_value_flipping: true,
             ..legacy(false)
         };
-        assert_eq!(generate_rtl("cursor", "e-resize", leg_flip), None);
+        assert_eq!(rtl("cursor", "e-resize", leg_flip), None);
         let leg_flip_poly = RtlContext {
             enable_logical_styles_polyfill: true,
             ..leg_flip
         };
         assert_eq!(
-            generate_rtl("cursor", "e-resize", leg_flip_poly),
+            rtl("cursor", "e-resize", leg_flip_poly),
             Some(("cursor".to_string(), "w-resize".to_string()))
         );
     }
@@ -414,12 +430,12 @@ mod tests {
     #[test]
     fn cursor_and_shadow_flips() {
         let f = flipping();
-        let rtl = |k: &str, v: &str| generate_rtl(k, v, f).map(|(_, v)| v);
+        let rtl = |k: &str, v: &str| rtl(k, v, f).map(|(_, v)| v);
         assert_eq!(rtl("cursor", "nesw-resize").as_deref(), Some("nwse-resize"));
         assert_eq!(rtl("cursor", "n-resize"), None);
         assert_eq!(rtl("cursor", "E-resize"), None);
         assert_eq!(rtl("cursor", "url(a.png),e-resize"), None);
-        assert_eq!(generate_ltr("cursor", "e-resize", f).1, "e-resize");
+        assert_eq!(ltr("cursor", "e-resize", f).1, "e-resize");
 
         assert_eq!(
             rtl("box-shadow", "1px 1px #000").as_deref(),

--- a/crates/stylex/src/shared/split_css_value.rs
+++ b/crates/stylex/src/shared/split_css_value.rs
@@ -1,0 +1,121 @@
+//! `splitValue`: the value splitter the legacy shorthand expansions run on.
+// parity: babel-plugin src/shared/utils/split-css-value.js
+
+use crate::shared::css_value::{Kind, Node, parse};
+use crate::shared::flatten::StyleScalar;
+use std::borrow::Cow;
+
+/// `null`, `undefined` and numbers pass through as a single part; a string
+/// splits on the top-level space/div nodes, re-printed without their padding.
+pub fn split_value<'a>(value: Option<&StyleScalar<'a>>) -> Vec<Option<StyleScalar<'a>>> {
+    let Some(StyleScalar::Str(raw)) = value else {
+        return vec![value.cloned()];
+    };
+    let nodes = parse(raw.trim());
+    let mut parts: Vec<String> = nodes
+        .iter()
+        .filter(|n| n.kind != Kind::Space && n.kind != Kind::Div)
+        .map(print_node)
+        .collect();
+    if parts.len() > 1
+        && parts
+            .last()
+            .is_some_and(|p| p.eq_ignore_ascii_case("!important"))
+    {
+        parts.pop();
+        for part in &mut parts {
+            part.push_str(" !important");
+        }
+    }
+    parts
+        .into_iter()
+        .map(|p| Some(StyleScalar::Str(Cow::Owned(p))))
+        .collect()
+}
+
+// parity: split-css-value.js printNode — `before`/`after` padding is dropped
+// and an unclosed function is re-printed closed.
+fn print_node(node: &Node) -> String {
+    match node.kind {
+        Kind::Str => {
+            let quote = node.quote as char;
+            let mut out = String::with_capacity(node.value.len() + 2);
+            out.push(quote);
+            out.push_str(&node.value);
+            out.push(quote);
+            out
+        }
+        Kind::Func => {
+            let mut out = String::with_capacity(node.value.len() + 2);
+            out.push_str(&node.value);
+            out.push('(');
+            for child in &node.nodes {
+                out.push_str(&print_node(child));
+            }
+            out.push(')');
+            out
+        }
+        _ => node.value.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn split(v: &str) -> Vec<String> {
+        split_value(Some(&StyleScalar::Str(Cow::Borrowed(v))))
+            .into_iter()
+            .map(|p| match p {
+                Some(StyleScalar::Str(s)) => s.into_owned(),
+                other => format!("{other:?}"),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn oracle_pinned_splits() {
+        // Pinned via live-oracle probes 2026-08-29 against babel-plugin 0.19.0.
+        assert_eq!(split("1px 2px"), vec!["1px", "2px"]);
+        assert_eq!(split("  1px 2px  "), vec!["1px", "2px"]);
+        assert_eq!(split("1px,2px"), vec!["1px", "2px"]);
+        assert_eq!(split("1px 2px / 3px 4px"), vec!["1px", "2px", "3px", "4px"]);
+        assert_eq!(
+            split("calc(1px + 2px) min(1px, 2px)"),
+            vec!["calc(1px + 2px)", "min(1px,2px)"]
+        );
+        // The parser closes the function; property-specificity throws instead.
+        assert_eq!(split("calc(1px + 2px"), vec!["calc(1px + 2px)"]);
+        assert_eq!(split("var(--a, 1px) 2px"), vec!["var(--a,1px)", "2px"]);
+        assert_eq!(split("'a' \"b\""), vec!["'a'", "\"b\""]);
+        assert!(split("").is_empty());
+        assert!(split("   ").is_empty());
+    }
+
+    #[test]
+    fn important_suffixing() {
+        assert_eq!(
+            split("1px 2px !IMPORTANT"),
+            vec!["1px !important", "2px !important"]
+        );
+        // A lone "!important" is length 1, so nothing is sliced off.
+        assert_eq!(split("!important"), vec!["!important"]);
+        assert_eq!(
+            split("1px !important 2px"),
+            vec!["1px", "!important", "2px"]
+        );
+    }
+
+    #[test]
+    fn non_strings_pass_through() {
+        assert_eq!(split_value(None), vec![None]);
+        assert_eq!(
+            split_value(Some(&StyleScalar::Num(5.0))),
+            vec![Some(StyleScalar::Num(5.0))]
+        );
+        assert_eq!(
+            split_value(Some(&StyleScalar::Undefined)),
+            vec![Some(StyleScalar::Undefined)]
+        );
+    }
+}

--- a/crates/stylex/src/shared/transform_value.rs
+++ b/crates/stylex/src/shared/transform_value.rs
@@ -1,0 +1,187 @@
+//! JS style value → final CSS string value.
+// parity: babel-plugin/src/shared/utils/transform-value.js
+
+use crate::jsrt::{js_math_round, js_number_to_string};
+use crate::shared::normalize_value::{CssValueError, normalize_value};
+
+pub fn transform_value_str(
+    key: &str,
+    value: &str,
+    font_size_px_to_rem: bool,
+) -> Result<String, CssValueError> {
+    if let Some(out) = transform_content_like(key, value) {
+        return Ok(out);
+    }
+    normalize_value(value, key, font_size_px_to_rem)
+}
+
+pub fn transform_value_num(
+    key: &str,
+    value: f64,
+    font_size_px_to_rem: bool,
+) -> Result<String, CssValueError> {
+    let rounded = js_math_round(value * 10000.0) / 10000.0;
+    let as_string = js_number_to_string(rounded) + get_number_suffix(key);
+    if let Some(out) = transform_content_like(key, &as_string) {
+        return Ok(out);
+    }
+    normalize_value(&as_string, key, font_size_px_to_rem)
+}
+
+// content/hyphenateCharacter auto-quoting; short-circuits normalization.
+fn transform_content_like(key: &str, value: &str) -> Option<String> {
+    if key != "content" && key != "hyphenateCharacter" && key != "hyphenate-character" {
+        return None;
+    }
+    let val = value.trim_matches(is_js_whitespace);
+
+    const CSS_CONTENT_FUNCTIONS: [&str; 7] = [
+        "attr(",
+        "counter(",
+        "counters(",
+        "url(",
+        "linear-gradient(",
+        "image-set(",
+        "var(--",
+    ];
+    let is_css_function = CSS_CONTENT_FUNCTIONS.iter().any(|f| val.contains(f));
+    let is_keyword = matches!(
+        val,
+        "normal"
+            | "none"
+            | "open-quote"
+            | "close-quote"
+            | "no-open-quote"
+            | "no-close-quote"
+            | "inherit"
+            | "initial"
+            | "revert"
+            | "revert-layer"
+            | "unset"
+    );
+    let has_matching_quotes = val.matches('"').count() >= 2 || val.matches('\'').count() >= 2;
+
+    if is_css_function || is_keyword || has_matching_quotes {
+        Some(val.to_string())
+    } else {
+        Some(format!("\"{val}\""))
+    }
+}
+
+// JS String.prototype.trim character set (differs from Rust char::is_whitespace
+// on U+FEFF and U+0085).
+fn is_js_whitespace(c: char) -> bool {
+    matches!(
+        c,
+        '\t' | '\n' | '\u{000B}' | '\u{000C}' | '\r' | ' ' | '\u{00A0}' | '\u{1680}' | '\u{2000}'
+            ..='\u{200A}'
+                | '\u{2028}'
+                | '\u{2029}'
+                | '\u{202F}'
+                | '\u{205F}'
+                | '\u{3000}'
+                | '\u{FEFF}'
+    )
+}
+
+pub fn get_number_suffix(key: &str) -> &'static str {
+    if is_unitless_number_property(key) || key.starts_with("--") {
+        return "";
+    }
+    match key {
+        "animationDelay" | "animationDuration" | "transitionDelay" | "transitionDuration"
+        | "voiceDuration" => "ms",
+        _ => "px",
+    }
+}
+
+fn is_unitless_number_property(key: &str) -> bool {
+    matches!(
+        key,
+        "WebkitLineClamp"
+            | "animationIterationCount"
+            | "aspectRatio"
+            | "borderImageOutset"
+            | "borderImageSlice"
+            | "borderImageWidth"
+            | "counterSet"
+            | "counterReset"
+            | "columnCount"
+            | "flex"
+            | "flexGrow"
+            | "flexShrink"
+            | "flexOrder"
+            | "gridRow"
+            | "gridRowStart"
+            | "gridRowEnd"
+            | "gridColumn"
+            | "gridColumnStart"
+            | "gridColumnEnd"
+            | "gridArea"
+            | "fontWeight"
+            | "hyphenateLimitChars"
+            | "lineClamp"
+            | "lineHeight"
+            | "maskBorderOutset"
+            | "maskBorderSlice"
+            | "maskBorderWidth"
+            | "opacity"
+            | "order"
+            | "orphans"
+            | "tabSize"
+            | "widows"
+            | "zIndex"
+            | "fillOpacity"
+            | "floodOpacity"
+            | "rotate"
+            | "scale"
+            | "shapeImageThreshold"
+            | "stopOpacity"
+            | "strokeDasharray"
+            | "strokeDashoffset"
+            | "strokeMiterlimit"
+            | "strokeOpacity"
+            | "strokeWidth"
+            | "mathDepth"
+            | "zoom"
+    )
+}
+
+// Also exercised end-to-end by tests/values.rs against oracle pins.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn number_suffix_rules() {
+        assert_eq!(get_number_suffix("width"), "px");
+        assert_eq!(get_number_suffix("opacity"), "");
+        assert_eq!(get_number_suffix("--anything"), "");
+        assert_eq!(get_number_suffix("transitionDuration"), "ms");
+        // dashed form is not in the ms table
+        assert_eq!(get_number_suffix("transition-duration"), "px");
+    }
+
+    #[test]
+    fn negative_zero_prints_unsigned() {
+        // String(-0) is "0" in JS; the pipeline depends on ryu-js matching that.
+        assert_eq!(js_number_to_string(-0.0), "0");
+        assert_eq!(transform_value_num("width", -0.0, false).unwrap(), "0");
+    }
+
+    #[test]
+    fn content_wraps_number_output() {
+        assert_eq!(
+            transform_value_num("content", 5.0, false).unwrap(),
+            "\"5px\""
+        );
+        assert_eq!(
+            transform_value_str("content", "hello", false).unwrap(),
+            "\"hello\""
+        );
+        assert_eq!(
+            transform_value_str("content", "attr(href)", false).unwrap(),
+            "attr(href)"
+        );
+    }
+}

--- a/crates/stylex/src/shared/types.rs
+++ b/crates/stylex/src/shared/types.rs
@@ -1,0 +1,294 @@
+//! `stylex.types.*` CSS type wrappers for defineVars/createTheme.
+// parity: babel-plugin src/shared/types/index.js
+
+use std::sync::Arc;
+
+use crate::errors::StylexError;
+use crate::eval::JsValue;
+use crate::eval::value::{EvalValue, JsObjectMap};
+use crate::jsrt::js_number_to_string;
+
+pub const TYPES_MEMBERS: [&str; 13] = [
+    "angle",
+    "color",
+    "url",
+    "image",
+    "integer",
+    "lengthPercentage",
+    "length",
+    "percentage",
+    "number",
+    "resolution",
+    "time",
+    "transformFunction",
+    "transformList",
+];
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CssType {
+    pub syntax: String,
+    pub value: EvalValue,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Conversion {
+    Raw,
+    BareNumber,
+    Length,
+    Percentage,
+    IntegerString,
+}
+
+fn kind_table(kind: &str) -> Option<(&'static str, Conversion)> {
+    Some(match kind {
+        "angle" => ("<angle>", Conversion::Raw),
+        "color" => ("<color>", Conversion::Raw),
+        "url" => ("<url>", Conversion::Raw),
+        "image" => ("<image>", Conversion::Raw),
+        "integer" => ("<integer>", Conversion::IntegerString),
+        "lengthPercentage" => ("<length-percentage>", Conversion::Length),
+        "length" => ("<length>", Conversion::Length),
+        "percentage" => ("<percentage>", Conversion::Percentage),
+        "number" => ("<number>", Conversion::BareNumber),
+        "resolution" => ("<resolution>", Conversion::Raw),
+        "time" => ("<time>", Conversion::Raw),
+        "transformFunction" => ("<transform-function>", Conversion::Raw),
+        "transformList" => ("<transform-list>", Conversion::Raw),
+        _ => return None,
+    })
+}
+
+/// Builds the CSSType stand-in: own `value`/`syntax` keys (class fields, so
+/// spreads copy them) plus the out-of-band `instanceof BaseCSSType` brand.
+pub fn create_css_type(kind: &str, args: &[EvalValue]) -> Result<EvalValue, StylexError> {
+    let (syntax, conversion) =
+        kind_table(kind).ok_or_else(|| StylexError::unsupported_api("types.*"))?;
+    let raw = args.first().cloned().unwrap_or(EvalValue::Undefined);
+    let value = convert(&raw, conversion)?;
+    let mut obj = JsObjectMap::new();
+    obj.insert("value", value);
+    obj.insert("syntax", EvalValue::Str(syntax.to_string()));
+    obj.set_css_type(syntax.to_string());
+    Ok(EvalValue::Obj(Arc::new(obj)))
+}
+
+// parity: types/index.js convertNumberToStringUsing (null → Object.keys crash).
+fn convert(value: &EvalValue, conversion: Conversion) -> Result<EvalValue, StylexError> {
+    if matches!(conversion, Conversion::Raw) {
+        return Ok(value.clone());
+    }
+    Ok(match value {
+        EvalValue::Num(n) => EvalValue::Str(match conversion {
+            Conversion::Raw => unreachable!("raw returns above"),
+            Conversion::BareNumber | Conversion::IntegerString => js_number_to_string(*n),
+            Conversion::Length => {
+                if *n == 0.0 {
+                    "0".to_string()
+                } else {
+                    format!("{}px", js_number_to_string(*n))
+                }
+            }
+            Conversion::Percentage => {
+                if *n == 0.0 {
+                    "0".to_string()
+                } else {
+                    format!("{}%", js_number_to_string(*n * 100.0))
+                }
+            }
+        }),
+        EvalValue::Str(s) => EvalValue::Str(s.clone()),
+        EvalValue::Null => {
+            return Err(StylexError::upstream_type_crash(
+                "a null value inside a numeric types.* wrapper",
+            ));
+        }
+        EvalValue::Obj(map) => {
+            let mut out = JsObjectMap::new();
+            for (k, v) in map.entries() {
+                out.insert(k.to_string(), convert(v, conversion)?);
+            }
+            EvalValue::Obj(Arc::new(out))
+        }
+        EvalValue::Arr(items) => {
+            // typeof [] is 'object': Object.keys gives index keys upstream.
+            let mut out = JsObjectMap::new();
+            for (i, v) in items.iter().enumerate() {
+                out.insert(i.to_string(), convert(v, conversion)?);
+            }
+            EvalValue::Obj(Arc::new(out))
+        }
+        EvalValue::Undefined | EvalValue::Bool(_) => value.clone(),
+    })
+}
+
+/// `String(types.<kind>)` of the uninvoked wrapper — the 0.19.0 dist source of
+/// each `create` static method, pinned live (r4#8 conditional-leaf coercion).
+pub fn types_member_source(kind: &str) -> Option<&'static str> {
+    Some(match kind {
+        "angle" => "create(value) {\n    return new Angle(value);\n  }",
+        "color" => "create(value) {\n    return new Color(value);\n  }",
+        "url" => "create(value) {\n    return new Url(value);\n  }",
+        "image" => "create(value) {\n    return new Image(value);\n  }",
+        "integer" => {
+            "create(value) {\n    return new Integer(convertNumberToStringUsing(String)(value));\n  }"
+        }
+        "lengthPercentage" => {
+            "createLength(value) {\n    return new LengthPercentage(convertNumberToLength(value));\n  }"
+        }
+        "length" => "create(value) {\n    return new Length(convertNumberToLength(value));\n  }",
+        "percentage" => {
+            "create(value) {\n    return new Percentage(convertNumberToPercentage(value));\n  }"
+        }
+        "number" => "create(value) {\n    return new Num(convertNumberToBareString(value));\n  }",
+        "resolution" => "create(value) {\n    return new Resolution(value);\n  }",
+        "time" => "create(value) {\n    return new Time(value);\n  }",
+        "transformFunction" => "create(value) {\n    return new TransformFunction(value);\n  }",
+        "transformList" => "create(value) {\n    return new TransformList(value);\n  }",
+        _ => return None,
+    })
+}
+
+// parity: types/index.js isCSSType — instanceof BaseCSSType (the out-of-band
+// brand) && value != null && typeof syntax === 'string' (the own key).
+pub fn as_css_type(value: &EvalValue) -> Option<CssType> {
+    let EvalValue::Obj(map) = value else {
+        return None;
+    };
+    map.css_type()?;
+    let Some(EvalValue::Str(syntax)) = map.get("syntax") else {
+        return None;
+    };
+    match map.get("value") {
+        None | Some(EvalValue::Null | EvalValue::Undefined) => None,
+        Some(inner) => Some(CssType {
+            syntax: syntax.clone(),
+            value: inner.clone(),
+        }),
+    }
+}
+
+/// `as_css_type` over the evaluator-local value model; the inner value is
+/// returned in `JsValue` form for the collectors.
+pub fn as_css_type_js(value: &JsValue) -> Option<(String, JsValue)> {
+    let JsValue::Obj(obj) = value else {
+        return None;
+    };
+    obj.css_type()?;
+    let Some(JsValue::Str(syntax)) = obj.get("syntax") else {
+        return None;
+    };
+    match obj.get("value") {
+        None | Some(JsValue::Null | JsValue::Undefined) => None,
+        Some(inner) => Some((syntax.clone(), inner.clone())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn value_of(kind: &str, arg: EvalValue) -> EvalValue {
+        let EvalValue::Obj(map) = create_css_type(kind, &[arg]).unwrap() else {
+            panic!("expected object");
+        };
+        map.get("value").unwrap().clone()
+    }
+
+    #[test]
+    fn syntax_strings_cover_all_kinds() {
+        // Pinned via live-oracle probe 2026-08-28 (@property syntax fields).
+        let expected = [
+            ("angle", "<angle>"),
+            ("color", "<color>"),
+            ("url", "<url>"),
+            ("image", "<image>"),
+            ("integer", "<integer>"),
+            ("lengthPercentage", "<length-percentage>"),
+            ("length", "<length>"),
+            ("percentage", "<percentage>"),
+            ("number", "<number>"),
+            ("resolution", "<resolution>"),
+            ("time", "<time>"),
+            ("transformFunction", "<transform-function>"),
+            ("transformList", "<transform-list>"),
+        ];
+        assert_eq!(TYPES_MEMBERS.len(), expected.len());
+        for (kind, syntax) in expected {
+            let created = create_css_type(kind, &[EvalValue::Str("x".into())]).unwrap();
+            let css = as_css_type(&created).unwrap();
+            assert_eq!(css.syntax, syntax, "{kind}");
+        }
+    }
+
+    #[test]
+    fn number_conversions_match_oracle() {
+        // Pinned via live-oracle probe 2026-08-28.
+        assert_eq!(
+            value_of("length", EvalValue::Num(0.0)),
+            EvalValue::Str("0".into())
+        );
+        assert_eq!(
+            value_of("length", EvalValue::Num(5.0)),
+            EvalValue::Str("5px".into())
+        );
+        assert_eq!(
+            value_of("lengthPercentage", EvalValue::Num(0.5)),
+            EvalValue::Str("0.5px".into())
+        );
+        assert_eq!(
+            value_of("percentage", EvalValue::Num(0.0)),
+            EvalValue::Str("0".into())
+        );
+        assert_eq!(
+            value_of("percentage", EvalValue::Num(0.07)),
+            EvalValue::Str("7.000000000000001%".into())
+        );
+        assert_eq!(
+            value_of("integer", EvalValue::Num(1.5)),
+            EvalValue::Str("1.5".into())
+        );
+        assert_eq!(
+            value_of("number", EvalValue::Num(0.0)),
+            EvalValue::Str("0".into())
+        );
+        // Raw kinds keep numbers untouched.
+        assert_eq!(
+            value_of("angle", EvalValue::Num(45.0)),
+            EvalValue::Num(45.0)
+        );
+        assert_eq!(
+            value_of("time", EvalValue::Num(500.0)),
+            EvalValue::Num(500.0)
+        );
+        assert_eq!(
+            value_of("percentage", EvalValue::Str("50%".into())),
+            EvalValue::Str("50%".into())
+        );
+    }
+
+    #[test]
+    fn nullish_values_are_not_css_types() {
+        let created = create_css_type("color", &[EvalValue::Null]).unwrap();
+        assert!(as_css_type(&created).is_none());
+        let none = create_css_type("color", &[]).unwrap();
+        assert!(as_css_type(&none).is_none());
+        let err = create_css_type("length", &[EvalValue::Null]).unwrap_err();
+        assert_eq!(err.code, crate::errors::ErrorCode::UpstreamTypeError);
+    }
+
+    #[test]
+    fn nested_objects_convert_recursively() {
+        let mut inner = JsObjectMap::new();
+        inner.insert("default", EvalValue::Num(0.5));
+        inner.insert("@media (min-width: 900px)", EvalValue::Num(0.75));
+        let value = value_of("percentage", EvalValue::Obj(inner.into()));
+        let EvalValue::Obj(map) = value else {
+            panic!("expected object");
+        };
+        assert_eq!(map.get("default"), Some(&EvalValue::Str("50%".into())));
+        assert_eq!(
+            map.get("@media (min-width: 900px)"),
+            Some(&EvalValue::Str("75%".into()))
+        );
+    }
+}

--- a/crates/stylex/src/shared/view_transition.rs
+++ b/crates/stylex/src/shared/view_transition.rs
@@ -1,0 +1,209 @@
+//! `stylex.viewTransitionClass` over an already-evaluated styles object.
+// parity: babel-plugin src/shared/stylex-view-transition-class.js + its visitor
+
+use crate::errors::StylexError;
+use crate::eval::value::{EvalValue, JsObjectMap};
+use crate::hash::hash;
+use crate::options::ResolvedOptions;
+use crate::rules::StylexRule;
+use crate::shared::dashify::dashify;
+use crate::shared::position_try::expand_dashify_transform;
+
+const VALID_VIEW_TRANSITION_CLASS_PROPERTIES: [&str; 4] = ["group", "imagePair", "old", "new"];
+
+/// Returns the class name and its single injectable rule (priority 1, no rtl).
+pub fn view_transition_class(
+    styles: &EvalValue,
+    options: &ResolvedOptions,
+) -> Result<(String, StylexRule), StylexError> {
+    let styles = assert_valid_view_transition_class(styles)?;
+    assert_valid_properties(styles)?;
+
+    // (selector, joined decls) per top-level key, in insertion order.
+    let mut style_strings: Vec<(String, String)> = Vec::new();
+    for (key, style) in styles.entries() {
+        let entries = object_entries_js(style, "a nullish viewTransitionClass style value")?;
+        let transformed = expand_dashify_transform(&entries, options)?;
+        let mut decls = String::new();
+        for (k, v) in transformed.entries() {
+            let EvalValue::Str(v) = v else {
+                unreachable!("transform stage only stores strings");
+            };
+            decls.push_str(&format!("{k}:{v};"));
+        }
+        style_strings.push((format!("::view-transition-{}", dashify(key)), decls));
+    }
+
+    // The hash recipe reuses the decl-joiner over the selector→string map.
+    let mut recipe = String::new();
+    for (selector, decls) in &style_strings {
+        recipe.push_str(&format!("{selector}:{decls};"));
+    }
+    let class_name = format!("{}{}", options.class_name_prefix, hash(&recipe));
+
+    let mut ltr = String::new();
+    for (selector, decls) in &style_strings {
+        ltr.push_str(&format!("{selector}(*.{class_name}){{{decls}}}"));
+    }
+
+    let rule = StylexRule {
+        class_name: class_name.as_str().into(),
+        ltr: ltr.into(),
+        rtl: None,
+        const_key: None,
+        const_val: None,
+        priority: 1.0,
+    };
+    Ok((class_name, rule))
+}
+
+// parity: visitor assertValidViewTransitionClass
+fn assert_valid_view_transition_class(styles: &EvalValue) -> Result<&JsObjectMap, StylexError> {
+    match styles {
+        EvalValue::Obj(map) => Ok(map),
+        _ => Err(StylexError::non_style_object("viewTransitionClass")),
+    }
+}
+
+fn assert_valid_properties(styles: &JsObjectMap) -> Result<(), StylexError> {
+    if styles
+        .keys()
+        .any(|key| !VALID_VIEW_TRANSITION_CLASS_PROPERTIES.contains(&key))
+    {
+        return Err(StylexError::view_transition_class_invalid_property());
+    }
+    Ok(())
+}
+
+// parity: Object.keys/entries semantics (strings split into UTF-16 units;
+// numbers/bools have no own keys; nullish crashes upstream).
+pub(crate) fn object_entries_js(
+    value: &EvalValue,
+    crash_context: &str,
+) -> Result<JsObjectMap, StylexError> {
+    let mut out = JsObjectMap::new();
+    match value {
+        EvalValue::Obj(map) => {
+            for (k, v) in map.entries() {
+                out.insert(k, v.clone());
+            }
+        }
+        EvalValue::Arr(items) => {
+            for (i, v) in items.iter().enumerate() {
+                out.insert(i.to_string(), v.clone());
+            }
+        }
+        EvalValue::Str(s) => {
+            for (i, unit) in s.encode_utf16().enumerate() {
+                let ch = String::from_utf16_lossy(&[unit]);
+                out.insert(i.to_string(), EvalValue::Str(ch));
+            }
+        }
+        EvalValue::Num(_) | EvalValue::Bool(_) => {}
+        EvalValue::Null | EvalValue::Undefined => {
+            return Err(StylexError::upstream_type_crash(crash_context));
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn obj(entries: &[(&str, EvalValue)]) -> EvalValue {
+        EvalValue::Obj(
+            entries
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), v.clone()))
+                .collect::<JsObjectMap>()
+                .into(),
+        )
+    }
+
+    #[test]
+    fn basic_output_matches_oracle() {
+        // Pinned via live-oracle probe 2026-08-28.
+        let options = ResolvedOptions::default();
+        let styles = obj(&[
+            (
+                "group",
+                obj(&[("transitionProperty", EvalValue::Str("none".to_string()))]),
+            ),
+            ("imagePair", obj(&[("borderRadius", EvalValue::Num(16.0))])),
+            (
+                "old",
+                obj(&[("animationDuration", EvalValue::Str("0.5s".to_string()))]),
+            ),
+            (
+                "new",
+                obj(&[(
+                    "animationTimingFunction",
+                    EvalValue::Str("ease-out".to_string()),
+                )]),
+            ),
+        ]);
+        let (name, rule) = view_transition_class(&styles, &options).unwrap();
+        assert_eq!(name, "xchu1hv");
+        assert_eq!(
+            &*rule.ltr,
+            "::view-transition-group(*.xchu1hv){transition-property:none;}::view-transition-image-pair(*.xchu1hv){border-radius:16px;}::view-transition-old(*.xchu1hv){animation-duration:.5s;}::view-transition-new(*.xchu1hv){animation-timing-function:ease-out;}"
+        );
+        assert_eq!(rule.rtl, None);
+        assert!(rule.priority == 1.0);
+    }
+
+    #[test]
+    fn key_order_changes_hash() {
+        let options = ResolvedOptions::default();
+        let styles = obj(&[
+            (
+                "new",
+                obj(&[(
+                    "animationTimingFunction",
+                    EvalValue::Str("ease-out".to_string()),
+                )]),
+            ),
+            (
+                "old",
+                obj(&[("animationDuration", EvalValue::Str("0.5s".to_string()))]),
+            ),
+        ]);
+        let (name, _) = view_transition_class(&styles, &options).unwrap();
+        assert_eq!(name, "x1ujng0t");
+    }
+
+    #[test]
+    fn weird_style_values() {
+        let options = ResolvedOptions::default();
+        // Strings char-split; numbers keep an empty block; null crashes upstream.
+        let (name, rule) = view_transition_class(
+            &obj(&[("group", EvalValue::Str("ab".to_string()))]),
+            &options,
+        )
+        .unwrap();
+        assert_eq!(name, "xw9mpwj");
+        assert_eq!(&*rule.ltr, "::view-transition-group(*.xw9mpwj){0:a;1:b;}");
+        let (name, rule) =
+            view_transition_class(&obj(&[("group", EvalValue::Num(5.0))]), &options).unwrap();
+        assert_eq!(name, "x1od172d");
+        assert_eq!(&*rule.ltr, "::view-transition-group(*.x1od172d){}");
+        let err = view_transition_class(&obj(&[("group", EvalValue::Null)]), &options).unwrap_err();
+        assert_eq!(err.code, crate::errors::ErrorCode::UpstreamTypeError);
+    }
+
+    #[test]
+    fn validation_errors() {
+        let options = ResolvedOptions::default();
+        let err = view_transition_class(&EvalValue::Str("x".to_string()), &options).unwrap_err();
+        assert_eq!(
+            err.message,
+            "viewTransitionClass() can only accept an object."
+        );
+        let err = view_transition_class(&obj(&[("groups", obj(&[]))]), &options).unwrap_err();
+        assert_eq!(
+            err.code,
+            crate::errors::ErrorCode::ViewTransitionClassInvalidProperty
+        );
+    }
+}

--- a/crates/stylex/src/shared/when.rs
+++ b/crates/stylex/src/shared/when.rs
@@ -1,0 +1,213 @@
+//! `stylex.when.*` relational selectors -> `:where(...)` condition keys.
+// parity: src/shared/when/when.js + visitors/stylex-create.js:174-180
+
+use crate::errors::StylexError;
+use crate::eval::value::EvalValue;
+use crate::jsrt::js_number_to_string;
+use crate::options::ResolvedOptions;
+use crate::shared::markers::default_marker_class_name;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WhenRelation {
+    Ancestor,
+    Descendant,
+    SiblingBefore,
+    SiblingAfter,
+    AnySibling,
+}
+
+impl WhenRelation {
+    /// The exported member name (`when.ancestor` …).
+    pub fn from_name(name: &str) -> Option<Self> {
+        Some(match name {
+            "ancestor" => Self::Ancestor,
+            "descendant" => Self::Descendant,
+            "siblingBefore" => Self::SiblingBefore,
+            "siblingAfter" => Self::SiblingAfter,
+            "anySibling" => Self::AnySibling,
+            _ => return None,
+        })
+    }
+}
+
+/// `marker` is the evaluated second argument (`None` when absent). Cross-file
+/// marker proxies must be resolved to `EvalValue::Str` before this call.
+pub fn when_selector(
+    relation: WhenRelation,
+    pseudo: &str,
+    marker: Option<&EvalValue>,
+    options: &ResolvedOptions,
+) -> Result<String, StylexError> {
+    validate_pseudo_selector(pseudo)?;
+    let m = resolve_marker_class(marker, options);
+    Ok(match relation {
+        WhenRelation::Ancestor => format!(":where(.{m}{pseudo} *)"),
+        WhenRelation::Descendant => format!(":where(:has(.{m}{pseudo}))"),
+        WhenRelation::SiblingBefore => format!(":where(.{m}{pseudo} ~ *)"),
+        WhenRelation::SiblingAfter => format!(":where(:has(~ .{m}{pseudo}))"),
+        WhenRelation::AnySibling => {
+            format!(":where(.{m}{pseudo} ~ *, :has(~ .{m}{pseudo}))")
+        }
+    })
+}
+
+// parity: when.js validatePseudoSelector (exact messages, exact check order).
+fn validate_pseudo_selector(pseudo: &str) -> Result<(), StylexError> {
+    if !(pseudo.starts_with(':') || pseudo.starts_with('[')) {
+        return Err(StylexError::invalid_when_selector(
+            "Pseudo selector must start with \":\" or \"[\"",
+        ));
+    }
+    if pseudo.starts_with("::") {
+        return Err(StylexError::invalid_when_selector(
+            "Pseudo selector cannot start with \"::\" (pseudo-elements are not supported)",
+        ));
+    }
+    if pseudo.starts_with('[') && !pseudo.ends_with(']') {
+        return Err(StylexError::invalid_when_selector(
+            "Attribute selector must end with \"]\"",
+        ));
+    }
+    Ok(())
+}
+
+// parity: `marker ?? state.options` + getDefaultMarkerClassName; a `??` miss
+// reads the real options, any other non-string goes through the object probes.
+pub fn resolve_marker_class(marker: Option<&EvalValue>, options: &ResolvedOptions) -> String {
+    let value = match marker {
+        None | Some(EvalValue::Null) | Some(EvalValue::Undefined) => {
+            return default_marker_class_name(options);
+        }
+        Some(EvalValue::Str(s)) => return s.clone(),
+        Some(other) => other,
+    };
+    if let EvalValue::Obj(obj) = value {
+        if matches!(obj.get("$$css"), Some(EvalValue::Bool(true)))
+            && let Some(key) = obj.keys().find(|k| *k != "$$css")
+        {
+            return key.to_string();
+        }
+        // Fallback reads `classNamePrefix` off the marker object itself.
+        if let Some(prefix) = obj.get("classNamePrefix")
+            && !matches!(prefix, EvalValue::Null | EvalValue::Undefined)
+        {
+            return format!("{}-default-marker", coerce_to_string(prefix));
+        }
+    }
+    "default-marker".to_string()
+}
+
+// JS template-literal coercion for the values realistically reaching the
+// classNamePrefix fallback.
+fn coerce_to_string(value: &EvalValue) -> String {
+    match value {
+        EvalValue::Str(s) => s.clone(),
+        EvalValue::Num(n) => js_number_to_string(*n),
+        EvalValue::Bool(b) => b.to_string(),
+        EvalValue::Null => "null".to_string(),
+        EvalValue::Undefined => "undefined".to_string(),
+        EvalValue::Obj(_) => "[object Object]".to_string(),
+        EvalValue::Arr(_) => "".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eval::value::JsObjectMap;
+
+    fn opts() -> ResolvedOptions {
+        ResolvedOptions::default()
+    }
+
+    #[test]
+    fn five_shapes_with_default_marker() {
+        // Pinned via live-oracle probe 2026-08-27 (legacy-keys key extraction).
+        let o = opts();
+        let cases = [
+            (WhenRelation::Ancestor, ":where(.x-default-marker:hover *)"),
+            (
+                WhenRelation::Descendant,
+                ":where(:has(.x-default-marker:hover))",
+            ),
+            (
+                WhenRelation::SiblingBefore,
+                ":where(.x-default-marker:hover ~ *)",
+            ),
+            (
+                WhenRelation::SiblingAfter,
+                ":where(:has(~ .x-default-marker:hover))",
+            ),
+            (
+                WhenRelation::AnySibling,
+                ":where(.x-default-marker:hover ~ *, :has(~ .x-default-marker:hover))",
+            ),
+        ];
+        for (relation, expected) in cases {
+            assert_eq!(
+                when_selector(relation, ":hover", None, &o).unwrap(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn marker_resolution() {
+        let o = opts();
+        assert_eq!(
+            resolve_marker_class(Some(&EvalValue::Str("my-marker".to_string())), &o),
+            "my-marker"
+        );
+        assert_eq!(resolve_marker_class(None, &o), "x-default-marker");
+        assert_eq!(
+            resolve_marker_class(Some(&EvalValue::Null), &o),
+            "x-default-marker"
+        );
+        let marker: JsObjectMap = [
+            ("xleysvp".to_string(), EvalValue::Str("xleysvp".to_string())),
+            ("$$css".to_string(), EvalValue::Bool(true)),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(
+            resolve_marker_class(Some(&EvalValue::Obj(marker.into())), &o),
+            "xleysvp"
+        );
+        // Oracle-pinned quirks: non-marker objects and numbers lose the prefix.
+        assert_eq!(
+            resolve_marker_class(Some(&EvalValue::Obj(JsObjectMap::new().into())), &o),
+            "default-marker"
+        );
+        assert_eq!(
+            resolve_marker_class(Some(&EvalValue::Num(5.0)), &o),
+            "default-marker"
+        );
+        let css_only: JsObjectMap = [("$$css".to_string(), EvalValue::Bool(true))]
+            .into_iter()
+            .collect();
+        assert_eq!(
+            resolve_marker_class(Some(&EvalValue::Obj(css_only.into())), &o),
+            "default-marker"
+        );
+    }
+
+    #[test]
+    fn validation_messages() {
+        let o = opts();
+        let err = when_selector(WhenRelation::Ancestor, "hover", None, &o).unwrap_err();
+        assert_eq!(
+            err.message,
+            "Pseudo selector must start with \":\" or \"[\""
+        );
+        let err = when_selector(WhenRelation::Ancestor, "::before", None, &o).unwrap_err();
+        assert_eq!(
+            err.message,
+            "Pseudo selector cannot start with \"::\" (pseudo-elements are not supported)"
+        );
+        let err = when_selector(WhenRelation::Ancestor, "[data-open", None, &o).unwrap_err();
+        assert_eq!(err.message, "Attribute selector must end with \"]\"");
+        // Oracle-accepted degenerate forms.
+        assert!(when_selector(WhenRelation::Ancestor, ":", None, &o).is_ok());
+        assert!(when_selector(WhenRelation::Ancestor, "[]", None, &o).is_ok());
+    }
+}

--- a/crates/stylex/src/state.rs
+++ b/crates/stylex/src/state.rs
@@ -1,19 +1,23 @@
 //! Per-file compile state: semantic model, import tables, collected rules.
 // parity: babel-plugin src/utils/state-manager.js (traversal-state subset)
 
-use crate::fxhash::{FxHashMap, FxHashSet};
+use std::cell::RefCell;
+
+use crate::fxhash::FxHashMap;
 
 use oxc_ast::AstKind;
 use oxc_ast::ast::{
     BindingPattern, Expression, ForStatementLeft, IdentifierReference, Program,
     VariableDeclarationKind, VariableDeclarator,
 };
-use oxc_semantic::{AstNodes, Semantic, SemanticBuilder};
+use oxc_semantic::{AstNodes, Semantic, SemanticBuilder, Stats};
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::node::NodeId;
+use oxc_syntax::reference::ReferenceId;
 use oxc_syntax::symbol::SymbolId;
 
 use crate::errors::StylexError;
+use crate::eval::cross_file::VarGroupProxy;
 use crate::eval::value::EvalValue;
 use crate::imports::{ImportTable, scan_imports};
 use crate::options::ResolvedOptions;
@@ -71,10 +75,9 @@ pub struct CompileState<'a> {
     pub cwd: String,
     pub imports: ImportTable,
     pub semantic: Semantic<'a>,
-    /// babel constantViolations: write references, redeclarations, var for-heads.
-    violation_symbols: FxHashSet<SymbolId>,
-    /// evaluate-path.js isMutated: member-level mutations of the binding.
-    mutated_symbols: FxHashSet<SymbolId>,
+    /// (babel constantViolations non-empty, evaluate-path.js isMutated) per
+    /// symbol, computed on first query: eval touches a handful of symbols.
+    constness: RefCell<FxHashMap<SymbolId, (bool, bool)>>,
     pub style_vars_to_keep: Vec<StyleVarToKeep>,
     /// metadata.stylex accumulator in traversal order (integrator appends).
     pub rules: Vec<StylexRule>,
@@ -90,6 +93,9 @@ pub struct CompileState<'a> {
     /// `import_path_resolver` memo, keyed by specifier (filename + options are
     /// fixed per compile): otherwise every evaluated reference re-walks the fs.
     import_resolutions: FxHashMap<String, Option<String>>,
+    /// Theme-file proxies by import symbol: the `seen` cache is per entry, so
+    /// every evaluated reference would otherwise re-hash the var group.
+    theme_proxies: Vec<(SymbolId, VarGroupProxy)>,
 }
 
 impl<'a> CompileState<'a> {
@@ -103,28 +109,52 @@ impl<'a> CompileState<'a> {
             let _t = crate::timings::start(crate::timings::Stage::ImportScan);
             scan_imports(program, options)?
         };
+        Ok(Self::build_with_imports(
+            program, options, filename, cwd, imports,
+        ))
+    }
+
+    /// [`Self::build`] over an import table the caller already scanned.
+    pub fn build_with_imports(
+        program: &'a Program<'a>,
+        options: &'a ResolvedOptions,
+        filename: Option<String>,
+        cwd: String,
+        imports: ImportTable,
+    ) -> Self {
         let _t = crate::timings::start(crate::timings::Stage::Semantic);
         let semantic = SemanticBuilder::new()
+            .with_stats(estimated_stats(program.source_text.len()))
             .with_build_nodes(true)
             .build(program)
             .semantic;
-        let (violation_symbols, mutated_symbols) = scan_non_constant_symbols(&semantic);
         drop(_t);
-        Ok(CompileState {
+        CompileState {
             options,
             filename,
             cwd,
             imports,
             semantic,
-            violation_symbols,
-            mutated_symbols,
+            constness: RefCell::new(FxHashMap::default()),
             style_vars_to_keep: Vec::new(),
             rules: Vec::new(),
             other_injected_rules: Vec::new(),
             treeshake_imports: Vec::new(),
             binding_overrides: FxHashMap::default(),
             import_resolutions: FxHashMap::default(),
-        })
+            theme_proxies: Vec::new(),
+        }
+    }
+
+    pub fn theme_proxy(&self, symbol: SymbolId) -> Option<&VarGroupProxy> {
+        self.theme_proxies
+            .iter()
+            .find(|(s, _)| *s == symbol)
+            .map(|(_, proxy)| proxy)
+    }
+
+    pub fn record_theme_proxy(&mut self, symbol: SymbolId, proxy: VarGroupProxy) {
+        self.theme_proxies.push((symbol, proxy));
     }
 
     /// Memoized [`crate::module_resolution::import_path_resolver`]: the dep
@@ -159,12 +189,21 @@ impl<'a> CompileState<'a> {
 
     /// babel `binding.constantViolations.length > 0` (= `!binding.constant`).
     pub fn is_non_constant(&self, symbol: SymbolId) -> bool {
-        self.violation_symbols.contains(&symbol)
+        self.constness(symbol).0
     }
 
     /// evaluate-path.js `isMutated(binding)` — resolve() chains bypass this.
     pub fn is_mutated(&self, symbol: SymbolId) -> bool {
-        self.mutated_symbols.contains(&symbol)
+        self.constness(symbol).1
+    }
+
+    fn constness(&self, symbol: SymbolId) -> (bool, bool) {
+        if let Some(&flags) = self.constness.borrow().get(&symbol) {
+            return flags;
+        }
+        let flags = non_constant_flags(&self.semantic, symbol);
+        self.constness.borrow_mut().insert(symbol, flags);
+        flags
     }
 
     pub fn binding_info(&self, symbol: SymbolId) -> BindingInfo<'a> {
@@ -260,6 +299,48 @@ impl<'a> CompileState<'a> {
         scoping
             .symbol_ids()
             .any(|symbol| scoping.symbol_name(symbol) == name)
+    }
+
+    /// Sorted start offsets of every identifier reference named in `names`,
+    /// whichever binding it resolves to (the visitors match by name, as upstream).
+    pub fn reference_starts(&self, names: &[&str]) -> Vec<u32> {
+        self.reference_starts_where(names, |_, _, _| true)
+    }
+
+    /// [`Self::reference_starts`] keeping only the references `keep` accepts,
+    /// given the reference's name and node.
+    pub fn reference_starts_where(
+        &self,
+        names: &[&str],
+        keep: impl Fn(&str, &AstNodes<'a>, NodeId) -> bool,
+    ) -> Vec<u32> {
+        let mut starts = Vec::new();
+        if names.is_empty() {
+            return starts;
+        }
+        let scoping = self.semantic.scoping();
+        let nodes = self.semantic.nodes();
+        let mut push_all = |name: &str, ids: &[ReferenceId]| {
+            for &id in ids {
+                let node_id = scoping.get_reference(id).node_id();
+                if keep(name, nodes, node_id) {
+                    starts.push(nodes.kind(node_id).span().start);
+                }
+            }
+        };
+        for symbol in scoping.symbol_ids() {
+            let name = scoping.symbol_name(symbol);
+            if names.contains(&name) {
+                push_all(name, scoping.get_resolved_reference_ids(symbol));
+            }
+        }
+        for (name, ids) in scoping.root_unresolved_references() {
+            if names.contains(&name.as_str()) {
+                push_all(name.as_str(), ids);
+            }
+        }
+        starts.sort_unstable();
+        starts
     }
 
     /// Whether `name` at the scope holding `node` resolves to the given
@@ -387,46 +468,55 @@ fn binding_pattern_type_name(pattern: &BindingPattern<'_>) -> &'static str {
     }
 }
 
+// Capacity hints only (release builds never check them), so oxc skips its
+// counting walk; web-corpus p90 ratios, so a rare larger file regrows once.
+fn estimated_stats(source_len: usize) -> Stats {
+    let per_kb = |n: u64| {
+        u32::try_from((source_len as u64 * n) / 1024)
+            .unwrap_or(u32::MAX / 2)
+            .max(64)
+    };
+    Stats::new(per_kb(150), per_kb(4), per_kb(10), per_kb(20))
+}
+
 // parity: babel constantViolations (write references, redeclarations, var
-// for-in/of heads) + evaluate-path.js isMutated, keyed by symbol.
-fn scan_non_constant_symbols(
-    semantic: &Semantic<'_>,
-) -> (FxHashSet<SymbolId>, FxHashSet<SymbolId>) {
+// for-in/of heads) + evaluate-path.js isMutated, for one symbol.
+fn non_constant_flags(semantic: &Semantic<'_>, symbol: SymbolId) -> (bool, bool) {
     let scoping = semantic.scoping();
     let nodes = semantic.nodes();
-    let mut violations = FxHashSet::default();
-    let mut mutations = FxHashSet::default();
-    for symbol in scoping.symbol_ids() {
-        if !scoping.symbol_redeclarations(symbol).is_empty() {
-            violations.insert(symbol);
+    let mut violated = !scoping.symbol_redeclarations(symbol).is_empty()
+        || is_var_for_head(nodes, scoping.symbol_declaration(symbol));
+    let mut mutated = false;
+    for reference in scoping.get_resolved_references(symbol) {
+        if reference.is_write() {
+            violated = true;
+        } else if !mutated && reference_is_mutation(nodes, reference.node_id()) {
+            mutated = true;
         }
-        for reference in scoping.get_resolved_references(symbol) {
-            if reference.is_write() {
-                violations.insert(symbol);
-            } else if reference_is_mutation(nodes, reference.node_id()) {
-                mutations.insert(symbol);
-            }
-        }
-    }
-    for node in nodes.iter() {
-        let left = match node.kind() {
-            AstKind::ForInStatement(stmt) => &stmt.left,
-            AstKind::ForOfStatement(stmt) => &stmt.left,
-            _ => continue,
-        };
-        if let ForStatementLeft::VariableDeclaration(decl) = left
-            && decl.kind == VariableDeclarationKind::Var
-        {
-            for declarator in &decl.declarations {
-                for id in declarator.id.get_binding_identifiers() {
-                    if let Some(symbol) = id.symbol_id.get() {
-                        violations.insert(symbol);
-                    }
-                }
-            }
+        if violated && mutated {
+            break;
         }
     }
-    (violations, mutations)
+    (violated, mutated)
+}
+
+fn is_var_for_head(nodes: &AstNodes<'_>, declaration: NodeId) -> bool {
+    if !matches!(nodes.kind(declaration), AstKind::VariableDeclarator(_)) {
+        return false;
+    }
+    let decl_id = nodes.parent_id(declaration);
+    let AstKind::VariableDeclaration(decl) = nodes.kind(decl_id) else {
+        return false;
+    };
+    if decl.kind != VariableDeclarationKind::Var {
+        return false;
+    }
+    let left = match nodes.kind(nodes.parent_id(decl_id)) {
+        AstKind::ForInStatement(stmt) => &stmt.left,
+        AstKind::ForOfStatement(stmt) => &stmt.left,
+        _ => return false,
+    };
+    matches!(left, ForStatementLeft::VariableDeclaration(head) if std::ptr::eq(&**head, decl))
 }
 
 const MUTATING_ARRAY_METHODS: [&str; 9] = [
@@ -450,7 +540,7 @@ const MUTATING_OBJECT_STATICS: [&str; 4] = [
 
 /// Climbs from `node` through ParenthesizedExpression parents (babel has no
 /// paren nodes, so they are transparent to its parent checks).
-fn climb_parens(nodes: &AstNodes<'_>, node: NodeId) -> (NodeId, NodeId) {
+pub(crate) fn climb_parens(nodes: &AstNodes<'_>, node: NodeId) -> (NodeId, NodeId) {
     let mut child = node;
     let mut parent = nodes.parent_id(child);
     while child != parent && matches!(nodes.kind(parent), AstKind::ParenthesizedExpression(_)) {
@@ -460,7 +550,7 @@ fn climb_parens(nodes: &AstNodes<'_>, node: NodeId) -> (NodeId, NodeId) {
     (child, parent)
 }
 
-fn member_object_span(kind: AstKind<'_>) -> Option<(Span, Option<&str>)> {
+pub(crate) fn member_object_span(kind: AstKind<'_>) -> Option<(Span, Option<&str>)> {
     match kind {
         AstKind::StaticMemberExpression(member) => {
             Some((member.object.span(), Some(member.property.name.as_str())))
@@ -705,6 +795,27 @@ mod tests {
                 assert!(state.is_non_constant(root_symbol(state, "k")));
                 assert!(!state.is_non_constant(c));
                 assert!(state.is_non_constant(root_symbol(state, "d")));
+            },
+        );
+    }
+
+    #[test]
+    fn for_head_rule_is_the_loop_left_only() {
+        with_state(
+            "for (var k in {}) var body = 1;\nfor (var [a, { b }] of []) {}\n\
+             var early; for (var early in {}) {}\nfor (let l of []) {}\n",
+            |state| {
+                assert!(state.is_non_constant(root_symbol(state, "k")));
+                assert!(!state.is_non_constant(root_symbol(state, "body")));
+                assert!(state.is_non_constant(root_symbol(state, "a")));
+                assert!(state.is_non_constant(root_symbol(state, "b")));
+                assert!(state.is_non_constant(root_symbol(state, "early")));
+                let scoping = state.semantic.scoping();
+                let l = scoping
+                    .symbol_ids()
+                    .find(|s| scoping.symbol_name(*s) == "l")
+                    .expect("for-of let binding");
+                assert!(!state.is_non_constant(l));
             },
         );
     }

--- a/crates/stylex/src/state.rs
+++ b/crates/stylex/src/state.rs
@@ -1,0 +1,773 @@
+//! Per-file compile state: semantic model, import tables, collected rules.
+// parity: babel-plugin src/utils/state-manager.js (traversal-state subset)
+
+use crate::fxhash::{FxHashMap, FxHashSet};
+
+use oxc_ast::AstKind;
+use oxc_ast::ast::{
+    BindingPattern, Expression, ForStatementLeft, IdentifierReference, Program,
+    VariableDeclarationKind, VariableDeclarator,
+};
+use oxc_semantic::{AstNodes, Semantic, SemanticBuilder};
+use oxc_span::{GetSpan, Span};
+use oxc_syntax::node::NodeId;
+use oxc_syntax::symbol::SymbolId;
+
+use crate::errors::StylexError;
+use crate::eval::value::EvalValue;
+use crate::imports::{ImportTable, scan_imports};
+use crate::options::ResolvedOptions;
+use crate::rules::StylexRule;
+
+/// A style variable the bail path must keep alive (namespace `None` = all).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StyleVarToKeep {
+    pub var_name: String,
+    pub namespace: Option<String>,
+}
+
+/// One recorded treeshake-compensation insertion site.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TreeshakeImport {
+    pub specifier: String,
+    /// Start offset of the declaring ImportDeclaration.
+    pub decl_start: u32,
+    /// Span of that declaration's source literal (for raw-quoted reprint).
+    pub source_span: Span,
+}
+
+/// What a symbol's declaration site is, shaped the way babel `binding.path`
+/// exposes it to `resolve()`/`_evaluate`.
+#[derive(Debug, Clone, Copy)]
+pub enum BindingDecl<'a> {
+    Declarator(&'a VariableDeclarator<'a>),
+    NamedImport,
+    DefaultImport,
+    NamespaceImport,
+    /// The babel node-type name evaluating the declaration would report
+    /// ("Identifier" for simple params, "FunctionDeclaration", ...).
+    Opaque(&'static str),
+}
+
+impl BindingDecl<'_> {
+    pub fn is_import(&self) -> bool {
+        matches!(
+            self,
+            BindingDecl::NamedImport | BindingDecl::DefaultImport | BindingDecl::NamespaceImport
+        )
+    }
+}
+
+pub struct BindingInfo<'a> {
+    pub decl: BindingDecl<'a>,
+    /// babel `binding.path.node` span; use-before-declaration compares `end`.
+    pub span: Span,
+}
+
+pub struct CompileState<'a> {
+    pub options: &'a ResolvedOptions,
+    /// Absolute source filename, '/'-separated.
+    pub filename: Option<String>,
+    pub cwd: String,
+    pub imports: ImportTable,
+    pub semantic: Semantic<'a>,
+    /// babel constantViolations: write references, redeclarations, var for-heads.
+    violation_symbols: FxHashSet<SymbolId>,
+    /// evaluate-path.js isMutated: member-level mutations of the binding.
+    mutated_symbols: FxHashSet<SymbolId>,
+    pub style_vars_to_keep: Vec<StyleVarToKeep>,
+    /// metadata.stylex accumulator in traversal order (integrator appends).
+    pub rules: Vec<StylexRule>,
+    /// keyframes()/positionTry() injections recorded during evaluation, keyed
+    /// by generated name; upstream emits these before the create rules.
+    pub other_injected_rules: Vec<StylexRule>,
+    /// Treeshake-compensation side-effect imports in first-evaluation order
+    /// (upstream addedImports): (specifier, declaring-import span offsets).
+    pub treeshake_imports: Vec<TreeshakeImport>,
+    /// Values of declarators whose init a visitor already replaced (babel
+    /// re-resolves the binding to the replacement node).
+    binding_overrides: FxHashMap<SymbolId, EvalValue>,
+    /// `import_path_resolver` memo, keyed by specifier (filename + options are
+    /// fixed per compile): otherwise every evaluated reference re-walks the fs.
+    import_resolutions: FxHashMap<String, Option<String>>,
+}
+
+impl<'a> CompileState<'a> {
+    pub fn build(
+        program: &'a Program<'a>,
+        options: &'a ResolvedOptions,
+        filename: Option<String>,
+        cwd: String,
+    ) -> Result<Self, StylexError> {
+        let imports = {
+            let _t = crate::timings::start(crate::timings::Stage::ImportScan);
+            scan_imports(program, options)?
+        };
+        let _t = crate::timings::start(crate::timings::Stage::Semantic);
+        let semantic = SemanticBuilder::new()
+            .with_build_nodes(true)
+            .build(program)
+            .semantic;
+        let (violation_symbols, mutated_symbols) = scan_non_constant_symbols(&semantic);
+        drop(_t);
+        Ok(CompileState {
+            options,
+            filename,
+            cwd,
+            imports,
+            semantic,
+            violation_symbols,
+            mutated_symbols,
+            style_vars_to_keep: Vec::new(),
+            rules: Vec::new(),
+            other_injected_rules: Vec::new(),
+            treeshake_imports: Vec::new(),
+            binding_overrides: FxHashMap::default(),
+            import_resolutions: FxHashMap::default(),
+        })
+    }
+
+    /// Memoized [`crate::module_resolution::import_path_resolver`]: the dep
+    /// log and treeshake records both dedup, so a memo hit records identically.
+    pub fn resolve_import_path(
+        &mut self,
+        fs: &dyn crate::module_resolution::FsProvider,
+        specifier: &str,
+    ) -> Option<String> {
+        if let Some(hit) = self.import_resolutions.get(specifier) {
+            return hit.clone();
+        }
+        let resolved = crate::module_resolution::import_path_resolver(
+            fs,
+            specifier,
+            self.filename.as_deref().map(std::path::Path::new),
+            self.options,
+        );
+        self.import_resolutions
+            .insert(specifier.to_string(), resolved.clone());
+        resolved
+    }
+
+    /// babel `path.scope.getBinding(name)` for a reference site.
+    pub fn symbol_of(&self, id: &IdentifierReference<'a>) -> Option<SymbolId> {
+        let reference_id = id.reference_id.get()?;
+        self.semantic
+            .scoping()
+            .get_reference(reference_id)
+            .symbol_id()
+    }
+
+    /// babel `binding.constantViolations.length > 0` (= `!binding.constant`).
+    pub fn is_non_constant(&self, symbol: SymbolId) -> bool {
+        self.violation_symbols.contains(&symbol)
+    }
+
+    /// evaluate-path.js `isMutated(binding)` — resolve() chains bypass this.
+    pub fn is_mutated(&self, symbol: SymbolId) -> bool {
+        self.mutated_symbols.contains(&symbol)
+    }
+
+    pub fn binding_info(&self, symbol: SymbolId) -> BindingInfo<'a> {
+        let node = self.semantic.symbol_declaration(symbol);
+        let span = node.kind().span();
+        match node.kind() {
+            AstKind::VariableDeclarator(declarator) => BindingInfo {
+                decl: BindingDecl::Declarator(declarator),
+                span,
+            },
+            AstKind::ImportSpecifier(_) => BindingInfo {
+                decl: BindingDecl::NamedImport,
+                span,
+            },
+            AstKind::ImportDefaultSpecifier(_) => BindingInfo {
+                decl: BindingDecl::DefaultImport,
+                span,
+            },
+            AstKind::ImportNamespaceSpecifier(_) => BindingInfo {
+                decl: BindingDecl::NamespaceImport,
+                span,
+            },
+            AstKind::FormalParameter(param) => BindingInfo {
+                decl: BindingDecl::Opaque(binding_pattern_type_name(&param.pattern)),
+                span,
+            },
+            AstKind::CatchParameter(_) => {
+                // babel registers catch bindings on the whole CatchClause.
+                let clause_span = self
+                    .semantic
+                    .nodes()
+                    .ancestors(node.id())
+                    .find_map(|ancestor| match ancestor.kind() {
+                        AstKind::CatchClause(clause) => Some(clause.span),
+                        _ => None,
+                    })
+                    .unwrap_or(span);
+                BindingInfo {
+                    decl: BindingDecl::Opaque("CatchClause"),
+                    span: clause_span,
+                }
+            }
+            AstKind::Function(function) => BindingInfo {
+                decl: BindingDecl::Opaque(if function.is_expression() {
+                    "FunctionExpression"
+                } else {
+                    "FunctionDeclaration"
+                }),
+                span,
+            },
+            AstKind::Class(class) => BindingInfo {
+                decl: BindingDecl::Opaque(if class.is_expression() {
+                    "ClassExpression"
+                } else {
+                    "ClassDeclaration"
+                }),
+                span,
+            },
+            AstKind::TSEnumDeclaration(_) => BindingInfo {
+                decl: BindingDecl::Opaque("TSEnumDeclaration"),
+                span,
+            },
+            _ => BindingInfo {
+                decl: BindingDecl::Opaque("Identifier"),
+                span,
+            },
+        }
+    }
+
+    pub fn binding_override(&self, symbol: SymbolId) -> Option<&EvalValue> {
+        self.binding_overrides.get(&symbol)
+    }
+
+    /// Records a replaced-init value for a module-level binding by name
+    /// (visitors only replace top-level declarator inits).
+    pub fn record_root_override(&mut self, name: &str, value: EvalValue) {
+        if let Some(symbol) = self.semantic.scoping().get_root_binding(name.into()) {
+            self.binding_overrides.insert(symbol, value);
+        }
+    }
+
+    /// babel generateUid collision surface: globals plus every declaration in
+    /// the file (registerBinding marks program.references even when unused).
+    pub fn uid_name_taken(&self, name: &str) -> bool {
+        let scoping = self.semantic.scoping();
+        if scoping
+            .root_unresolved_references()
+            .keys()
+            .any(|n| n.as_str() == name)
+        {
+            return true;
+        }
+        scoping
+            .symbol_ids()
+            .any(|symbol| scoping.symbol_name(symbol) == name)
+    }
+
+    /// Whether `name` at the scope holding `node` resolves to the given
+    /// program-level symbol (babel `path.scope.getBinding(n) === programBinding`).
+    pub fn resolves_to_root_binding(&self, node_id: NodeId, name: &str) -> bool {
+        let scoping = self.semantic.scoping();
+        let Some(root_symbol) = scoping.get_root_binding(name.into()) else {
+            return false;
+        };
+        let scope = self.semantic.nodes().get_node(node_id).scope_id();
+        scoping.find_binding(scope, name.into()) == Some(root_symbol)
+    }
+
+    // parity: ast-helpers.js isProgramLevel — false when the walk to Program
+    // crosses a function or a statement hanging off anything but Program/export.
+    pub fn is_program_level(&self, node_id: NodeId) -> bool {
+        let nodes = self.semantic.nodes();
+        let mut current = nodes.get_node(node_id);
+        for parent in nodes.ancestors(node_id) {
+            let parent_kind = parent.kind();
+            if babel_is_statement(current.kind())
+                && !matches!(parent_kind, AstKind::Program(_))
+                && !babel_is_export_declaration(parent_kind)
+            {
+                return false;
+            }
+            if current.kind().is_function_like() {
+                return false;
+            }
+            current = parent;
+        }
+        true
+    }
+
+    /// babel getProgramStatement: start offset of the top-level statement
+    /// containing `node` (hoisted consts insert before it).
+    pub fn program_statement_start(&self, node_id: NodeId) -> u32 {
+        let nodes = self.semantic.nodes();
+        let mut current = nodes.get_node(node_id);
+        for parent in nodes.ancestors(node_id) {
+            if matches!(parent.kind(), AstKind::Program(_)) {
+                break;
+            }
+            current = parent;
+        }
+        current.kind().span().start
+    }
+
+    /// babel `path.scope.hasBinding(name)` at the scope holding `node`.
+    pub fn any_binding_at(&self, node_id: NodeId, name: &str) -> bool {
+        let scope = self.semantic.nodes().get_node(node_id).scope_id();
+        self.semantic
+            .scoping()
+            .find_binding(scope, name.into())
+            .is_some()
+    }
+
+    pub fn record_treeshake_import(&mut self, specifier: &str, decl_start: u32, source_span: Span) {
+        if self.options.treeshake_compensation
+            && !self
+                .treeshake_imports
+                .iter()
+                .any(|t| t.specifier == specifier)
+        {
+            self.treeshake_imports.push(TreeshakeImport {
+                specifier: specifier.to_string(),
+                decl_start,
+                source_span,
+            });
+        }
+    }
+
+    /// Records a keyframes/positionTry injectable; a repeated name overwrites
+    /// in place (upstream keys them by name in one object).
+    pub fn record_other_injected_rule(&mut self, rule: StylexRule) {
+        if let Some(existing) = self
+            .other_injected_rules
+            .iter_mut()
+            .find(|r| r.class_name == rule.class_name)
+        {
+            *existing = rule;
+        } else {
+            self.other_injected_rules.push(rule);
+        }
+    }
+}
+
+// babel's Statement alias: oxc's list plus declaration statements it omits
+// (fn/class declarations, imports, named/all exports, TS decl statements).
+fn babel_is_statement(kind: AstKind<'_>) -> bool {
+    kind.is_statement()
+        || matches!(kind, AstKind::Function(f) if f.is_declaration())
+        || matches!(kind, AstKind::Class(c) if c.is_declaration())
+        || matches!(
+            kind,
+            AstKind::ImportDeclaration(_)
+                | AstKind::ExportDeclaration(_)
+                | AstKind::ExportNamedDeclaration(_)
+                | AstKind::ExportAllDeclaration(_)
+                | AstKind::TSExportAssignment(_)
+                | AstKind::TSImportEqualsDeclaration(_)
+                | AstKind::TSEnumDeclaration(_)
+                | AstKind::TSNamespaceDeclaration(_)
+                | AstKind::TSInterfaceDeclaration(_)
+                | AstKind::TSTypeAliasDeclaration(_)
+        )
+}
+
+fn babel_is_export_declaration(kind: AstKind<'_>) -> bool {
+    matches!(
+        kind,
+        AstKind::ExportDeclaration(_)
+            | AstKind::ExportNamedDeclaration(_)
+            | AstKind::ExportDefaultDeclaration(_)
+            | AstKind::ExportAllDeclaration(_)
+    )
+}
+
+fn binding_pattern_type_name(pattern: &BindingPattern<'_>) -> &'static str {
+    match pattern {
+        BindingPattern::BindingIdentifier(_) => "Identifier",
+        BindingPattern::ObjectPattern(_) => "ObjectPattern",
+        BindingPattern::ArrayPattern(_) => "ArrayPattern",
+        BindingPattern::AssignmentPattern(_) => "AssignmentPattern",
+    }
+}
+
+// parity: babel constantViolations (write references, redeclarations, var
+// for-in/of heads) + evaluate-path.js isMutated, keyed by symbol.
+fn scan_non_constant_symbols(
+    semantic: &Semantic<'_>,
+) -> (FxHashSet<SymbolId>, FxHashSet<SymbolId>) {
+    let scoping = semantic.scoping();
+    let nodes = semantic.nodes();
+    let mut violations = FxHashSet::default();
+    let mut mutations = FxHashSet::default();
+    for symbol in scoping.symbol_ids() {
+        if !scoping.symbol_redeclarations(symbol).is_empty() {
+            violations.insert(symbol);
+        }
+        for reference in scoping.get_resolved_references(symbol) {
+            if reference.is_write() {
+                violations.insert(symbol);
+            } else if reference_is_mutation(nodes, reference.node_id()) {
+                mutations.insert(symbol);
+            }
+        }
+    }
+    for node in nodes.iter() {
+        let left = match node.kind() {
+            AstKind::ForInStatement(stmt) => &stmt.left,
+            AstKind::ForOfStatement(stmt) => &stmt.left,
+            _ => continue,
+        };
+        if let ForStatementLeft::VariableDeclaration(decl) = left
+            && decl.kind == VariableDeclarationKind::Var
+        {
+            for declarator in &decl.declarations {
+                for id in declarator.id.get_binding_identifiers() {
+                    if let Some(symbol) = id.symbol_id.get() {
+                        violations.insert(symbol);
+                    }
+                }
+            }
+        }
+    }
+    (violations, mutations)
+}
+
+const MUTATING_ARRAY_METHODS: [&str; 9] = [
+    "push",
+    "pop",
+    "shift",
+    "unshift",
+    "splice",
+    "sort",
+    "reverse",
+    "fill",
+    "copyWithin",
+];
+
+const MUTATING_OBJECT_STATICS: [&str; 4] = [
+    "assign",
+    "defineProperty",
+    "defineProperties",
+    "setPrototypeOf",
+];
+
+/// Climbs from `node` through ParenthesizedExpression parents (babel has no
+/// paren nodes, so they are transparent to its parent checks).
+fn climb_parens(nodes: &AstNodes<'_>, node: NodeId) -> (NodeId, NodeId) {
+    let mut child = node;
+    let mut parent = nodes.parent_id(child);
+    while child != parent && matches!(nodes.kind(parent), AstKind::ParenthesizedExpression(_)) {
+        child = parent;
+        parent = nodes.parent_id(child);
+    }
+    (child, parent)
+}
+
+fn member_object_span(kind: AstKind<'_>) -> Option<(Span, Option<&str>)> {
+    match kind {
+        AstKind::StaticMemberExpression(member) => {
+            Some((member.object.span(), Some(member.property.name.as_str())))
+        }
+        AstKind::ComputedMemberExpression(member) => {
+            let property = match &member.expression {
+                Expression::Identifier(id) => Some(id.name.as_str()),
+                _ => None,
+            };
+            Some((member.object.span(), property))
+        }
+        _ => None,
+    }
+}
+
+fn reference_is_mutation(nodes: &AstNodes<'_>, ref_node: NodeId) -> bool {
+    let ref_span = nodes.kind(ref_node).span();
+    let (child, parent) = climb_parens(nodes, ref_node);
+    if child == parent {
+        return false;
+    }
+    let child_span = nodes.kind(child).span();
+    if let Some((object_span, property)) = member_object_span(nodes.kind(parent)) {
+        if object_span != child_span {
+            return false;
+        }
+        let _ = ref_span;
+        let (member, grandparent) = climb_parens(nodes, parent);
+        if member == grandparent {
+            return false;
+        }
+        let member_span = nodes.kind(member).span();
+        return match nodes.kind(grandparent) {
+            AstKind::AssignmentExpression(assignment) => assignment.left.span() == member_span,
+            AstKind::UpdateExpression(_) => true,
+            AstKind::UnaryExpression(unary) => {
+                unary.operator == oxc_syntax::operator::UnaryOperator::Delete
+            }
+            AstKind::CallExpression(call) => {
+                call.callee.span() == member_span
+                    && property.is_some_and(|p| MUTATING_ARRAY_METHODS.contains(&p))
+            }
+            _ => false,
+        };
+    }
+    if let AstKind::CallExpression(call) = nodes.kind(parent) {
+        let first_arg_span = call
+            .arguments
+            .first()
+            .and_then(|a| a.as_expression())
+            .map(GetSpan::span);
+        return first_arg_span == Some(child_span) && callee_is_object_mutator(&call.callee);
+    }
+    false
+}
+
+// parity: babel matchesPattern('Object.assign') & co — name-only, no bindings.
+fn callee_is_object_mutator(callee: &Expression<'_>) -> bool {
+    let mut expr = callee;
+    while let Expression::ParenthesizedExpression(paren) = expr {
+        expr = &paren.expression;
+    }
+    let Some(member) = expr.as_member_expression() else {
+        return false;
+    };
+    let mut object = member.object();
+    while let Expression::ParenthesizedExpression(paren) = object {
+        object = &paren.expression;
+    }
+    let Expression::Identifier(id) = object else {
+        return false;
+    };
+    if id.name != "Object" {
+        return false;
+    }
+    let property = match member {
+        oxc_ast::ast::MemberExpression::StaticMemberExpression(m) => Some(m.property.name.as_str()),
+        oxc_ast::ast::MemberExpression::ComputedMemberExpression(m) => match &m.expression {
+            Expression::StringLiteral(lit) => Some(lit.value.as_str()),
+            _ => None,
+        },
+        oxc_ast::ast::MemberExpression::PrivateFieldExpression(_) => None,
+    };
+    property.is_some_and(|p| MUTATING_OBJECT_STATICS.contains(&p))
+}
+
+/// Per-file newline index: line-start offsets past each `\n`/`\r`/`\r\n`
+/// terminator, built in one memchr2 pass and shared by every lookup.
+pub struct LineIndex {
+    starts: Vec<u32>,
+}
+
+impl LineIndex {
+    pub fn build(source: &str) -> Self {
+        let bytes = source.as_bytes();
+        let mut starts: Vec<u32> = Vec::new();
+        let mut iter = memchr::memchr2_iter(b'\n', b'\r', bytes).peekable();
+        while let Some(i) = iter.next() {
+            if bytes[i] == b'\r' && bytes.get(i + 1) == Some(&b'\n') {
+                if iter.peek() == Some(&(i + 1)) {
+                    iter.next();
+                }
+                starts.push((i + 2) as u32);
+            } else {
+                starts.push((i + 1) as u32);
+            }
+        }
+        LineIndex { starts }
+    }
+
+    pub fn line_of(&self, offset: u32) -> u32 {
+        1 + self.starts.partition_point(|&start| start <= offset) as u32
+    }
+}
+
+/// 1-based line of a byte offset, counting `\n`/`\r`/`\r\n` terminators the way
+/// Babel `loc.start.line` does.
+pub fn line_of_offset(source: &str, offset: u32) -> u32 {
+    let head = &source.as_bytes()[..(offset as usize).min(source.len())];
+    let mut line = 1;
+    let mut i = 0;
+    while i < head.len() {
+        match head[i] {
+            b'\n' => line += 1,
+            b'\r' => {
+                line += 1;
+                if head.get(i + 1) == Some(&b'\n') {
+                    i += 1;
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    line
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxc_allocator::Allocator;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    fn with_state<R>(source: &str, f: impl FnOnce(&CompileState<'_>) -> R) -> R {
+        let allocator = Allocator::default();
+        let ret = Parser::new(&allocator, source, SourceType::tsx()).parse();
+        assert!(!ret.panicked);
+        let options = ResolvedOptions::default();
+        let state = CompileState::build(&ret.program, &options, None, String::new()).unwrap();
+        f(&state)
+    }
+
+    fn root_symbol(state: &CompileState<'_>, name: &str) -> SymbolId {
+        state
+            .semantic
+            .scoping()
+            .get_root_binding(name.into())
+            .unwrap_or_else(|| panic!("no root binding {name}"))
+    }
+
+    #[test]
+    fn module_bindings_resolve_to_declarators() {
+        with_state(
+            "const a = 1;\nexport const b = 'x';\nlet c;\nfunction f() { const inner = 2; }\n",
+            |state| {
+                for name in ["a", "b", "c"] {
+                    let info = state.binding_info(root_symbol(state, name));
+                    assert!(matches!(info.decl, BindingDecl::Declarator(_)), "{name}");
+                }
+                let f = state.binding_info(root_symbol(state, "f"));
+                assert!(matches!(f.decl, BindingDecl::Opaque("FunctionDeclaration")));
+                assert!(
+                    state
+                        .semantic
+                        .scoping()
+                        .get_root_binding("inner".into())
+                        .is_none()
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn mutation_scan_matches_upstream_shallow_member_rule() {
+        with_state(
+            "let a = 1; a = 2;\nconst b = {}; b.x = 1;\nconst c = {}; c.x.y = 1;\n\
+             const d = []; d.push(1);\nconst e = {}; Object.assign(e, {});\n\
+             const g = {}; delete g.x;\nconst h = 0; h2++;\nvar h2 = 1;\n",
+            |state| {
+                let non_constant = |name: &str| {
+                    let symbol = root_symbol(state, name);
+                    state.is_non_constant(symbol) || state.is_mutated(symbol)
+                };
+                assert!(non_constant("a"));
+                assert!(non_constant("b"));
+                // Deep member writes do not flag the root, mirroring upstream.
+                assert!(!non_constant("c"));
+                assert!(non_constant("d"));
+                assert!(non_constant("e"));
+                assert!(non_constant("g"));
+                assert!(non_constant("h2"));
+                assert!(!non_constant("h"));
+            },
+        );
+    }
+
+    #[test]
+    fn mutation_scan_is_symbol_keyed_and_paren_transparent() {
+        with_state(
+            "const t = {}; function f() { let t = {}; t.x = 1; }\n\
+             const u = {}; (u).x = 1;\n\
+             const v = {}; Object.assign((v), {});\n\
+             const w = {}; Object.assign((w as any), {});\n\
+             const q = []; (q)[\"x\"] = 1;\n",
+            |state| {
+                let non_constant = |name: &str| {
+                    let symbol = root_symbol(state, name);
+                    state.is_non_constant(symbol) || state.is_mutated(symbol)
+                };
+                // Same-named local mutation must not poison the module const.
+                assert!(!non_constant("t"));
+                assert!(non_constant("u"));
+                assert!(non_constant("v"));
+                // babel: the TSAsExpression wrapper hides the mutation.
+                assert!(!non_constant("w"));
+                assert!(non_constant("q"));
+            },
+        );
+    }
+
+    #[test]
+    fn for_heads_and_redeclarations_are_violations() {
+        with_state(
+            "for (var k in {}) {}\nfor (const c of []) {}\nvar d = 1;\nvar d = 2;\n",
+            |state| {
+                let scoping = state.semantic.scoping();
+                let c = scoping
+                    .symbol_ids()
+                    .find(|s| scoping.symbol_name(*s) == "c")
+                    .expect("for-of binding");
+                assert!(state.is_non_constant(root_symbol(state, "k")));
+                assert!(!state.is_non_constant(c));
+                assert!(state.is_non_constant(root_symbol(state, "d")));
+            },
+        );
+    }
+
+    #[test]
+    fn uid_taken_covers_all_declarations_and_references() {
+        // codex r4 m14: babel counts unreferenced declarations everywhere,
+        // TS type-only ones included (oracle-probed 2026-08-28).
+        with_state(
+            "const taken = 1;\nfunction f(param) { used; const unused = 1; }\n\
+             try {} catch (caught) {}\ntype T = number;\ninterface I { x: number }\n",
+            |state| {
+                for name in ["taken", "used", "unused", "param", "caught", "T", "I"] {
+                    assert!(state.uid_name_taken(name), "{name}");
+                }
+                assert!(!state.uid_name_taken("_stylex"));
+            },
+        );
+    }
+
+    #[test]
+    fn treeshake_and_injected_rule_recording() {
+        let options = crate::options::CompilerOptions::from_json(
+            &serde_json::json!({ "treeshakeCompensation": true }),
+        )
+        .unwrap()
+        .resolve()
+        .unwrap();
+        let allocator = Allocator::default();
+        let ret = Parser::new(&allocator, "", SourceType::tsx()).parse();
+        let mut state = CompileState::build(&ret.program, &options, None, String::new()).unwrap();
+        state.record_treeshake_import("./a.stylex", 0, Span::new(7, 19));
+        state.record_treeshake_import("./b.stylex", 20, Span::new(27, 39));
+        state.record_treeshake_import("./a.stylex", 40, Span::new(47, 59));
+        let specs: Vec<&str> = state
+            .treeshake_imports
+            .iter()
+            .map(|t| t.specifier.as_str())
+            .collect();
+        assert_eq!(specs, vec!["./a.stylex", "./b.stylex"]);
+        // First evaluation wins the insertion site.
+        assert_eq!(state.treeshake_imports[0].decl_start, 0);
+    }
+
+    #[test]
+    fn line_counting() {
+        assert_eq!(line_of_offset("a\nb\nc", 0), 1);
+        assert_eq!(line_of_offset("a\nb\nc", 2), 2);
+        assert_eq!(line_of_offset("a\nb\nc", 4), 3);
+        assert_eq!(line_of_offset("a\r\nb", 3), 2);
+        assert_eq!(line_of_offset("a\rb", 2), 2);
+        let index = LineIndex::build("a\nb\nc\r\nd\re");
+        for offset in 0..=9u32 {
+            // The \n of a \r\n diverges (bare-\r count vs same-line); no AST
+            // span start can land on that byte, so it is unobservable.
+            if offset == 6 {
+                continue;
+            }
+            assert_eq!(
+                index.line_of(offset),
+                line_of_offset("a\nb\nc\r\nd\re", offset),
+                "offset {offset}"
+            );
+        }
+    }
+}

--- a/crates/stylex/src/state.rs
+++ b/crates/stylex/src/state.rs
@@ -22,6 +22,7 @@ use crate::eval::value::EvalValue;
 use crate::imports::{ImportTable, scan_imports};
 use crate::options::ResolvedOptions;
 use crate::rules::StylexRule;
+use crate::scopes::{ScopeBackend, ScopeModel};
 
 /// A style variable the bail path must keep alive (namespace `None` = all).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -68,13 +69,56 @@ pub struct BindingInfo<'a> {
     pub span: Span,
 }
 
+/// A reference's parent after climbing parens, as far as the site indexes
+/// look: a member expression naming `property`, or anything else.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RefParent<'a> {
+    Other,
+    Member { property: Option<&'a str> },
+}
+
+/// One reference handed to a `reference_starts_where` filter; the parent is
+/// computed only when asked for (the oxc path climbs the node table).
+#[derive(Clone, Copy)]
+pub struct RefSite<'n, 'a> {
+    inner: RefSiteInner<'n, 'a>,
+}
+
+#[derive(Clone, Copy)]
+enum RefSiteInner<'n, 'a> {
+    Oxc(&'n AstNodes<'a>, NodeId),
+    Native(RefParent<'a>),
+}
+
+impl<'a> RefSite<'_, 'a> {
+    pub(crate) fn native(parent: RefParent<'a>) -> Self {
+        RefSite {
+            inner: RefSiteInner::Native(parent),
+        }
+    }
+
+    pub fn parent(&self) -> RefParent<'a> {
+        match self.inner {
+            RefSiteInner::Oxc(nodes, node) => ref_parent_of(nodes, node),
+            RefSiteInner::Native(parent) => parent,
+        }
+    }
+}
+
+// One per compile; boxing the oxc side would only add an allocation.
+#[allow(clippy::large_enum_variant)]
+enum Scoping<'a> {
+    Oxc(Semantic<'a>),
+    Native(ScopeModel<'a>),
+}
+
 pub struct CompileState<'a> {
     pub options: &'a ResolvedOptions,
     /// Absolute source filename, '/'-separated.
     pub filename: Option<String>,
     pub cwd: String,
     pub imports: ImportTable,
-    pub semantic: Semantic<'a>,
+    scoping: Scoping<'a>,
     /// (babel constantViolations non-empty, evaluate-path.js isMutated) per
     /// symbol, computed on first query: eval touches a handful of symbols.
     constness: RefCell<FxHashMap<SymbolId, (bool, bool)>>,
@@ -122,19 +166,43 @@ impl<'a> CompileState<'a> {
         cwd: String,
         imports: ImportTable,
     ) -> Self {
+        Self::build_with_imports_using(
+            program,
+            options,
+            filename,
+            cwd,
+            imports,
+            ScopeBackend::from_env(),
+        )
+    }
+
+    /// [`Self::build_with_imports`] on an explicit scope backend.
+    pub fn build_with_imports_using(
+        program: &'a Program<'a>,
+        options: &'a ResolvedOptions,
+        filename: Option<String>,
+        cwd: String,
+        imports: ImportTable,
+        backend: ScopeBackend,
+    ) -> Self {
         let _t = crate::timings::start(crate::timings::Stage::Semantic);
-        let semantic = SemanticBuilder::new()
-            .with_stats(estimated_stats(program.source_text.len()))
-            .with_build_nodes(true)
-            .build(program)
-            .semantic;
+        let scoping = match backend {
+            ScopeBackend::Oxc => Scoping::Oxc(
+                SemanticBuilder::new()
+                    .with_stats(estimated_stats(program.source_text.len()))
+                    .with_build_nodes(true)
+                    .build(program)
+                    .semantic,
+            ),
+            ScopeBackend::Native => Scoping::Native(ScopeModel::build(program)),
+        };
         drop(_t);
         CompileState {
             options,
             filename,
             cwd,
             imports,
-            semantic,
+            scoping,
             constness: RefCell::new(FxHashMap::default()),
             style_vars_to_keep: Vec::new(),
             rules: Vec::new(),
@@ -178,13 +246,22 @@ impl<'a> CompileState<'a> {
         resolved
     }
 
+    pub fn backend(&self) -> ScopeBackend {
+        match &self.scoping {
+            Scoping::Oxc(_) => ScopeBackend::Oxc,
+            Scoping::Native(_) => ScopeBackend::Native,
+        }
+    }
+
     /// babel `path.scope.getBinding(name)` for a reference site.
     pub fn symbol_of(&self, id: &IdentifierReference<'a>) -> Option<SymbolId> {
-        let reference_id = id.reference_id.get()?;
-        self.semantic
-            .scoping()
-            .get_reference(reference_id)
-            .symbol_id()
+        match &self.scoping {
+            Scoping::Oxc(semantic) => {
+                let reference_id = id.reference_id.get()?;
+                semantic.scoping().get_reference(reference_id).symbol_id()
+            }
+            Scoping::Native(model) => model.symbol_of(id),
+        }
     }
 
     /// babel `binding.constantViolations.length > 0` (= `!binding.constant`).
@@ -198,16 +275,24 @@ impl<'a> CompileState<'a> {
     }
 
     fn constness(&self, symbol: SymbolId) -> (bool, bool) {
+        let semantic = match &self.scoping {
+            Scoping::Oxc(semantic) => semantic,
+            Scoping::Native(model) => return model.constness(symbol),
+        };
         if let Some(&flags) = self.constness.borrow().get(&symbol) {
             return flags;
         }
-        let flags = non_constant_flags(&self.semantic, symbol);
+        let flags = non_constant_flags(semantic, symbol);
         self.constness.borrow_mut().insert(symbol, flags);
         flags
     }
 
     pub fn binding_info(&self, symbol: SymbolId) -> BindingInfo<'a> {
-        let node = self.semantic.symbol_declaration(symbol);
+        let semantic = match &self.scoping {
+            Scoping::Oxc(semantic) => semantic,
+            Scoping::Native(model) => return model.binding_info(symbol),
+        };
+        let node = semantic.symbol_declaration(symbol);
         let span = node.kind().span();
         match node.kind() {
             AstKind::VariableDeclarator(declarator) => BindingInfo {
@@ -232,8 +317,7 @@ impl<'a> CompileState<'a> {
             },
             AstKind::CatchParameter(_) => {
                 // babel registers catch bindings on the whole CatchClause.
-                let clause_span = self
-                    .semantic
+                let clause_span = semantic
                     .nodes()
                     .ancestors(node.id())
                     .find_map(|ancestor| match ancestor.kind() {
@@ -280,15 +364,27 @@ impl<'a> CompileState<'a> {
     /// Records a replaced-init value for a module-level binding by name
     /// (visitors only replace top-level declarator inits).
     pub fn record_root_override(&mut self, name: &str, value: EvalValue) {
-        if let Some(symbol) = self.semantic.scoping().get_root_binding(name.into()) {
+        if let Some(symbol) = self.root_binding(name) {
             self.binding_overrides.insert(symbol, value);
+        }
+    }
+
+    /// babel `program.scope.getBinding(name)`.
+    pub fn root_binding(&self, name: &str) -> Option<SymbolId> {
+        match &self.scoping {
+            Scoping::Oxc(semantic) => semantic.scoping().get_root_binding(name.into()),
+            Scoping::Native(model) => model.root_binding(name),
         }
     }
 
     /// babel generateUid collision surface: globals plus every declaration in
     /// the file (registerBinding marks program.references even when unused).
     pub fn uid_name_taken(&self, name: &str) -> bool {
-        let scoping = self.semantic.scoping();
+        let semantic = match &self.scoping {
+            Scoping::Oxc(semantic) => semantic,
+            Scoping::Native(model) => return model.uid_name_taken(name),
+        };
+        let scoping = semantic.scoping();
         if scoping
             .root_unresolved_references()
             .keys()
@@ -304,26 +400,33 @@ impl<'a> CompileState<'a> {
     /// Sorted start offsets of every identifier reference named in `names`,
     /// whichever binding it resolves to (the visitors match by name, as upstream).
     pub fn reference_starts(&self, names: &[&str]) -> Vec<u32> {
-        self.reference_starts_where(names, |_, _, _| true)
+        self.reference_starts_where(names, |_, _| true)
     }
 
     /// [`Self::reference_starts`] keeping only the references `keep` accepts,
-    /// given the reference's name and node.
+    /// given the reference's name and site.
     pub fn reference_starts_where(
         &self,
         names: &[&str],
-        keep: impl Fn(&str, &AstNodes<'a>, NodeId) -> bool,
+        keep: impl Fn(&str, RefSite<'_, 'a>) -> bool,
     ) -> Vec<u32> {
         let mut starts = Vec::new();
         if names.is_empty() {
             return starts;
         }
-        let scoping = self.semantic.scoping();
-        let nodes = self.semantic.nodes();
+        let semantic = match &self.scoping {
+            Scoping::Oxc(semantic) => semantic,
+            Scoping::Native(model) => return model.reference_starts_where(names, keep),
+        };
+        let scoping = semantic.scoping();
+        let nodes = semantic.nodes();
         let mut push_all = |name: &str, ids: &[ReferenceId]| {
             for &id in ids {
                 let node_id = scoping.get_reference(id).node_id();
-                if keep(name, nodes, node_id) {
+                let site = RefSite {
+                    inner: RefSiteInner::Oxc(nodes, node_id),
+                };
+                if keep(name, site) {
                     starts.push(nodes.kind(node_id).span().start);
                 }
             }
@@ -346,18 +449,26 @@ impl<'a> CompileState<'a> {
     /// Whether `name` at the scope holding `node` resolves to the given
     /// program-level symbol (babel `path.scope.getBinding(n) === programBinding`).
     pub fn resolves_to_root_binding(&self, node_id: NodeId, name: &str) -> bool {
-        let scoping = self.semantic.scoping();
+        let semantic = match &self.scoping {
+            Scoping::Oxc(semantic) => semantic,
+            Scoping::Native(model) => return model.resolves_to_root_binding(node_id, name),
+        };
+        let scoping = semantic.scoping();
         let Some(root_symbol) = scoping.get_root_binding(name.into()) else {
             return false;
         };
-        let scope = self.semantic.nodes().get_node(node_id).scope_id();
+        let scope = semantic.nodes().get_node(node_id).scope_id();
         scoping.find_binding(scope, name.into()) == Some(root_symbol)
     }
 
     // parity: ast-helpers.js isProgramLevel — false when the walk to Program
     // crosses a function or a statement hanging off anything but Program/export.
     pub fn is_program_level(&self, node_id: NodeId) -> bool {
-        let nodes = self.semantic.nodes();
+        let semantic = match &self.scoping {
+            Scoping::Oxc(semantic) => semantic,
+            Scoping::Native(model) => return model.is_program_level(node_id),
+        };
+        let nodes = semantic.nodes();
         let mut current = nodes.get_node(node_id);
         for parent in nodes.ancestors(node_id) {
             let parent_kind = parent.kind();
@@ -378,7 +489,11 @@ impl<'a> CompileState<'a> {
     /// babel getProgramStatement: start offset of the top-level statement
     /// containing `node` (hoisted consts insert before it).
     pub fn program_statement_start(&self, node_id: NodeId) -> u32 {
-        let nodes = self.semantic.nodes();
+        let semantic = match &self.scoping {
+            Scoping::Oxc(semantic) => semantic,
+            Scoping::Native(model) => return model.program_statement_start(node_id),
+        };
+        let nodes = semantic.nodes();
         let mut current = nodes.get_node(node_id);
         for parent in nodes.ancestors(node_id) {
             if matches!(parent.kind(), AstKind::Program(_)) {
@@ -391,11 +506,61 @@ impl<'a> CompileState<'a> {
 
     /// babel `path.scope.hasBinding(name)` at the scope holding `node`.
     pub fn any_binding_at(&self, node_id: NodeId, name: &str) -> bool {
-        let scope = self.semantic.nodes().get_node(node_id).scope_id();
-        self.semantic
+        let semantic = match &self.scoping {
+            Scoping::Oxc(semantic) => semantic,
+            Scoping::Native(model) => return model.any_binding_at(node_id, name),
+        };
+        let scope = semantic.nodes().get_node(node_id).scope_id();
+        semantic
             .scoping()
             .find_binding(scope, name.into())
             .is_some()
+    }
+
+    /// Every symbol as (name, babel decl type, declaring span), unordered.
+    #[cfg(test)]
+    pub(crate) fn debug_symbols(&self) -> Vec<(String, &'static str, Span)> {
+        let label = |info: BindingInfo<'_>| match info.decl {
+            BindingDecl::Declarator(_) => "VariableDeclarator",
+            BindingDecl::NamedImport => "NamedImport",
+            BindingDecl::DefaultImport => "DefaultImport",
+            BindingDecl::NamespaceImport => "NamespaceImport",
+            BindingDecl::Opaque(type_name) => type_name,
+        };
+        match &self.scoping {
+            Scoping::Oxc(semantic) => {
+                let scoping = semantic.scoping();
+                scoping
+                    .symbol_ids()
+                    .map(|s| {
+                        let info = self.binding_info(s);
+                        let span = info.span;
+                        (scoping.symbol_name(s).to_string(), label(info), span)
+                    })
+                    .collect()
+            }
+            Scoping::Native(model) => model
+                .symbol_ids()
+                .map(|s| {
+                    let info = model.binding_info(s);
+                    let span = info.span;
+                    (model.symbol_name(s).to_string(), label(info), span)
+                })
+                .collect(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn any_symbol_named(&self, name: &str) -> Option<SymbolId> {
+        match &self.scoping {
+            Scoping::Oxc(semantic) => {
+                let scoping = semantic.scoping();
+                scoping
+                    .symbol_ids()
+                    .find(|s| scoping.symbol_name(*s) == name)
+            }
+            Scoping::Native(model) => model.symbol_ids().find(|s| model.symbol_name(*s) == name),
+        }
     }
 
     pub fn record_treeshake_import(&mut self, specifier: &str, decl_start: u32, source_span: Span) {
@@ -428,9 +593,17 @@ impl<'a> CompileState<'a> {
     }
 }
 
+fn ref_parent_of<'a>(nodes: &AstNodes<'a>, node: NodeId) -> RefParent<'a> {
+    let (_, parent) = climb_parens(nodes, node);
+    match member_object_span(nodes.kind(parent)) {
+        Some((_, property)) => RefParent::Member { property },
+        None => RefParent::Other,
+    }
+}
+
 // babel's Statement alias: oxc's list plus declaration statements it omits
 // (fn/class declarations, imports, named/all exports, TS decl statements).
-fn babel_is_statement(kind: AstKind<'_>) -> bool {
+pub(crate) fn babel_is_statement(kind: AstKind<'_>) -> bool {
     kind.is_statement()
         || matches!(kind, AstKind::Function(f) if f.is_declaration())
         || matches!(kind, AstKind::Class(c) if c.is_declaration())
@@ -449,7 +622,7 @@ fn babel_is_statement(kind: AstKind<'_>) -> bool {
         )
 }
 
-fn babel_is_export_declaration(kind: AstKind<'_>) -> bool {
+pub(crate) fn babel_is_export_declaration(kind: AstKind<'_>) -> bool {
     matches!(
         kind,
         AstKind::ExportDeclaration(_)
@@ -459,7 +632,7 @@ fn babel_is_export_declaration(kind: AstKind<'_>) -> bool {
     )
 }
 
-fn binding_pattern_type_name(pattern: &BindingPattern<'_>) -> &'static str {
+pub(crate) fn binding_pattern_type_name(pattern: &BindingPattern<'_>) -> &'static str {
     match pattern {
         BindingPattern::BindingIdentifier(_) => "Identifier",
         BindingPattern::ObjectPattern(_) => "ObjectPattern",
@@ -519,7 +692,7 @@ fn is_var_for_head(nodes: &AstNodes<'_>, declaration: NodeId) -> bool {
     matches!(left, ForStatementLeft::VariableDeclaration(head) if std::ptr::eq(&**head, decl))
 }
 
-const MUTATING_ARRAY_METHODS: [&str; 9] = [
+pub(crate) const MUTATING_ARRAY_METHODS: [&str; 9] = [
     "push",
     "pop",
     "shift",
@@ -540,7 +713,7 @@ const MUTATING_OBJECT_STATICS: [&str; 4] = [
 
 /// Climbs from `node` through ParenthesizedExpression parents (babel has no
 /// paren nodes, so they are transparent to its parent checks).
-pub(crate) fn climb_parens(nodes: &AstNodes<'_>, node: NodeId) -> (NodeId, NodeId) {
+fn climb_parens(nodes: &AstNodes<'_>, node: NodeId) -> (NodeId, NodeId) {
     let mut child = node;
     let mut parent = nodes.parent_id(child);
     while child != parent && matches!(nodes.kind(parent), AstKind::ParenthesizedExpression(_)) {
@@ -608,7 +781,7 @@ fn reference_is_mutation(nodes: &AstNodes<'_>, ref_node: NodeId) -> bool {
 }
 
 // parity: babel matchesPattern('Object.assign') & co — name-only, no bindings.
-fn callee_is_object_mutator(callee: &Expression<'_>) -> bool {
+pub(crate) fn callee_is_object_mutator(callee: &Expression<'_>) -> bool {
     let mut expr = callee;
     while let Expression::ParenthesizedExpression(paren) = expr {
         expr = &paren.expression;
@@ -695,21 +868,32 @@ mod tests {
     use oxc_parser::Parser;
     use oxc_span::SourceType;
 
-    fn with_state<R>(source: &str, f: impl FnOnce(&CompileState<'_>) -> R) -> R {
-        let allocator = Allocator::default();
-        let ret = Parser::new(&allocator, source, SourceType::tsx()).parse();
-        assert!(!ret.panicked);
-        let options = ResolvedOptions::default();
-        let state = CompileState::build(&ret.program, &options, None, String::new()).unwrap();
-        f(&state)
+    /// Runs `f` once per scope backend: every assertion pins both.
+    fn with_state<R>(source: &str, f: impl Fn(&CompileState<'_>) -> R) -> R {
+        let mut out = None;
+        for backend in [ScopeBackend::Oxc, ScopeBackend::Native] {
+            let allocator = Allocator::default();
+            let ret = Parser::new(&allocator, source, SourceType::tsx()).parse();
+            assert!(!ret.panicked);
+            let options = ResolvedOptions::default();
+            let imports = scan_imports(&ret.program, &options).unwrap();
+            let state = CompileState::build_with_imports_using(
+                &ret.program,
+                &options,
+                None,
+                String::new(),
+                imports,
+                backend,
+            );
+            out = Some(f(&state));
+        }
+        out.unwrap()
     }
 
     fn root_symbol(state: &CompileState<'_>, name: &str) -> SymbolId {
         state
-            .semantic
-            .scoping()
-            .get_root_binding(name.into())
-            .unwrap_or_else(|| panic!("no root binding {name}"))
+            .root_binding(name)
+            .unwrap_or_else(|| panic!("no root binding {name} ({:?})", state.backend()))
     }
 
     #[test]
@@ -723,13 +907,7 @@ mod tests {
                 }
                 let f = state.binding_info(root_symbol(state, "f"));
                 assert!(matches!(f.decl, BindingDecl::Opaque("FunctionDeclaration")));
-                assert!(
-                    state
-                        .semantic
-                        .scoping()
-                        .get_root_binding("inner".into())
-                        .is_none()
-                );
+                assert!(state.root_binding("inner").is_none());
             },
         );
     }
@@ -787,11 +965,7 @@ mod tests {
         with_state(
             "for (var k in {}) {}\nfor (const c of []) {}\nvar d = 1;\nvar d = 2;\n",
             |state| {
-                let scoping = state.semantic.scoping();
-                let c = scoping
-                    .symbol_ids()
-                    .find(|s| scoping.symbol_name(*s) == "c")
-                    .expect("for-of binding");
+                let c = state.any_symbol_named("c").expect("for-of binding");
                 assert!(state.is_non_constant(root_symbol(state, "k")));
                 assert!(!state.is_non_constant(c));
                 assert!(state.is_non_constant(root_symbol(state, "d")));
@@ -810,11 +984,7 @@ mod tests {
                 assert!(state.is_non_constant(root_symbol(state, "a")));
                 assert!(state.is_non_constant(root_symbol(state, "b")));
                 assert!(state.is_non_constant(root_symbol(state, "early")));
-                let scoping = state.semantic.scoping();
-                let l = scoping
-                    .symbol_ids()
-                    .find(|s| scoping.symbol_name(*s) == "l")
-                    .expect("for-of let binding");
+                let l = state.any_symbol_named("l").expect("for-of let binding");
                 assert!(!state.is_non_constant(l));
             },
         );

--- a/crates/stylex/src/timings.rs
+++ b/crates/stylex/src/timings.rs
@@ -17,6 +17,7 @@ pub enum Stage {
     Eval,
     Create,
     PrintSplice,
+    ApplyPlan,
     PrintAst,
     NdjsonOut,
     JobTotal,
@@ -24,9 +25,16 @@ pub enum Stage {
     CacheParse,
     CacheReplay,
     CacheDecode,
+    Fs,
+    AssembleConsts,
+    AssembleDedupe,
+    AssembleKeys,
+    AssembleSort,
+    AssembleSubst,
+    AssembleRender,
 }
 
-const STAGE_COUNT: usize = 16;
+const STAGE_COUNT: usize = 24;
 const NAMES: [&str; STAGE_COUNT] = [
     "ndjson_in",
     "options",
@@ -37,6 +45,7 @@ const NAMES: [&str; STAGE_COUNT] = [
     "eval",
     "create",
     "print_splice",
+    "apply_plan",
     "print_ast",
     "ndjson_out",
     "job_total",
@@ -44,6 +53,13 @@ const NAMES: [&str; STAGE_COUNT] = [
     "cache_parse",
     "cache_replay",
     "cache_decode",
+    "fs",
+    "assemble_consts",
+    "assemble_dedupe",
+    "assemble_keys",
+    "assemble_sort",
+    "assemble_subst",
+    "assemble_render",
 ];
 
 static TOTAL_NS: [AtomicU64; STAGE_COUNT] = [const { AtomicU64::new(0) }; STAGE_COUNT];

--- a/crates/stylex/src/timings.rs
+++ b/crates/stylex/src/timings.rs
@@ -1,0 +1,117 @@
+//! Env-gated stage timers (`STYLEX_STAGE_TIMINGS=1`): outermost-only per
+//! stage, so re-entrant paths (nested eval, cross-file parse) never double-count.
+
+use std::cell::RefCell;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+#[derive(Clone, Copy)]
+pub enum Stage {
+    NdjsonIn = 0,
+    Options,
+    Parse,
+    ImportScan,
+    Semantic,
+    Transform,
+    Eval,
+    Create,
+    PrintSplice,
+    PrintAst,
+    NdjsonOut,
+    JobTotal,
+    CacheRead,
+    CacheParse,
+    CacheReplay,
+    CacheDecode,
+}
+
+const STAGE_COUNT: usize = 16;
+const NAMES: [&str; STAGE_COUNT] = [
+    "ndjson_in",
+    "options",
+    "parse",
+    "import_scan",
+    "semantic",
+    "transform",
+    "eval",
+    "create",
+    "print_splice",
+    "print_ast",
+    "ndjson_out",
+    "job_total",
+    "cache_read",
+    "cache_parse",
+    "cache_replay",
+    "cache_decode",
+];
+
+static TOTAL_NS: [AtomicU64; STAGE_COUNT] = [const { AtomicU64::new(0) }; STAGE_COUNT];
+static COUNTS: [AtomicU64; STAGE_COUNT] = [const { AtomicU64::new(0) }; STAGE_COUNT];
+
+#[inline]
+pub fn enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var("STYLEX_STAGE_TIMINGS").is_ok_and(|v| v == "1"))
+}
+
+thread_local! {
+    static DEPTH: RefCell<[u32; STAGE_COUNT]> = const { RefCell::new([0; STAGE_COUNT]) };
+}
+
+pub struct StageGuard {
+    stage: usize,
+    start: Option<Instant>,
+}
+
+/// Hold the returned guard for the span of the stage; `None`/nested guards
+/// are inert. Disabled cost: one lazy-static bool load and branch.
+#[inline]
+#[must_use]
+pub fn start(stage: Stage) -> Option<StageGuard> {
+    if !enabled() {
+        return None;
+    }
+    let stage = stage as usize;
+    let outermost = DEPTH.with(|d| {
+        let mut d = d.borrow_mut();
+        d[stage] += 1;
+        d[stage] == 1
+    });
+    Some(StageGuard {
+        stage,
+        start: outermost.then(Instant::now),
+    })
+}
+
+impl Drop for StageGuard {
+    fn drop(&mut self) {
+        DEPTH.with(|d| d.borrow_mut()[self.stage] -= 1);
+        if let Some(start) = self.start {
+            let ns = start.elapsed().as_nanos() as u64;
+            TOTAL_NS[self.stage].fetch_add(ns, Ordering::Relaxed);
+            COUNTS[self.stage].fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+/// One `{"stageTimings": …}` JSON line to stderr; no-op when disabled.
+pub fn report_to_stderr() {
+    if !enabled() {
+        return;
+    }
+    let mut body = String::from("{\"stageTimings\":{");
+    for (i, name) in NAMES.iter().enumerate() {
+        if i > 0 {
+            body.push(',');
+        }
+        let total = TOTAL_NS[i].load(Ordering::Relaxed);
+        let count = COUNTS[i].load(Ordering::Relaxed);
+        body.push_str(&format!(
+            "\"{name}\":{{\"total_ms\":{:.3},\"count\":{count}}}",
+            total as f64 / 1e6
+        ));
+    }
+    body.push_str("}}");
+    eprintln!("{body}");
+}

--- a/crates/stylex/src/timings.rs
+++ b/crates/stylex/src/timings.rs
@@ -32,9 +32,10 @@ pub enum Stage {
     AssembleSort,
     AssembleSubst,
     AssembleRender,
+    CreateMiss,
 }
 
-const STAGE_COUNT: usize = 24;
+const STAGE_COUNT: usize = 25;
 const NAMES: [&str; STAGE_COUNT] = [
     "ndjson_in",
     "options",
@@ -60,6 +61,7 @@ const NAMES: [&str; STAGE_COUNT] = [
     "assemble_sort",
     "assemble_subst",
     "assemble_render",
+    "create_miss",
 ];
 
 static TOTAL_NS: [AtomicU64; STAGE_COUNT] = [const { AtomicU64::new(0) }; STAGE_COUNT];

--- a/crates/stylex/src/transform/ast_backend.rs
+++ b/crates/stylex/src/transform/ast_backend.rs
@@ -4,7 +4,7 @@
 // Span invariant: synthesized nodes carry the replaced node's span (generated
 // runtime imports an empty one — codegen skips those); clones keep their own.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use oxc_allocator::{Allocator, CloneIn, Vec as ArenaVec};
@@ -14,9 +14,10 @@ use oxc_ast::ast::{
     FormalParameter, FormalParameterKind, FormalParameters, IdentifierName, ImportDeclaration,
     ImportDeclarationSpecifier, ImportDefaultSpecifier, ImportNamespaceSpecifier,
     ImportOrExportKind, ImportSpecifier, JSXAttribute, JSXAttributeItem, JSXAttributeName,
-    JSXAttributeValue, JSXOpeningElement, JSXSpreadAttribute, ModuleExportName, NumberBase,
-    ObjectExpression, ObjectProperty, ObjectPropertyKind, Program, PropertyKey, PropertyKind,
-    Statement, StringLiteral, VariableDeclaration, VariableDeclarationKind, VariableDeclarator,
+    JSXAttributeValue, JSXElement, JSXOpeningElement, JSXSpreadAttribute, ModuleExportName,
+    NumberBase, ObjectExpression, ObjectProperty, ObjectPropertyKind, Program, PropertyKey,
+    PropertyKind, Statement, StringLiteral, VariableDeclaration, VariableDeclarationKind,
+    VariableDeclarator,
 };
 use oxc_ast::builder::AstBuilder;
 use oxc_ast_visit::{Visit, VisitMut, walk, walk_mut};
@@ -362,7 +363,7 @@ impl<'a> Synth<'a> {
         )])
     }
 
-    /// Mirrors js_out::print_class_segments: an unfolded `+` chain.
+    /// Mirrors js_out::write_class_segments: an unfolded `+` chain.
     fn class_segments(&self, segments: &[String]) -> Expression<'a> {
         let mut iter = segments.iter();
         let Some(first) = iter.next() else {
@@ -776,7 +777,7 @@ impl<'a> Synth<'a> {
         ))
     }
 
-    /// Mirrors js_out::print_inject_arg (fixed key order, numeric constVal).
+    /// Mirrors js_out::inject_call_text (fixed key order, numeric constVal).
     fn inject_call(&self, callee: &str, rule: &StylexRule) -> Statement<'a> {
         let mut props = vec![self.prop(self.prop_key("ltr"), self.string(&rule.ltr))];
         if let Some(rtl) = &rule.rtl {
@@ -849,19 +850,57 @@ impl<'a> Visit<'a> for SpanCloner<'_, 'a> {
     }
 }
 
-fn clone_expr_in_program<'a>(
+/// [`SpanCloner`] over a span set in one walk: outermost match per span.
+struct SpanSetCloner<'x, 'a> {
+    alloc: &'a Allocator,
+    targets: &'x BTreeSet<SpanKey>,
+    found: &'x mut BTreeMap<SpanKey, Expression<'a>>,
+}
+
+impl<'a> Visit<'a> for SpanSetCloner<'_, 'a> {
+    fn visit_statement(&mut self, it: &Statement<'a>) {
+        if span_set_within(self.targets, it.span()) {
+            walk::walk_statement(self, it);
+        }
+    }
+
+    fn visit_expression(&mut self, it: &Expression<'a>) {
+        let span = it.span();
+        if !span_set_within(self.targets, span) {
+            return;
+        }
+        let k = key(span);
+        if self.targets.contains(&k) && !self.found.contains_key(&k) {
+            self.found.insert(k, it.clone_in(self.alloc));
+        }
+        walk::walk_expression(self, it);
+    }
+}
+
+fn clone_exprs_in_program<'a>(
     alloc: &'a Allocator,
     program: &Program<'a>,
-    span: Span,
-) -> Option<Expression<'a>> {
-    let mut found = None;
-    let mut cloner = SpanCloner {
-        alloc,
-        target: span,
-        found: &mut found,
-    };
-    cloner.visit_program(program);
+    targets: &BTreeSet<SpanKey>,
+) -> BTreeMap<SpanKey, Expression<'a>> {
+    let mut found = BTreeMap::new();
+    if !targets.is_empty() {
+        let mut cloner = SpanSetCloner {
+            alloc,
+            targets,
+            found: &mut found,
+        };
+        cloner.visit_program(program);
+    }
     found
+}
+
+/// Node spans nest, so a key starting inside `span` names a node inside it.
+fn span_range(span: Span) -> std::ops::RangeInclusive<SpanKey> {
+    (span.start, 0)..=(span.end, u32::MAX)
+}
+
+fn span_set_within(set: &BTreeSet<SpanKey>, span: Span) -> bool {
+    set.range(span_range(span)).next().is_some()
 }
 
 fn clone_expr_within<'a>(
@@ -941,6 +980,12 @@ impl<'a> Applier<'a> {
                     span.start, span.end
                 ))
             })
+    }
+
+    fn pending_within(&self, span: Span) -> bool {
+        self.error.is_none()
+            && (self.replace.range(span_range(span)).next().is_some()
+                || self.jsx.range(span_range(span)).next().is_some())
     }
 
     /// `old` is child-mutated before cloning, so table tests carry nested
@@ -1062,8 +1107,20 @@ impl<'a> Applier<'a> {
 }
 
 impl<'a> VisitMut<'a> for Applier<'a> {
+    fn visit_statement(&mut self, stmt: &mut Statement<'a>) {
+        if self.pending_within(stmt.span()) {
+            walk_mut::walk_statement(self, stmt);
+        }
+    }
+
+    fn visit_jsx_element(&mut self, el: &mut JSXElement<'a>) {
+        if self.pending_within(el.span) {
+            walk_mut::walk_jsx_element(self, el);
+        }
+    }
+
     fn visit_expression(&mut self, expr: &mut Expression<'a>) {
-        if self.error.is_some() {
+        if !self.pending_within(expr.span()) {
             return;
         }
         // Post-order: nested replacements land before enclosing ones, so a
@@ -1118,30 +1175,40 @@ fn retarget_comments(comments: &mut ArenaVec<'_, Comment>, from: u32, to: Option
 pub fn apply_plan<'a>(
     allocator: &'a Allocator,
     program: &mut Program<'a>,
-    plan: &AstPlan,
+    plan: AstPlan,
 ) -> Result<(), StylexError> {
+    if plan.is_empty() {
+        return Ok(());
+    }
+    let AstPlan {
+        replace_exprs,
+        jsx_ops,
+        inserts: insert_ops,
+        removes: remove_ops,
+        import_sources,
+    } = plan;
     // Collect the pre-mutation clones every dynamic arrow needs.
-    let mut wanted: Vec<Span> = Vec::new();
+    let mut wanted: BTreeSet<SpanKey> = BTreeSet::new();
     let mut collect_dynamic = |dynamic: &[DynamicEntry]| {
         for entry in dynamic {
             for var in &entry.compiled.inline_vars {
-                wanted.push(var.expr);
+                wanted.insert(key(var.expr));
             }
             for (_, parts) in &entry.compiled.conditional_props {
                 for part in parts {
                     if let ClassPart::Guarded { expr, .. } = part {
-                        wanted.push(*expr);
+                        wanted.insert(key(*expr));
                     }
                 }
             }
         }
     };
-    for (_, synth_expr) in &plan.replace_exprs {
+    for (_, synth_expr) in &replace_exprs {
         if let SynthExpr::CreateObject { dynamic, .. } = synth_expr {
             collect_dynamic(dynamic);
         }
     }
-    for insert in &plan.inserts {
+    for insert in &insert_ops {
         if let SynthStmt::ConstDecl {
             value: HoistValue::CreateObject { dynamic, .. },
             ..
@@ -1150,19 +1217,11 @@ pub fn apply_plan<'a>(
             collect_dynamic(dynamic);
         }
     }
-    let mut preclones: BTreeMap<SpanKey, Expression<'a>> = BTreeMap::new();
-    for span in wanted {
-        if preclones.contains_key(&key(span)) {
-            continue;
-        }
-        if let Some(cloned) = clone_expr_in_program(allocator, program, span) {
-            preclones.insert(key(span), cloned);
-        }
-    }
+    let preclones = clone_exprs_in_program(allocator, program, &wanted);
 
     // parity: the source literal is retargeted in place (Program.exit), so the
     // raw text carries the splice backend's exact quoting.
-    for (span, value) in &plan.import_sources {
+    for (span, value) in &import_sources {
         for statement in &mut program.body {
             if let Statement::ImportDeclaration(decl) = statement
                 && decl.source.span == *span
@@ -1175,15 +1234,13 @@ pub fn apply_plan<'a>(
 
     let mut applier = Applier {
         alloc: allocator,
-        replace: plan
-            .replace_exprs
-            .iter()
-            .map(|(span, synth_expr)| (key(*span), synth_expr.clone()))
+        replace: replace_exprs
+            .into_iter()
+            .map(|(span, synth_expr)| (key(span), synth_expr))
             .collect(),
-        jsx: plan
-            .jsx_ops
-            .iter()
-            .map(|(span, op)| (key(*span), op.clone()))
+        jsx: jsx_ops
+            .into_iter()
+            .map(|(span, op)| (key(span), op))
             .collect(),
         preclones,
         error: None,
@@ -1206,12 +1263,11 @@ pub fn apply_plan<'a>(
     }
 
     // Statement surgery: removals + anchored insertions over program.body.
-    let removes: BTreeMap<SpanKey, &RemoveOp> = plan
-        .removes
+    let removes: BTreeMap<SpanKey, &RemoveOp> = remove_ops
         .iter()
         .map(|remove| (key(remove.stmt_span), remove))
         .collect();
-    let mut inserts: Vec<&InsertOp> = plan.inserts.iter().collect();
+    let mut inserts: Vec<&InsertOp> = insert_ops.iter().collect();
     inserts.sort_by_key(|insert| (insert.anchor, insert.seq));
     let mut inserts = inserts.into_iter().peekable();
 

--- a/crates/stylex/src/transform/ast_backend.rs
+++ b/crates/stylex/src/transform/ast_backend.rs
@@ -1,0 +1,1349 @@
+//! AST-mutation output backend (design-core.md §3a): replays the visitor's
+//! structured replacement values onto the caller's `Program` via `AstBuilder`.
+
+// Span invariant: synthesized nodes carry the replaced node's span (generated
+// runtime imports an empty one — codegen skips those); clones keep their own.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use oxc_allocator::{Allocator, CloneIn, Vec as ArenaVec};
+use oxc_ast::ast::{
+    Argument, ArrayExpressionElement, ArrowFunctionBody, ArrowFunctionExpression,
+    BindingIdentifier, BindingPattern, Comment, ComputedMemberExpression, Declaration, Expression,
+    FormalParameter, FormalParameterKind, FormalParameters, IdentifierName, ImportDeclaration,
+    ImportDeclarationSpecifier, ImportDefaultSpecifier, ImportNamespaceSpecifier,
+    ImportOrExportKind, ImportSpecifier, JSXAttribute, JSXAttributeItem, JSXAttributeName,
+    JSXAttributeValue, JSXOpeningElement, JSXSpreadAttribute, ModuleExportName, NumberBase,
+    ObjectExpression, ObjectProperty, ObjectPropertyKind, Program, PropertyKey, PropertyKind,
+    Statement, StringLiteral, VariableDeclaration, VariableDeclarationKind, VariableDeclarator,
+};
+use oxc_ast::builder::AstBuilder;
+use oxc_ast_visit::{Visit, VisitMut, walk, walk_mut};
+use oxc_span::{GetSpan, Span};
+use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
+
+use crate::errors::{ErrorCode, StylexError};
+use crate::eval::value::{EvalValue, JsObjectMap};
+use crate::jsrt::js_number_to_string;
+use crate::rules::StylexRule;
+use crate::shared::dynamic::{ClassPart, DynamicCompiled};
+use crate::transform::js_out::{
+    const_val_number, const_val_string, is_identifier_key, js_string_literal,
+};
+
+// ---------------------------------------------------------------------------
+
+// Plan: owned, span-keyed mutation descriptors the visitor records beside its
+// splice edits; applying them to the program matches splicing the text.
+
+#[derive(Debug, Clone)]
+pub struct DynamicEntry {
+    pub namespace: String,
+    pub compiled: DynamicCompiled,
+    /// Hoisted static-chunk const name; `None` prints the chunk inline.
+    pub static_ident: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub enum SynthExpr {
+    /// `js_string_literal(text)` replacements (keyframes/positionTry names).
+    Str(String),
+    /// `print_parens`-style replacements (theming, markers, inlined props).
+    ParenValue(EvalValue),
+    /// Hoisted-create references.
+    Ident(String),
+    /// `print_create_parens(map, dynamic)` — compiled create objects.
+    CreateObject {
+        map: Arc<JsObjectMap>,
+        dynamic: Vec<DynamicEntry>,
+    },
+    /// `table_text(entries, tests)` — the props/attrs/legacy bitmask lookup;
+    /// leaves are merged objects for props/attrs, class strings for legacy.
+    Table {
+        entries: Vec<(u32, EvalValue)>,
+        tests: Vec<Span>,
+    },
+    /// `{hoisted}.{property}` — a dynamic atom's rewritten callee.
+    AtomCallee { hoisted: String, property: String },
+}
+
+#[derive(Debug, Clone)]
+pub enum HoistValue {
+    /// `print_static_chunk` — the shared dynamic static chunk.
+    StaticChunk(DynamicCompiled),
+    /// `print_create_parens` — non-program-level create result.
+    CreateObject {
+        map: Arc<JsObjectMap>,
+        dynamic: Vec<DynamicEntry>,
+    },
+    /// A static atom props() could not merge, hoisted to module scope.
+    ParenValue(EvalValue),
+    /// The `{property: _v => [...]}` object a dynamic atom hoists.
+    AtomDynamic {
+        property: String,
+        prop_key: String,
+        class_name: String,
+        var_name: String,
+    },
+}
+
+/// One generated program-prologue statement, already in final body order
+/// (unshift order resolved, block-hoist sort applied).
+#[derive(Debug, Clone)]
+pub enum PrologueStmt {
+    NamespaceImport {
+        local: String,
+        source: String,
+    },
+    InjectImport {
+        local: String,
+        source: String,
+        named: Option<String>,
+    },
+    InjectAlias {
+        name: String,
+        local: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub enum SynthStmt {
+    /// `const {name} = {value};`
+    ConstDecl { name: String, value: HoistValue },
+    /// The generated program-prologue block.
+    Prologue(Vec<PrologueStmt>),
+    /// One runtime-injection call: `{callee}({ltr, …});`
+    InjectCall {
+        callee: String,
+        rule: Box<StylexRule>,
+    },
+    /// `import "{specifier}";` treeshake compensation.
+    SideEffectImport {
+        specifier: String,
+        source_span: Span,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub enum JsxOp {
+    /// The spread/sx attribute becomes plain string attributes.
+    Attrs(JsObjectMap),
+    /// `{...({})}`
+    SpreadEmptyObject,
+    /// `{...({…}[lookup])}`
+    SpreadTable {
+        entries: Vec<(u32, EvalValue)>,
+        tests: Vec<Span>,
+    },
+    /// `{...{local}.props({expr})}` — the sx bail path.
+    SpreadProps { local: String, expr_span: Span },
+}
+
+#[derive(Debug, Clone)]
+pub struct InsertOp {
+    pub anchor: u32,
+    /// Splice edit-slot order: ties at one anchor apply in ascending seq.
+    pub seq: usize,
+    /// Span stamped on the synthesized statement (see module invariant).
+    pub span: Span,
+    pub stmt: SynthStmt,
+}
+
+#[derive(Debug, Clone)]
+pub struct RemoveOp {
+    pub stmt_span: Span,
+    pub decl_count: usize,
+    pub indices: Vec<usize>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct AstPlan {
+    pub replace_exprs: Vec<(Span, SynthExpr)>,
+    pub jsx_ops: Vec<(Span, JsxOp)>,
+    pub inserts: Vec<InsertOp>,
+    pub removes: Vec<RemoveOp>,
+    /// `rewriteAliases`: (source literal span, its replacement value).
+    pub import_sources: Vec<(Span, String)>,
+}
+
+impl AstPlan {
+    pub fn is_empty(&self) -> bool {
+        self.replace_exprs.is_empty()
+            && self.jsx_ops.is_empty()
+            && self.inserts.is_empty()
+            && self.removes.is_empty()
+            && self.import_sources.is_empty()
+    }
+}
+
+fn internal(detail: String) -> StylexError {
+    StylexError::new(ErrorCode::AstBackend, detail)
+}
+
+// ---------------------------------------------------------------------------
+
+// Expression synthesis: mirrors the js_out.rs printers node-for-node, parens
+// included, so reprints of both backends stay byte-equal.
+
+struct Synth<'a> {
+    b: AstBuilder<'a>,
+    alloc: &'a Allocator,
+    /// The replaced node's span, stamped on every synthesized node.
+    span: Span,
+}
+
+impl<'a> Synth<'a> {
+    fn s(&self, text: &str) -> &'a str {
+        self.alloc.alloc_str(text)
+    }
+
+    fn ident(&self, name: &str) -> Expression<'a> {
+        Expression::new_identifier(self.span, self.s(name), &self.b)
+    }
+
+    fn string(&self, value: &str) -> Expression<'a> {
+        Expression::new_string_literal(self.span, self.s(value), None, &self.b)
+    }
+
+    fn paren(&self, inner: Expression<'a>) -> Expression<'a> {
+        Expression::new_parenthesized_expression(self.span, inner, &self.b)
+    }
+
+    // Mirrors js_number_to_string output re-parsed: NaN/Infinity are
+    // identifiers, a leading `-` is a unary minus, `-0` prints as `0`.
+    fn number(&self, n: f64) -> Expression<'a> {
+        let text = js_number_to_string(n);
+        match text.as_str() {
+            "NaN" | "Infinity" => self.ident(&text),
+            t if t.starts_with('-') => {
+                let inner = if &t[1..] == "Infinity" {
+                    self.ident("Infinity")
+                } else {
+                    let value: f64 = t[1..].parse().unwrap_or(n.abs());
+                    Expression::new_numeric_literal(
+                        self.span,
+                        value,
+                        None,
+                        NumberBase::Decimal,
+                        &self.b,
+                    )
+                };
+                Expression::new_unary_expression(
+                    self.span,
+                    UnaryOperator::UnaryNegation,
+                    inner,
+                    &self.b,
+                )
+            }
+            t => {
+                let value: f64 = t.parse().unwrap_or(n);
+                Expression::new_numeric_literal(
+                    self.span,
+                    value,
+                    None,
+                    NumberBase::Decimal,
+                    &self.b,
+                )
+            }
+        }
+    }
+
+    fn prop_key(&self, key: &str) -> PropertyKey<'a> {
+        if is_identifier_key(key) {
+            PropertyKey::new_static_identifier(self.span, self.s(key), &self.b)
+        } else {
+            self.string_key(key)
+        }
+    }
+
+    fn string_key(&self, key: &str) -> PropertyKey<'a> {
+        PropertyKey::new_string_literal(self.span, self.s(key), None, &self.b)
+    }
+
+    fn prop(&self, key: PropertyKey<'a>, value: Expression<'a>) -> ObjectPropertyKind<'a> {
+        ObjectPropertyKind::ObjectProperty(ObjectProperty::boxed(
+            self.span,
+            PropertyKind::Init,
+            key,
+            value,
+            false,
+            false,
+            false,
+            &self.b,
+        ))
+    }
+
+    fn object(&self, props: Vec<ObjectPropertyKind<'a>>) -> Expression<'a> {
+        let mut list = ArenaVec::with_capacity_in(props.len(), &self.b);
+        list.extend(props);
+        Expression::ObjectExpression(ObjectExpression::boxed(self.span, list, &self.b))
+    }
+
+    /// Mirrors js_out::write_value (arrays print as index-keyed objects).
+    fn value(&self, value: &EvalValue) -> Expression<'a> {
+        match value {
+            EvalValue::Null => Expression::new_null_literal(self.span, &self.b),
+            EvalValue::Undefined => self.ident("undefined"),
+            EvalValue::Bool(b) => Expression::new_boolean_literal(self.span, *b, &self.b),
+            EvalValue::Num(n) => self.number(*n),
+            EvalValue::Str(s) => self.string(s),
+            EvalValue::Arr(items) => {
+                let props = items
+                    .iter()
+                    .enumerate()
+                    .map(|(i, item)| self.prop(self.string_key(&i.to_string()), self.value(item)))
+                    .collect();
+                self.object(props)
+            }
+            EvalValue::Obj(map) => self.object_value(map),
+        }
+    }
+
+    fn object_value(&self, map: &JsObjectMap) -> Expression<'a> {
+        let props = map
+            .entries()
+            .map(|(key, value)| self.prop(self.prop_key(key), self.value(value)))
+            .collect();
+        self.object(props)
+    }
+
+    /// Mirrors js_out::print_static_chunk (`"$$css"` stays a quoted key).
+    fn static_chunk(&self, compiled: &DynamicCompiled) -> Expression<'a> {
+        let mut props: Vec<ObjectPropertyKind<'a>> = compiled
+            .static_props
+            .iter()
+            .map(|(key, segments)| self.prop(self.prop_key(key), self.class_segments(segments)))
+            .collect();
+        props.push(self.prop(self.string_key("$$css"), self.value(&compiled.css_tag)));
+        self.object(props)
+    }
+
+    /// The atoms transform builds both the key and the member with
+    /// `t.identifier(property)`, so a non-identifier property prints raw.
+    fn raw_member(&self, object: &str, property: &str) -> Expression<'a> {
+        Expression::new_static_member_expression(
+            self.span,
+            self.ident(object),
+            IdentifierName::new(self.span, self.s(property), &self.b),
+            false,
+            &self.b,
+        )
+    }
+
+    /// Mirrors the `const _temp = {prop: _v => [...]}` a dynamic atom hoists.
+    fn atom_dynamic(
+        &self,
+        property: &str,
+        prop_key: &str,
+        class_name: &str,
+        var_name: &str,
+    ) -> Expression<'a> {
+        let not_null = || self.binary(BinaryOperator::Inequality, self.ident("_v"), self.null());
+        let compiled = self.object(vec![
+            self.prop(
+                self.string_key(prop_key),
+                self.cond(not_null(), self.string(class_name), self.ident("_v")),
+            ),
+            self.prop(self.string_key("$$css"), self.value(&EvalValue::Bool(true))),
+        ]);
+        let vars = self.object(vec![self.prop(
+            self.string_key(var_name),
+            self.cond(not_null(), self.ident("_v"), self.ident("undefined")),
+        )]);
+        let mut items = ArenaVec::with_capacity_in(2, &self.b);
+        items.push(ArrayExpressionElement::from(compiled));
+        items.push(ArrayExpressionElement::from(vars));
+        let body = Expression::new_array_expression(self.span, items, &self.b);
+        let arrow = self.arrow(&["_v".to_string()], body);
+        self.object(vec![self.prop(
+            PropertyKey::new_static_identifier(self.span, self.s(property), &self.b),
+            arrow,
+        )])
+    }
+
+    /// Mirrors js_out::print_class_segments: an unfolded `+` chain.
+    fn class_segments(&self, segments: &[String]) -> Expression<'a> {
+        let mut iter = segments.iter();
+        let Some(first) = iter.next() else {
+            return self.string("");
+        };
+        iter.fold(self.string(first), |acc, seg| {
+            self.binary(BinaryOperator::Addition, acc, self.string(seg))
+        })
+    }
+
+    fn binary(
+        &self,
+        op: BinaryOperator,
+        left: Expression<'a>,
+        right: Expression<'a>,
+    ) -> Expression<'a> {
+        Expression::new_binary_expression(self.span, left, op, right, &self.b)
+    }
+
+    fn cond(
+        &self,
+        test: Expression<'a>,
+        consequent: Expression<'a>,
+        alternate: Expression<'a>,
+    ) -> Expression<'a> {
+        Expression::new_conditional_expression(self.span, test, consequent, alternate, &self.b)
+    }
+
+    fn null(&self) -> Expression<'a> {
+        Expression::new_null_literal(self.span, &self.b)
+    }
+
+    fn arrow(&self, params: &[String], body: Expression<'a>) -> Expression<'a> {
+        let mut items = ArenaVec::with_capacity_in(params.len(), &self.b);
+        for name in params {
+            let pattern = BindingPattern::BindingIdentifier(oxc_allocator::Box::new_in(
+                BindingIdentifier::new(self.span, self.s(name), &self.b),
+                &self.b,
+            ));
+            items.push(FormalParameter::new(
+                self.span,
+                ArenaVec::new_in(&self.b),
+                pattern,
+                None,
+                None,
+                false,
+                None,
+                false,
+                false,
+                &self.b,
+            ));
+        }
+        let params = FormalParameters::boxed(
+            self.span,
+            FormalParameterKind::ArrowFormalParameters,
+            items,
+            None,
+            &self.b,
+        );
+        Expression::ArrowFunctionExpression(ArrowFunctionExpression::boxed(
+            self.span,
+            false,
+            None,
+            params,
+            None,
+            ArrowFunctionBody::from(body),
+            &self.b,
+        ))
+    }
+
+    /// Mirrors js_out::print_dynamic_arrow; `resolve` clones the original
+    /// expression at a recorded span (pre-mutation, like the splice printer).
+    fn dynamic_arrow(
+        &self,
+        compiled: &DynamicCompiled,
+        static_ident: Option<&str>,
+        resolve: &mut dyn FnMut(Span) -> Result<Expression<'a>, StylexError>,
+    ) -> Result<Expression<'a>, StylexError> {
+        let mut var_props: Vec<ObjectPropertyKind<'a>> = Vec::new();
+        for var in &compiled.inline_vars {
+            let value = if var.unit.is_empty() {
+                // ({src}) != null ? ({src}) : undefined
+                let test = self.binary(
+                    BinaryOperator::Inequality,
+                    self.paren(resolve(var.expr)?),
+                    self.null(),
+                );
+                self.cond(
+                    test,
+                    self.paren(resolve(var.expr)?),
+                    self.ident("undefined"),
+                )
+            } else {
+                // ((val) => typeof val === "number" ? val + {unit}
+                //   : val != null ? val : undefined)(({src}))
+                let typeof_test = self.binary(
+                    BinaryOperator::StrictEquality,
+                    Expression::new_unary_expression(
+                        self.span,
+                        UnaryOperator::Typeof,
+                        self.ident("val"),
+                        &self.b,
+                    ),
+                    self.string("number"),
+                );
+                let with_unit = self.binary(
+                    BinaryOperator::Addition,
+                    self.ident("val"),
+                    self.string(&var.unit),
+                );
+                let nullish = self.cond(
+                    self.binary(BinaryOperator::Inequality, self.ident("val"), self.null()),
+                    self.ident("val"),
+                    self.ident("undefined"),
+                );
+                let body = self.cond(typeof_test, with_unit, nullish);
+                let callee = self.paren(self.arrow(&["val".to_string()], body));
+                let mut args = ArenaVec::with_capacity_in(1, &self.b);
+                args.push(Argument::from(self.paren(resolve(var.expr)?)));
+                Expression::CallExpression(oxc_ast::ast::CallExpression::boxed(
+                    self.span, callee, None, args, false, &self.b,
+                ))
+            };
+            var_props.push(self.prop(self.string_key(&var.var_name), value));
+        }
+        let vars_obj = self.object(var_props);
+
+        if !compiled.has_container() {
+            return Ok(self.arrow(&compiled.params, self.paren(vars_obj)));
+        }
+
+        let mut items: Vec<Expression<'a>> = Vec::new();
+        if !compiled.static_props.is_empty() {
+            items.push(match static_ident {
+                Some(name) => self.ident(name),
+                None => self.static_chunk(compiled),
+            });
+        }
+        if !compiled.conditional_props.is_empty() {
+            let mut props: Vec<ObjectPropertyKind<'a>> = Vec::new();
+            for (key, parts) in &compiled.conditional_props {
+                let mut rendered: Vec<Expression<'a>> = Vec::new();
+                for part in parts {
+                    rendered.push(match part {
+                        ClassPart::Lit(lit) => self.string(lit),
+                        ClassPart::Guarded { lit, expr } => {
+                            // (({src}) != null ? {lit} : ({src}))
+                            let test = self.binary(
+                                BinaryOperator::Inequality,
+                                self.paren(resolve(*expr)?),
+                                self.null(),
+                            );
+                            self.paren(self.cond(
+                                test,
+                                self.string(lit),
+                                self.paren(resolve(*expr)?),
+                            ))
+                        }
+                    });
+                }
+                let value = match rendered
+                    .into_iter()
+                    .reduce(|left, right| self.binary(BinaryOperator::Addition, left, right))
+                {
+                    Some(joined) => joined,
+                    None => self.string(""),
+                };
+                props.push(self.prop(self.prop_key(key), value));
+            }
+            // parity: the conditional chunk's $$css key is an identifier.
+            props.push(self.prop(
+                PropertyKey::new_static_identifier(self.span, self.s("$$css"), &self.b),
+                self.value(&compiled.css_tag),
+            ));
+            items.push(self.object(props));
+        }
+        items.push(vars_obj);
+        let mut elements = ArenaVec::with_capacity_in(items.len(), &self.b);
+        for item in items {
+            elements.push(oxc_ast::ast::ArrayExpressionElement::from(item));
+        }
+        let array = Expression::ArrayExpression(oxc_ast::ast::ArrayExpression::boxed(
+            self.span, elements, &self.b,
+        ));
+        Ok(self.arrow(&compiled.params, array))
+    }
+
+    /// Mirrors visitor::print_create_parens (the fns rewrite only fires on
+    /// object-shaped values).
+    fn create_object(
+        &self,
+        map: &JsObjectMap,
+        dynamic: &[DynamicEntry],
+        resolve: &mut dyn FnMut(Span) -> Result<Expression<'a>, StylexError>,
+    ) -> Result<Expression<'a>, StylexError> {
+        if dynamic.is_empty() {
+            return Ok(self.paren(self.object_value(map)));
+        }
+        let mut props: Vec<ObjectPropertyKind<'a>> = Vec::new();
+        for (key, value) in map.entries() {
+            let entry = dynamic.iter().find(|e| e.namespace == key);
+            let built = match entry {
+                Some(entry) if matches!(value, EvalValue::Obj(_)) => {
+                    self.dynamic_arrow(&entry.compiled, entry.static_ident.as_deref(), resolve)?
+                }
+                _ => self.value(value),
+            };
+            props.push(self.prop(self.prop_key(key), built));
+        }
+        Ok(self.paren(self.object(props)))
+    }
+
+    /// Mirrors visitor::table_text: `({k: {…}, …}[!!(t0) << n-1 | …])`.
+    fn table(&self, entries: &[(u32, EvalValue)], tests: Vec<Expression<'a>>) -> Expression<'a> {
+        let props = entries
+            .iter()
+            .map(|(key, leaf)| {
+                self.prop(
+                    PropertyKey::new_numeric_literal(
+                        self.span,
+                        f64::from(*key),
+                        None,
+                        NumberBase::Decimal,
+                        &self.b,
+                    ),
+                    self.value(leaf),
+                )
+            })
+            .collect();
+        let object = self.object(props);
+        let n = tests.len();
+        let lookup = tests
+            .into_iter()
+            .enumerate()
+            .map(|(i, test)| {
+                let bang = Expression::new_unary_expression(
+                    self.span,
+                    UnaryOperator::LogicalNot,
+                    Expression::new_unary_expression(
+                        self.span,
+                        UnaryOperator::LogicalNot,
+                        self.paren(test),
+                        &self.b,
+                    ),
+                    &self.b,
+                );
+                self.binary(
+                    BinaryOperator::ShiftLeft,
+                    bang,
+                    self.number((n - 1 - i) as f64),
+                )
+            })
+            .reduce(|left, right| self.binary(BinaryOperator::BitwiseOR, left, right))
+            .expect("plan_merge tables carry at least one conditional");
+        self.paren(Expression::ComputedMemberExpression(
+            ComputedMemberExpression::boxed(self.span, object, lookup, false, &self.b),
+        ))
+    }
+
+    /// Mirrors visitor::jsx_attrs_text (`&quot;`-escaped string attributes).
+    fn jsx_attrs(&self, map: &JsObjectMap) -> Vec<JSXAttributeItem<'a>> {
+        map.entries()
+            .map(|(key, value)| {
+                let text = match value {
+                    EvalValue::Str(s) => s.replace('"', "&quot;"),
+                    _ => "[object Object]".to_string(),
+                };
+                JSXAttributeItem::Attribute(JSXAttribute::boxed(
+                    self.span,
+                    JSXAttributeName::new_identifier(self.span, self.s(key), &self.b),
+                    Some(JSXAttributeValue::new_string_literal(
+                        self.span,
+                        self.s(&text),
+                        None,
+                        &self.b,
+                    )),
+                    &self.b,
+                ))
+            })
+            .collect()
+    }
+
+    fn spread_attr(&self, argument: Expression<'a>) -> JSXAttributeItem<'a> {
+        JSXAttributeItem::SpreadAttribute(JSXSpreadAttribute::boxed(self.span, argument, &self.b))
+    }
+
+    fn props_call(&self, local: &str, argument: Expression<'a>) -> Expression<'a> {
+        let callee = Expression::new_static_member_expression(
+            self.span,
+            self.ident(local),
+            IdentifierName::new(self.span, self.s("props"), &self.b),
+            false,
+            &self.b,
+        );
+        let mut args = ArenaVec::with_capacity_in(1, &self.b);
+        args.push(Argument::from(argument));
+        Expression::CallExpression(oxc_ast::ast::CallExpression::boxed(
+            self.span, callee, None, args, false, &self.b,
+        ))
+    }
+
+    fn const_stmt(&self, name: &str, init: Expression<'a>) -> Statement<'a> {
+        let id = BindingPattern::BindingIdentifier(oxc_allocator::Box::new_in(
+            BindingIdentifier::new(self.span, self.s(name), &self.b),
+            &self.b,
+        ));
+        let mut decls = ArenaVec::with_capacity_in(1, &self.b);
+        decls.push(VariableDeclarator::new(
+            self.span,
+            id,
+            None,
+            Some(init),
+            false,
+            &self.b,
+        ));
+        Statement::VariableDeclaration(oxc_allocator::Box::new_in(
+            VariableDeclaration::new(
+                self.span,
+                VariableDeclarationKind::Const,
+                decls,
+                false,
+                &self.b,
+            ),
+            &self.b,
+        ))
+    }
+
+    fn namespace_import(&self, local: &str, source: &str) -> Statement<'a> {
+        self.import_stmt(
+            ImportDeclarationSpecifier::ImportNamespaceSpecifier(oxc_allocator::Box::new_in(
+                ImportNamespaceSpecifier::new(self.span, self.binding(local), &self.b),
+                &self.b,
+            )),
+            source,
+        )
+    }
+
+    fn import_stmt(
+        &self,
+        specifier: ImportDeclarationSpecifier<'a>,
+        source: &str,
+    ) -> Statement<'a> {
+        let mut specifiers = ArenaVec::with_capacity_in(1, &self.b);
+        specifiers.push(specifier);
+        Statement::ImportDeclaration(oxc_allocator::Box::new_in(
+            ImportDeclaration::new(
+                self.span,
+                Some(specifiers),
+                StringLiteral::new(self.span, self.s(source), None, &self.b),
+                None,
+                None,
+                ImportOrExportKind::Value,
+                &self.b,
+            ),
+            &self.b,
+        ))
+    }
+
+    fn binding(&self, name: &str) -> BindingIdentifier<'a> {
+        BindingIdentifier::new(self.span, self.s(name), &self.b)
+    }
+
+    fn inject_import(&self, local: &str, source: &str, named: Option<&str>) -> Statement<'a> {
+        let specifier = match named {
+            Some(imported) => {
+                ImportDeclarationSpecifier::ImportSpecifier(oxc_allocator::Box::new_in(
+                    ImportSpecifier::new(
+                        self.span,
+                        ModuleExportName::IdentifierName(IdentifierName::new(
+                            self.span,
+                            self.s(imported),
+                            &self.b,
+                        )),
+                        self.binding(local),
+                        ImportOrExportKind::Value,
+                        &self.b,
+                    ),
+                    &self.b,
+                ))
+            }
+            None => ImportDeclarationSpecifier::ImportDefaultSpecifier(oxc_allocator::Box::new_in(
+                ImportDefaultSpecifier::new(self.span, self.binding(local), &self.b),
+                &self.b,
+            )),
+        };
+        self.import_stmt(specifier, source)
+    }
+
+    fn var_alias(&self, name: &str, local: &str) -> Statement<'a> {
+        let mut decls = ArenaVec::with_capacity_in(1, &self.b);
+        decls.push(VariableDeclarator::new(
+            self.span,
+            BindingPattern::BindingIdentifier(oxc_allocator::Box::new_in(
+                self.binding(name),
+                &self.b,
+            )),
+            None,
+            Some(self.ident(local)),
+            false,
+            &self.b,
+        ));
+        Statement::VariableDeclaration(oxc_allocator::Box::new_in(
+            VariableDeclaration::new(
+                self.span,
+                VariableDeclarationKind::Var,
+                decls,
+                false,
+                &self.b,
+            ),
+            &self.b,
+        ))
+    }
+
+    /// Mirrors js_out::print_inject_arg (fixed key order, numeric constVal).
+    fn inject_call(&self, callee: &str, rule: &StylexRule) -> Statement<'a> {
+        let mut props = vec![self.prop(self.prop_key("ltr"), self.string(&rule.ltr))];
+        if let Some(rtl) = &rule.rtl {
+            props.push(self.prop(self.prop_key("rtl"), self.string(rtl)));
+        }
+        props.push(self.prop(self.prop_key("priority"), self.number(rule.priority)));
+        if let Some(const_key) = &rule.const_key {
+            props.push(self.prop(self.prop_key("constKey"), self.string(const_key)));
+        }
+        if let Some(const_val) = &rule.const_val {
+            let value = match const_val_number(const_val) {
+                Some(n) => self.number(n),
+                None => self.string(&const_val_string(const_val)),
+            };
+            props.push(self.prop(self.prop_key("constVal"), value));
+        }
+        let mut args = ArenaVec::with_capacity_in(1, &self.b);
+        args.push(Argument::from(self.object(props)));
+        let call = Expression::CallExpression(oxc_ast::ast::CallExpression::boxed(
+            self.span,
+            self.ident(callee),
+            None,
+            args,
+            false,
+            &self.b,
+        ));
+        Statement::ExpressionStatement(oxc_allocator::Box::new_in(
+            oxc_ast::ast::ExpressionStatement::new(self.span, call, &self.b),
+            &self.b,
+        ))
+    }
+
+    fn side_effect_import(&self, specifier: &str, source_span: Span) -> Statement<'a> {
+        Statement::ImportDeclaration(oxc_allocator::Box::new_in(
+            ImportDeclaration::new(
+                self.span,
+                None,
+                StringLiteral::new(source_span, self.s(specifier), None, &self.b),
+                None,
+                None,
+                ImportOrExportKind::Value,
+                &self.b,
+            ),
+            &self.b,
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Span-addressed clone helpers
+
+/// Clones the outermost expression whose span equals `target` (parity with
+/// `expr_text(span)`: the recorded span always names a real expression node).
+struct SpanCloner<'x, 'a> {
+    alloc: &'a Allocator,
+    target: Span,
+    found: &'x mut Option<Expression<'a>>,
+}
+
+impl<'a> Visit<'a> for SpanCloner<'_, 'a> {
+    fn visit_expression(&mut self, it: &Expression<'a>) {
+        if self.found.is_some() {
+            return;
+        }
+        if it.span() == self.target {
+            *self.found = Some(it.clone_in(self.alloc));
+            return;
+        }
+        walk::walk_expression(self, it);
+    }
+}
+
+fn clone_expr_in_program<'a>(
+    alloc: &'a Allocator,
+    program: &Program<'a>,
+    span: Span,
+) -> Option<Expression<'a>> {
+    let mut found = None;
+    let mut cloner = SpanCloner {
+        alloc,
+        target: span,
+        found: &mut found,
+    };
+    cloner.visit_program(program);
+    found
+}
+
+fn clone_expr_within<'a>(
+    alloc: &'a Allocator,
+    root: &Expression<'a>,
+    span: Span,
+) -> Option<Expression<'a>> {
+    let mut found = None;
+    let mut cloner = SpanCloner {
+        alloc,
+        target: span,
+        found: &mut found,
+    };
+    cloner.visit_expression(root);
+    found
+}
+
+fn clone_expr_within_attr<'a>(
+    alloc: &'a Allocator,
+    root: &JSXAttributeItem<'a>,
+    span: Span,
+) -> Option<Expression<'a>> {
+    let mut found = None;
+    let mut cloner = SpanCloner {
+        alloc,
+        target: span,
+        found: &mut found,
+    };
+    match root {
+        JSXAttributeItem::Attribute(attr) => cloner.visit_jsx_attribute(attr),
+        JSXAttributeItem::SpreadAttribute(attr) => cloner.visit_jsx_spread_attribute(attr),
+    }
+    found
+}
+
+// ---------------------------------------------------------------------------
+// Plan application
+
+type SpanKey = (u32, u32);
+
+fn key(span: Span) -> SpanKey {
+    (span.start, span.end)
+}
+
+struct Applier<'a> {
+    alloc: &'a Allocator,
+    replace: BTreeMap<SpanKey, SynthExpr>,
+    jsx: BTreeMap<SpanKey, JsxOp>,
+    /// Pre-mutation clones of the dynamic-arrow expression spans (the splice
+    /// printer reads them from the raw source, before any nested edit).
+    preclones: BTreeMap<SpanKey, Expression<'a>>,
+    error: Option<StylexError>,
+}
+
+impl<'a> Applier<'a> {
+    fn synth(&self, span: Span) -> Synth<'a> {
+        Synth {
+            b: AstBuilder::new(self.alloc),
+            alloc: self.alloc,
+            span,
+        }
+    }
+
+    fn fail(&mut self, error: StylexError) {
+        if self.error.is_none() {
+            self.error = Some(error);
+        }
+    }
+
+    fn preclone(&self, span: Span) -> Result<Expression<'a>, StylexError> {
+        self.preclones
+            .get(&key(span))
+            .map(|expr| expr.clone_in(self.alloc))
+            .ok_or_else(|| {
+                internal(format!(
+                    "unresolved dynamic span {}..{}",
+                    span.start, span.end
+                ))
+            })
+    }
+
+    /// `old` is child-mutated before cloning, so table tests carry nested
+    /// replacements (the splice path's render-with-inner-edits).
+    fn build_expr(
+        &self,
+        span: Span,
+        synth_expr: &SynthExpr,
+        old: &Expression<'a>,
+    ) -> Result<Expression<'a>, StylexError> {
+        let s = self.synth(span);
+        match synth_expr {
+            SynthExpr::Str(text) => Ok(s.string(text)),
+            SynthExpr::ParenValue(value) => Ok(s.paren(s.value(value))),
+            SynthExpr::Ident(name) => Ok(s.ident(name)),
+            SynthExpr::AtomCallee { hoisted, property } => Ok(s.raw_member(hoisted, property)),
+            SynthExpr::CreateObject { map, dynamic } => {
+                s.create_object(map, dynamic, &mut |expr_span| self.preclone(expr_span))
+            }
+            SynthExpr::Table { entries, tests } => {
+                let mut test_exprs = Vec::with_capacity(tests.len());
+                for test in tests {
+                    let cloned = clone_expr_within(self.alloc, old, *test).ok_or_else(|| {
+                        internal(format!(
+                            "unresolved table test span {}..{}",
+                            test.start, test.end
+                        ))
+                    })?;
+                    test_exprs.push(cloned);
+                }
+                Ok(s.table(entries, test_exprs))
+            }
+        }
+    }
+
+    fn build_jsx(
+        &self,
+        span: Span,
+        op: &JsxOp,
+        old: &JSXAttributeItem<'a>,
+    ) -> Result<Vec<JSXAttributeItem<'a>>, StylexError> {
+        let s = self.synth(span);
+        match op {
+            JsxOp::Attrs(map) => Ok(s.jsx_attrs(map)),
+            JsxOp::SpreadEmptyObject => Ok(vec![s.spread_attr(s.paren(s.object(Vec::new())))]),
+            JsxOp::SpreadTable { entries, tests } => {
+                let mut test_exprs = Vec::with_capacity(tests.len());
+                for test in tests {
+                    let cloned =
+                        clone_expr_within_attr(self.alloc, old, *test).ok_or_else(|| {
+                            internal(format!(
+                                "unresolved sx test span {}..{}",
+                                test.start, test.end
+                            ))
+                        })?;
+                    test_exprs.push(cloned);
+                }
+                Ok(vec![s.spread_attr(s.table(entries, test_exprs))])
+            }
+            JsxOp::SpreadProps { local, expr_span } => {
+                let argument =
+                    clone_expr_within_attr(self.alloc, old, *expr_span).ok_or_else(|| {
+                        internal(format!(
+                            "unresolved sx bail span {}..{}",
+                            expr_span.start, expr_span.end
+                        ))
+                    })?;
+                Ok(vec![s.spread_attr(s.props_call(local, argument))])
+            }
+        }
+    }
+
+    fn build_stmt(
+        &self,
+        insert: &InsertOp,
+        out: &mut Vec<Statement<'a>>,
+    ) -> Result<(), StylexError> {
+        let s = self.synth(insert.span);
+        match &insert.stmt {
+            SynthStmt::ConstDecl { name, value } => {
+                let init = match value {
+                    HoistValue::StaticChunk(compiled) => s.static_chunk(compiled),
+                    HoistValue::CreateObject { map, dynamic } => {
+                        s.create_object(map, dynamic, &mut |expr_span| self.preclone(expr_span))?
+                    }
+                    HoistValue::ParenValue(value) => s.paren(s.value(value)),
+                    HoistValue::AtomDynamic {
+                        property,
+                        prop_key,
+                        class_name,
+                        var_name,
+                    } => s.atom_dynamic(property, prop_key, class_name, var_name),
+                };
+                out.push(s.const_stmt(name, init));
+            }
+            SynthStmt::Prologue(stmts) => {
+                for stmt in stmts {
+                    out.push(match stmt {
+                        PrologueStmt::NamespaceImport { local, source } => {
+                            s.namespace_import(local, source)
+                        }
+                        PrologueStmt::InjectImport {
+                            local,
+                            source,
+                            named,
+                        } => s.inject_import(local, source, named.as_deref()),
+                        PrologueStmt::InjectAlias { name, local } => s.var_alias(name, local),
+                    });
+                }
+            }
+            SynthStmt::InjectCall { callee, rule } => out.push(s.inject_call(callee, rule)),
+            SynthStmt::SideEffectImport {
+                specifier,
+                source_span,
+            } => out.push(s.side_effect_import(specifier, *source_span)),
+        }
+        Ok(())
+    }
+}
+
+impl<'a> VisitMut<'a> for Applier<'a> {
+    fn visit_expression(&mut self, expr: &mut Expression<'a>) {
+        if self.error.is_some() {
+            return;
+        }
+        // Post-order: nested replacements land before enclosing ones, so a
+        // table's cloned tests see their inner replacements (splice parity).
+        walk_mut::walk_expression(self, expr);
+        if let Some(synth_expr) = self.replace.remove(&key(expr.span())) {
+            match self.build_expr(expr.span(), &synth_expr, expr) {
+                Ok(built) => *expr = built,
+                Err(error) => self.fail(error),
+            }
+        }
+    }
+
+    fn visit_jsx_opening_element(&mut self, el: &mut JSXOpeningElement<'a>) {
+        if self.error.is_some() {
+            return;
+        }
+        walk_mut::walk_jsx_opening_element(self, el);
+        if !el
+            .attributes
+            .iter()
+            .any(|item| self.jsx.contains_key(&key(item.span())))
+        {
+            return;
+        }
+        let old = std::mem::replace(&mut el.attributes, ArenaVec::new_in(&self.alloc));
+        for item in old {
+            match self.jsx.remove(&key(item.span())) {
+                None => el.attributes.push(item),
+                Some(op) => match self.build_jsx(item.span(), &op, &item) {
+                    Ok(built) => el.attributes.extend(built),
+                    Err(error) => {
+                        self.fail(error);
+                        el.attributes.push(item);
+                    }
+                },
+            }
+        }
+    }
+}
+
+/// Re-anchors comments where the splice text leaves them: before the
+/// statements inserted at the offset, else before the next kept statement.
+fn retarget_comments(comments: &mut ArenaVec<'_, Comment>, from: u32, to: Option<u32>) {
+    for comment in comments.iter_mut() {
+        if comment.attached_to == from {
+            comment.attached_to = to.unwrap_or(u32::MAX);
+        }
+    }
+}
+
+pub fn apply_plan<'a>(
+    allocator: &'a Allocator,
+    program: &mut Program<'a>,
+    plan: &AstPlan,
+) -> Result<(), StylexError> {
+    // Collect the pre-mutation clones every dynamic arrow needs.
+    let mut wanted: Vec<Span> = Vec::new();
+    let mut collect_dynamic = |dynamic: &[DynamicEntry]| {
+        for entry in dynamic {
+            for var in &entry.compiled.inline_vars {
+                wanted.push(var.expr);
+            }
+            for (_, parts) in &entry.compiled.conditional_props {
+                for part in parts {
+                    if let ClassPart::Guarded { expr, .. } = part {
+                        wanted.push(*expr);
+                    }
+                }
+            }
+        }
+    };
+    for (_, synth_expr) in &plan.replace_exprs {
+        if let SynthExpr::CreateObject { dynamic, .. } = synth_expr {
+            collect_dynamic(dynamic);
+        }
+    }
+    for insert in &plan.inserts {
+        if let SynthStmt::ConstDecl {
+            value: HoistValue::CreateObject { dynamic, .. },
+            ..
+        } = &insert.stmt
+        {
+            collect_dynamic(dynamic);
+        }
+    }
+    let mut preclones: BTreeMap<SpanKey, Expression<'a>> = BTreeMap::new();
+    for span in wanted {
+        if preclones.contains_key(&key(span)) {
+            continue;
+        }
+        if let Some(cloned) = clone_expr_in_program(allocator, program, span) {
+            preclones.insert(key(span), cloned);
+        }
+    }
+
+    // parity: the source literal is retargeted in place (Program.exit), so the
+    // raw text carries the splice backend's exact quoting.
+    for (span, value) in &plan.import_sources {
+        for statement in &mut program.body {
+            if let Statement::ImportDeclaration(decl) = statement
+                && decl.source.span == *span
+            {
+                decl.source.value = allocator.alloc_str(value).into();
+                decl.source.raw = Some(allocator.alloc_str(&js_string_literal(value)).into());
+            }
+        }
+    }
+
+    let mut applier = Applier {
+        alloc: allocator,
+        replace: plan
+            .replace_exprs
+            .iter()
+            .map(|(span, synth_expr)| (key(*span), synth_expr.clone()))
+            .collect(),
+        jsx: plan
+            .jsx_ops
+            .iter()
+            .map(|(span, op)| (key(*span), op.clone()))
+            .collect(),
+        preclones,
+        error: None,
+    };
+    applier.visit_program(program);
+    if let Some(error) = applier.error.take() {
+        return Err(error);
+    }
+    if !applier.replace.is_empty() || !applier.jsx.is_empty() {
+        let leftover: Vec<String> = applier
+            .replace
+            .keys()
+            .chain(applier.jsx.keys())
+            .map(|(start, end)| format!("{start}..{end}"))
+            .collect();
+        return Err(internal(format!(
+            "unmatched replacement spans: {}",
+            leftover.join(", ")
+        )));
+    }
+
+    // Statement surgery: removals + anchored insertions over program.body.
+    let removes: BTreeMap<SpanKey, &RemoveOp> = plan
+        .removes
+        .iter()
+        .map(|remove| (key(remove.stmt_span), remove))
+        .collect();
+    let mut inserts: Vec<&InsertOp> = plan.inserts.iter().collect();
+    inserts.sort_by_key(|insert| (insert.anchor, insert.seq));
+    let mut inserts = inserts.into_iter().peekable();
+
+    let old_body = std::mem::replace(&mut program.body, ArenaVec::new_in(&allocator));
+    let mut new_body: Vec<Statement<'a>> = Vec::with_capacity(old_body.len());
+    let mut comments = std::mem::replace(&mut program.comments, ArenaVec::new_in(&allocator));
+    let mut pending_retarget: Vec<u32> = Vec::new();
+    let mut anchors_retargeted: Vec<u32> = Vec::new();
+    let handle_insert = |applier: &Applier<'a>,
+                         insert: &InsertOp,
+                         new_body: &mut Vec<Statement<'a>>,
+                         comments: &mut ArenaVec<'a, Comment>,
+                         pending_retarget: &mut Vec<u32>,
+                         anchors_retargeted: &mut Vec<u32>|
+     -> Result<(), StylexError> {
+        let at = new_body.len();
+        applier.build_stmt(insert, new_body)?;
+        if let Some(first) = new_body.get(at) {
+            let target = first.span().start;
+            // Comments right before the splice offset stay above the inserted
+            // block; move their attachment onto its first statement.
+            if target != insert.anchor && !anchors_retargeted.contains(&insert.anchor) {
+                retarget_comments(comments, insert.anchor, Some(target));
+                anchors_retargeted.push(insert.anchor);
+            }
+            for from in pending_retarget.drain(..) {
+                retarget_comments(comments, from, Some(target));
+            }
+        }
+        Ok(())
+    };
+    for stmt in old_body {
+        let stmt_start = stmt.span().start;
+        while let Some(insert) = inserts.peek() {
+            if insert.anchor > stmt_start {
+                break;
+            }
+            let insert = inserts.next().expect("peeked");
+            handle_insert(
+                &applier,
+                insert,
+                &mut new_body,
+                &mut comments,
+                &mut pending_retarget,
+                &mut anchors_retargeted,
+            )?;
+        }
+        match removes.get(&key(stmt.span())) {
+            None => {
+                for from in pending_retarget.drain(..) {
+                    retarget_comments(&mut comments, from, Some(stmt_start));
+                }
+                new_body.push(stmt);
+            }
+            Some(remove) if remove.indices.len() >= remove.decl_count => {
+                pending_retarget.push(stmt_start);
+            }
+            Some(remove) => {
+                let mut stmt = stmt;
+                retain_declarators(allocator, &mut stmt, &remove.indices);
+                new_body.push(stmt);
+            }
+        }
+    }
+    for insert in inserts {
+        handle_insert(
+            &applier,
+            insert,
+            &mut new_body,
+            &mut comments,
+            &mut pending_retarget,
+            &mut anchors_retargeted,
+        )?;
+    }
+    for from in pending_retarget.drain(..) {
+        retarget_comments(&mut comments, from, None);
+    }
+    program.body.extend(new_body);
+    program.comments = comments;
+    Ok(())
+}
+
+fn retain_declarators<'a>(allocator: &'a Allocator, stmt: &mut Statement<'a>, removed: &[usize]) {
+    let decl = match stmt {
+        Statement::VariableDeclaration(decl) => &mut **decl,
+        Statement::ExportDeclaration(export) => match &mut export.declaration {
+            Declaration::VariableDeclaration(decl) => &mut **decl,
+            _ => return,
+        },
+        _ => return,
+    };
+    let old = std::mem::replace(&mut decl.declarations, ArenaVec::new_in(&allocator));
+    for (index, declarator) in old.into_iter().enumerate() {
+        if !removed.contains(&index) {
+            decl.declarations.push(declarator);
+        }
+    }
+}
+
+/// Debug-facing invariant check: every span in the program is in-range and
+/// well-formed (start <= end <= source length).
+pub fn assert_spans_in_range(program: &Program<'_>, source_len: u32) -> Result<(), String> {
+    struct SpanCheck {
+        len: u32,
+        bad: Vec<String>,
+    }
+    impl<'a> Visit<'a> for SpanCheck {
+        fn visit_expression(&mut self, it: &Expression<'a>) {
+            self.check(it.span());
+            walk::walk_expression(self, it);
+        }
+        fn visit_statement(&mut self, it: &oxc_ast::ast::Statement<'a>) {
+            self.check(it.span());
+            walk::walk_statement(self, it);
+        }
+    }
+    impl SpanCheck {
+        fn check(&mut self, span: Span) {
+            if span.start > span.end || span.end > self.len {
+                self.bad
+                    .push(format!("{}..{} (len {})", span.start, span.end, self.len));
+            }
+        }
+    }
+    let mut check = SpanCheck {
+        len: source_len,
+        bad: Vec::new(),
+    };
+    check.visit_program(program);
+    if check.bad.is_empty() {
+        Ok(())
+    } else {
+        Err(check.bad.join(", "))
+    }
+}

--- a/crates/stylex/src/transform/atoms.rs
+++ b/crates/stylex/src/transform/atoms.rs
@@ -1,0 +1,131 @@
+//! `@stylexjs/atoms` recognition: the compile-away sugar the babel plugin
+//! bundles from `@stylexjs/atoms/babel-transform` and runs in `Program.exit`.
+
+use oxc_ast::ast::{CallExpression, Expression, IdentifierReference};
+use oxc_span::{GetSpan, Span};
+use oxc_syntax::node::NodeId;
+
+use crate::imports::ATOM_NAMESPACE;
+use crate::state::CompileState;
+
+/// A recognised atom expression.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AtomStyle {
+    /// `x.display.flex` / `color.red` → one raw declaration.
+    Static { property: String, value: String },
+    /// `x.color(v)` → a hoisted arrow taking the call's single argument.
+    Dynamic { property: String },
+}
+
+/// A member expression split the way the atoms transform reads it.
+pub struct MemberParts<'a> {
+    pub object: &'a Expression<'a>,
+    /// `getPropKey(node.property, node.computed)`.
+    pub key: Option<String>,
+}
+
+// parity: atoms babel-transform getPropKey. Anything else (template literals,
+// identifiers used computed) reads as "no key", never as an error.
+pub fn member_parts<'a>(expr: &'a Expression<'a>) -> Option<MemberParts<'a>> {
+    match expr {
+        Expression::StaticMemberExpression(m) if !m.optional => Some(MemberParts {
+            object: &m.object,
+            key: Some(m.property.name.to_string()),
+        }),
+        Expression::ComputedMemberExpression(m) if !m.optional => Some(MemberParts {
+            object: &m.object,
+            key: match &m.expression {
+                Expression::StringLiteral(s) => Some(s.value.to_string()),
+                Expression::NumericLiteral(n) => Some(crate::jsrt::js_number_to_string(n.value)),
+                _ => None,
+            },
+        }),
+        _ => None,
+    }
+}
+
+/// parity: atoms babel-transform normalizeValue — one leading `_` only.
+pub fn normalize_value(value: &str) -> &str {
+    value.strip_prefix('_').unwrap_or(value)
+}
+
+/// parity: isUtilityStylesIdentifier. The `atomImports` hit is scope-blind
+/// upstream; the binding fallback below is not, and reaches `import type` too.
+pub fn is_atom_identifier(
+    base: &IdentifierReference<'_>,
+    node_id: NodeId,
+    state: &CompileState<'_>,
+) -> bool {
+    state.imports.atom_import(&base.name).is_some()
+        || (state.imports.is_atom_binding_local(&base.name)
+            && state.resolves_to_root_binding(node_id, &base.name))
+}
+
+/// parity: getStaticStyleFromPath. `object`/`key` come from the member the
+/// caller is visiting.
+pub fn static_style(
+    object: &Expression<'_>,
+    key: Option<&str>,
+    node_id: NodeId,
+    state: &CompileState<'_>,
+) -> Option<AtomStyle> {
+    let value_key = key?;
+    if let Some(inner) = member_parts(object)
+        && let Some(property) = inner.key
+        && let Expression::Identifier(base) = inner.object
+        && is_atom_identifier(base, node_id, state)
+    {
+        return Some(AtomStyle::Static {
+            property,
+            value: normalize_value(value_key).to_string(),
+        });
+    }
+    let Expression::Identifier(base) = object else {
+        return None;
+    };
+    if !is_atom_identifier(base, node_id, state) {
+        return None;
+    }
+    // The single-level form reads atomImports directly, so a binding reachable
+    // only through the scope fallback (a type import) stays inert here.
+    let imported = state.imports.atom_import(&base.name)?;
+    let property = if imported == ATOM_NAMESPACE {
+        value_key.to_string()
+    } else {
+        imported.to_string()
+    };
+    Some(AtomStyle::Static {
+        property,
+        value: normalize_value(value_key).to_string(),
+    })
+}
+
+/// parity: getDynamicStyleFromPath. Returns the property plus the single
+/// argument's span; zero or two arguments leave the call untouched.
+pub fn dynamic_style<'a>(
+    call: &'a CallExpression<'a>,
+    node_id: NodeId,
+    state: &CompileState<'_>,
+) -> Option<(AtomStyle, Span)> {
+    let callee = member_parts(&call.callee)?;
+    let value_key = callee.key?;
+    if call.arguments.len() != 1 {
+        return None;
+    }
+    let arg = call.arguments[0].as_expression()?;
+    let property = match callee.object {
+        Expression::Identifier(base) if is_atom_identifier(base, node_id, state) => value_key,
+        object => {
+            let inner = member_parts(object)?;
+            let property = inner.key?;
+            let Expression::Identifier(base) = inner.object else {
+                return None;
+            };
+            if !is_atom_identifier(base, node_id, state) {
+                return None;
+            }
+            property
+        }
+    };
+    Some((AtomStyle::Dynamic { property }, arg.span()))
+}

--- a/crates/stylex/src/transform/dce.rs
+++ b/crates/stylex/src/transform/dce.rs
@@ -1,0 +1,182 @@
+//! Unused compiled-create declarator pruning at Program.exit.
+// parity: babel-plugin src/index.js:187-301 (varsToKeep + styleVarsToKeep)
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use crate::eval::value::{EvalValue, JsObjectMap};
+use crate::transform::merge::{NonNullProps, StyleVarToKeep};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Keep {
+    All,
+    Namespaces(Vec<String>),
+}
+
+pub fn compute_vars_to_keep(tuples: &[StyleVarToKeep]) -> BTreeMap<String, Keep> {
+    let mut out: BTreeMap<String, Keep> = BTreeMap::new();
+    for tuple in tuples {
+        match out.get_mut(&tuple.var_name) {
+            Some(Keep::All) => {}
+            Some(Keep::Namespaces(list)) => match &tuple.namespace {
+                None => {
+                    out.insert(tuple.var_name.clone(), Keep::All);
+                }
+                Some(ns) => list.push(ns.clone()),
+            },
+            None => {
+                let keep = match &tuple.namespace {
+                    None => Keep::All,
+                    Some(ns) => Keep::Namespaces(vec![ns.clone()]),
+                };
+                out.insert(tuple.var_name.clone(), keep);
+            }
+        }
+    }
+    out
+}
+
+#[derive(Debug, PartialEq)]
+pub enum DceAction {
+    KeepAll,
+    Remove,
+    Prune(JsObjectMap),
+}
+
+pub fn dce_action(
+    var_name: &str,
+    compiled: &JsObjectMap,
+    exported: bool,
+    vars_to_keep: &BTreeMap<String, Keep>,
+    tuples: &[StyleVarToKeep],
+) -> DceAction {
+    if exported {
+        return DceAction::KeepAll;
+    }
+    match vars_to_keep.get(var_name) {
+        Some(Keep::All) => DceAction::KeepAll,
+        None => DceAction::Remove,
+        Some(Keep::Namespaces(namespaces)) => {
+            let mut pruned = JsObjectMap::new();
+            for (key, value) in compiled.entries() {
+                if !namespaces.iter().any(|ns| ns == key) {
+                    continue;
+                }
+                pruned.insert(key, prune_namespace(var_name, key, value, tuples));
+            }
+            DceAction::Prune(pruned)
+        }
+    }
+}
+
+fn prune_namespace(
+    var_name: &str,
+    namespace: &str,
+    value: &EvalValue,
+    tuples: &[StyleVarToKeep],
+) -> EvalValue {
+    let relevant: Vec<&NonNullProps> = tuples
+        .iter()
+        .filter(|t| t.var_name == var_name && t.namespace.as_deref() == Some(namespace))
+        .map(|t| &t.non_null_props)
+        .collect();
+    if relevant.iter().any(|p| matches!(p, NonNullProps::True)) {
+        return value.clone();
+    }
+    let EvalValue::Obj(map) = value else {
+        return value.clone();
+    };
+    let mut keep_nulls: Vec<&str> = Vec::new();
+    for props in relevant {
+        if let NonNullProps::Props(list) = props {
+            keep_nulls.extend(list.iter().map(String::as_str));
+        }
+    }
+    let mut pruned = JsObjectMap::new();
+    for (key, prop_value) in map.entries() {
+        if matches!(prop_value, EvalValue::Null) && !keep_nulls.contains(&key) {
+            continue;
+        }
+        pruned.insert(key, prop_value.clone());
+    }
+    EvalValue::Obj(Arc::new(pruned))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tuple(var: &str, ns: Option<&str>, props: NonNullProps) -> StyleVarToKeep {
+        StyleVarToKeep {
+            var_name: var.to_string(),
+            namespace: ns.map(str::to_string),
+            non_null_props: props,
+        }
+    }
+
+    fn compiled() -> JsObjectMap {
+        let mut a = JsObjectMap::new();
+        a.insert("k1", EvalValue::Str("x1".into()));
+        a.insert("k2", EvalValue::Null);
+        a.insert("$$css", EvalValue::Bool(true));
+        let mut b = JsObjectMap::new();
+        b.insert("k3", EvalValue::Null);
+        b.insert("$$css", EvalValue::Bool(true));
+        let mut top = JsObjectMap::new();
+        top.insert("a", EvalValue::Obj(a.into()));
+        top.insert("b", EvalValue::Obj(b.into()));
+        top
+    }
+
+    #[test]
+    fn unreferenced_vars_are_removed_and_exported_kept() {
+        let vars = compute_vars_to_keep(&[]);
+        assert_eq!(
+            dce_action("styles", &compiled(), false, &vars, &[]),
+            DceAction::Remove
+        );
+        assert_eq!(
+            dce_action("styles", &compiled(), true, &vars, &[]),
+            DceAction::KeepAll
+        );
+    }
+
+    #[test]
+    fn namespace_and_null_prop_pruning() {
+        let tuples = vec![tuple(
+            "styles",
+            Some("a"),
+            NonNullProps::Props(vec!["k1".to_string()]),
+        )];
+        let vars = compute_vars_to_keep(&tuples);
+        let DceAction::Prune(map) = dce_action("styles", &compiled(), false, &vars, &tuples) else {
+            panic!("expected prune");
+        };
+        assert_eq!(map.keys().collect::<Vec<_>>(), vec!["a"]);
+        let EvalValue::Obj(a) = map.get("a").unwrap() else {
+            panic!("namespace object");
+        };
+        // k2 is null and not in the keep list; $$css survives (non-null).
+        assert_eq!(a.keys().collect::<Vec<_>>(), vec!["k1", "$$css"]);
+    }
+
+    #[test]
+    fn true_tuple_disables_null_pruning_and_bare_use_keeps_all() {
+        let tuples = vec![
+            tuple("styles", Some("b"), NonNullProps::True),
+            tuple("other", None, NonNullProps::True),
+        ];
+        let vars = compute_vars_to_keep(&tuples);
+        let DceAction::Prune(map) = dce_action("styles", &compiled(), false, &vars, &tuples) else {
+            panic!("expected prune");
+        };
+        let EvalValue::Obj(b) = map.get("b").unwrap() else {
+            panic!("namespace object");
+        };
+        assert_eq!(b.keys().collect::<Vec<_>>(), vec!["k3", "$$css"]);
+        assert_eq!(
+            dce_action("other", &compiled(), false, &vars, &tuples),
+            DceAction::KeepAll
+        );
+    }
+}

--- a/crates/stylex/src/transform/js_out.rs
+++ b/crates/stylex/src/transform/js_out.rs
@@ -4,7 +4,7 @@
 use oxc_span::Span;
 
 use crate::eval::value::{EvalValue, JsObjectMap};
-use crate::jsrt::js_number_to_string;
+use crate::jsrt::{js_number_to_string, write_js_number};
 
 /// One text edit; `start == end` is a pure insertion.
 #[derive(Debug, Clone)]
@@ -47,7 +47,9 @@ pub fn apply_edits_tracked(
 ) -> String {
     let mut ordered: Vec<(usize, &Edit)> = edits.iter().enumerate().collect();
     ordered.sort_by_key(|(i, e)| (e.start, e.end, *i));
-    let mut out = String::with_capacity(source.len());
+    let inserted: usize = edits.iter().map(|e| e.text.len()).sum();
+    let replaced: usize = edits.iter().map(|e| (e.end - e.start) as usize).sum();
+    let mut out = String::with_capacity(source.len().saturating_sub(replaced) + inserted);
     let mut cursor = 0usize;
     for (_, edit) in ordered {
         let start = edit.start as usize;
@@ -221,9 +223,37 @@ fn json_string_literal(value: &str) -> String {
     serde_json::to_string(value).expect("string serialization is infallible")
 }
 
+/// Printed-size estimate for pre-sizing buffers: exact for keywords and
+/// ASCII strings, a typical width for numbers.
+pub fn estimate_len(value: &EvalValue) -> usize {
+    match value {
+        EvalValue::Null => 4,
+        EvalValue::Undefined => 9,
+        EvalValue::Bool(_) => 5,
+        EvalValue::Num(_) => 8,
+        EvalValue::Str(s) => s.len() + 2,
+        EvalValue::Arr(items) => {
+            2 + items
+                .iter()
+                .map(|item| estimate_len(item) + 7)
+                .sum::<usize>()
+        }
+        EvalValue::Obj(map) => estimate_object_len(map),
+    }
+}
+
+pub fn estimate_object_len(map: &JsObjectMap) -> usize {
+    2 + map
+        .entries()
+        .map(|(key, value)| {
+            key.len() + if is_identifier_key(key) { 4 } else { 6 } + estimate_len(value)
+        })
+        .sum::<usize>()
+}
+
 /// Prints an `EvalValue` as a JS expression (object/array literal shape).
 pub fn print_value(value: &EvalValue) -> String {
-    let mut out = String::new();
+    let mut out = String::with_capacity(estimate_len(value));
     write_value(value, &mut out);
     out
 }
@@ -233,7 +263,7 @@ pub fn write_value(value: &EvalValue, out: &mut String) {
         EvalValue::Null => out.push_str("null"),
         EvalValue::Undefined => out.push_str("undefined"),
         EvalValue::Bool(b) => out.push_str(if *b { "true" } else { "false" }),
-        EvalValue::Num(n) => out.push_str(&js_number_to_string(*n)),
+        EvalValue::Num(n) => write_js_number(*n, out),
         EvalValue::Str(s) => write_js_string_literal(s, out),
         // parity: convertObjectToAST recurses into arrays via Object.entries,
         // printing them as index-keyed objects ({"0": …, "1": …}).
@@ -271,17 +301,21 @@ pub fn write_object(map: &JsObjectMap, out: &mut String) {
     out.push('}');
 }
 
-/// The runtime-injection call argument: `{ltr, rtl?, priority, constKey?,
-/// constVal?}`. parity: state-manager.js addStyleToInject key order.
-pub fn print_inject_arg(rule: &crate::rules::StylexRule) -> String {
-    let mut out = String::from("{ltr: ");
+/// One runtime-injection statement, `callee({ltr, rtl?, priority, constKey?,
+/// constVal?});\n`. parity: state-manager.js addStyleToInject key order.
+pub fn inject_call_text(callee: &str, rule: &crate::rules::StylexRule) -> String {
+    let mut out = String::with_capacity(
+        callee.len() + rule.ltr.len() + rule.rtl.as_ref().map_or(0, |rtl| rtl.len() + 9) + 40,
+    );
+    out.push_str(callee);
+    out.push_str("({ltr: ");
     write_js_string_literal(&rule.ltr, &mut out);
     if let Some(rtl) = &rule.rtl {
         out.push_str(", rtl: ");
         write_js_string_literal(rtl, &mut out);
     }
     out.push_str(", priority: ");
-    out.push_str(&js_number_to_string(rule.priority));
+    write_js_number(rule.priority, &mut out);
     if let Some(const_key) = &rule.const_key {
         out.push_str(", constKey: ");
         write_js_string_literal(const_key, &mut out);
@@ -290,7 +324,7 @@ pub fn print_inject_arg(rule: &crate::rules::StylexRule) -> String {
         out.push_str(", constVal: ");
         out.push_str(&print_const_val(const_val));
     }
-    out.push('}');
+    out.push_str("});\n");
     out
 }
 
@@ -333,15 +367,17 @@ pub fn const_val_string(value: &serde_json::Value) -> String {
 
 // parity: upstream builds the class list as a `+` chain of string literals
 // and never folds it, even when every operand is static.
-pub fn print_class_segments(segments: &[String]) -> String {
+fn write_class_segments(segments: &[String], out: &mut String) {
     if segments.is_empty() {
-        return js_string_literal("");
+        out.push_str("\"\"");
+        return;
     }
-    segments
-        .iter()
-        .map(|s| js_string_literal(s))
-        .collect::<Vec<_>>()
-        .join(" + ")
+    for (i, segment) in segments.iter().enumerate() {
+        if i > 0 {
+            out.push_str(" + ");
+        }
+        write_js_string_literal(segment, out);
+    }
 }
 
 /// Static chunk printer (the object upstream hoists via hoistExpression);
@@ -352,13 +388,15 @@ pub fn print_static_chunk(compiled: &crate::shared::dynamic::DynamicCompiled) ->
         if is_identifier_key(key) {
             obj.push_str(key);
         } else {
-            obj.push_str(&js_string_literal(key));
+            write_js_string_literal(key, &mut obj);
         }
         obj.push_str(": ");
-        obj.push_str(&print_class_segments(segments));
+        write_class_segments(segments, &mut obj);
         obj.push_str(", ");
     }
-    obj.push_str(&format!("\"$$css\": {}}}", print_value(&compiled.css_tag)));
+    obj.push_str("\"$$css\": ");
+    write_value(&compiled.css_tag, &mut obj);
+    obj.push('}');
     obj
 }
 
@@ -454,7 +492,7 @@ fn write_json(value: &EvalValue, out: &mut String) {
         EvalValue::Bool(b) => out.push_str(if *b { "true" } else { "false" }),
         EvalValue::Num(n) => {
             if n.is_finite() {
-                out.push_str(&js_number_to_string(*n));
+                write_js_number(*n, out);
             } else {
                 out.push_str(&format!(
                     "{{\"__jsnum\":{}}}",

--- a/crates/stylex/src/transform/js_out.rs
+++ b/crates/stylex/src/transform/js_out.rs
@@ -1,0 +1,591 @@
+//! Span-splice output: compiled values printed as parseable JS and applied as
+//! non-overlapping text edits over the original source (design-core.md §3b/§3c).
+
+use oxc_span::Span;
+
+use crate::eval::value::{EvalValue, JsObjectMap};
+use crate::jsrt::js_number_to_string;
+
+/// One text edit; `start == end` is a pure insertion.
+#[derive(Debug, Clone)]
+pub struct Edit {
+    pub start: u32,
+    pub end: u32,
+    pub text: String,
+}
+
+impl Edit {
+    pub fn replace(span: Span, text: String) -> Self {
+        Edit {
+            start: span.start,
+            end: span.end,
+            text,
+        }
+    }
+
+    pub fn insert(offset: u32, text: String) -> Self {
+        Edit {
+            start: offset,
+            end: offset,
+            text,
+        }
+    }
+}
+
+/// Applies edits to `source`. Edits must be non-overlapping; same-position
+/// insertions apply in their submission order.
+pub fn apply_edits(source: &str, edits: &[Edit]) -> String {
+    apply_edits_tracked(source, edits, None)
+}
+
+/// [`apply_edits`] that also records generated-to-original positions when
+/// `map` is supplied; the returned text is byte-identical either way.
+pub fn apply_edits_tracked(
+    source: &str,
+    edits: &[Edit],
+    mut map: Option<&mut SpliceMap>,
+) -> String {
+    let mut ordered: Vec<(usize, &Edit)> = edits.iter().enumerate().collect();
+    ordered.sort_by_key(|(i, e)| (e.start, e.end, *i));
+    let mut out = String::with_capacity(source.len());
+    let mut cursor = 0usize;
+    for (_, edit) in ordered {
+        let start = edit.start as usize;
+        let end = edit.end as usize;
+        assert!(start >= cursor, "overlapping stylex output edits");
+        if let Some(map) = map.as_mut() {
+            map.copy(&source[cursor..start]);
+            map.insert(&edit.text);
+            map.skip(&source[start..end]);
+        }
+        out.push_str(&source[cursor..start]);
+        out.push_str(&edit.text);
+        cursor = end;
+    }
+    if let Some(map) = map.as_mut() {
+        map.copy(&source[cursor..]);
+    }
+    out.push_str(&source[cursor..]);
+    out
+}
+
+/// Generated-to-original positions for a splice compile, built by walking the
+/// source left to right exactly as [`apply_edits_tracked`] does.
+#[derive(Debug, Default)]
+pub struct SpliceMap {
+    /// (generated line, generated column, source line, source column), all
+    /// zero-based; columns are UTF-16 code units, as JS tooling reads them.
+    pub tokens: Vec<(u32, u32, u32, u32)>,
+    out_line: u32,
+    out_col: u32,
+    src_line: u32,
+    src_col: u32,
+}
+
+impl SpliceMap {
+    fn token(&mut self) {
+        self.tokens
+            .push((self.out_line, self.out_col, self.src_line, self.src_col));
+    }
+
+    /// Verbatim text: source and output advance together, so one token per
+    /// generated line carries the whole run at exact columns.
+    fn copy(&mut self, text: &str) {
+        let mut at_line_start = true;
+        for ch in text.chars() {
+            if at_line_start {
+                self.token();
+                at_line_start = false;
+            }
+            if ch == '\n' {
+                self.out_line += 1;
+                self.out_col = 0;
+                self.src_line += 1;
+                self.src_col = 0;
+                at_line_start = true;
+            } else {
+                let w = ch.len_utf16() as u32;
+                self.out_col += w;
+                self.src_col += w;
+            }
+        }
+    }
+
+    /// Synthesized text: every generated line it spans points at the start of
+    /// the span it replaced, so a frame inside it resolves to the original.
+    fn insert(&mut self, text: &str) {
+        let mut at_line_start = true;
+        for ch in text.chars() {
+            if at_line_start {
+                self.token();
+                at_line_start = false;
+            }
+            if ch == '\n' {
+                self.out_line += 1;
+                self.out_col = 0;
+                at_line_start = true;
+            } else {
+                self.out_col += ch.len_utf16() as u32;
+            }
+        }
+    }
+
+    /// Replaced source: consumed without emitting, keeping the source cursor
+    /// aligned for the next copied run.
+    fn skip(&mut self, text: &str) {
+        for ch in text.chars() {
+            if ch == '\n' {
+                self.src_line += 1;
+                self.src_col = 0;
+            } else {
+                self.src_col += ch.len_utf16() as u32;
+            }
+        }
+    }
+}
+
+/// Renders `span`'s source text with the given (contained) edits applied.
+pub fn render_span(source: &str, span: Span, edits: &[Edit]) -> String {
+    let base = span.start as usize;
+    let slice = &source[base..span.end as usize];
+    let contained: Vec<Edit> = edits
+        .iter()
+        .filter(|e| e.start >= span.start && e.end <= span.end)
+        .map(|e| Edit {
+            start: e.start - span.start,
+            end: e.end - span.start,
+            text: e.text.clone(),
+        })
+        .collect();
+    apply_edits(slice, &contained)
+}
+
+// parity: @babel/types isValidIdentifier(name, false) — keywords stay valid
+// as object keys; non-ASCII identifiers conservatively print quoted instead.
+pub fn is_identifier_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' || c == '$' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
+}
+
+// parity: @babel/generator via jsesc {quotes: 'double', wrap: true,
+// minimal: false} — ASCII-safe output, \xXX below U+0100, \uXXXX above.
+pub fn js_string_literal(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    write_js_string_literal(value, &mut out);
+    out
+}
+
+pub fn write_js_string_literal(value: &str, out: &mut String) {
+    use std::fmt::Write;
+    out.push('"');
+    if value
+        .bytes()
+        .all(|b| matches!(b, 0x20..=0x7E) && b != b'"' && b != b'\\')
+    {
+        out.push_str(value);
+        out.push('"');
+        return;
+    }
+    let mut units = value.encode_utf16().peekable();
+    while let Some(unit) = units.next() {
+        match unit {
+            0x0000 => {
+                let digit_next = units.peek().is_some_and(|n| (0x0030..=0x0039).contains(n));
+                out.push_str(if digit_next { "\\x00" } else { "\\0" });
+            }
+            0x0008 => out.push_str("\\b"),
+            0x0009 => out.push_str("\\t"),
+            0x000A => out.push_str("\\n"),
+            0x000C => out.push_str("\\f"),
+            0x000D => out.push_str("\\r"),
+            0x0022 => out.push_str("\\\""),
+            0x005C => out.push_str("\\\\"),
+            0x0020..=0x007E => out.push(unit as u8 as char),
+            _ if unit < 0x0100 => {
+                let _ = write!(out, "\\x{unit:02X}");
+            }
+            _ => {
+                let _ = write!(out, "\\u{unit:04X}");
+            }
+        }
+    }
+    out.push('"');
+}
+
+/// JSON string escaping for the canonical-JSON surface (never JS-printed).
+fn json_string_literal(value: &str) -> String {
+    serde_json::to_string(value).expect("string serialization is infallible")
+}
+
+/// Prints an `EvalValue` as a JS expression (object/array literal shape).
+pub fn print_value(value: &EvalValue) -> String {
+    let mut out = String::new();
+    write_value(value, &mut out);
+    out
+}
+
+pub fn write_value(value: &EvalValue, out: &mut String) {
+    match value {
+        EvalValue::Null => out.push_str("null"),
+        EvalValue::Undefined => out.push_str("undefined"),
+        EvalValue::Bool(b) => out.push_str(if *b { "true" } else { "false" }),
+        EvalValue::Num(n) => out.push_str(&js_number_to_string(*n)),
+        EvalValue::Str(s) => write_js_string_literal(s, out),
+        // parity: convertObjectToAST recurses into arrays via Object.entries,
+        // printing them as index-keyed objects ({"0": …, "1": …}).
+        EvalValue::Arr(items) => {
+            use std::fmt::Write;
+            out.push('{');
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                let _ = write!(out, "\"{i}\"");
+                out.push_str(": ");
+                write_value(item, out);
+            }
+            out.push('}');
+        }
+        EvalValue::Obj(map) => write_object(map, out),
+    }
+}
+
+pub fn write_object(map: &JsObjectMap, out: &mut String) {
+    out.push('{');
+    for (i, (key, value)) in map.entries().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        if is_identifier_key(key) {
+            out.push_str(key);
+        } else {
+            write_js_string_literal(key, out);
+        }
+        out.push_str(": ");
+        write_value(value, out);
+    }
+    out.push('}');
+}
+
+/// The runtime-injection call argument: `{ltr, rtl?, priority, constKey?,
+/// constVal?}`. parity: state-manager.js addStyleToInject key order.
+pub fn print_inject_arg(rule: &crate::rules::StylexRule) -> String {
+    let mut out = String::from("{ltr: ");
+    write_js_string_literal(&rule.ltr, &mut out);
+    if let Some(rtl) = &rule.rtl {
+        out.push_str(", rtl: ");
+        write_js_string_literal(rtl, &mut out);
+    }
+    out.push_str(", priority: ");
+    out.push_str(&js_number_to_string(rule.priority));
+    if let Some(const_key) = &rule.const_key {
+        out.push_str(", constKey: ");
+        write_js_string_literal(const_key, &mut out);
+    }
+    if let Some(const_val) = &rule.const_val {
+        out.push_str(", constVal: ");
+        out.push_str(&print_const_val(const_val));
+    }
+    out.push('}');
+    out
+}
+
+/// parity: `typeof v === 'number' ? numericLiteral(v) : stringLiteral(String(v))`.
+pub fn print_const_val(value: &serde_json::Value) -> String {
+    match const_val_number(value) {
+        Some(n) => js_number_to_string(n),
+        None => js_string_literal(&const_val_string(value)),
+    }
+}
+
+pub fn const_val_number(value: &serde_json::Value) -> Option<f64> {
+    match value {
+        serde_json::Value::Number(n) => n.as_f64(),
+        other => crate::rules::non_finite_from_tag(other),
+    }
+}
+
+// JS String(v) for the non-numeric constVal shapes defineConsts can carry.
+pub fn const_val_string(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Null => "null".to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Array(items) => items
+            .iter()
+            .map(|item| {
+                if item.is_null() {
+                    String::new()
+                } else {
+                    const_val_string(item)
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(","),
+        serde_json::Value::Object(_) => "[object Object]".to_string(),
+        serde_json::Value::Number(n) => js_number_to_string(n.as_f64().unwrap_or(f64::NAN)),
+    }
+}
+
+// parity: upstream builds the class list as a `+` chain of string literals
+// and never folds it, even when every operand is static.
+pub fn print_class_segments(segments: &[String]) -> String {
+    if segments.is_empty() {
+        return js_string_literal("");
+    }
+    segments
+        .iter()
+        .map(|s| js_string_literal(s))
+        .collect::<Vec<_>>()
+        .join(" + ")
+}
+
+/// Static chunk printer (the object upstream hoists via hoistExpression);
+/// its `$$css` key is a string literal, the conditional chunk's an identifier.
+pub fn print_static_chunk(compiled: &crate::shared::dynamic::DynamicCompiled) -> String {
+    let mut obj = String::from("{");
+    for (key, segments) in &compiled.static_props {
+        if is_identifier_key(key) {
+            obj.push_str(key);
+        } else {
+            obj.push_str(&js_string_literal(key));
+        }
+        obj.push_str(": ");
+        obj.push_str(&print_class_segments(segments));
+        obj.push_str(", ");
+    }
+    obj.push_str(&format!("\"$$css\": {}}}", print_value(&compiled.css_tag)));
+    obj
+}
+
+/// Dynamic-namespace arrow printer: spans splice verbatim (parenthesized),
+/// hoisted static chunks splice as `static_ident`. parity: stylex-create.js:294-485
+pub fn print_dynamic_arrow(
+    compiled: &crate::shared::dynamic::DynamicCompiled,
+    source: &str,
+    static_ident: Option<&str>,
+) -> String {
+    use crate::shared::dynamic::ClassPart;
+    let expr_text = |span: Span| -> &str { &source[span.start as usize..span.end as usize] };
+
+    let mut vars = String::from("{");
+    for (i, var) in compiled.inline_vars.iter().enumerate() {
+        if i > 0 {
+            vars.push_str(", ");
+        }
+        vars.push_str(&js_string_literal(&var.var_name));
+        vars.push_str(": ");
+        let src = expr_text(var.expr);
+        if var.unit.is_empty() {
+            vars.push_str(&format!("({src}) != null ? ({src}) : undefined"));
+        } else {
+            vars.push_str(&format!(
+                "((val) => typeof val === \"number\" ? val + {unit} : val != null ? val : undefined)(({src}))",
+                unit = js_string_literal(&var.unit)
+            ));
+        }
+    }
+    vars.push('}');
+
+    let params = compiled.params.join(", ");
+    if !compiled.has_container() {
+        return format!("({params}) => ({vars})");
+    }
+
+    let css_tag = print_value(&compiled.css_tag);
+    let write_key = |out: &mut String, key: &str| {
+        if is_identifier_key(key) {
+            out.push_str(key);
+        } else {
+            out.push_str(&js_string_literal(key));
+        }
+    };
+    let mut items: Vec<String> = Vec::new();
+    if !compiled.static_props.is_empty() {
+        items.push(match static_ident {
+            Some(ident) => ident.to_string(),
+            None => print_static_chunk(compiled),
+        });
+    }
+    if !compiled.conditional_props.is_empty() {
+        let mut obj = String::from("{");
+        for (key, parts) in &compiled.conditional_props {
+            write_key(&mut obj, key);
+            obj.push_str(": ");
+            let rendered: Vec<String> = parts
+                .iter()
+                .map(|part| match part {
+                    ClassPart::Lit(lit) => js_string_literal(lit),
+                    ClassPart::Guarded { lit, expr } => {
+                        let src = expr_text(*expr);
+                        format!("(({src}) != null ? {} : ({src}))", js_string_literal(lit))
+                    }
+                })
+                .collect();
+            if rendered.is_empty() {
+                obj.push_str("\"\"");
+            } else {
+                obj.push_str(&rendered.join(" + "));
+            }
+            obj.push_str(", ");
+        }
+        // parity: the conditional chunk's $$css key is an identifier upstream.
+        obj.push_str(&format!("$$css: {css_tag}}}"));
+        items.push(obj);
+    }
+    items.push(vars);
+    format!("({params}) => [{}]", items.join(", "))
+}
+
+/// Canonical JSON (keys in JS ownKeys order) for the extract-objects surface.
+pub fn to_canonical_json(value: &EvalValue) -> String {
+    let mut out = String::new();
+    write_json(value, &mut out);
+    out
+}
+
+fn write_json(value: &EvalValue, out: &mut String) {
+    match value {
+        EvalValue::Null | EvalValue::Undefined => out.push_str("null"),
+        EvalValue::Bool(b) => out.push_str(if *b { "true" } else { "false" }),
+        EvalValue::Num(n) => {
+            if n.is_finite() {
+                out.push_str(&js_number_to_string(*n));
+            } else {
+                out.push_str(&format!(
+                    "{{\"__jsnum\":{}}}",
+                    json_string_literal(&js_number_to_string(*n))
+                ));
+            }
+        }
+        EvalValue::Str(s) => out.push_str(&json_string_literal(s)),
+        EvalValue::Arr(items) => {
+            out.push('[');
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                write_json(item, out);
+            }
+            out.push(']');
+        }
+        EvalValue::Obj(map) => {
+            out.push('{');
+            for (i, (key, item)) in map.entries().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push_str(&json_string_literal(key));
+                out.push(':');
+                write_json(item, out);
+            }
+            out.push('}');
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn obj(entries: &[(&str, EvalValue)]) -> EvalValue {
+        EvalValue::Obj(
+            entries
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), v.clone()))
+                .collect::<JsObjectMap>()
+                .into(),
+        )
+    }
+
+    #[test]
+    fn prints_identifier_and_quoted_keys() {
+        let v = obj(&[
+            ("kMwMTN", EvalValue::Str("xju2f9n".into())),
+            ("$$css", EvalValue::Bool(true)),
+            ("data-style-src", EvalValue::Str("f.ts:3".into())),
+            ("0", EvalValue::Null),
+        ]);
+        assert_eq!(
+            print_value(&v),
+            "{\"0\": null, kMwMTN: \"xju2f9n\", $$css: true, \"data-style-src\": \"f.ts:3\"}"
+        );
+    }
+
+    #[test]
+    fn prints_numbers_via_jsrt() {
+        let v = obj(&[
+            ("a", EvalValue::Num(12.0)),
+            ("b", EvalValue::Num(0.5)),
+            ("c", EvalValue::Num(-4.0)),
+        ]);
+        assert_eq!(print_value(&v), "{a: 12, b: 0.5, c: -4}");
+    }
+
+    #[test]
+    fn jsesc_escapes_match_babel_generator() {
+        // Pinned live against @babel/generator 7.29.8 (probe 2026-08-28).
+        assert_eq!(
+            js_string_literal("\"a\u{2028}b\u{2029}c\0d\u{000B}e\u{1F600}f\u{00E9}\""),
+            "\"\\\"a\\u2028b\\u2029c\\0d\\x0Be\\uD83D\\uDE00f\\xE9\\\"\""
+        );
+        assert_eq!(js_string_literal("\x001"), r#""\x001""#);
+        assert_eq!(js_string_literal("a'`b"), "\"a'`b\"");
+        assert_eq!(
+            js_string_literal("\\\n\t\r\x08\x0C\x7F"),
+            r#""\\\n\t\r\b\f\x7F""#
+        );
+    }
+
+    #[test]
+    fn arrays_print_as_indexed_objects() {
+        // parity: convertObjectToAST via Object.entries over the array.
+        let v = obj(&[(
+            "fontFamily",
+            EvalValue::Arr(vec![
+                EvalValue::Str("Arial".into()),
+                EvalValue::Str("sans-serif".into()),
+            ]),
+        )]);
+        assert_eq!(
+            print_value(&v),
+            "{fontFamily: {\"0\": \"Arial\", \"1\": \"sans-serif\"}}"
+        );
+        assert_eq!(print_value(&EvalValue::Arr(vec![])), "{}");
+        let nested = EvalValue::Arr(vec![EvalValue::Arr(vec![EvalValue::Num(1.0)])]);
+        assert_eq!(print_value(&nested), "{\"0\": {\"0\": 1}}");
+    }
+
+    #[test]
+    fn edits_apply_in_order_with_insertions() {
+        let src = "abcdef";
+        let edits = vec![
+            Edit::insert(0, "X".into()),
+            Edit::replace(Span::new(2, 4), "Y".into()),
+        ];
+        assert_eq!(apply_edits(src, &edits), "XabYef");
+    }
+
+    #[test]
+    fn render_span_applies_nested_edits() {
+        let src = "foo(bar(baz))";
+        let edits = vec![Edit::replace(Span::new(4, 12), "Q".into())];
+        assert_eq!(render_span(src, Span::new(0, 13), &edits), "foo(Q)");
+    }
+
+    #[test]
+    fn canonical_json_preserves_key_order() {
+        let v = obj(&[
+            ("z", EvalValue::Num(1.0)),
+            ("a", EvalValue::Num(f64::INFINITY)),
+        ]);
+        assert_eq!(
+            to_canonical_json(&v),
+            "{\"z\":1,\"a\":{\"__jsnum\":\"Infinity\"}}"
+        );
+    }
+}

--- a/crates/stylex/src/transform/merge.rs
+++ b/crates/stylex/src/transform/merge.rs
@@ -1,0 +1,873 @@
+//! Compile-time `props()`/`attrs()`/`stylex()` merge, oracle-pinned runtime port.
+// parity: stylex-props.js + stylex-merge.js + @stylexjs/stylex over styleq@0.2.1
+
+use crate::errors::StylexError;
+use crate::eval::value::{EvalValue, JsObjectMap};
+use crate::jsrt::js_number_to_string;
+use crate::options::ResolvedOptions;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MergeMode {
+    Props,
+    Attrs,
+}
+
+/// parseNullableStyle output: null/`undefined` literal, an evaluated style
+/// object, or the non-static `'other'` marker.
+#[derive(Debug, Clone, PartialEq)]
+pub enum NullableStyle {
+    Null,
+    Style(EvalValue),
+    Other,
+}
+
+/// One flattened call argument (one level of array args expands beforehand),
+/// classified by the AST-side caller.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MergeArg {
+    /// object / identifier / member / call argument, via parseNullableStyle
+    Resolved(NullableStyle),
+    /// `test ? a : b` — the test expression stays in the AST
+    Conditional {
+        primary: NullableStyle,
+        fallback: NullableStyle,
+    },
+    /// `left && right`, both sides via parseNullableStyle
+    LogicalAnd {
+        left: NullableStyle,
+        right: NullableStyle,
+    },
+    /// any other argument shape (bare null/boolean/number/string literals,
+    /// spreads, arrays nested beyond one level, …)
+    Unsupported,
+    /// logical expression with an operator other than `&&`
+    NonAndLogical,
+}
+
+/// `T` is the merged leaf: a props/attrs object, or the legacy class string.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MergePlan<T> {
+    /// no conditionals: one merged leaf replaces the call
+    Inlined(T),
+    /// 1..=4 conditionals, in upstream emission order; the lookup expression is
+    /// `!!c0 << (n-1) | … | !!c(n-1) << 0` over the conditionals in arg order
+    Table(Vec<(u32, T)>),
+    /// keep the runtime call; consume with StyleVarsCollector for DCE
+    Bail { bail_out_index: Option<usize> },
+}
+
+// parity: stylex-props.js argument loop (bail policy, conditional cap of 4,
+// enableInlinedConditionalMerge gate).
+pub fn plan_merge(
+    args: &[MergeArg],
+    mode: MergeMode,
+    options: &ResolvedOptions,
+) -> Result<MergePlan<JsObjectMap>, StylexError> {
+    plan_with(args, options, false, |values| match mode {
+        MergeMode::Props => merge_props(&values),
+        MergeMode::Attrs => merge_attrs(&values),
+    })
+}
+
+/// parity: stylex-merge.js — the same loop, except it breaks on the first bail,
+/// which makes `bailOutIndex` differ from props on some argument lists.
+pub fn plan_legacy_merge(
+    args: &[MergeArg],
+    options: &ResolvedOptions,
+) -> Result<MergePlan<String>, StylexError> {
+    plan_with(args, options, true, |values| merge_legacy(&values))
+}
+
+fn plan_with<T>(
+    args: &[MergeArg],
+    options: &ResolvedOptions,
+    stop_on_first_bail: bool,
+    merge: impl Fn(Vec<EvalValue>) -> Result<T, StylexError>,
+) -> Result<MergePlan<T>, StylexError> {
+    enum Resolved {
+        Static(EvalValue),
+        Conditional(EvalValue, EvalValue),
+    }
+    let mut bail = false;
+    let mut bail_out_index: Option<usize> = None;
+    let mut conditional = 0usize;
+    let mut resolved: Vec<Resolved> = Vec::new();
+
+    let to_value = |style: &NullableStyle| match style {
+        NullableStyle::Null => EvalValue::Null,
+        NullableStyle::Style(v) => v.clone(),
+        NullableStyle::Other => unreachable!("Other never reaches merging"),
+    };
+
+    for (index, arg) in args.iter().enumerate() {
+        match arg {
+            MergeArg::Resolved(NullableStyle::Other) | MergeArg::Unsupported => {
+                bail_out_index.get_or_insert(index);
+                bail = true;
+            }
+            MergeArg::Resolved(style) => resolved.push(Resolved::Static(to_value(style))),
+            MergeArg::Conditional { primary, fallback } => {
+                if primary == &NullableStyle::Other || fallback == &NullableStyle::Other {
+                    bail_out_index.get_or_insert(index);
+                    bail = true;
+                } else {
+                    resolved.push(Resolved::Conditional(to_value(primary), to_value(fallback)));
+                    conditional += 1;
+                }
+            }
+            MergeArg::LogicalAnd { left, right } => {
+                // Inlining needs a non-static left (the runtime test) and a static right.
+                if left != &NullableStyle::Other || right == &NullableStyle::Other {
+                    bail_out_index.get_or_insert(index);
+                    bail = true;
+                } else {
+                    resolved.push(Resolved::Conditional(to_value(right), EvalValue::Null));
+                    conditional += 1;
+                }
+            }
+            MergeArg::NonAndLogical => {
+                // Upstream overwrites bailOutIndex here (no null guard) and breaks.
+                bail_out_index = Some(index);
+                bail = true;
+                break;
+            }
+        }
+        if conditional > 4 {
+            bail = true;
+        }
+        if bail && stop_on_first_bail {
+            break;
+        }
+    }
+    if !options.enable_inlined_conditional_merge && conditional > 0 {
+        bail = true;
+    }
+    if bail {
+        return Ok(MergePlan::Bail { bail_out_index });
+    }
+
+    if conditional == 0 {
+        let values = resolved
+            .iter()
+            .map(|r| match r {
+                Resolved::Static(v) => v.clone(),
+                Resolved::Conditional(..) => unreachable!("conditional == 0"),
+            })
+            .collect();
+        return Ok(MergePlan::Inlined(merge(values)?));
+    }
+
+    let mut entries = Vec::with_capacity(1 << conditional);
+    for i in 0u32..(1 << conditional) {
+        let mut bit = 0u32;
+        let mut key = 0u32;
+        let values: Vec<EvalValue> = resolved
+            .iter()
+            .map(|r| match r {
+                Resolved::Static(v) => v.clone(),
+                Resolved::Conditional(primary, fallback) => {
+                    let taken = (i >> bit) & 1 == 1;
+                    bit += 1;
+                    if taken {
+                        primary.clone()
+                    } else {
+                        fallback.clone()
+                    }
+                }
+            })
+            .collect();
+        for j in 0..conditional {
+            key = (key << 1) | ((i >> j) & 1);
+        }
+        entries.push((key, merge(values)?));
+    }
+    Ok(MergePlan::Table(entries))
+}
+
+/// Runtime `props(...args)` over evaluated values; args are one level flat
+/// (styleq flattens nested arrays itself).
+pub fn merge_props(args: &[EvalValue]) -> Result<JsObjectMap, StylexError> {
+    let (class_name, inline_style, debug) = styleq(args)?;
+    let mut result = JsObjectMap::new();
+    if !class_name.is_empty() {
+        result.insert("className", EvalValue::Str(class_name));
+    }
+    if let Some(style) = inline_style
+        && !style.is_empty()
+    {
+        result.insert("style", EvalValue::Obj(style.into()));
+    }
+    // `dataStyleSrc != null && dataStyleSrc !== ''` keeps non-string debug
+    // values (a `$$css: false` chunk stays boolean).
+    let keep_debug = match &debug {
+        EvalValue::Str(s) => !s.is_empty(),
+        EvalValue::Null | EvalValue::Undefined => false,
+        _ => true,
+    };
+    if keep_debug {
+        result.insert("data-style-src", debug);
+    }
+    Ok(result)
+}
+
+/// Runtime `attrs(...args)`: props reshaped, with the style object serialized.
+pub fn merge_attrs(args: &[EvalValue]) -> Result<JsObjectMap, StylexError> {
+    let props = merge_props(args)?;
+    let mut result = JsObjectMap::new();
+    if let Some(class_name) = props.get("className") {
+        result.insert("class", class_name.clone());
+    }
+    if let Some(EvalValue::Obj(style)) = props.get("style") {
+        let serialized: Vec<String> = style
+            .entries()
+            .map(|(k, v)| format!("{}:{}", to_kebab_case(k), js_to_string(v)))
+            .collect();
+        result.insert("style", EvalValue::Str(serialized.join(";")));
+    }
+    if let Some(debug) = props.get("data-style-src") {
+        result.insert("data-style-src", debug.clone());
+    }
+    Ok(result)
+}
+
+/// Runtime `legacyMerge(...args)`: `styleq(args)[0]`. The inline-style object
+/// and the debug source string are discarded, empty string included.
+pub fn merge_legacy(args: &[EvalValue]) -> Result<String, StylexError> {
+    Ok(styleq(args)?.0)
+}
+
+// parity: styleq@0.2.1 (cache-free path; the WeakMap cache is behaviorally
+// transparent for identical style sequences).
+fn styleq(args: &[EvalValue]) -> Result<(String, Option<JsObjectMap>, EvalValue), StylexError> {
+    let mut defined: Vec<String> = Vec::new();
+    let mut class_name = String::new();
+    let mut inline_style: Option<JsObjectMap> = None;
+    let mut debug = EvalValue::Str(String::new());
+    let mut stack: Vec<EvalValue> = args.to_vec();
+
+    while let Some(style) = stack.pop() {
+        match style {
+            EvalValue::Null | EvalValue::Undefined | EvalValue::Bool(false) => {}
+            EvalValue::Arr(items) => stack.extend(items),
+            // `true` and numbers have no enumerable own props upstream.
+            EvalValue::Bool(true) | EvalValue::Num(_) => {}
+            // styleq's `for..in` over a primitive string enumerates its
+            // UTF-16 index keys ({0: 'a', 1: 'b'}) down the inline branch.
+            EvalValue::Str(s) => {
+                let mut sub_style = JsObjectMap::new();
+                for (i, unit) in s.encode_utf16().enumerate() {
+                    let prop = i.to_string();
+                    if defined.contains(&prop) {
+                        continue;
+                    }
+                    let value = String::from_utf16(&[unit])
+                        .map_err(|_| StylexError::lone_surrogate("a styleq string argument"))?;
+                    sub_style.insert(&prop, EvalValue::Str(value));
+                    defined.push(prop);
+                }
+                if !sub_style.is_empty() {
+                    if let Some(prev) = inline_style.take() {
+                        for (k, v) in prev.entries() {
+                            sub_style.insert(k, v.clone());
+                        }
+                    }
+                    inline_style = Some(sub_style);
+                }
+            }
+            EvalValue::Obj(style) => {
+                let is_compiled = style
+                    .get("$$css")
+                    .is_some_and(|v| !matches!(v, EvalValue::Null | EvalValue::Undefined));
+                if is_compiled {
+                    let mut chunk = String::new();
+                    for (prop, value) in style.entries() {
+                        if prop == "$$css" {
+                            if !matches!(value, EvalValue::Bool(true)) {
+                                debug = if js_truthy(&debug) {
+                                    EvalValue::Str(format!(
+                                        "{}; {}",
+                                        js_to_string(value),
+                                        js_to_string(&debug)
+                                    ))
+                                } else {
+                                    value.clone()
+                                };
+                            }
+                            continue;
+                        }
+                        match value {
+                            EvalValue::Str(s) if !defined.iter().any(|d| d == prop) => {
+                                defined.push(prop.to_string());
+                                if !chunk.is_empty() {
+                                    chunk.push(' ');
+                                }
+                                chunk.push_str(s);
+                            }
+                            EvalValue::Null if !defined.iter().any(|d| d == prop) => {
+                                defined.push(prop.to_string());
+                            }
+                            // other value types: styleq logs and skips
+                            _ => {}
+                        }
+                    }
+                    if !chunk.is_empty() {
+                        class_name = if class_name.is_empty() {
+                            chunk
+                        } else {
+                            format!("{chunk} {class_name}")
+                        };
+                    }
+                } else {
+                    let mut sub_style = JsObjectMap::new();
+                    for (prop, value) in style.entries() {
+                        if matches!(value, EvalValue::Undefined) {
+                            continue;
+                        }
+                        if defined.iter().any(|d| d == prop) {
+                            continue;
+                        }
+                        if !matches!(value, EvalValue::Null) {
+                            sub_style.insert(prop, value.clone());
+                        }
+                        defined.push(prop.to_string());
+                    }
+                    if !sub_style.is_empty() {
+                        if let Some(prev) = inline_style.take() {
+                            for (k, v) in prev.entries() {
+                                sub_style.insert(k, v.clone());
+                            }
+                        }
+                        inline_style = Some(sub_style);
+                    }
+                }
+            }
+        }
+    }
+    Ok((class_name, inline_style, debug))
+}
+
+// ---- styleVarsToKeep (the bail path's DCE contract) ----
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NonNullProps {
+    /// keep every prop of the namespace
+    True,
+    /// null-valued props outside this list may be pruned
+    Props(Vec<String>),
+}
+
+/// One `state.styleVarsToKeep` tuple: `[objName, propName | true, nonNullProps]`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StyleVarToKeep {
+    pub var_name: String,
+    /// `None` mirrors the literal `true` (keep all namespaces).
+    pub namespace: Option<String>,
+    pub non_null_props: NonNullProps,
+}
+
+/// The member-expression evaluation outcome: NonStatic covers `!confident`,
+/// nullish results, and cross-file proxies.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MemberEval {
+    NonStatic,
+    Value(EvalValue),
+}
+
+/// Bail-path per-member accumulator: callers record each unflattened argument's
+/// members in traversal order. parity: stylex-props.js bailOut MemberExpression.
+#[derive(Debug)]
+pub struct StyleVarsCollector {
+    bail_out_index: Option<usize>,
+    acc: NonNullProps,
+}
+
+impl StyleVarsCollector {
+    pub fn new(bail_out_index: Option<usize>) -> Self {
+        Self {
+            bail_out_index,
+            acc: NonNullProps::Props(Vec::new()),
+        }
+    }
+
+    /// `style_map_member` = (objName, propName) for tracked style maps (None =
+    /// computed non-literal prop); `eval` runs lazily like upstream's evaluate().
+    pub fn record(
+        &mut self,
+        arg_index: usize,
+        style_map_member: Option<(&str, Option<&str>)>,
+        eval: impl FnOnce() -> MemberEval,
+    ) -> Option<StyleVarToKeep> {
+        if self.bail_out_index.is_some_and(|b| arg_index > b) {
+            self.acc = NonNullProps::True;
+        }
+        let style_non_null = if self.acc == NonNullProps::True {
+            NonNullProps::True
+        } else {
+            match eval() {
+                MemberEval::NonStatic => {
+                    self.acc = NonNullProps::True;
+                    NonNullProps::True
+                }
+                MemberEval::Value(value) => {
+                    // Snapshot BEFORE extending: each tuple carries the props
+                    // accumulated from previously-visited members only.
+                    let NonNullProps::Props(list) = &mut self.acc else {
+                        unreachable!("acc checked above");
+                    };
+                    let snapshot = NonNullProps::Props(list.clone());
+                    list.extend(non_null_keys(&value));
+                    snapshot
+                }
+            }
+        };
+        style_map_member.map(|(var_name, namespace)| StyleVarToKeep {
+            var_name: var_name.to_string(),
+            namespace: namespace.map(str::to_string),
+            non_null_props: style_non_null,
+        })
+    }
+}
+
+// `Object.keys(styleValue).filter((key) => styleValue[key] !== null)` — note
+// undefined values pass the !== null filter.
+fn non_null_keys(value: &EvalValue) -> Vec<String> {
+    match value {
+        EvalValue::Obj(map) => map
+            .entries()
+            .filter(|(_, v)| !matches!(v, EvalValue::Null))
+            .map(|(k, _)| k.to_string())
+            .collect(),
+        EvalValue::Arr(items) => (0..items.len())
+            .filter(|i| !matches!(items[*i], EvalValue::Null))
+            .map(|i| i.to_string())
+            .collect(),
+        EvalValue::Str(s) => (0..s.encode_utf16().count())
+            .map(|i| i.to_string())
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn js_truthy(value: &EvalValue) -> bool {
+    match value {
+        EvalValue::Null | EvalValue::Undefined | EvalValue::Bool(false) => false,
+        EvalValue::Bool(true) | EvalValue::Obj(_) | EvalValue::Arr(_) => true,
+        EvalValue::Str(s) => !s.is_empty(),
+        EvalValue::Num(n) => *n != 0.0 && !n.is_nan(),
+    }
+}
+
+// JS template-literal coercion (`${value}`).
+fn js_to_string(value: &EvalValue) -> String {
+    match value {
+        EvalValue::Str(s) => s.clone(),
+        EvalValue::Num(n) => js_number_to_string(*n),
+        EvalValue::Bool(b) => b.to_string(),
+        EvalValue::Null => "null".to_string(),
+        EvalValue::Undefined => "undefined".to_string(),
+        EvalValue::Obj(_) => "[object Object]".to_string(),
+        EvalValue::Arr(items) => items
+            .iter()
+            .map(|v| match v {
+                EvalValue::Null | EvalValue::Undefined => String::new(),
+                other => js_to_string(other),
+            })
+            .collect::<Vec<_>>()
+            .join(","),
+    }
+}
+
+// parity: runtime toKebabCase — `str.replace(/([A-Z])/g, '-$1').toLowerCase()`.
+// Whole-string lowercasing keeps ES final-sigma context ("ΟΣ" → "ος").
+fn to_kebab_case(s: &str) -> String {
+    let mut dashed = String::with_capacity(s.len() + 4);
+    for c in s.chars() {
+        if c.is_ascii_uppercase() {
+            dashed.push('-');
+        }
+        dashed.push(c);
+    }
+    dashed.to_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(v: &str) -> EvalValue {
+        EvalValue::Str(v.to_string())
+    }
+
+    fn obj(entries: &[(&str, EvalValue)]) -> EvalValue {
+        EvalValue::Obj(
+            entries
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), v.clone()))
+                .collect::<JsObjectMap>()
+                .into(),
+        )
+    }
+
+    fn compiled(entries: &[(&str, EvalValue)]) -> EvalValue {
+        let mut all: Vec<(&str, EvalValue)> = entries.to_vec();
+        all.push(("$$css", EvalValue::Bool(true)));
+        obj(&all)
+    }
+
+    // The `styles` fixture from the oracle probes 2026-08-27:
+    // a: color red + marginStart 4, b: color blue + width 10, c: color null + width 20.
+    fn ns_a() -> EvalValue {
+        compiled(&[("kMwMTN", s("x1e2nbdu")), ("keTefX", s("xdwrcjd"))])
+    }
+    fn ns_b() -> EvalValue {
+        compiled(&[("kMwMTN", s("xju2f9n")), ("kzqmXN", s("x1fsd2vl"))])
+    }
+    fn ns_c() -> EvalValue {
+        compiled(&[("kMwMTN", EvalValue::Null), ("kzqmXN", s("xw4jnvo"))])
+    }
+
+    fn class_of(result: &JsObjectMap) -> Option<String> {
+        result.get("className").map(|v| match v {
+            EvalValue::Str(s) => s.clone(),
+            _ => panic!("className must be a string"),
+        })
+    }
+
+    #[test]
+    fn last_wins_and_null_deletes() {
+        let merged = merge_props(&[ns_a(), ns_b()]).unwrap();
+        assert_eq!(
+            class_of(&merged).as_deref(),
+            Some("xdwrcjd xju2f9n x1fsd2vl")
+        );
+        let merged = merge_props(&[ns_a(), ns_c()]).unwrap();
+        assert_eq!(class_of(&merged).as_deref(), Some("xdwrcjd xw4jnvo"));
+        assert_eq!(merge_props(&[ns_c()]).unwrap().len(), 1);
+        let c_only: JsObjectMap = [("kMwMTN".to_string(), EvalValue::Null)]
+            .into_iter()
+            .collect();
+        let mut with_css = c_only;
+        with_css.insert("$$css", EvalValue::Bool(true));
+        assert!(
+            merge_props(&[EvalValue::Obj(with_css.into())])
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn array_args_flatten_lifo() {
+        let merged = merge_props(&[EvalValue::Arr(vec![ns_a(), ns_b()])]).unwrap();
+        assert_eq!(
+            class_of(&merged).as_deref(),
+            Some("xdwrcjd xju2f9n x1fsd2vl")
+        );
+    }
+
+    #[test]
+    fn inline_styles_merge_and_shadow() {
+        // props(styles.a, { kMwMTN: 'z' }) — oracle: className xdwrcjd, style {kMwMTN: z}.
+        let merged = merge_props(&[ns_a(), obj(&[("kMwMTN", s("z"))])]).unwrap();
+        assert_eq!(class_of(&merged).as_deref(), Some("xdwrcjd"));
+        assert_eq!(merged.get("style"), Some(&obj(&[("kMwMTN", s("z"))])));
+        // Two inline objects: first arg's key order, later values win.
+        let merged = merge_props(&[
+            obj(&[("color", s("x")), ("width", EvalValue::Num(1.0))]),
+            obj(&[("color", s("y")), ("height", EvalValue::Num(2.0))]),
+        ])
+        .unwrap();
+        let EvalValue::Obj(style) = merged.get("style").unwrap() else {
+            panic!("style object expected");
+        };
+        assert_eq!(
+            style.keys().collect::<Vec<_>>(),
+            vec!["width", "color", "height"]
+        );
+        assert_eq!(style.get("color"), Some(&s("y")));
+    }
+
+    #[test]
+    fn debug_strings_join_in_source_order() {
+        let a = obj(&[("k1", s("c1")), ("$$css", s("f.ts:3"))]);
+        let b = obj(&[("k2", s("c2")), ("$$css", s("f.ts:4"))]);
+        let merged = merge_props(&[a, b]).unwrap();
+        assert_eq!(merged.get("data-style-src"), Some(&s("f.ts:3; f.ts:4")));
+        // Oracle-pinned quirk: `$$css: false` chunks survive as booleans.
+        let weird = obj(&[("$$css", EvalValue::Bool(false)), ("foo", s("bar"))]);
+        let merged = merge_props(&[weird]).unwrap();
+        assert_eq!(class_of(&merged).as_deref(), Some("bar"));
+        assert_eq!(merged.get("data-style-src"), Some(&EvalValue::Bool(false)));
+    }
+
+    #[test]
+    fn string_args_enumerate_utf16_indices() {
+        // parity: styleq's for..in over a primitive string — oracle emits
+        // {style: {"0": "a", "1": "b"}} for props(['ab']).
+        let merged = merge_props(&[s("ab")]).unwrap();
+        let EvalValue::Obj(style) = merged.get("style").unwrap() else {
+            panic!("style object expected");
+        };
+        assert_eq!(style.get("0"), Some(&s("a")));
+        assert_eq!(style.get("1"), Some(&s("b")));
+        assert!(merge_props(&[s("")]).unwrap().is_empty());
+        // Index keys already defined by a later-popped arg stay first-wins.
+        let merged = merge_props(&[s("xy"), s("ab")]).unwrap();
+        let EvalValue::Obj(style) = merged.get("style").unwrap() else {
+            panic!("style object expected");
+        };
+        assert_eq!(style.get("0"), Some(&s("a")));
+        // Divergence pin (rust rejects more): astral chars would split into
+        // lone surrogates upstream; we hard-error instead of corrupting.
+        let err = merge_props(&[s("😀")]).unwrap_err();
+        assert_eq!(err.code, crate::errors::ErrorCode::UnsupportedApi);
+    }
+
+    #[test]
+    fn kebab_case_lowercases_whole_string() {
+        // Oracle probe 2026-08-28: attrs({'ΟΣ': 'v'}) → style "ος:v" (final sigma).
+        let merged = merge_attrs(&[obj(&[("ΟΣ", s("v"))])]).unwrap();
+        assert_eq!(merged.get("style"), Some(&s("ος:v")));
+        let merged = merge_attrs(&[obj(&[("backgroundColor", s("red"))])]).unwrap();
+        assert_eq!(merged.get("style"), Some(&s("background-color:red")));
+    }
+
+    #[test]
+    fn attrs_reshapes_and_serializes() {
+        let merged = merge_attrs(&[ns_a(), ns_b()]).unwrap();
+        assert_eq!(merged.get("class"), Some(&s("xdwrcjd xju2f9n x1fsd2vl")));
+        let merged = merge_attrs(&[
+            ns_a(),
+            obj(&[
+                ("width", EvalValue::Num(5.0)),
+                ("backgroundColor", s("red")),
+            ]),
+        ])
+        .unwrap();
+        assert_eq!(
+            merged.get("style"),
+            Some(&s("width:5;background-color:red"))
+        );
+        // Whole-map arg: object values coerce like the runtime template literal.
+        let whole = obj(&[("a", ns_a())]);
+        let merged = merge_attrs(&[whole]).unwrap();
+        assert_eq!(merged.get("style"), Some(&s("a:[object Object]")));
+    }
+
+    #[test]
+    fn plan_table_orders_keys_bit_reversed() {
+        let options = ResolvedOptions::default();
+        // props(x ? a : null, y && b) — oracle emits keys 0, 2, 1, 3.
+        let args = [
+            MergeArg::Conditional {
+                primary: NullableStyle::Style(ns_a()),
+                fallback: NullableStyle::Null,
+            },
+            MergeArg::LogicalAnd {
+                left: NullableStyle::Other,
+                right: NullableStyle::Style(ns_b()),
+            },
+        ];
+        let MergePlan::Table(entries) = plan_merge(&args, MergeMode::Props, &options).unwrap()
+        else {
+            panic!("expected table");
+        };
+        let keys: Vec<u32> = entries.iter().map(|(k, _)| *k).collect();
+        assert_eq!(keys, vec![0, 2, 1, 3]);
+        assert!(entries[0].1.is_empty());
+        assert_eq!(class_of(&entries[1].1).as_deref(), Some("x1e2nbdu xdwrcjd"));
+        assert_eq!(class_of(&entries[2].1).as_deref(), Some("xju2f9n x1fsd2vl"));
+        assert_eq!(
+            class_of(&entries[3].1).as_deref(),
+            Some("xdwrcjd xju2f9n x1fsd2vl")
+        );
+    }
+
+    #[test]
+    fn plan_bail_policies() {
+        let options = ResolvedOptions::default();
+        let cond = |v: EvalValue| MergeArg::Conditional {
+            primary: NullableStyle::Style(v),
+            fallback: NullableStyle::Null,
+        };
+        // five conditionals
+        let args: Vec<MergeArg> = (0..5).map(|_| cond(ns_a())).collect();
+        assert_eq!(
+            plan_merge(&args, MergeMode::Props, &options).unwrap(),
+            MergePlan::Bail {
+                bail_out_index: None
+            }
+        );
+        // non-static arg records the first bail index
+        let args = [
+            MergeArg::Resolved(NullableStyle::Style(ns_a())),
+            MergeArg::Resolved(NullableStyle::Other),
+            MergeArg::Resolved(NullableStyle::Other),
+        ];
+        assert_eq!(
+            plan_merge(&args, MergeMode::Props, &options).unwrap(),
+            MergePlan::Bail {
+                bail_out_index: Some(1)
+            }
+        );
+        // non-&& logical overwrites the index and stops parsing
+        let args = [
+            MergeArg::Resolved(NullableStyle::Other),
+            MergeArg::NonAndLogical,
+            MergeArg::Resolved(NullableStyle::Style(ns_a())),
+        ];
+        assert_eq!(
+            plan_merge(&args, MergeMode::Props, &options).unwrap(),
+            MergePlan::Bail {
+                bail_out_index: Some(1)
+            }
+        );
+        // static left of && bails
+        let args = [MergeArg::LogicalAnd {
+            left: NullableStyle::Style(ns_a()),
+            right: NullableStyle::Style(ns_b()),
+        }];
+        assert_eq!(
+            plan_merge(&args, MergeMode::Props, &options).unwrap(),
+            MergePlan::Bail {
+                bail_out_index: Some(0)
+            }
+        );
+        // flag off + any conditional bails
+        let flag_off = ResolvedOptions {
+            enable_inlined_conditional_merge: false,
+            ..ResolvedOptions::default()
+        };
+        assert_eq!(
+            plan_merge(&[cond(ns_a())], MergeMode::Props, &flag_off).unwrap(),
+            MergePlan::Bail {
+                bail_out_index: None
+            }
+        );
+    }
+
+    #[test]
+    fn legacy_projects_styleq_to_the_class_name_only() {
+        assert_eq!(
+            merge_legacy(&[ns_a(), ns_b()]).unwrap(),
+            "xdwrcjd xju2f9n x1fsd2vl"
+        );
+        // Empty merges keep the empty string props() would have dropped.
+        assert_eq!(merge_legacy(&[]).unwrap(), "");
+        let only_null = compiled(&[("kMwMTN", EvalValue::Null)]);
+        assert_eq!(merge_legacy(&[only_null]).unwrap(), "");
+        // The debug channel props() surfaces as data-style-src is discarded.
+        let debug = obj(&[("k1", s("c1")), ("$$css", s("f.ts:3"))]);
+        assert_eq!(merge_legacy(&[debug]).unwrap(), "c1");
+    }
+
+    #[test]
+    fn legacy_plan_stops_at_the_first_bail() {
+        let options = ResolvedOptions::default();
+        // legacy(styles.a, other, flag || styles.e): legacy records index 1,
+        // props keeps scanning and the non-&& logical overwrites it with 2.
+        let args = [
+            MergeArg::Resolved(NullableStyle::Style(ns_a())),
+            MergeArg::Resolved(NullableStyle::Other),
+            MergeArg::NonAndLogical,
+        ];
+        assert_eq!(
+            plan_legacy_merge(&args, &options).unwrap(),
+            MergePlan::Bail {
+                bail_out_index: Some(1)
+            }
+        );
+        assert_eq!(
+            plan_merge(&args, MergeMode::Props, &options).unwrap(),
+            MergePlan::Bail {
+                bail_out_index: Some(2)
+            }
+        );
+    }
+
+    #[test]
+    fn legacy_plan_leaves_are_strings() {
+        let options = ResolvedOptions::default();
+        assert_eq!(
+            plan_legacy_merge(
+                &[MergeArg::Resolved(NullableStyle::Style(ns_a()))],
+                &options
+            )
+            .unwrap(),
+            MergePlan::Inlined("x1e2nbdu xdwrcjd".to_string())
+        );
+        let args = [MergeArg::Conditional {
+            primary: NullableStyle::Style(ns_a()),
+            fallback: NullableStyle::Null,
+        }];
+        assert_eq!(
+            plan_legacy_merge(&args, &options).unwrap(),
+            MergePlan::Table(vec![
+                (0, String::new()),
+                (1, "x1e2nbdu xdwrcjd".to_string())
+            ])
+        );
+        // Five conditionals blow the cap before any argument bails, so the
+        // index stays unset even though legacy breaks out of the loop.
+        let args: Vec<MergeArg> = (0..5)
+            .map(|_| MergeArg::Conditional {
+                primary: NullableStyle::Style(ns_a()),
+                fallback: NullableStyle::Null,
+            })
+            .collect();
+        assert_eq!(
+            plan_legacy_merge(&args, &options).unwrap(),
+            MergePlan::Bail {
+                bail_out_index: None
+            }
+        );
+    }
+
+    #[test]
+    fn collector_mirrors_upstream_accumulator() {
+        // props(styles.a, ext, styles.c) — bailOutIndex 1 (oracle: c keeps its null prop).
+        let mut collector = StyleVarsCollector::new(Some(1));
+        let kept = collector
+            .record(0, Some(("styles", Some("a"))), || MemberEval::Value(ns_a()))
+            .unwrap();
+        assert_eq!(kept.non_null_props, NonNullProps::Props(vec![]));
+        let kept = collector
+            .record(2, Some(("styles", Some("c"))), || {
+                panic!("eval must not run past the bail index")
+            })
+            .unwrap();
+        assert_eq!(kept.non_null_props, NonNullProps::True);
+
+        // props(ext, styles.c), bail at 0: members past the bail index keep
+        // everything (oracle keeps c's null prop here).
+        let mut collector = StyleVarsCollector::new(Some(0));
+        let kept = collector
+            .record(1, Some(("styles", Some("c"))), || MemberEval::Value(ns_c()))
+            .unwrap();
+        assert_eq!(kept.non_null_props, NonNullProps::True);
+
+        // Non-static member poisons the accumulator globally.
+        let mut collector = StyleVarsCollector::new(None);
+        assert!(
+            collector
+                .record(0, None, || MemberEval::NonStatic)
+                .is_none()
+        );
+        let kept = collector
+            .record(0, Some(("styles", None)), || panic!("acc is already true"))
+            .unwrap();
+        assert_eq!(kept.namespace, None);
+        assert_eq!(kept.non_null_props, NonNullProps::True);
+
+        // Snapshot-before-extend: the second member sees the first's keys only.
+        let mut collector = StyleVarsCollector::new(None);
+        collector.record(0, Some(("styles", Some("c"))), || MemberEval::Value(ns_c()));
+        let kept = collector
+            .record(1, Some(("styles", Some("a"))), || MemberEval::Value(ns_a()))
+            .unwrap();
+        // Object.keys includes $$css: true (non-null), so it lands in the list.
+        assert_eq!(
+            kept.non_null_props,
+            NonNullProps::Props(vec!["kzqmXN".to_string(), "$$css".to_string()])
+        );
+    }
+}

--- a/crates/stylex/src/transform/visitor.rs
+++ b/crates/stylex/src/transform/visitor.rs
@@ -1,0 +1,3835 @@
+//! Whole-module transform: call-site discovery in babel visitor order, splice
+//! edits, DCE, treeshake compensation. parity: babel-plugin src/index.js:71-386
+
+use std::cell::Cell;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use oxc_ast::ast::{
+    Argument, ArrayExpressionElement, BindingPattern, CallExpression, ChainElement, ClassElement,
+    Declaration, ExportDefaultDeclarationKind, Expression, ForStatementInit, ForStatementLeft,
+    Function, JSXAttribute, JSXAttributeItem, JSXAttributeName, JSXAttributeValue, JSXChild,
+    JSXElement, JSXElementName, JSXExpression, JSXFragment, JSXOpeningElement, ModuleExportName,
+    ObjectPropertyKind, Program, SimpleAssignmentTarget, Statement, TSNamespaceDeclarationBody,
+    VariableDeclaration,
+};
+use oxc_span::{GetSpan, Span};
+
+use crate::errors::StylexError;
+use crate::eval::functions::{
+    EvalCallables, StylexCallable, coerce_vars_keyframes_frames, vars_registry,
+};
+use crate::eval::value::{EvalValue, JsObjectMap};
+use crate::eval::{
+    EvalOutcome, Evaluator, FunctionRegistry, JsValue, evaluate_stylex_create_arg, from_eval_value,
+    is_nullish, to_eval_value, unwrap_parens, validate_create_arg,
+};
+use crate::imports::StylexNamedImport;
+use crate::jsrt::js_number_to_string;
+use crate::module_resolution::{
+    FsProvider, canonical_file_path, matches_file_suffix, node_basename, rewritten_import_source,
+};
+use crate::options::ModuleResolutionType;
+use crate::rules::{StylexRule, non_finite_to_tag};
+use crate::shared::create::{CreateContext, INLINE_NAMESPACE, compile_atom, compile_namespaces};
+use crate::shared::create_theme::{apply_theme_dev_naming, create_theme};
+use crate::shared::define_consts::define_consts;
+use crate::shared::define_vars::{define_vars, define_vars_core};
+use crate::shared::dynamic::{compile_dynamic_namespace, inherit_rules};
+use crate::shared::keyframes::keyframes;
+use crate::shared::markers::{default_marker_object, define_marker_object};
+use crate::shared::nested::{
+    define_consts_nested, flatten_nested_consts_config, flatten_nested_overrides_config,
+    flatten_nested_string_config, flatten_nested_vars_config, nest_define_vars_js_output,
+};
+use crate::shared::position_try::{position_try, position_try_shared};
+use crate::shared::types::create_css_type;
+use crate::shared::view_transition::view_transition_class;
+use crate::shared::when::{WhenRelation, when_selector};
+use crate::state::CompileState;
+use crate::transform::ast_backend::{
+    AstPlan, DynamicEntry, HoistValue, InsertOp, JsxOp, PrologueStmt, RemoveOp, SynthExpr,
+    SynthStmt,
+};
+use crate::transform::atoms::{AtomStyle, dynamic_style, static_style};
+use crate::transform::dce::{DceAction, compute_vars_to_keep, dce_action};
+use crate::transform::js_out::{
+    Edit, SpliceMap, apply_edits_tracked, is_identifier_key, js_string_literal,
+    print_dynamic_arrow, print_inject_arg, print_static_chunk, render_span, write_value,
+};
+use crate::transform::merge::{
+    MemberEval, MergeArg, MergeMode, MergePlan, NullableStyle, StyleVarToKeep, StyleVarsCollector,
+    plan_legacy_merge, plan_merge,
+};
+
+// ---------------------------------------------------------------------------
+// Compile-time callables (the create-evaluation FunctionConfig implementations)
+
+pub struct RealCallables;
+
+impl EvalCallables for RealCallables {
+    fn call(
+        &self,
+        callee: &StylexCallable,
+        args: &[EvalValue],
+        state: &mut CompileState<'_>,
+    ) -> Result<EvalValue, StylexError> {
+        match callee {
+            StylexCallable::Keyframes => {
+                let frames = args.first().cloned().unwrap_or(EvalValue::Undefined);
+                let (name, rule) = keyframes(&frames, state.options)?;
+                state.record_other_injected_rule(rule);
+                Ok(EvalValue::Str(name))
+            }
+            StylexCallable::FirstThatWorks => first_that_works(args),
+            StylexCallable::DefaultMarker => {
+                Ok(EvalValue::Obj(default_marker_object(state.options).into()))
+            }
+            StylexCallable::WhenAncestor
+            | StylexCallable::WhenDescendant
+            | StylexCallable::WhenSiblingBefore
+            | StylexCallable::WhenSiblingAfter
+            | StylexCallable::WhenAnySibling => {
+                let relation = match callee {
+                    StylexCallable::WhenAncestor => WhenRelation::Ancestor,
+                    StylexCallable::WhenDescendant => WhenRelation::Descendant,
+                    StylexCallable::WhenSiblingBefore => WhenRelation::SiblingBefore,
+                    StylexCallable::WhenSiblingAfter => WhenRelation::SiblingAfter,
+                    _ => WhenRelation::AnySibling,
+                };
+                let Some(EvalValue::Str(pseudo)) = args.first() else {
+                    return Err(StylexError::upstream_type_crash(
+                        "a non-string when.* pseudo selector",
+                    ));
+                };
+                when_selector(relation, pseudo, args.get(1), state.options).map(EvalValue::Str)
+            }
+            StylexCallable::PositionTry => {
+                let styles = args.first().cloned().unwrap_or(EvalValue::Undefined);
+                let (name, rule) = position_try_shared(&styles, state.options)?;
+                state.record_other_injected_rule(rule);
+                Ok(EvalValue::Str(name))
+            }
+            StylexCallable::Conditional => {
+                Ok(args.first().cloned().unwrap_or(EvalValue::Undefined))
+            }
+            StylexCallable::Types(_) => Err(StylexError::unsupported_api("types.*")),
+        }
+    }
+}
+
+/// Theming-visitor FunctionConfig callables: keyframes skips visitor-level
+/// validation there, and `types.*` builds compile-time CSSType values.
+pub struct VarsCallables;
+
+impl EvalCallables for VarsCallables {
+    fn call(
+        &self,
+        callee: &StylexCallable,
+        args: &[EvalValue],
+        state: &mut CompileState<'_>,
+    ) -> Result<EvalValue, StylexError> {
+        match callee {
+            StylexCallable::Keyframes => {
+                let raw = args.first().cloned().unwrap_or(EvalValue::Undefined);
+                let frames = coerce_vars_keyframes_frames(&raw)?;
+                let (name, rule) = keyframes(&frames, state.options)?;
+                state.record_other_injected_rule(rule);
+                Ok(EvalValue::Str(name))
+            }
+            StylexCallable::Types(kind) => create_css_type(kind, args),
+            StylexCallable::FirstThatWorks => first_that_works(args),
+            other => RealCallables.call(other, args, state),
+        }
+    }
+}
+
+// parity: shared/stylex-first-that-works.js (exact truncation + reduce shape)
+fn is_var_arg(value: &EvalValue) -> bool {
+    let EvalValue::Str(s) = value else {
+        return false;
+    };
+    let Some(body) = s.strip_prefix("var(--").and_then(|r| r.strip_suffix(')')) else {
+        return false;
+    };
+    !body.is_empty()
+        && body
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+fn first_that_works(args: &[EvalValue]) -> Result<EvalValue, StylexError> {
+    let Some(first_var) = args.iter().position(is_var_arg) else {
+        return Ok(EvalValue::Arr(args.iter().rev().cloned().collect()));
+    };
+    let priorities: Vec<EvalValue> = args[..first_var].iter().rev().cloned().collect();
+    let rest = &args[first_var..];
+    let first_non_var = rest.iter().position(|a| !is_var_arg(a));
+    let cut = first_non_var.map_or(rest.len(), |i| (i + 1).min(rest.len()));
+    let var_parts: Vec<&EvalValue> = rest[..cut].iter().rev().collect();
+
+    let mut so_far = String::new();
+    for part in var_parts {
+        let name: String = match part {
+            EvalValue::Str(s) if is_var_arg(part) => s[4..s.len() - 1].to_string(),
+            EvalValue::Str(s) => s.clone(),
+            EvalValue::Num(n) if !so_far.is_empty() => js_number_to_string(*n),
+            _ => {
+                return Err(StylexError::upstream_type_crash(
+                    "a non-string firstThatWorks argument",
+                ));
+            }
+        };
+        so_far = if !so_far.is_empty() {
+            format!("var({name}, {so_far})")
+        } else if name.starts_with("--") {
+            format!("var({name})")
+        } else {
+            name
+        };
+    }
+    let mut out = vec![EvalValue::Str(so_far)];
+    out.extend(priorities);
+    if out.len() == 1 {
+        Ok(out.pop().expect("one element"))
+    } else {
+        Ok(EvalValue::Arr(out))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Call-site classification
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CallKind {
+    Create,
+    Keyframes,
+    PositionTry,
+    ViewTransitionClass,
+    DefaultMarker,
+    DefineMarker,
+    DefineVars,
+    DefineConsts,
+    CreateTheme,
+    DefineVarsNested,
+    DefineConstsNested,
+    CreateThemeNested,
+    Props,
+    Attrs,
+    LegacyMerge,
+}
+
+// parity: each visitor's `property.type === 'Identifier'` check admits
+// computed members with identifier keys (`stylex[create]`), never literals.
+fn member_prop_name<'b>(callee: &'b Expression<'_>) -> Option<(&'b str, &'b str)> {
+    match unwrap_parens(callee) {
+        Expression::StaticMemberExpression(m) => match unwrap_parens(&m.object) {
+            Expression::Identifier(obj) => Some((obj.name.as_str(), m.property.name.as_str())),
+            _ => None,
+        },
+        Expression::ComputedMemberExpression(m) => {
+            match (unwrap_parens(&m.object), &m.expression) {
+                (Expression::Identifier(obj), Expression::Identifier(prop)) => {
+                    Some((obj.name.as_str(), prop.name.as_str()))
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn call_kind(call: &CallExpression<'_>, state: &CompileState<'_>) -> Option<CallKind> {
+    let imports = &state.imports;
+    if let Expression::Identifier(id) = unwrap_parens(&call.callee) {
+        let name = id.name.as_str();
+        if let Some(binding) = imports.named_binding(name) {
+            return Some(match binding {
+                StylexNamedImport::Create => CallKind::Create,
+                StylexNamedImport::Keyframes => CallKind::Keyframes,
+                StylexNamedImport::PositionTry => CallKind::PositionTry,
+                StylexNamedImport::ViewTransitionClass => CallKind::ViewTransitionClass,
+                StylexNamedImport::DefaultMarker => CallKind::DefaultMarker,
+                StylexNamedImport::DefineMarker => CallKind::DefineMarker,
+                StylexNamedImport::DefineVars => CallKind::DefineVars,
+                StylexNamedImport::DefineConsts => CallKind::DefineConsts,
+                StylexNamedImport::CreateTheme => CallKind::CreateTheme,
+                StylexNamedImport::DefineVarsNested => CallKind::DefineVarsNested,
+                StylexNamedImport::DefineConstsNested => CallKind::DefineConstsNested,
+                StylexNamedImport::CreateThemeNested => CallKind::CreateThemeNested,
+                StylexNamedImport::Props => CallKind::Props,
+                StylexNamedImport::Attrs => CallKind::Attrs,
+                _ => return None,
+            });
+        }
+        if imports.is_stylex_namespace(name) {
+            return Some(CallKind::LegacyMerge);
+        }
+        return None;
+    }
+    let (object, property) = member_prop_name(&call.callee)?;
+    if !imports.is_stylex_namespace(object) {
+        return None;
+    }
+    Some(match property {
+        "create" => CallKind::Create,
+        "keyframes" => CallKind::Keyframes,
+        "positionTry" => CallKind::PositionTry,
+        "viewTransitionClass" => CallKind::ViewTransitionClass,
+        "defaultMarker" => CallKind::DefaultMarker,
+        "defineMarker" => CallKind::DefineMarker,
+        "defineVars" => CallKind::DefineVars,
+        "defineConsts" => CallKind::DefineConsts,
+        "createTheme" => CallKind::CreateTheme,
+        "unstable_defineVarsNested" => CallKind::DefineVarsNested,
+        "unstable_defineConstsNested" => CallKind::DefineConstsNested,
+        "unstable_createThemeNested" => CallKind::CreateThemeNested,
+        "props" => CallKind::Props,
+        "attrs" => CallKind::Attrs,
+        _ => return None,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Generic AST walk with the hooks the three passes need
+
+/// Where a top-level declarator sits in its statement; DCE plans removal
+/// edits per statement so sibling-declarator spans stay disjoint.
+#[derive(Debug, Clone)]
+struct DeclRemoval {
+    stmt_span: Span,
+    decl_index: usize,
+    decl_spans: Rc<[Span]>,
+}
+
+#[derive(Debug, Clone)]
+struct DeclCtx {
+    name: Option<String>,
+    top_level: bool,
+    exported: bool,
+    removal: Option<DeclRemoval>,
+}
+
+#[derive(Clone, Copy)]
+enum ExprParent<'c> {
+    Statement,
+    Declarator(&'c DeclCtx),
+    JsxSpread(Span),
+    Other,
+}
+
+#[derive(PartialEq, Eq, Clone, Copy)]
+enum Flow {
+    Walk,
+    Skip,
+    /// Callee replaced, arguments still live (the atoms dynamic form).
+    ArgsOnly,
+}
+
+enum MemberProp<'a> {
+    Static(&'a str),
+    Computed(&'a Expression<'a>),
+}
+
+struct MemberInfo<'a> {
+    object: &'a Expression<'a>,
+    prop: MemberProp<'a>,
+    optional: bool,
+    span: Span,
+    node_id: oxc_syntax::node::NodeId,
+    /// The member as an `Expression` when one wraps it (assignment-target
+    /// members have none); the collector's lazy evaluate needs it.
+    expr: Option<&'a Expression<'a>>,
+}
+
+#[derive(PartialEq, Eq, Clone, Copy)]
+enum MemberFlow {
+    Walk,
+    SkipObject,
+}
+
+trait Hooks<'a> {
+    fn done(&self) -> bool;
+    fn call(&mut self, _call: &'a CallExpression<'a>, _parent: ExprParent<'_>) -> Flow {
+        Flow::Walk
+    }
+    fn jsx_opening(&mut self, _el: &'a JSXOpeningElement<'a>) {}
+    fn jsx_attribute(&mut self, _attr: &'a JSXAttribute<'a>) -> Flow {
+        Flow::Walk
+    }
+    fn identifier(&mut self, _name: &str, _span: Span) {}
+    fn member(&mut self, _info: &MemberInfo<'a>) -> MemberFlow {
+        MemberFlow::Walk
+    }
+    fn export_local(&mut self, _name: &str, _span: Span) {}
+}
+
+fn walk_program<'a>(hooks: &mut dyn Hooks<'a>, program: &'a Program<'a>) {
+    for statement in &program.body {
+        walk_top_statement(hooks, statement);
+        if hooks.done() {
+            return;
+        }
+    }
+}
+
+fn walk_top_statement<'a>(hooks: &mut dyn Hooks<'a>, statement: &'a Statement<'a>) {
+    match statement {
+        Statement::VariableDeclaration(decl) => {
+            walk_variable_declaration(hooks, decl, Some((false, statement.span())));
+        }
+        Statement::ExportDeclaration(export) => match &export.declaration {
+            Declaration::VariableDeclaration(decl) => {
+                walk_variable_declaration(hooks, decl, Some((true, statement.span())));
+            }
+            other => walk_declaration(hooks, other),
+        },
+        Statement::ExportNamedDeclaration(export) => {
+            for specifier in &export.specifiers {
+                if specifier.export_kind.is_type() {
+                    continue;
+                }
+                match &specifier.local {
+                    ModuleExportName::IdentifierReference(id) => {
+                        hooks.export_local(id.name.as_str(), id.span);
+                    }
+                    ModuleExportName::IdentifierName(id) => {
+                        hooks.export_local(id.name.as_str(), id.span);
+                    }
+                    ModuleExportName::StringLiteral(_) => {}
+                }
+            }
+        }
+        other => walk_statement(hooks, other),
+    }
+}
+
+fn walk_statement<'a>(hooks: &mut dyn Hooks<'a>, statement: &'a Statement<'a>) {
+    if hooks.done() {
+        return;
+    }
+    match statement {
+        Statement::BlockStatement(block) => {
+            for s in &block.body {
+                walk_statement(hooks, s);
+            }
+        }
+        Statement::BreakStatement(_)
+        | Statement::ContinueStatement(_)
+        | Statement::DebuggerStatement(_)
+        | Statement::EmptyStatement(_) => {}
+        Statement::DoWhileStatement(s) => {
+            walk_statement(hooks, &s.body);
+            walk_expression(hooks, &s.test, ExprParent::Other);
+        }
+        Statement::ExpressionStatement(s) => {
+            walk_expression(hooks, &s.expression, ExprParent::Statement);
+        }
+        Statement::ForInStatement(s) => {
+            walk_for_left(hooks, &s.left);
+            walk_expression(hooks, &s.right, ExprParent::Other);
+            walk_statement(hooks, &s.body);
+        }
+        Statement::ForOfStatement(s) => {
+            walk_for_left(hooks, &s.left);
+            walk_expression(hooks, &s.right, ExprParent::Other);
+            walk_statement(hooks, &s.body);
+        }
+        Statement::ForStatement(s) => {
+            match &s.init {
+                Some(ForStatementInit::VariableDeclaration(decl)) => {
+                    walk_variable_declaration(hooks, decl, None);
+                }
+                Some(init) => {
+                    if let Some(expr) = init.as_expression() {
+                        walk_expression(hooks, expr, ExprParent::Other);
+                    }
+                }
+                None => {}
+            }
+            if let Some(test) = &s.test {
+                walk_expression(hooks, test, ExprParent::Other);
+            }
+            if let Some(update) = &s.update {
+                walk_expression(hooks, update, ExprParent::Other);
+            }
+            walk_statement(hooks, &s.body);
+        }
+        Statement::IfStatement(s) => {
+            walk_expression(hooks, &s.test, ExprParent::Other);
+            walk_statement(hooks, &s.consequent);
+            if let Some(alt) = &s.alternate {
+                walk_statement(hooks, alt);
+            }
+        }
+        Statement::LabeledStatement(s) => walk_statement(hooks, &s.body),
+        Statement::ReturnStatement(s) => {
+            if let Some(argument) = &s.argument {
+                walk_expression(hooks, argument, ExprParent::Other);
+            }
+        }
+        Statement::SwitchStatement(s) => {
+            walk_expression(hooks, &s.discriminant, ExprParent::Other);
+            for case in &s.cases {
+                if let Some(test) = &case.test {
+                    walk_expression(hooks, test, ExprParent::Other);
+                }
+                for st in &case.consequent {
+                    walk_statement(hooks, st);
+                }
+            }
+        }
+        Statement::ThrowStatement(s) => walk_expression(hooks, &s.argument, ExprParent::Other),
+        Statement::TryStatement(s) => {
+            for st in &s.block.body {
+                walk_statement(hooks, st);
+            }
+            if let Some(handler) = &s.handler {
+                for st in &handler.body.body {
+                    walk_statement(hooks, st);
+                }
+            }
+            if let Some(finalizer) = &s.finalizer {
+                for st in &finalizer.body {
+                    walk_statement(hooks, st);
+                }
+            }
+        }
+        Statement::WhileStatement(s) => {
+            walk_expression(hooks, &s.test, ExprParent::Other);
+            walk_statement(hooks, &s.body);
+        }
+        Statement::WithStatement(s) => {
+            walk_expression(hooks, &s.object, ExprParent::Other);
+            walk_statement(hooks, &s.body);
+        }
+        Statement::VariableDeclaration(decl) => walk_variable_declaration(hooks, decl, None),
+        Statement::FunctionDeclaration(f) => walk_function(hooks, f),
+        Statement::ClassDeclaration(class) => walk_class(hooks, class),
+        Statement::TSNamespaceDeclaration(ns) => {
+            if let TSNamespaceDeclarationBody::TSModuleBlock(block) = &ns.body {
+                for st in &block.body {
+                    walk_statement(hooks, st);
+                }
+            }
+        }
+        Statement::TSEnumDeclaration(e) => {
+            for member in &e.body.members {
+                if let Some(init) = &member.initializer {
+                    walk_expression(hooks, init, ExprParent::Other);
+                }
+            }
+        }
+        Statement::TSExportAssignment(e) => {
+            walk_expression(hooks, &e.expression, ExprParent::Other);
+        }
+        Statement::ExportDefaultDeclaration(export) => match &export.declaration {
+            ExportDefaultDeclarationKind::FunctionDeclaration(f) => walk_function(hooks, f),
+            ExportDefaultDeclarationKind::ClassDeclaration(class) => walk_class(hooks, class),
+            other => {
+                if let Some(expr) = other.as_expression() {
+                    walk_expression(hooks, expr, ExprParent::Other);
+                }
+            }
+        },
+        Statement::ExportDeclaration(export) => walk_declaration(hooks, &export.declaration),
+        _ => {}
+    }
+}
+
+fn walk_declaration<'a>(hooks: &mut dyn Hooks<'a>, declaration: &'a Declaration<'a>) {
+    match declaration {
+        Declaration::VariableDeclaration(decl) => walk_variable_declaration(hooks, decl, None),
+        Declaration::FunctionDeclaration(f) => walk_function(hooks, f),
+        Declaration::ClassDeclaration(class) => walk_class(hooks, class),
+        _ => {}
+    }
+}
+
+fn walk_for_left<'a>(hooks: &mut dyn Hooks<'a>, left: &'a ForStatementLeft<'a>) {
+    match left {
+        ForStatementLeft::VariableDeclaration(decl) => {
+            walk_variable_declaration(hooks, decl, None);
+        }
+        other => {
+            if let Some(target) = other.as_assignment_target() {
+                walk_assignment_target(hooks, target);
+            }
+        }
+    }
+}
+
+fn walk_variable_declaration<'a>(
+    hooks: &mut dyn Hooks<'a>,
+    decl: &'a VariableDeclaration<'a>,
+    top: Option<(bool, Span)>,
+) {
+    let decl_spans: Option<Rc<[Span]>> =
+        top.map(|_| decl.declarations.iter().map(|d| d.span).collect());
+    for (i, declarator) in decl.declarations.iter().enumerate() {
+        let ctx = DeclCtx {
+            name: declarator
+                .id
+                .get_binding_identifier()
+                .map(|id| id.name.to_string()),
+            top_level: top.is_some(),
+            exported: top.is_some_and(|(exported, _)| exported),
+            removal: top.map(|(_, stmt_span)| DeclRemoval {
+                stmt_span,
+                decl_index: i,
+                decl_spans: Rc::clone(decl_spans.as_ref().expect("built when top is Some")),
+            }),
+        };
+        walk_binding_pattern(hooks, &declarator.id);
+        if let Some(init) = &declarator.init {
+            walk_expression(hooks, init, ExprParent::Declarator(&ctx));
+        }
+        if hooks.done() {
+            return;
+        }
+    }
+}
+
+fn walk_binding_pattern<'a>(hooks: &mut dyn Hooks<'a>, pattern: &'a BindingPattern<'a>) {
+    match pattern {
+        BindingPattern::BindingIdentifier(_) => {}
+        BindingPattern::ObjectPattern(p) => {
+            for prop in &p.properties {
+                if prop.computed
+                    && let Some(key) = prop.key.as_expression()
+                {
+                    walk_expression(hooks, key, ExprParent::Other);
+                }
+                walk_binding_pattern(hooks, &prop.value);
+            }
+            if let Some(rest) = &p.rest {
+                walk_binding_pattern(hooks, &rest.argument);
+            }
+        }
+        BindingPattern::ArrayPattern(p) => {
+            for element in p.elements.iter().flatten() {
+                walk_binding_pattern(hooks, element);
+            }
+            if let Some(rest) = &p.rest {
+                walk_binding_pattern(hooks, &rest.argument);
+            }
+        }
+        BindingPattern::AssignmentPattern(p) => {
+            walk_binding_pattern(hooks, &p.left);
+            walk_expression(hooks, &p.right, ExprParent::Other);
+        }
+    }
+}
+
+fn walk_function<'a>(hooks: &mut dyn Hooks<'a>, function: &'a Function<'a>) {
+    for param in &function.params.items {
+        walk_binding_pattern(hooks, &param.pattern);
+    }
+    if let Some(rest) = &function.params.rest {
+        walk_binding_pattern(hooks, &rest.rest.argument);
+    }
+    if let Some(body) = &function.body {
+        for statement in &body.statements {
+            walk_statement(hooks, statement);
+        }
+    }
+}
+
+fn walk_class<'a>(hooks: &mut dyn Hooks<'a>, class: &'a oxc_ast::ast::Class<'a>) {
+    if let Some(heritage) = &class.heritage {
+        walk_expression(hooks, &heritage.expression, ExprParent::Other);
+    }
+    for element in &class.body.body {
+        match element {
+            ClassElement::MethodDefinition(m) => {
+                if m.computed
+                    && let Some(key) = m.key.as_expression()
+                {
+                    walk_expression(hooks, key, ExprParent::Other);
+                }
+                walk_function(hooks, &m.value);
+            }
+            ClassElement::PropertyDefinition(p) => {
+                if p.computed
+                    && let Some(key) = p.key.as_expression()
+                {
+                    walk_expression(hooks, key, ExprParent::Other);
+                }
+                if let Some(value) = &p.value {
+                    walk_expression(hooks, value, ExprParent::Other);
+                }
+            }
+            ClassElement::AccessorProperty(p) => {
+                if let Some(value) = &p.value {
+                    walk_expression(hooks, value, ExprParent::Other);
+                }
+            }
+            ClassElement::StaticBlock(block) => {
+                for statement in &block.body {
+                    walk_statement(hooks, statement);
+                }
+            }
+            ClassElement::TSIndexSignature(_) => {}
+        }
+    }
+}
+
+fn walk_assignment_target<'a>(
+    hooks: &mut dyn Hooks<'a>,
+    target: &'a oxc_ast::ast::AssignmentTarget<'a>,
+) {
+    use oxc_ast::ast::AssignmentTarget as At;
+    match target {
+        At::AssignmentTargetIdentifier(_) => {}
+        At::StaticMemberExpression(m) => {
+            walk_member_static(hooks, m, None);
+        }
+        At::ComputedMemberExpression(m) => {
+            walk_member_computed(hooks, m, None);
+        }
+        At::PrivateFieldExpression(m) => {
+            walk_expression(hooks, &m.object, ExprParent::Other);
+        }
+        At::TSAsExpression(e) => walk_expression(hooks, &e.expression, ExprParent::Other),
+        At::TSSatisfiesExpression(e) => walk_expression(hooks, &e.expression, ExprParent::Other),
+        At::TSNonNullExpression(e) => walk_expression(hooks, &e.expression, ExprParent::Other),
+        At::TSTypeAssertion(e) => walk_expression(hooks, &e.expression, ExprParent::Other),
+        At::ArrayAssignmentTarget(arr) => {
+            for element in arr.elements.iter().flatten() {
+                walk_assignment_target_maybe(hooks, element);
+            }
+            if let Some(rest) = &arr.rest {
+                walk_assignment_target(hooks, &rest.target);
+            }
+        }
+        At::ObjectAssignmentTarget(obj) => {
+            use oxc_ast::ast::AssignmentTargetProperty as Atp;
+            for prop in &obj.properties {
+                match prop {
+                    Atp::AssignmentTargetPropertyIdentifier(p) => {
+                        if let Some(init) = &p.init {
+                            walk_expression(hooks, init, ExprParent::Other);
+                        }
+                    }
+                    Atp::AssignmentTargetPropertyProperty(p) => {
+                        if p.computed
+                            && let Some(key) = p.name.as_expression()
+                        {
+                            walk_expression(hooks, key, ExprParent::Other);
+                        }
+                        walk_assignment_target_maybe(hooks, &p.binding);
+                    }
+                }
+            }
+            if let Some(rest) = &obj.rest {
+                walk_assignment_target(hooks, &rest.target);
+            }
+        }
+    }
+}
+
+fn walk_assignment_target_maybe<'a>(
+    hooks: &mut dyn Hooks<'a>,
+    target: &'a oxc_ast::ast::AssignmentTargetMaybeDefault<'a>,
+) {
+    use oxc_ast::ast::AssignmentTargetMaybeDefault as Atd;
+    match target {
+        Atd::AssignmentTargetWithDefault(t) => {
+            walk_assignment_target(hooks, &t.binding);
+            walk_expression(hooks, &t.init, ExprParent::Other);
+        }
+        other => {
+            if let Some(target) = other.as_assignment_target() {
+                walk_assignment_target(hooks, target);
+            }
+        }
+    }
+}
+
+fn walk_member_static<'a>(
+    hooks: &mut dyn Hooks<'a>,
+    m: &'a oxc_ast::ast::StaticMemberExpression<'a>,
+    expr: Option<&'a Expression<'a>>,
+) {
+    let info = MemberInfo {
+        object: &m.object,
+        prop: MemberProp::Static(m.property.name.as_str()),
+        optional: m.optional,
+        span: m.span,
+        node_id: m.node_id.get(),
+        expr,
+    };
+    if hooks.member(&info) == MemberFlow::Walk {
+        walk_expression(hooks, &m.object, ExprParent::Other);
+    }
+}
+
+fn walk_member_computed<'a>(
+    hooks: &mut dyn Hooks<'a>,
+    m: &'a oxc_ast::ast::ComputedMemberExpression<'a>,
+    expr: Option<&'a Expression<'a>>,
+) {
+    let info = MemberInfo {
+        object: &m.object,
+        prop: MemberProp::Computed(&m.expression),
+        optional: m.optional,
+        span: m.span,
+        node_id: m.node_id.get(),
+        expr,
+    };
+    if hooks.member(&info) == MemberFlow::Walk {
+        walk_expression(hooks, &m.object, ExprParent::Other);
+    }
+    walk_expression(hooks, &m.expression, ExprParent::Other);
+}
+
+fn walk_call<'a>(hooks: &mut dyn Hooks<'a>, call: &'a CallExpression<'a>, parent: ExprParent<'_>) {
+    match hooks.call(call, parent) {
+        Flow::Skip => return,
+        Flow::Walk => walk_expression(hooks, &call.callee, ExprParent::Other),
+        Flow::ArgsOnly => {}
+    }
+    walk_arguments(hooks, &call.arguments);
+}
+
+fn walk_arguments<'a>(hooks: &mut dyn Hooks<'a>, arguments: &'a [Argument<'a>]) {
+    for argument in arguments {
+        match argument {
+            Argument::SpreadElement(spread) => {
+                walk_expression(hooks, &spread.argument, ExprParent::Other);
+            }
+            other => {
+                if let Some(expr) = other.as_expression() {
+                    walk_expression(hooks, expr, ExprParent::Other);
+                }
+            }
+        }
+    }
+}
+
+fn walk_expression<'a>(
+    hooks: &mut dyn Hooks<'a>,
+    expr: &'a Expression<'a>,
+    parent: ExprParent<'_>,
+) {
+    if hooks.done() {
+        return;
+    }
+    match expr {
+        Expression::ParenthesizedExpression(e) => walk_expression(hooks, &e.expression, parent),
+        Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::NumericLiteral(_)
+        | Expression::BigIntLiteral(_)
+        | Expression::RegExpLiteral(_)
+        | Expression::StringLiteral(_)
+        | Expression::ThisExpression(_)
+        | Expression::Super(_)
+        | Expression::ImportMeta(_)
+        | Expression::NewTarget(_) => {}
+        Expression::TemplateLiteral(t) => {
+            for e in &t.expressions {
+                walk_expression(hooks, e, ExprParent::Other);
+            }
+        }
+        Expression::Identifier(id) => hooks.identifier(id.name.as_str(), id.span),
+        Expression::ArrayExpression(arr) => {
+            for element in &arr.elements {
+                match element {
+                    ArrayExpressionElement::Elision(_) => {}
+                    ArrayExpressionElement::SpreadElement(spread) => {
+                        walk_expression(hooks, &spread.argument, ExprParent::Other);
+                    }
+                    other => {
+                        if let Some(e) = other.as_expression() {
+                            walk_expression(hooks, e, ExprParent::Other);
+                        }
+                    }
+                }
+            }
+        }
+        Expression::ArrowFunctionExpression(arrow) => {
+            for param in &arrow.params.items {
+                walk_binding_pattern(hooks, &param.pattern);
+            }
+            if let Some(rest) = &arrow.params.rest {
+                walk_binding_pattern(hooks, &rest.rest.argument);
+            }
+            match &arrow.body {
+                oxc_ast::ast::ArrowFunctionBody::FunctionBody(body) => {
+                    for statement in &body.statements {
+                        walk_statement(hooks, statement);
+                    }
+                }
+                // Babel has no statement around an expression body, so a call
+                // there never sees an ExpressionStatement parent.
+                other => {
+                    if let Some(e) = other.as_expression() {
+                        walk_expression(hooks, e, ExprParent::Other);
+                    }
+                }
+            }
+        }
+        Expression::AssignmentExpression(a) => {
+            walk_assignment_target(hooks, &a.left);
+            walk_expression(hooks, &a.right, ExprParent::Other);
+        }
+        Expression::AwaitExpression(a) => walk_expression(hooks, &a.argument, ExprParent::Other),
+        Expression::BinaryExpression(b) => {
+            walk_expression(hooks, &b.left, ExprParent::Other);
+            walk_expression(hooks, &b.right, ExprParent::Other);
+        }
+        Expression::CallExpression(call) => walk_call(hooks, call, parent),
+        Expression::ChainExpression(chain) => walk_chain(hooks, &chain.expression),
+        Expression::ClassExpression(class) => walk_class(hooks, class),
+        Expression::ConditionalExpression(c) => {
+            walk_expression(hooks, &c.test, ExprParent::Other);
+            walk_expression(hooks, &c.consequent, ExprParent::Other);
+            walk_expression(hooks, &c.alternate, ExprParent::Other);
+        }
+        Expression::FunctionExpression(f) => walk_function(hooks, f),
+        Expression::ImportExpression(i) => {
+            walk_expression(hooks, &i.source, ExprParent::Other);
+            if let Some(options) = &i.options {
+                walk_expression(hooks, options, ExprParent::Other);
+            }
+        }
+        Expression::LogicalExpression(l) => {
+            walk_expression(hooks, &l.left, ExprParent::Other);
+            walk_expression(hooks, &l.right, ExprParent::Other);
+        }
+        Expression::NewExpression(n) => {
+            walk_expression(hooks, &n.callee, ExprParent::Other);
+            walk_arguments(hooks, &n.arguments);
+        }
+        Expression::ObjectExpression(o) => {
+            for property in &o.properties {
+                match property {
+                    ObjectPropertyKind::ObjectProperty(p) => {
+                        if p.computed
+                            && let Some(key) = p.key.as_expression()
+                        {
+                            walk_expression(hooks, key, ExprParent::Other);
+                        }
+                        walk_expression(hooks, &p.value, ExprParent::Other);
+                    }
+                    ObjectPropertyKind::SpreadProperty(spread) => {
+                        walk_expression(hooks, &spread.argument, ExprParent::Other);
+                    }
+                }
+            }
+        }
+        Expression::SequenceExpression(s) => {
+            for e in &s.expressions {
+                walk_expression(hooks, e, ExprParent::Other);
+            }
+        }
+        Expression::TaggedTemplateExpression(t) => {
+            walk_expression(hooks, &t.tag, ExprParent::Other);
+            for e in &t.quasi.expressions {
+                walk_expression(hooks, e, ExprParent::Other);
+            }
+        }
+        Expression::UnaryExpression(u) => walk_expression(hooks, &u.argument, ExprParent::Other),
+        Expression::UpdateExpression(u) => match &u.argument {
+            SimpleAssignmentTarget::AssignmentTargetIdentifier(_) => {}
+            SimpleAssignmentTarget::StaticMemberExpression(m) => {
+                walk_member_static(hooks, m, None);
+            }
+            SimpleAssignmentTarget::ComputedMemberExpression(m) => {
+                walk_member_computed(hooks, m, None);
+            }
+            _ => {}
+        },
+        Expression::YieldExpression(y) => {
+            if let Some(argument) = &y.argument {
+                walk_expression(hooks, argument, ExprParent::Other);
+            }
+        }
+        Expression::PrivateInExpression(p) => {
+            walk_expression(hooks, &p.right, ExprParent::Other);
+        }
+        Expression::JSXElement(el) => walk_jsx_element(hooks, el),
+        Expression::JSXFragment(fragment) => walk_jsx_fragment(hooks, fragment),
+        Expression::TSAsExpression(e) => walk_expression(hooks, &e.expression, ExprParent::Other),
+        Expression::TSSatisfiesExpression(e) => {
+            walk_expression(hooks, &e.expression, ExprParent::Other);
+        }
+        Expression::TSTypeAssertion(e) => {
+            walk_expression(hooks, &e.expression, ExprParent::Other);
+        }
+        Expression::TSNonNullExpression(e) => {
+            walk_expression(hooks, &e.expression, ExprParent::Other);
+        }
+        Expression::TSInstantiationExpression(e) => {
+            walk_expression(hooks, &e.expression, ExprParent::Other);
+        }
+        Expression::V8IntrinsicExpression(e) => walk_arguments(hooks, &e.arguments),
+        Expression::StaticMemberExpression(m) => walk_member_static(hooks, m, Some(expr)),
+        Expression::ComputedMemberExpression(m) => walk_member_computed(hooks, m, Some(expr)),
+        Expression::PrivateFieldExpression(m) => {
+            walk_expression(hooks, &m.object, ExprParent::Other);
+        }
+    }
+}
+
+// Optional-chain tails are OptionalMemberExpression/OptionalCallExpression in
+// babel, so member/call hooks never fire for the links themselves.
+fn walk_chain<'a>(hooks: &mut dyn Hooks<'a>, element: &'a ChainElement<'a>) {
+    match element {
+        ChainElement::CallExpression(call) => {
+            walk_expression(hooks, &call.callee, ExprParent::Other);
+            walk_arguments(hooks, &call.arguments);
+        }
+        ChainElement::TSNonNullExpression(e) => {
+            walk_expression(hooks, &e.expression, ExprParent::Other);
+        }
+        ChainElement::StaticMemberExpression(m) => {
+            walk_expression(hooks, &m.object, ExprParent::Other);
+        }
+        ChainElement::ComputedMemberExpression(m) => {
+            walk_expression(hooks, &m.object, ExprParent::Other);
+            walk_expression(hooks, &m.expression, ExprParent::Other);
+        }
+        ChainElement::PrivateFieldExpression(m) => {
+            walk_expression(hooks, &m.object, ExprParent::Other);
+        }
+    }
+}
+
+fn walk_jsx_element<'a>(hooks: &mut dyn Hooks<'a>, el: &'a JSXElement<'a>) {
+    hooks.jsx_opening(&el.opening_element);
+    for item in &el.opening_element.attributes {
+        match item {
+            JSXAttributeItem::Attribute(attr) => {
+                if hooks.jsx_attribute(attr) == Flow::Walk
+                    && let Some(value) = &attr.value
+                {
+                    walk_jsx_attribute_value(hooks, value);
+                }
+            }
+            JSXAttributeItem::SpreadAttribute(spread) => {
+                walk_expression(hooks, &spread.argument, ExprParent::JsxSpread(spread.span));
+            }
+        }
+    }
+    walk_jsx_children(hooks, &el.children);
+}
+
+fn walk_jsx_fragment<'a>(hooks: &mut dyn Hooks<'a>, fragment: &'a JSXFragment<'a>) {
+    walk_jsx_children(hooks, &fragment.children);
+}
+
+fn walk_jsx_children<'a>(hooks: &mut dyn Hooks<'a>, children: &'a [JSXChild<'a>]) {
+    for child in children {
+        match child {
+            JSXChild::Text(_) => {}
+            JSXChild::Element(el) => walk_jsx_element(hooks, el),
+            JSXChild::Fragment(fragment) => walk_jsx_fragment(hooks, fragment),
+            JSXChild::ExpressionContainer(container) => {
+                walk_jsx_expression(hooks, &container.expression);
+            }
+            JSXChild::Spread(spread) => {
+                walk_expression(hooks, &spread.expression, ExprParent::Other);
+            }
+        }
+    }
+}
+
+fn walk_jsx_attribute_value<'a>(hooks: &mut dyn Hooks<'a>, value: &'a JSXAttributeValue<'a>) {
+    match value {
+        JSXAttributeValue::StringLiteral(_) => {}
+        JSXAttributeValue::ExpressionContainer(container) => {
+            walk_jsx_expression(hooks, &container.expression);
+        }
+        JSXAttributeValue::Element(el) => walk_jsx_element(hooks, el),
+        JSXAttributeValue::Fragment(fragment) => walk_jsx_fragment(hooks, fragment),
+    }
+}
+
+fn walk_jsx_expression<'a>(hooks: &mut dyn Hooks<'a>, expression: &'a JSXExpression<'a>) {
+    match expression {
+        JSXExpression::EmptyExpression(_) => {}
+        other => {
+            if let Some(expr) = other.as_expression() {
+                walk_expression(hooks, expr, ExprParent::Other);
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Module transform driver
+
+pub struct TransformOutput {
+    pub code: String,
+    pub modified: bool,
+    /// Generated-to-original positions, only when the caller asked for them.
+    pub splice_map: Option<SpliceMap>,
+    /// (var name, compiled namespaces) per create call, pre-DCE, in order.
+    pub create_objects: Vec<(Option<String>, Arc<JsObjectMap>)>,
+    /// The same edits as span-keyed AST mutations (transform_program backend).
+    pub plan: AstPlan,
+}
+
+struct CreateSite {
+    span: Span,
+    edit_idx: usize,
+    /// The create replacement's plan entry (program-level sites only); DCE
+    /// pruning rewrites it in lockstep with the splice edit.
+    plan_idx: Option<usize>,
+    /// Hoisted dynamic static-chunk consts; they survive DCE (upstream leaves
+    /// hoistExpression output behind when the create declarator is removed).
+    hoist_edit_idxs: Vec<usize>,
+    compiled: Arc<JsObjectMap>,
+    /// namespace → printed arrow text for dynamic (fns) namespaces.
+    dynamic: Vec<(String, String)>,
+    /// The structured twins of `dynamic` for the AST plan.
+    dynamic_entries: Vec<DynamicEntry>,
+    style_var: bool,
+    var_name: Option<String>,
+    exported: bool,
+    removal: Option<DeclRemoval>,
+}
+
+struct SxSite<'a> {
+    attr_span: Span,
+    expr: &'a Expression<'a>,
+    local: String,
+    bailed: Cell<bool>,
+}
+
+enum FlatArg<'a> {
+    Expr(&'a Expression<'a>),
+    Bad,
+}
+
+struct Classified {
+    args: Vec<MergeArg>,
+    tests: Vec<Span>,
+}
+
+/// One inlined static atom; props() hoists the ones it cannot merge away.
+struct AtomStaticSite {
+    span: Span,
+    node_id: oxc_syntax::node::NodeId,
+    edit_idx: usize,
+    plan_idx: Option<usize>,
+    compiled: Arc<JsObjectMap>,
+    hoisted: bool,
+}
+
+/// (nearest package.json (name, dir) above the file, cwd's package name).
+type DebugPaths = (Option<(String, String)>, Option<String>);
+
+struct Shared<'a, 'env> {
+    source: &'env str,
+    state: &'env mut CompileState<'a>,
+    fs: &'env dyn FsProvider,
+    edits: Vec<Option<Edit>>,
+    dead_spans: Vec<Span>,
+    /// Sub-spans of dead spans spliced verbatim into the output (dynamic-fn
+    /// expressions); the exit identifier pass still sees these upstream.
+    live_spans: Vec<Span>,
+    replaced_values: BTreeMap<u32, EvalValue>,
+    create_sites: Vec<CreateSite>,
+    sx_sites: Vec<SxSite<'a>>,
+    style_map: BTreeMap<String, Arc<JsObjectMap>>,
+    tuples: Vec<StyleVarToKeep>,
+    export_locals: BTreeSet<String>,
+    import_decls: Vec<(String, u32)>,
+    debug_paths: Option<DebugPaths>,
+    /// Generated sx runtime locals in generation order (babel state.stylexImport).
+    sx_locals: Vec<String>,
+    /// Generated prologue statements as (source offset of the site that made
+    /// them, the unshifted group); babel's traversal order is source order.
+    prologue_groups: Vec<(u32, Vec<PrologueStmt>)>,
+    prologue_edit: Option<usize>,
+    /// The `var _inject2 = _inject;` alias name — the callee of every inject
+    /// call, memoized like upstream's injectImportInserted.
+    inject_alias: Option<String>,
+    /// Inject-call edit slots; DCE must not swallow them with their anchor.
+    inject_edits: BTreeSet<usize>,
+    /// Program-body offset where a generated import lands (after any hashbang
+    /// and directive prologue, babel unshift-into-body semantics).
+    import_insert_offset: u32,
+    /// Uids handed out this compile (babel program.uids): later generateUid
+    /// calls must skip them.
+    generated_uids: BTreeSet<String>,
+    /// Newline index over `source`, built on first debug-data lookup.
+    line_index: Option<crate::state::LineIndex>,
+    /// Static atoms already inlined, in traversal order; props() may hoist them.
+    atom_static_sites: Vec<AtomStaticSite>,
+    /// Callee spans of compiled dynamic atoms (`x.color` in `x.color(v)`).
+    atom_dynamic_callees: BTreeSet<Span>,
+    /// AST-backend twin of `edits` (seq = edit slot index at record time).
+    plan: AstPlan,
+    /// False on the splice path: the plan would be dropped unread, and its
+    /// recording clones compiled maps and object values per site.
+    build_plan: bool,
+    error: Option<StylexError>,
+}
+
+pub fn transform_module<'a>(
+    program: &'a Program<'a>,
+    source: &str,
+    state: &mut CompileState<'a>,
+    fs: &dyn FsProvider,
+    build_plan: bool,
+    want_map: bool,
+) -> Result<TransformOutput, StylexError> {
+    let mut shared = Shared {
+        source,
+        state,
+        fs,
+        // Slot 0 is reserved for the generated prologue block: unshifted
+        // imports print before same-anchor pass-A hoists (babel body order).
+        edits: vec![None],
+        dead_spans: Vec::new(),
+        live_spans: Vec::new(),
+        replaced_values: BTreeMap::new(),
+        create_sites: Vec::new(),
+        sx_sites: Vec::new(),
+        style_map: BTreeMap::new(),
+        tuples: Vec::new(),
+        export_locals: collect_export_locals(program),
+        import_decls: collect_import_decls(program),
+        debug_paths: None,
+        sx_locals: Vec::new(),
+        prologue_groups: Vec::new(),
+        prologue_edit: Some(0),
+        inject_alias: None,
+        inject_edits: BTreeSet::new(),
+        import_insert_offset: import_insert_offset(program),
+        generated_uids: BTreeSet::new(),
+        line_index: None,
+        atom_static_sites: Vec::new(),
+        atom_dynamic_callees: BTreeSet::new(),
+        plan: AstPlan::default(),
+        build_plan,
+        error: None,
+    };
+    {
+        let mut pass = PassA { s: &mut shared };
+        walk_program(&mut pass, program);
+    }
+    if let Some(error) = shared.error.take() {
+        return Err(error);
+    }
+    {
+        let mut pass = PassB1 { s: &mut shared };
+        walk_program(&mut pass, program);
+    }
+    if !shared.state.imports.atom_imports.is_empty()
+        || !shared.state.imports.atom_binding_locals.is_empty()
+    {
+        let mut pass = PassAtoms {
+            s: &mut shared,
+            callee_spans: BTreeSet::new(),
+        };
+        walk_program(&mut pass, program);
+    }
+    if let Some(error) = shared.error.take() {
+        return Err(error);
+    }
+    {
+        let mut pass = PassB2 { s: &mut shared };
+        walk_program(&mut pass, program);
+    }
+    if let Some(error) = shared.error.take() {
+        return Err(error);
+    }
+    shared.finalize_sx_bails();
+    shared.apply_dce();
+    // Pre-DCE values by construction: apply_dce reads sites, never mutates
+    // them, so the compiled maps move out instead of cloning.
+    let create_objects: Vec<(Option<String>, Arc<JsObjectMap>)> = shared
+        .create_sites
+        .drain(..)
+        .map(|site| (site.var_name, site.compiled))
+        .collect();
+    // Upstream rewrites in Program.exit, by which time the compensation
+    // imports are in the tree: both copies of a source get the new text.
+    let rewrites = shared.rewrite_import_sources(program);
+    shared.insert_treeshake_imports(&rewrites);
+    if shared.build_plan && !shared.prologue_groups.is_empty() {
+        // Empty span at the anchor: no sourcemap mapping, and comments that
+        // precede the anchor keep printing before the generated imports.
+        let offset = shared.import_insert_offset;
+        let stmts = shared.prologue_statements();
+        shared.plan.inserts.push(InsertOp {
+            anchor: offset,
+            seq: 0,
+            span: Span::new(offset, offset),
+            stmt: SynthStmt::Prologue(stmts),
+        });
+    }
+    let plan = std::mem::take(&mut shared.plan);
+    let edits: Vec<Edit> = shared.edits.into_iter().flatten().collect();
+    let modified = !edits.is_empty();
+    // The AST backend emits from the mutated program, so splicing a whole
+    // second copy of the source here would only be dropped by the caller.
+    let mut splice_map = want_map.then(SpliceMap::default);
+    let code = if shared.build_plan {
+        String::new()
+    } else {
+        let _t = crate::timings::start(crate::timings::Stage::PrintSplice);
+        apply_edits_tracked(source, &edits, splice_map.as_mut())
+    };
+    Ok(TransformOutput {
+        code,
+        modified,
+        splice_map,
+        create_objects,
+        plan,
+    })
+}
+
+fn collect_export_locals(program: &Program<'_>) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for statement in &program.body {
+        let Statement::ExportNamedDeclaration(export) = statement else {
+            continue;
+        };
+        for specifier in &export.specifiers {
+            if specifier.export_kind.is_type() {
+                continue;
+            }
+            // parity: isVariableNamedExported — aliased exports do not count.
+            let local = match &specifier.local {
+                ModuleExportName::IdentifierReference(id) => id.name.as_str(),
+                ModuleExportName::IdentifierName(id) => id.name.as_str(),
+                ModuleExportName::StringLiteral(_) => continue,
+            };
+            let exported = match &specifier.exported {
+                ModuleExportName::IdentifierReference(id) => id.name.as_str(),
+                ModuleExportName::IdentifierName(id) => id.name.as_str(),
+                ModuleExportName::StringLiteral(_) => continue,
+            };
+            if local == exported {
+                out.insert(local.to_string());
+            }
+        }
+    }
+    out
+}
+
+fn import_insert_offset(program: &Program<'_>) -> u32 {
+    if let Some(statement) = program.body.first() {
+        return statement.span().start;
+    }
+    program
+        .directives
+        .last()
+        .map(|d| d.span.end)
+        .or_else(|| program.hashbang.as_ref().map(|h| h.span.end))
+        .unwrap_or(0)
+}
+
+fn collect_import_decls(program: &Program<'_>) -> Vec<(String, u32)> {
+    let mut out: Vec<(String, u32)> = Vec::new();
+    for statement in &program.body {
+        if let Statement::ImportDeclaration(decl) = statement
+            && !out.iter().any(|(s, _)| s == decl.source.value.as_str())
+        {
+            out.push((decl.source.value.to_string(), decl.span.start));
+        }
+    }
+    out
+}
+
+// parity: helper-module-imports stamps `_blockHoist = 3` on the inject import;
+// babel's block-hoist plugin then stable-sorts the body by it, descending.
+fn block_hoist(stmt: &PrologueStmt) -> u8 {
+    match stmt {
+        PrologueStmt::InjectImport { .. } => 3,
+        _ => 0,
+    }
+}
+
+fn prologue_text(stmt: &PrologueStmt) -> String {
+    match stmt {
+        PrologueStmt::NamespaceImport { local, source } => {
+            format!("import * as {local} from {};\n", js_string_literal(source))
+        }
+        PrologueStmt::InjectImport {
+            local,
+            source,
+            named: Some(imported),
+        } => format!(
+            "import {{ {imported} as {local} }} from {};\n",
+            js_string_literal(source)
+        ),
+        PrologueStmt::InjectImport { local, source, .. } => {
+            format!("import {local} from {};\n", js_string_literal(source))
+        }
+        PrologueStmt::InjectAlias { name, local } => format!("var {name} = {local};\n"),
+    }
+}
+
+fn print_parens(map: &JsObjectMap) -> String {
+    let mut out = String::from("(");
+    crate::transform::js_out::write_object(map, &mut out);
+    out.push(')');
+    out
+}
+
+/// `print_parens` with dynamic (fns) namespace values printed as arrow text.
+fn print_create_parens(map: &JsObjectMap, dynamic: &[(String, String)]) -> String {
+    if dynamic.is_empty() {
+        return print_parens(map);
+    }
+    let mut out = String::from("({");
+    for (i, (key, value)) in map.entries().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        if is_identifier_key(key) {
+            out.push_str(key);
+        } else {
+            crate::transform::js_out::write_js_string_literal(key, &mut out);
+        }
+        out.push_str(": ");
+        match dynamic.iter().find(|(name, _)| name == key) {
+            // parity: the fns rewrite only fires on object-shaped values.
+            Some((_, arrow)) if matches!(value, EvalValue::Obj(_)) => out.push_str(arrow),
+            _ => write_value(value, &mut out),
+        }
+    }
+    out.push_str("})");
+    out
+}
+
+fn jsx_attrs_text(map: &JsObjectMap) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    for (key, value) in map.entries() {
+        // parity: non-string AST values stringify as "[object Object]".
+        let text = match value {
+            EvalValue::Str(s) => s.replace('"', "&quot;"),
+            _ => "[object Object]".to_string(),
+        };
+        parts.push(format!("{key}=\"{text}\""));
+    }
+    parts.join(" ")
+}
+
+impl<'a, 'env> Shared<'a, 'env> {
+    fn fail(&mut self, error: StylexError) {
+        if self.error.is_none() {
+            self.error = Some(error);
+        }
+    }
+
+    fn push_edit(&mut self, edit: Edit) -> usize {
+        self.edits.push(Some(edit));
+        self.edits.len() - 1
+    }
+
+    fn in_dead(&self, span: Span) -> bool {
+        self.dead_spans
+            .iter()
+            .any(|d| span.start >= d.start && span.end <= d.end)
+            && !self
+                .live_spans
+                .iter()
+                .any(|l| span.start >= l.start && span.end <= l.end)
+    }
+
+    /// [`Self::in_dead`] ignoring live sub-spans: an edit there would overlap
+    /// the enclosing replacement, so atoms stay out of replaced source.
+    fn within_dead_span(&self, span: Span) -> bool {
+        self.dead_spans
+            .iter()
+            .any(|d| span.start >= d.start && span.end <= d.end)
+    }
+
+    fn contains_live(&self, span: Span) -> bool {
+        self.live_spans
+            .iter()
+            .any(|l| l.start >= span.start && l.end <= span.end)
+    }
+
+    fn take_edits_within(&mut self, span: Span) -> Vec<Edit> {
+        let mut taken = Vec::new();
+        // Statement-level inserts anchor at a span start they do not belong to.
+        let anchored = &self.inject_edits;
+        let prologue = self.prologue_edit;
+        for (idx, slot) in self.edits.iter_mut().enumerate() {
+            if anchored.contains(&idx) || prologue == Some(idx) {
+                continue;
+            }
+            if let Some(edit) = slot
+                && edit.start >= span.start
+                && edit.end <= span.end
+            {
+                taken.push(edit.clone());
+                *slot = None;
+            }
+        }
+        taken
+    }
+
+    fn is_named_export(&self, ctx: &DeclCtx) -> bool {
+        ctx.exported
+            || (ctx.top_level
+                && ctx
+                    .name
+                    .as_deref()
+                    .is_some_and(|n| self.export_locals.contains(n)))
+    }
+
+    // parity: state-manager fileNameForHashing.
+    fn file_name_for_hashing(&self) -> Option<String> {
+        let filename = self.state.filename.as_deref()?;
+        let resolution = self.state.options.unstable_module_resolution.as_ref()?;
+        if !matches_file_suffix(&resolution.theme_file_extension, filename)
+            && !matches_file_suffix(&resolution.consts_file_extension(), filename)
+        {
+            return None;
+        }
+        match resolution.kind {
+            ModuleResolutionType::Haste => Some(node_basename(filename).to_string()),
+            ModuleResolutionType::CommonJs => Some(canonical_file_path(
+                self.fs,
+                Path::new(filename),
+                resolution.root_dir.as_deref(),
+            )),
+        }
+    }
+
+    fn debug_paths(&mut self) -> DebugPaths {
+        if let Some(cached) = &self.debug_paths {
+            return cached.clone();
+        }
+        let need = self.state.options.debug && self.state.options.enable_debug_data_prop;
+        let value = match (&self.state.filename, need) {
+            (Some(filename), true) => {
+                let file_package = self
+                    .fs
+                    .nearest_package(Path::new(filename))
+                    .map(|(name, dir)| (name, dir.to_string_lossy().into_owned()));
+                let cwd_package_name = if file_package.is_some() {
+                    self.fs
+                        .nearest_package(Path::new(&self.state.cwd))
+                        .map(|(name, _)| name)
+                } else {
+                    None
+                };
+                (file_package, cwd_package_name)
+            }
+            _ => (None, None),
+        };
+        self.debug_paths = Some(value.clone());
+        value
+    }
+
+    fn record_override(&mut self, ctx: &DeclCtx, value: EvalValue) {
+        if ctx.top_level
+            && let Some(name) = &ctx.name
+        {
+            self.state.record_root_override(name, value);
+        }
+    }
+
+    fn line_of(&mut self, offset: u32) -> u32 {
+        self.line_index
+            .get_or_insert_with(|| crate::state::LineIndex::build(self.source))
+            .line_of(offset)
+    }
+
+    // ---- pass A transforms -------------------------------------------------
+
+    fn transform_create(&mut self, call: &'a CallExpression<'a>, parent: ExprParent<'_>) {
+        if matches!(parent, ExprParent::Statement) {
+            return self.fail(StylexError::unbound_call_value("create"));
+        }
+        let object = match validate_create_arg(call) {
+            Ok(object) => object,
+            Err(error) => return self.fail(error),
+        };
+        let arg = {
+            let mut evaluator = Evaluator::for_create(&mut *self.state, self.fs, &RealCallables);
+            evaluator.allow_dynamic_namespaces();
+            match evaluate_stylex_create_arg(&mut evaluator, object) {
+                Ok(arg) => arg,
+                Err(error) => return self.fail(error),
+            }
+        };
+        // Only the debug data-prop (`$$css: "file:line"`) reads these; prod
+        // compiles skip the per-key line lookups entirely.
+        let need_lines = self.state.options.debug && self.state.options.enable_debug_data_prop;
+        let mut namespace_lines = BTreeMap::new();
+        if need_lines {
+            for (key, offset) in &arg.key_spans {
+                let line = self.line_of(*offset);
+                namespace_lines.insert(key.clone(), line);
+            }
+        }
+        let decl = match parent {
+            ExprParent::Declarator(ctx) => Some(ctx.clone()),
+            _ => None,
+        };
+        let var_name = decl.as_ref().and_then(|c| c.name.clone());
+        let (file_package, cwd_package_name) = self.debug_paths();
+        let ctx = CreateContext {
+            options: self.state.options,
+            filename: self.state.filename.clone(),
+            cwd: self.state.cwd.clone(),
+            var_name: var_name.clone(),
+            namespace_lines: Some(namespace_lines),
+            file_package,
+            cwd_package_name,
+        };
+        let out = match compile_namespaces(&arg.namespaces, &ctx, !arg.fns.is_empty()) {
+            Ok(out) => out,
+            Err(error) => return self.fail(error),
+        };
+        // parity: injectedStyles = {...otherInjected, ...createRules, ...inherit}
+        // — one map, also the rule-lookup the fns rewrite scans.
+        let mut injected = std::mem::take(&mut self.state.other_injected_rules);
+        injected.extend(out.rules);
+        injected.extend(inherit_rules(&arg.fns));
+        let call_node = call.node_id.get();
+        let stmt_start = self.state.program_statement_start(call_node);
+        let mut dynamic: Vec<(String, String)> = Vec::new();
+        let mut dynamic_entries: Vec<DynamicEntry> = Vec::new();
+        let mut hoist_edit_idxs: Vec<usize> = Vec::new();
+        for (ns, fn_def) in &arg.fns {
+            let Some(EvalValue::Obj(compiled_ns)) = out.compiled.get(ns) else {
+                continue;
+            };
+            let empty = Vec::new();
+            let class_paths = out
+                .class_paths
+                .iter()
+                .find(|(name, _)| name == ns)
+                .map(|(_, paths)| paths)
+                .unwrap_or(&empty);
+            let dc = compile_dynamic_namespace(
+                compiled_ns,
+                class_paths,
+                fn_def,
+                &injected,
+                self.state.options,
+            );
+            for var in &dc.inline_vars {
+                self.live_spans.push(var.expr);
+            }
+            // parity: stylex-create.js:471 hoistExpression — the static chunk
+            // becomes a module const so call results share object identity.
+            let static_ident = if dc.static_props.is_empty() {
+                None
+            } else {
+                let uid = self.generate_uid("temp", call_node);
+                let idx = self.push_edit(Edit::insert(
+                    stmt_start,
+                    format!("const {uid} = {};\n", print_static_chunk(&dc)),
+                ));
+                hoist_edit_idxs.push(idx);
+                if self.build_plan {
+                    self.plan.inserts.push(InsertOp {
+                        anchor: stmt_start,
+                        seq: idx,
+                        span: call.span,
+                        stmt: SynthStmt::ConstDecl {
+                            name: uid.clone(),
+                            value: HoistValue::StaticChunk(dc.clone()),
+                        },
+                    });
+                }
+                Some(uid)
+            };
+            dynamic.push((
+                ns.clone(),
+                print_dynamic_arrow(&dc, self.source, static_ident.as_deref()),
+            ));
+            dynamic_entries.push(DynamicEntry {
+                namespace: ns.clone(),
+                compiled: dc,
+                static_ident,
+            });
+        }
+        self.register_rules(injected, call);
+
+        let style_var = decl
+            .as_ref()
+            .is_some_and(|c| c.top_level && c.name.is_some());
+        if style_var {
+            let name = var_name.clone().expect("style vars have names");
+            self.style_map.insert(name, out.compiled.clone());
+            if let Some(c) = &decl {
+                self.record_override(c, EvalValue::Obj(out.compiled.clone()));
+            }
+        }
+        // parity: pathReplaceHoisted — non-program-level create results hoist
+        // into a collision-free module const so object identity is shared.
+        let (edit_idx, plan_idx) = if self.state.is_program_level(call_node) {
+            let plan_idx = self.build_plan.then(|| {
+                let plan_idx = self.plan.replace_exprs.len();
+                self.plan.replace_exprs.push((
+                    call.span,
+                    SynthExpr::CreateObject {
+                        map: out.compiled.clone(),
+                        dynamic: dynamic_entries.clone(),
+                    },
+                ));
+                plan_idx
+            });
+            let edit_idx = self.push_edit(Edit::replace(
+                call.span,
+                print_create_parens(&out.compiled, &dynamic),
+            ));
+            (edit_idx, plan_idx)
+        } else {
+            let uid = self.generate_uid("styles", call_node);
+            let hoist_idx = self.push_edit(Edit::insert(
+                stmt_start,
+                format!(
+                    "const {uid} = {};\n",
+                    print_create_parens(&out.compiled, &dynamic)
+                ),
+            ));
+            if self.build_plan {
+                self.plan.inserts.push(InsertOp {
+                    anchor: stmt_start,
+                    seq: hoist_idx,
+                    span: call.span,
+                    stmt: SynthStmt::ConstDecl {
+                        name: uid.clone(),
+                        value: HoistValue::CreateObject {
+                            map: out.compiled.clone(),
+                            dynamic: dynamic_entries.clone(),
+                        },
+                    },
+                });
+                self.plan
+                    .replace_exprs
+                    .push((call.span, SynthExpr::Ident(uid.clone())));
+            }
+            (self.push_edit(Edit::replace(call.span, uid)), None)
+        };
+        self.dead_spans.push(call.span);
+        self.create_sites.push(CreateSite {
+            span: call.span,
+            edit_idx,
+            plan_idx,
+            hoist_edit_idxs,
+            compiled: out.compiled,
+            dynamic,
+            dynamic_entries,
+            style_var,
+            var_name,
+            exported: decl.as_ref().is_some_and(|c| c.exported),
+            removal: decl.and_then(|c| c.removal),
+        });
+    }
+
+    fn transform_keyframes(&mut self, call: &'a CallExpression<'a>, ctx: &DeclCtx) {
+        if call.arguments.len() != 1 {
+            return self.fail(StylexError::illegal_argument_length("keyframes", 1));
+        }
+        let arg_expr = call.arguments[0].as_expression();
+        let Some(arg_expr) = arg_expr else {
+            return self.fail(StylexError::non_style_object("keyframes"));
+        };
+        if !matches!(unwrap_parens(arg_expr), Expression::ObjectExpression(_)) {
+            return self.fail(StylexError::non_style_object("keyframes"));
+        }
+        let registry =
+            FunctionRegistry::for_keyframes(&self.state.imports, &self.state.options.env);
+        let outcome = {
+            let mut evaluator = Evaluator::with_registry(
+                &mut *self.state,
+                self.fs,
+                &RealCallables,
+                registry,
+                false,
+            );
+            evaluator.eval(arg_expr)
+        };
+        let value = match outcome {
+            Ok(EvalOutcome::Value(v)) => to_eval_value(&v),
+            Ok(EvalOutcome::NonStatic(_)) => {
+                return self.fail(StylexError::non_static_value("keyframes"));
+            }
+            Err(error) => return self.fail(error),
+        };
+        let (name, rule) = match keyframes(&value, self.state.options) {
+            Ok(out) => out,
+            Err(error) => return self.fail(error),
+        };
+        self.register_rules(vec![rule], call);
+        self.push_edit(Edit::replace(call.span, js_string_literal(&name)));
+        self.plan
+            .replace_exprs
+            .push((call.span, SynthExpr::Str(name.clone())));
+        self.dead_spans.push(call.span);
+        self.replaced_values
+            .insert(call.span.start, EvalValue::Str(name.clone()));
+        self.record_override(ctx, EvalValue::Str(name));
+    }
+
+    fn transform_default_marker(&mut self, call: &'a CallExpression<'a>, parent: ExprParent<'_>) {
+        if !call.arguments.is_empty() {
+            return self.fail(StylexError::illegal_argument_length("defaultMarker", 0));
+        }
+        let object = Arc::new(default_marker_object(self.state.options));
+        self.push_edit(Edit::replace(call.span, print_parens(&object)));
+        if self.build_plan {
+            self.plan.replace_exprs.push((
+                call.span,
+                SynthExpr::ParenValue(EvalValue::Obj(Arc::clone(&object))),
+            ));
+        }
+        self.dead_spans.push(call.span);
+        self.replaced_values
+            .insert(call.span.start, EvalValue::Obj(Arc::clone(&object)));
+        if let ExprParent::Declarator(ctx) = parent {
+            self.record_override(ctx, EvalValue::Obj(object));
+        }
+    }
+
+    fn transform_define_marker(&mut self, call: &'a CallExpression<'a>, parent: ExprParent<'_>) {
+        let ExprParent::Declarator(ctx) = parent else {
+            return self.fail(StylexError::unbound_call_value("defineMarker"));
+        };
+        let ctx = ctx.clone();
+        let Some(name) = ctx.name.clone() else {
+            return self.fail(StylexError::unbound_call_value("defineMarker"));
+        };
+        if !self.is_named_export(&ctx) {
+            return self.fail(StylexError::non_export_named_declaration("defineMarker"));
+        }
+        if !call.arguments.is_empty() {
+            return self.fail(StylexError::illegal_argument_length("defineMarker", 0));
+        }
+        let Some(file) = self.file_name_for_hashing() else {
+            return self.fail(StylexError::cannot_generate_hash("defineMarker"));
+        };
+        let object = Arc::new(define_marker_object(&file, &name, self.state.options));
+        self.push_edit(Edit::replace(call.span, print_parens(&object)));
+        if self.build_plan {
+            self.plan.replace_exprs.push((
+                call.span,
+                SynthExpr::ParenValue(EvalValue::Obj(Arc::clone(&object))),
+            ));
+        }
+        self.dead_spans.push(call.span);
+        self.replaced_values
+            .insert(call.span.start, EvalValue::Obj(Arc::clone(&object)));
+        self.record_override(&ctx, EvalValue::Obj(object));
+    }
+
+    fn transform_define_consts(&mut self, call: &'a CallExpression<'a>, parent: ExprParent<'_>) {
+        let ExprParent::Declarator(ctx) = parent else {
+            return self.fail(StylexError::unbound_call_value("defineConsts"));
+        };
+        let ctx = ctx.clone();
+        let Some(name) = ctx.name.clone() else {
+            return self.fail(StylexError::unbound_call_value("defineConsts"));
+        };
+        if !self.is_named_export(&ctx) {
+            return self.fail(StylexError::non_export_named_declaration("defineConsts"));
+        }
+        if call.arguments.len() != 1 {
+            return self.fail(StylexError::illegal_argument_length("defineConsts", 1));
+        }
+        let Some(arg_expr) = call.arguments[0].as_expression() else {
+            return self.fail(StylexError::non_static_value("defineConsts"));
+        };
+        let registry = FunctionRegistry::for_consts(&self.state.imports, &self.state.options.env);
+        let outcome = {
+            let mut evaluator =
+                Evaluator::with_registry(&mut *self.state, self.fs, &RealCallables, registry, true);
+            evaluator.eval(arg_expr)
+        };
+        let value = match outcome {
+            Ok(EvalOutcome::Value(v)) => to_eval_value(&v),
+            Ok(EvalOutcome::NonStatic(_)) => {
+                return self.fail(StylexError::non_static_value("defineConsts"));
+            }
+            Err(error) => return self.fail(error),
+        };
+        if !matches!(value, EvalValue::Obj(_) | EvalValue::Arr(_)) {
+            return self.fail(StylexError::non_style_object("defineConsts"));
+        }
+        let Some(file) = self.file_name_for_hashing() else {
+            return self.fail(StylexError::cannot_generate_hash("defineConsts"));
+        };
+        let entries: Vec<EvalValue> = match &value {
+            EvalValue::Obj(map) => map.entries().map(|(_, v)| v.clone()).collect(),
+            EvalValue::Arr(items) => items.clone(),
+            _ => unreachable!("checked above"),
+        };
+        let mut out = match define_consts(&value, &file, &name, self.state.options) {
+            Ok(out) => out,
+            Err(error) => return self.fail(error),
+        };
+        // JSON cannot carry the non-finite constVal babel emits; re-tag it.
+        for (rule, source_value) in out.rules.iter_mut().zip(entries.iter()) {
+            if let EvalValue::Num(n) = source_value
+                && !n.is_finite()
+            {
+                rule.const_val = non_finite_to_tag(*n);
+            }
+        }
+        self.register_rules(out.rules, call);
+        self.push_edit(Edit::replace(call.span, print_parens(&out.js_output)));
+        if self.build_plan {
+            self.plan.replace_exprs.push((
+                call.span,
+                SynthExpr::ParenValue(EvalValue::Obj(Arc::new(out.js_output.clone()))),
+            ));
+        }
+        self.dead_spans.push(call.span);
+        self.replaced_values.insert(
+            call.span.start,
+            EvalValue::Obj(Arc::new(out.js_output.clone())),
+        );
+        self.record_override(&ctx, EvalValue::Obj(Arc::new(out.js_output)));
+    }
+
+    /// Replaces a theming-call span and records both value seams (props()
+    /// nullable parsing + babel binding re-resolution).
+    fn finish_replacement(&mut self, ctx: &DeclCtx, span: Span, value: EvalValue, text: String) {
+        self.push_edit(Edit::replace(span, text));
+        if self.build_plan {
+            // The splice text is js_string_literal for strings, print_parens else.
+            let synth = match &value {
+                EvalValue::Str(name) => SynthExpr::Str(name.clone()),
+                other => SynthExpr::ParenValue(other.clone()),
+            };
+            self.plan.replace_exprs.push((span, synth));
+        }
+        self.dead_spans.push(span);
+        self.replaced_values.insert(span.start, value.clone());
+        self.record_override(ctx, value);
+    }
+
+    fn drain_injected_then(&mut self, rules: Vec<StylexRule>, call: &'a CallExpression<'a>) {
+        let mut injected = std::mem::take(&mut self.state.other_injected_rules);
+        injected.extend(rules);
+        self.register_rules(injected, call);
+    }
+
+    fn register_rules(&mut self, rules: Vec<StylexRule>, call: &'a CallExpression<'a>) {
+        self.register_rules_at(rules, call.node_id.get(), call.span.start);
+    }
+
+    /// parity: state-manager.js registerStyles — metadata plus, under
+    /// runtimeInjection, one inject call per rule before the anchor statement.
+    fn register_rules_at(
+        &mut self,
+        rules: Vec<StylexRule>,
+        node: oxc_syntax::node::NodeId,
+        site_offset: u32,
+    ) {
+        if self.state.options.runtime_injection.is_some() && !rules.is_empty() {
+            let callee = self.inject_callee(node, site_offset);
+            let anchor = self.state.program_statement_start(node);
+            for rule in &rules {
+                let idx = self.push_edit(Edit::insert(
+                    anchor,
+                    format!("{callee}({});\n", print_inject_arg(rule)),
+                ));
+                self.inject_edits.insert(idx);
+                if self.build_plan {
+                    self.plan.inserts.push(InsertOp {
+                        anchor,
+                        seq: idx,
+                        span: Span::new(anchor, anchor),
+                        stmt: SynthStmt::InjectCall {
+                            callee: callee.clone(),
+                            rule: Box::new(rule.clone()),
+                        },
+                    });
+                }
+            }
+        }
+        self.state.rules.extend(rules);
+    }
+
+    fn transform_position_try(&mut self, call: &'a CallExpression<'a>, ctx: &DeclCtx) {
+        if call.arguments.len() != 1 {
+            return self.fail(StylexError::illegal_argument_length("positionTry", 1));
+        }
+        let Some(arg_expr) = call.arguments[0].as_expression() else {
+            return self.fail(StylexError::non_static_value("positionTry"));
+        };
+        let registry =
+            FunctionRegistry::for_keyframes(&self.state.imports, &self.state.options.env);
+        let outcome = {
+            let mut evaluator = Evaluator::with_registry(
+                &mut *self.state,
+                self.fs,
+                &RealCallables,
+                registry,
+                false,
+            );
+            evaluator.eval(arg_expr)
+        };
+        let value = match outcome {
+            Ok(EvalOutcome::Value(v)) => to_eval_value(&v),
+            Ok(EvalOutcome::NonStatic(_)) => {
+                return self.fail(StylexError::non_static_value("positionTry"));
+            }
+            Err(error) => return self.fail(error),
+        };
+        let (name, rule) = match position_try(&value, self.state.options) {
+            Ok(out) => out,
+            Err(error) => return self.fail(error),
+        };
+        self.register_rules(vec![rule], call);
+        self.finish_replacement(
+            ctx,
+            call.span,
+            EvalValue::Str(name.clone()),
+            js_string_literal(&name),
+        );
+    }
+
+    fn transform_view_transition(&mut self, call: &'a CallExpression<'a>, ctx: &DeclCtx) {
+        if call.arguments.len() != 1 {
+            return self.fail(StylexError::illegal_argument_length(
+                "viewTransitionClass",
+                1,
+            ));
+        }
+        let Some(arg_expr) = call.arguments[0].as_expression() else {
+            return self.fail(StylexError::non_static_value("viewTransitionClass"));
+        };
+        let registry =
+            FunctionRegistry::for_view_transition(&self.state.imports, &self.state.options.env);
+        let outcome = {
+            let mut evaluator = Evaluator::with_registry(
+                &mut *self.state,
+                self.fs,
+                &VarsCallables,
+                registry,
+                false,
+            );
+            evaluator.eval(arg_expr)
+        };
+        let value = match outcome {
+            Ok(EvalOutcome::Value(v)) => to_eval_value(&v),
+            Ok(EvalOutcome::NonStatic(_)) => {
+                return self.fail(StylexError::non_static_value("viewTransitionClass"));
+            }
+            Err(error) => return self.fail(error),
+        };
+        let (name, rule) = match view_transition_class(&value, self.state.options) {
+            Ok(out) => out,
+            Err(error) => return self.fail(error),
+        };
+        self.drain_injected_then(vec![rule], call);
+        self.finish_replacement(
+            ctx,
+            call.span,
+            EvalValue::Str(name.clone()),
+            js_string_literal(&name),
+        );
+    }
+
+    fn transform_define_vars(&mut self, call: &'a CallExpression<'a>, parent: ExprParent<'_>) {
+        let ExprParent::Declarator(ctx) = parent else {
+            return self.fail(StylexError::unbound_call_value("defineVars"));
+        };
+        let ctx = ctx.clone();
+        let Some(name) = ctx.name.clone() else {
+            return self.fail(StylexError::unbound_call_value("defineVars"));
+        };
+        if !self.is_named_export(&ctx) {
+            return self.fail(StylexError::non_export_named_declaration("defineVars"));
+        }
+        if call.arguments.len() != 1 {
+            return self.fail(StylexError::illegal_argument_length("defineVars", 1));
+        }
+        let Some(canonical) = self.file_name_for_hashing() else {
+            return self.fail(StylexError::cannot_generate_hash("defineVars"));
+        };
+        let Some(arg_expr) = call.arguments[0].as_expression() else {
+            return self.fail(StylexError::non_static_value("defineVars"));
+        };
+        let registry = vars_registry(&self.state.imports, &self.state.options.env);
+        let output = {
+            let mut evaluator = Evaluator::with_registry(
+                &mut *self.state,
+                self.fs,
+                &VarsCallables,
+                registry,
+                false,
+            );
+            let value = match evaluator.eval(arg_expr) {
+                Ok(EvalOutcome::Value(v)) => v,
+                Ok(EvalOutcome::NonStatic(_)) => {
+                    return self.fail(StylexError::non_static_value("defineVars"));
+                }
+                Err(error) => return self.fail(error),
+            };
+            match define_vars(&mut evaluator, &value, &canonical, &name) {
+                Ok(out) => out,
+                Err(error) => return self.fail(error),
+            }
+        };
+        self.drain_injected_then(output.rules, call);
+        let text = print_parens(&output.js_output);
+        self.finish_replacement(
+            &ctx,
+            call.span,
+            EvalValue::Obj(Arc::new(output.js_output)),
+            text,
+        );
+    }
+
+    fn transform_create_theme(&mut self, call: &'a CallExpression<'a>, parent: ExprParent<'_>) {
+        let ExprParent::Declarator(ctx) = parent else {
+            return self.fail(StylexError::unbound_call_value("createTheme"));
+        };
+        let ctx = ctx.clone();
+        let Some(name) = ctx.name.clone() else {
+            return self.fail(StylexError::unbound_call_value("createTheme"));
+        };
+        if call.arguments.len() != 2 {
+            return self.fail(StylexError::illegal_argument_length("createTheme", 2));
+        }
+        let Some((theme_vars, overrides)) = self.eval_theme_args(call, "createTheme") else {
+            return;
+        };
+        let output = match create_theme(&theme_vars, &overrides, self.state.options) {
+            Ok(out) => out,
+            Err(error) => return self.fail(error),
+        };
+        let js_output = apply_theme_dev_naming(
+            output.js_output,
+            self.state.filename.as_deref(),
+            &name,
+            self.state.options,
+        );
+        self.drain_injected_then(output.rules, call);
+        let text = print_parens(&js_output);
+        self.finish_replacement(&ctx, call.span, EvalValue::Obj(Arc::new(js_output)), text);
+    }
+
+    /// The two createTheme argument evaluations: first with no FunctionConfig,
+    /// second with the vars registry. `None` = already failed.
+    fn eval_theme_args(
+        &mut self,
+        call: &'a CallExpression<'a>,
+        api: &str,
+    ) -> Option<(JsValue, JsValue)> {
+        let (Some(arg0), Some(arg1)) = (
+            call.arguments[0].as_expression(),
+            call.arguments[1].as_expression(),
+        ) else {
+            self.fail(StylexError::non_static_value(api));
+            return None;
+        };
+        let theme_vars = {
+            let mut evaluator = Evaluator::with_registry(
+                &mut *self.state,
+                self.fs,
+                &VarsCallables,
+                FunctionRegistry::default(),
+                false,
+            );
+            match evaluator.eval(arg0) {
+                Ok(EvalOutcome::Value(v)) => v,
+                Ok(EvalOutcome::NonStatic(_)) => {
+                    self.fail(StylexError::non_static_value(api));
+                    return None;
+                }
+                Err(error) => {
+                    self.fail(error);
+                    return None;
+                }
+            }
+        };
+        let registry = vars_registry(&self.state.imports, &self.state.options.env);
+        let overrides = {
+            let mut evaluator = Evaluator::with_registry(
+                &mut *self.state,
+                self.fs,
+                &VarsCallables,
+                registry,
+                false,
+            );
+            match evaluator.eval(arg1) {
+                Ok(EvalOutcome::Value(v)) => v,
+                Ok(EvalOutcome::NonStatic(_)) => {
+                    self.fail(StylexError::non_static_value(api));
+                    return None;
+                }
+                Err(error) => {
+                    self.fail(error);
+                    return None;
+                }
+            }
+        };
+        Some((theme_vars, overrides))
+    }
+
+    fn transform_define_vars_nested(
+        &mut self,
+        call: &'a CallExpression<'a>,
+        parent: ExprParent<'_>,
+    ) {
+        const API: &str = "unstable_defineVarsNested";
+        let ExprParent::Declarator(ctx) = parent else {
+            return self.fail(StylexError::unbound_call_value(API));
+        };
+        let ctx = ctx.clone();
+        let Some(name) = ctx.name.clone() else {
+            return self.fail(StylexError::unbound_call_value(API));
+        };
+        if !self.is_named_export(&ctx) {
+            return self.fail(StylexError::non_export_named_declaration(API));
+        }
+        if call.arguments.len() != 1 {
+            return self.fail(StylexError::illegal_argument_length(API, 1));
+        }
+        let Some(arg_expr) = call.arguments[0].as_expression() else {
+            return self.fail(StylexError::non_static_value(API));
+        };
+        let registry = vars_registry(&self.state.imports, &self.state.options.env);
+        let outcome = {
+            let mut evaluator = Evaluator::with_registry(
+                &mut *self.state,
+                self.fs,
+                &VarsCallables,
+                registry,
+                false,
+            );
+            evaluator.eval(arg_expr)
+        };
+        let value = match outcome {
+            Ok(EvalOutcome::Value(v)) => v,
+            Ok(EvalOutcome::NonStatic(_)) => {
+                return self.fail(StylexError::non_static_value(API));
+            }
+            Err(error) => return self.fail(error),
+        };
+        if !matches!(value, JsValue::Obj(_) | JsValue::Arr(_) | JsValue::Proxy(_)) {
+            return self.fail(StylexError::non_style_object(API));
+        }
+        let Some(canonical) = self.file_name_for_hashing() else {
+            return self.fail(StylexError::cannot_generate_hash(API));
+        };
+        let flat = match flatten_nested_vars_config(&value) {
+            Ok(flat) => flat,
+            Err(error) => return self.fail(error),
+        };
+        let entries: Vec<(String, JsValue)> = flat
+            .entries()
+            .map(|(k, v)| (k.to_string(), from_eval_value(v)))
+            .collect();
+        let output = match define_vars_core(&entries, &canonical, &name, self.state.options) {
+            Ok(out) => out,
+            Err(error) => return self.fail(error),
+        };
+        let js_output = nest_define_vars_js_output(&output.js_output);
+        self.drain_injected_then(output.rules, call);
+        let text = print_parens(&js_output);
+        self.finish_replacement(&ctx, call.span, EvalValue::Obj(Arc::new(js_output)), text);
+    }
+
+    fn transform_define_consts_nested(
+        &mut self,
+        call: &'a CallExpression<'a>,
+        parent: ExprParent<'_>,
+    ) {
+        const API: &str = "unstable_defineConstsNested";
+        let ExprParent::Declarator(ctx) = parent else {
+            return self.fail(StylexError::unbound_call_value(API));
+        };
+        let ctx = ctx.clone();
+        let Some(name) = ctx.name.clone() else {
+            return self.fail(StylexError::unbound_call_value(API));
+        };
+        if !self.is_named_export(&ctx) {
+            return self.fail(StylexError::non_export_named_declaration(API));
+        }
+        if call.arguments.len() != 1 {
+            return self.fail(StylexError::illegal_argument_length(API, 1));
+        }
+        let Some(arg_expr) = call.arguments[0].as_expression() else {
+            return self.fail(StylexError::non_static_value(API));
+        };
+        let registry = FunctionRegistry::for_consts(&self.state.imports, &self.state.options.env);
+        let outcome = {
+            let mut evaluator =
+                Evaluator::with_registry(&mut *self.state, self.fs, &RealCallables, registry, true);
+            evaluator.eval(arg_expr)
+        };
+        let value = match outcome {
+            Ok(EvalOutcome::Value(v)) => to_eval_value(&v),
+            Ok(EvalOutcome::NonStatic(_)) => {
+                return self.fail(StylexError::non_static_value(API));
+            }
+            Err(error) => return self.fail(error),
+        };
+        if !matches!(value, EvalValue::Obj(_) | EvalValue::Arr(_)) {
+            return self.fail(StylexError::non_style_object(API));
+        }
+        let Some(canonical) = self.file_name_for_hashing() else {
+            return self.fail(StylexError::cannot_generate_hash(API));
+        };
+        let mut output = match define_consts_nested(&value, &canonical, &name, self.state.options) {
+            Ok(out) => out,
+            Err(error) => return self.fail(error),
+        };
+        // JSON cannot carry non-finite constVals; re-tag from the flat entries.
+        if let Ok(flat) = flatten_nested_consts_config(&value) {
+            for (rule, (_, source_value)) in output.rules.iter_mut().zip(flat.entries()) {
+                if let EvalValue::Num(n) = source_value
+                    && !n.is_finite()
+                {
+                    rule.const_val = non_finite_to_tag(*n);
+                }
+            }
+        }
+        self.register_rules(output.rules, call);
+        let text = print_parens(&output.js_output);
+        self.finish_replacement(
+            &ctx,
+            call.span,
+            EvalValue::Obj(Arc::new(output.js_output)),
+            text,
+        );
+    }
+
+    fn transform_create_theme_nested(
+        &mut self,
+        call: &'a CallExpression<'a>,
+        parent: ExprParent<'_>,
+    ) {
+        const API: &str = "unstable_createThemeNested";
+        let ExprParent::Declarator(ctx) = parent else {
+            return self.fail(StylexError::unbound_call_value(API));
+        };
+        let ctx = ctx.clone();
+        let Some(name) = ctx.name.clone() else {
+            return self.fail(StylexError::unbound_call_value(API));
+        };
+        if call.arguments.len() != 2 {
+            return self.fail(StylexError::illegal_argument_length(API, 2));
+        }
+        let Some(arg0) = call.arguments[0].as_expression() else {
+            return self.fail(StylexError::non_static_value(API));
+        };
+        let theme_vars = {
+            let mut evaluator = Evaluator::with_registry(
+                &mut *self.state,
+                self.fs,
+                &VarsCallables,
+                FunctionRegistry::default(),
+                false,
+            );
+            match evaluator.eval(arg0) {
+                Ok(EvalOutcome::Value(v)) => v,
+                Ok(EvalOutcome::NonStatic(_)) => {
+                    return self.fail(StylexError::non_static_value(API));
+                }
+                Err(error) => return self.fail(error),
+            }
+        };
+        // parity: the __varGroupHash__ check runs before the overrides evaluate.
+        let var_group_hash = match &theme_vars {
+            JsValue::Proxy(proxy) => proxy.var_group_hash.clone(),
+            JsValue::Obj(obj) => match obj.get("__varGroupHash__") {
+                Some(JsValue::Str(s)) if !s.is_empty() => s.clone(),
+                _ => return self.fail(StylexError::nested_theme_invalid_vars()),
+            },
+            JsValue::Null | JsValue::Undefined => {
+                let kind = if matches!(theme_vars, JsValue::Null) {
+                    "null"
+                } else {
+                    "undefined"
+                };
+                return self.fail(StylexError::new(
+                    crate::errors::ErrorCode::NonStaticValue,
+                    format!("Cannot read properties of {kind} (reading '__varGroupHash__')"),
+                ));
+            }
+            _ => return self.fail(StylexError::nested_theme_invalid_vars()),
+        };
+        let Some(arg1) = call.arguments[1].as_expression() else {
+            return self.fail(StylexError::non_static_value(API));
+        };
+        let registry = vars_registry(&self.state.imports, &self.state.options.env);
+        let overrides = {
+            let mut evaluator = Evaluator::with_registry(
+                &mut *self.state,
+                self.fs,
+                &VarsCallables,
+                registry,
+                false,
+            );
+            match evaluator.eval(arg1) {
+                Ok(EvalOutcome::Value(v)) => v,
+                Ok(EvalOutcome::NonStatic(_)) => {
+                    return self.fail(StylexError::non_static_value(API));
+                }
+                Err(error) => return self.fail(error),
+            }
+        };
+        if !matches!(
+            overrides,
+            JsValue::Obj(_) | JsValue::Arr(_) | JsValue::Proxy(_)
+        ) {
+            return self.fail(StylexError::non_style_object(API));
+        }
+        let mut nested_refs = JsObjectMap::new();
+        if let EvalValue::Obj(map) = to_eval_value(&theme_vars) {
+            for (key, value) in map.entries() {
+                if key != "__varGroupHash__" {
+                    nested_refs.insert(key, value.clone());
+                }
+            }
+        }
+        let mut flat_theme_vars =
+            match flatten_nested_string_config(&EvalValue::Obj(Arc::new(nested_refs))) {
+                Ok(flat) => flat,
+                Err(error) => return self.fail(error),
+            };
+        flat_theme_vars.insert("__varGroupHash__", EvalValue::Str(var_group_hash));
+        let flat_overrides = match flatten_nested_overrides_config(&overrides) {
+            Ok(flat) => flat,
+            Err(error) => return self.fail(error),
+        };
+        let output = match create_theme(
+            &from_eval_value(&EvalValue::Obj(Arc::new(flat_theme_vars))),
+            &from_eval_value(&EvalValue::Obj(Arc::new(flat_overrides))),
+            self.state.options,
+        ) {
+            Ok(out) => out,
+            Err(error) => return self.fail(error),
+        };
+        let js_output = apply_theme_dev_naming(
+            output.js_output,
+            self.state.filename.as_deref(),
+            &name,
+            self.state.options,
+        );
+        self.drain_injected_then(output.rules, call);
+        let text = print_parens(&js_output);
+        self.finish_replacement(&ctx, call.span, EvalValue::Obj(Arc::new(js_output)), text);
+    }
+
+    // ---- pass Atoms: @stylexjs/atoms -------------------------------------
+
+    fn atom_site(&self, span: Span) -> Option<usize> {
+        self.atom_static_sites.iter().position(|s| s.span == span)
+    }
+
+    fn atom_context(&self) -> CreateContext<'_> {
+        CreateContext {
+            options: self.state.options,
+            filename: self.state.filename.clone(),
+            cwd: self.state.cwd.clone(),
+            var_name: None,
+            namespace_lines: None,
+            file_package: None,
+            cwd_package_name: None,
+        }
+    }
+
+    // parity: atoms babel-transform compileStaticStyle.
+    fn transform_atom_static(&mut self, info: &MemberInfo<'a>, property: &str, value: &str) {
+        let out = match compile_atom(property, value, &self.atom_context()) {
+            Ok(out) => out,
+            Err(error) => return self.fail(error),
+        };
+        self.register_rules_at(out.rules, info.node_id, info.span.start);
+        let Some(EvalValue::Obj(compiled)) = out.compiled.get(INLINE_NAMESPACE).cloned() else {
+            return;
+        };
+        // Upstream's replaceWith throws when the member is an assignment target.
+        if info.expr.is_none() {
+            return self.fail(StylexError::upstream_type_crash(
+                "an atom in assignment-target position",
+            ));
+        }
+        let plan_idx = self.build_plan.then(|| {
+            let plan_idx = self.plan.replace_exprs.len();
+            self.plan.replace_exprs.push((
+                info.span,
+                SynthExpr::ParenValue(EvalValue::Obj(compiled.clone())),
+            ));
+            plan_idx
+        });
+        let edit_idx = self.push_edit(Edit::replace(info.span, print_parens(&compiled)));
+        self.dead_spans.push(info.span);
+        self.atom_static_sites.push(AtomStaticSite {
+            span: info.span,
+            node_id: info.node_id,
+            edit_idx,
+            plan_idx,
+            compiled,
+            hoisted: false,
+        });
+    }
+
+    // parity: atoms babel-transform compileDynamicStyle. Only the callee is
+    // rewritten: upstream rebuilds the call around the same argument node.
+    fn transform_atom_dynamic(&mut self, call: &'a CallExpression<'a>, property: &str) {
+        let var_name = format!("--x-{property}");
+        let out = match compile_atom(property, &format!("var({var_name})"), &self.atom_context()) {
+            Ok(out) => out,
+            Err(error) => return self.fail(error),
+        };
+        let node = call.node_id.get();
+        let mut rules = out.rules;
+        rules.push(StylexRule {
+            class_name: var_name.as_str().into(),
+            ltr: format!("@property {var_name} {{ syntax: \"*\"; inherits: false;}}").into(),
+            rtl: None,
+            const_key: None,
+            const_val: None,
+            priority: 0.0,
+        });
+        self.register_rules_at(rules, node, call.span.start);
+        let Some(EvalValue::Obj(compiled)) = out.compiled.get(INLINE_NAMESPACE) else {
+            return;
+        };
+        // The dev class name maps its key to itself, so this skips it.
+        let hit = compiled.entries().find(|(key, value)| {
+            *key != "$$css" && !matches!(value, EvalValue::Str(s) if s == key)
+        });
+        let Some((prop_key, EvalValue::Str(class_name))) = hit else {
+            return;
+        };
+        let (prop_key, class_name) = (prop_key.to_string(), class_name.clone());
+        let uid = self.generate_uid("temp", node);
+        let anchor = self.state.program_statement_start(node);
+        let hoist_idx = self.push_edit(Edit::insert(
+            anchor,
+            format!(
+                "const {uid} = {{{property}: _v => [{{{key}: _v != null ? {class} : _v, \"$$css\": true}}, {{{var}: _v != null ? _v : undefined}}]}};\n",
+                key = js_string_literal(&prop_key),
+                class = js_string_literal(&class_name),
+                var = js_string_literal(&var_name),
+            ),
+        ));
+        let callee_span = call.callee.span();
+        self.push_edit(Edit::replace(callee_span, format!("{uid}.{property}")));
+        self.atom_dynamic_callees.insert(callee_span);
+        if self.build_plan {
+            self.plan.inserts.push(InsertOp {
+                anchor,
+                seq: hoist_idx,
+                span: call.span,
+                stmt: SynthStmt::ConstDecl {
+                    name: uid.clone(),
+                    value: HoistValue::AtomDynamic {
+                        property: property.to_string(),
+                        prop_key,
+                        class_name,
+                        var_name,
+                    },
+                },
+            });
+            self.plan.replace_exprs.push((
+                callee_span,
+                SynthExpr::AtomCallee {
+                    hoisted: uid,
+                    property: property.to_string(),
+                },
+            ));
+        }
+    }
+
+    // parity: scope.generateUid 7.29.8 — `_base`, `_base2`…`_base9`, `_base0`,
+    // `_base1`, `_base10`, … skipping the babel collision surface.
+    fn generate_uid(&mut self, base: &str, scope_node: oxc_syntax::node::NodeId) -> String {
+        let mut i = 0usize;
+        loop {
+            let candidate = match i {
+                0 => format!("_{base}"),
+                1..=8 => format!("_{base}{}", i + 1),
+                9 | 10 => format!("_{base}{}", i - 9),
+                _ => format!("_{base}{}", i - 1),
+            };
+            if !self.generated_uids.contains(&candidate)
+                && !self.state.uid_name_taken(&candidate)
+                && !self.state.any_binding_at(scope_node, &candidate)
+            {
+                self.generated_uids.insert(candidate.clone());
+                return candidate;
+            }
+            i += 1;
+        }
+    }
+
+    // parity: index.js getStylexRuntimeBinding — per-site scope check against
+    // the program-level import, then reuse of generated imports per site.
+    fn stylex_local_for_site(
+        &mut self,
+        site: oxc_syntax::node::NodeId,
+        site_offset: u32,
+    ) -> String {
+        let order = self.state.imports.stylex_namespace_order.clone();
+        for name in &order {
+            if self.state.resolves_to_root_binding(site, name) {
+                return name.clone();
+            }
+        }
+        // A generated import resolves at the site unless a source binding of
+        // the same name shadows it (its own binding is registerDeclaration'd).
+        let generated = self.sx_locals.clone();
+        for name in &generated {
+            if !self.state.any_binding_at(site, name) {
+                return name.clone();
+            }
+        }
+        let existing_source = self
+            .import_decls
+            .iter()
+            .map(|(source, _)| source.clone())
+            .find(|source| self.state.options.is_import_source(source));
+        // The synthesized statement is always `import * as <local> from
+        // "<from>"`, which an aliased source would not recognize on a re-run.
+        let source = existing_source.clone().unwrap_or_else(|| {
+            self.state
+                .options
+                .import_source_at(2)
+                .or_else(|| self.state.options.import_source_at(0))
+                .expect("the two built-in import sources are always present")
+                .to_string()
+        });
+        let name = if existing_source.is_none()
+            && self.sx_locals.is_empty()
+            && !self.state.any_binding_at(site, "stylex")
+        {
+            "stylex".to_string()
+        } else {
+            self.generate_uid("stylex", site)
+        };
+        self.push_prologue_group(
+            site_offset,
+            vec![PrologueStmt::NamespaceImport {
+                local: name.clone(),
+                source,
+            }],
+        );
+        self.sx_locals.push(name.clone());
+        name
+    }
+
+    /// parity: ast-helpers.js addDefaultImport/addNamedImport — the import
+    /// local is never called; an alias var beside it is.
+    fn inject_callee(&mut self, site: oxc_syntax::node::NodeId, site_offset: u32) -> String {
+        if let Some(alias) = &self.inject_alias {
+            return alias.clone();
+        }
+        let injection = self
+            .state
+            .options
+            .runtime_injection
+            .clone()
+            .expect("checked by the caller");
+        let local = self.generate_uid("inject", site);
+        let alias = match &injection.as_name {
+            Some(as_name) => self.generate_uid(as_name, site),
+            None => self.generate_uid("inject", site),
+        };
+        self.push_prologue_group(
+            site_offset,
+            vec![
+                PrologueStmt::InjectImport {
+                    local: local.clone(),
+                    source: injection.from,
+                    named: injection.as_name,
+                },
+                PrologueStmt::InjectAlias {
+                    name: alias.clone(),
+                    local,
+                },
+            ],
+        );
+        self.inject_alias = Some(alias.clone());
+        alias
+    }
+
+    fn push_prologue_group(&mut self, site_offset: u32, group: Vec<PrologueStmt>) {
+        self.prologue_groups.push((site_offset, group));
+        let offset = self.import_insert_offset;
+        let mut block: String = self
+            .prologue_statements()
+            .iter()
+            .map(prologue_text)
+            .collect();
+        // Empty program body: land on a fresh line after the directive prologue.
+        if offset > 0 && !self.source[..offset as usize].ends_with('\n') {
+            block = format!("\n{block}");
+        }
+        let idx = self.prologue_edit.expect("slot 0 is reserved at init");
+        self.edits[idx] = Some(Edit::insert(offset, block));
+    }
+
+    /// Replays babel's program.unshiftContainer per generating site in
+    /// traversal (= source) order, then its `_blockHoist` body sort.
+    fn prologue_statements(&self) -> Vec<PrologueStmt> {
+        let mut groups: Vec<&(u32, Vec<PrologueStmt>)> = self.prologue_groups.iter().collect();
+        groups.sort_by_key(|(offset, _)| *offset);
+        let mut out: Vec<PrologueStmt> = Vec::new();
+        for (_, group) in groups {
+            for (i, stmt) in group.iter().enumerate() {
+                out.insert(i, stmt.clone());
+            }
+        }
+        out.sort_by_key(|stmt| std::cmp::Reverse(block_hoist(stmt)));
+        out
+    }
+
+    // ---- pass B2: props()/attrs() and the sx spread ------------------------
+
+    fn props_eval(&mut self, expr: &'a Expression<'a>) -> Result<EvalOutcome, StylexError> {
+        let registry = FunctionRegistry::for_props(&self.state.imports, &self.state.options.env);
+        let mut evaluator =
+            Evaluator::with_registry(&mut *self.state, self.fs, &RealCallables, registry, true);
+        evaluator.eval(expr)
+    }
+
+    // parity: stylex-props.js parseNullableStyle.
+    fn parse_nullable(&mut self, expr: &'a Expression<'a>) -> Result<NullableStyle, StylexError> {
+        let expr = unwrap_parens(expr);
+        match expr {
+            Expression::NullLiteral(_) => return Ok(NullableStyle::Null),
+            Expression::Identifier(id) if id.name == "undefined" => {
+                return Ok(NullableStyle::Null);
+            }
+            Expression::CallExpression(call) => {
+                // A marker call replaced in pass A is an object literal by now.
+                if let Some(value) = self.replaced_values.get(&call.span.start) {
+                    if matches!(value, EvalValue::Obj(_) | EvalValue::Arr(_)) {
+                        return Ok(NullableStyle::Style(value.clone()));
+                    }
+                    return Ok(NullableStyle::Other);
+                }
+                return Ok(NullableStyle::Other);
+            }
+            Expression::StaticMemberExpression(_) | Expression::ComputedMemberExpression(_) => {
+                // An atom the previous pass inlined is an object literal here.
+                if let Some(site) = self.atom_site(expr.span()) {
+                    return Ok(NullableStyle::Style(EvalValue::Obj(
+                        self.atom_static_sites[site].compiled.clone(),
+                    )));
+                }
+                if let Some((object_name, Some(prop))) = style_map_member(expr)
+                    && let Some(namespaces) = self.style_map.get(&object_name)
+                    && let Some(value) = namespaces.get(&prop)
+                    && !matches!(value, EvalValue::Null | EvalValue::Undefined)
+                {
+                    return Ok(NullableStyle::Style(value.clone()));
+                }
+            }
+            _ => {}
+        }
+        match self.props_eval(expr)? {
+            EvalOutcome::NonStatic(_) => Ok(NullableStyle::Other),
+            EvalOutcome::Value(JsValue::Proxy(_)) => Ok(NullableStyle::Other),
+            EvalOutcome::Value(v) => {
+                let value = to_eval_value(&v);
+                match &value {
+                    EvalValue::Obj(map)
+                        if map.get("__IS_PROXY") == Some(&EvalValue::Bool(true)) =>
+                    {
+                        Ok(NullableStyle::Other)
+                    }
+                    EvalValue::Obj(_) | EvalValue::Arr(_) => Ok(NullableStyle::Style(value)),
+                    _ => Ok(NullableStyle::Other),
+                }
+            }
+        }
+    }
+
+    /// parity: stylex-merge.js parseNullableStyle — node-based only, with no
+    /// `evaluate()` fallback, so identifiers and object literals are 'other'.
+    fn parse_nullable_legacy(&self, expr: &'a Expression<'a>) -> NullableStyle {
+        let expr = unwrap_parens(expr);
+        match expr {
+            Expression::NullLiteral(_) => return NullableStyle::Null,
+            Expression::Identifier(id) if id.name == "undefined" => return NullableStyle::Null,
+            Expression::StaticMemberExpression(_) | Expression::ComputedMemberExpression(_) => {
+                if let Some((object_name, Some(prop))) = style_map_member(expr)
+                    && let Some(namespaces) = self.style_map.get(&object_name)
+                    && let Some(value) = namespaces.get(&prop)
+                    && !matches!(value, EvalValue::Null | EvalValue::Undefined)
+                {
+                    return NullableStyle::Style(value.clone());
+                }
+            }
+            _ => {}
+        }
+        NullableStyle::Other
+    }
+
+    /// parity: stylex-merge.js `switch (arg.type)` over the *unflattened*
+    /// arguments — no arrays, no identifiers, no object literals, no calls.
+    fn classify_legacy(&mut self, arguments: &'a [Argument<'a>]) -> Classified {
+        let mut args = Vec::with_capacity(arguments.len());
+        let mut tests = Vec::new();
+        for argument in arguments {
+            let Some(expr) = argument.as_expression() else {
+                args.push(MergeArg::Unsupported);
+                continue;
+            };
+            match unwrap_parens(expr) {
+                Expression::ConditionalExpression(c) => {
+                    let primary = self.parse_nullable_legacy(&c.consequent);
+                    let fallback = self.parse_nullable_legacy(&c.alternate);
+                    if primary != NullableStyle::Other && fallback != NullableStyle::Other {
+                        tests.push(c.test.span());
+                    }
+                    args.push(MergeArg::Conditional { primary, fallback });
+                }
+                Expression::LogicalExpression(l)
+                    if l.operator == oxc_syntax::operator::LogicalOperator::And =>
+                {
+                    let left = self.parse_nullable_legacy(&l.left);
+                    let right = self.parse_nullable_legacy(&l.right);
+                    if left == NullableStyle::Other && right != NullableStyle::Other {
+                        tests.push(l.left.span());
+                    }
+                    args.push(MergeArg::LogicalAnd { left, right });
+                }
+                Expression::LogicalExpression(_) => args.push(MergeArg::NonAndLogical),
+                member @ (Expression::StaticMemberExpression(_)
+                | Expression::ComputedMemberExpression(_)) => {
+                    args.push(MergeArg::Resolved(self.parse_nullable_legacy(member)));
+                }
+                _ => args.push(MergeArg::Unsupported),
+            }
+        }
+        Classified { args, tests }
+    }
+
+    fn classify(&mut self, flat: &[FlatArg<'a>]) -> Result<Classified, StylexError> {
+        let mut args = Vec::with_capacity(flat.len());
+        let mut tests = Vec::new();
+        for entry in flat {
+            let FlatArg::Expr(expr) = entry else {
+                args.push(MergeArg::Unsupported);
+                continue;
+            };
+            match expr {
+                Expression::ConditionalExpression(c) => {
+                    let primary = self.parse_nullable(&c.consequent)?;
+                    let fallback = self.parse_nullable(&c.alternate)?;
+                    if primary != NullableStyle::Other && fallback != NullableStyle::Other {
+                        tests.push(c.test.span());
+                    }
+                    args.push(MergeArg::Conditional { primary, fallback });
+                }
+                Expression::LogicalExpression(l)
+                    if l.operator == oxc_syntax::operator::LogicalOperator::And =>
+                {
+                    let left = self.parse_nullable(&l.left)?;
+                    let right = self.parse_nullable(&l.right)?;
+                    if left == NullableStyle::Other && right != NullableStyle::Other {
+                        tests.push(l.left.span());
+                    }
+                    args.push(MergeArg::LogicalAnd { left, right });
+                }
+                Expression::LogicalExpression(_) => args.push(MergeArg::NonAndLogical),
+                Expression::ObjectExpression(_)
+                | Expression::Identifier(_)
+                | Expression::StaticMemberExpression(_)
+                | Expression::ComputedMemberExpression(_)
+                | Expression::CallExpression(_) => {
+                    args.push(MergeArg::Resolved(self.parse_nullable(expr)?));
+                }
+                _ => args.push(MergeArg::Unsupported),
+            }
+        }
+        Ok(Classified { args, tests })
+    }
+
+    fn table_text(&self, entries: &[(u32, EvalValue)], tests: &[Span], inner: &[Edit]) -> String {
+        let n = tests.len();
+        let body: Vec<String> = entries
+            .iter()
+            .map(|(key, leaf)| {
+                let mut out = format!("{key}: ");
+                write_value(leaf, &mut out);
+                out
+            })
+            .collect();
+        let lookup: Vec<String> = tests
+            .iter()
+            .enumerate()
+            .map(|(i, span)| {
+                format!(
+                    "!!({}) << {}",
+                    render_span(self.source, *span, inner),
+                    n - 1 - i
+                )
+            })
+            .collect();
+        format!("({{{}}}[{}])", body.join(", "), lookup.join(" | "))
+    }
+
+    fn process_props_call(
+        &mut self,
+        call: &'a CallExpression<'a>,
+        parent: ExprParent<'_>,
+        mode: MergeMode,
+    ) -> Flow {
+        let flat = flatten_call_args(&call.arguments);
+        let classified = match self.classify(&flat) {
+            Ok(c) => c,
+            Err(error) => {
+                self.fail(error);
+                return Flow::Skip;
+            }
+        };
+        let plan = match plan_merge(&classified.args, mode, self.state.options) {
+            Ok(plan) => plan,
+            Err(error) => {
+                self.fail(error);
+                return Flow::Skip;
+            }
+        };
+        match plan {
+            MergePlan::Bail { bail_out_index } => {
+                if let Err(error) = self.collect_from_arguments(&call.arguments, bail_out_index) {
+                    self.fail(error);
+                    return Flow::Skip;
+                }
+                self.hoist_atoms_in_arguments(call);
+                Flow::Walk
+            }
+            MergePlan::Inlined(map) => {
+                if let ExprParent::JsxSpread(attr_span) = parent
+                    && !map.is_empty()
+                {
+                    let _ = self.take_edits_within(attr_span);
+                    self.push_edit(Edit::replace(attr_span, jsx_attrs_text(&map)));
+                    if self.build_plan {
+                        self.plan.jsx_ops.push((attr_span, JsxOp::Attrs(map)));
+                    }
+                } else {
+                    let _ = self.take_edits_within(call.span);
+                    self.push_edit(Edit::replace(call.span, print_parens(&map)));
+                    if self.build_plan {
+                        self.plan.replace_exprs.push((
+                            call.span,
+                            SynthExpr::ParenValue(EvalValue::Obj(Arc::new(map))),
+                        ));
+                    }
+                }
+                Flow::Skip
+            }
+            MergePlan::Table(entries) => {
+                let entries = object_leaves(entries);
+                let inner = self.take_edits_within(call.span);
+                let text = self.table_text(&entries, &classified.tests, &inner);
+                self.push_edit(Edit::replace(call.span, text));
+                if self.build_plan {
+                    self.plan.replace_exprs.push((
+                        call.span,
+                        SynthExpr::Table {
+                            entries,
+                            tests: classified.tests,
+                        },
+                    ));
+                }
+                Flow::Skip
+            }
+        }
+    }
+
+    // parity: stylex-merge.js — the merged value is `styleq(args)[0]`, emitted
+    // as a bare string; there is no JSX-spread fast path and no bail hoisting.
+    fn process_legacy_merge_call(&mut self, call: &'a CallExpression<'a>) -> Flow {
+        let classified = self.classify_legacy(&call.arguments);
+        let plan = match plan_legacy_merge(&classified.args, self.state.options) {
+            Ok(plan) => plan,
+            Err(error) => {
+                self.fail(error);
+                return Flow::Skip;
+            }
+        };
+        match plan {
+            MergePlan::Bail { bail_out_index } => {
+                if let Err(error) = self.collect_from_arguments(&call.arguments, bail_out_index) {
+                    self.fail(error);
+                    return Flow::Skip;
+                }
+                Flow::Walk
+            }
+            MergePlan::Inlined(class_name) => {
+                let _ = self.take_edits_within(call.span);
+                self.push_edit(Edit::replace(call.span, js_string_literal(&class_name)));
+                if self.build_plan {
+                    self.plan
+                        .replace_exprs
+                        .push((call.span, SynthExpr::Str(class_name)));
+                }
+                Flow::Skip
+            }
+            MergePlan::Table(entries) => {
+                let entries: Vec<(u32, EvalValue)> = entries
+                    .into_iter()
+                    .map(|(key, class_name)| (key, EvalValue::Str(class_name)))
+                    .collect();
+                let inner = self.take_edits_within(call.span);
+                let text = self.table_text(&entries, &classified.tests, &inner);
+                self.push_edit(Edit::replace(call.span, text));
+                if self.build_plan {
+                    self.plan.replace_exprs.push((
+                        call.span,
+                        SynthExpr::Table {
+                            entries,
+                            tests: classified.tests,
+                        },
+                    ));
+                }
+                Flow::Skip
+            }
+        }
+    }
+
+    fn process_sx(&mut self, index: usize) -> Flow {
+        let (attr_span, expr) = {
+            let site = &self.sx_sites[index];
+            (site.attr_span, site.expr)
+        };
+        let flat = flatten_single(expr);
+        let classified = match self.classify(&flat) {
+            Ok(c) => c,
+            Err(error) => {
+                self.fail(error);
+                return Flow::Skip;
+            }
+        };
+        let plan = match plan_merge(&classified.args, MergeMode::Props, self.state.options) {
+            Ok(plan) => plan,
+            Err(error) => {
+                self.fail(error);
+                return Flow::Skip;
+            }
+        };
+        match plan {
+            MergePlan::Bail { bail_out_index } => {
+                if let Err(error) = self.collect_single(expr, bail_out_index) {
+                    self.fail(error);
+                    return Flow::Skip;
+                }
+                self.sx_sites[index].bailed.set(true);
+                Flow::Walk
+            }
+            MergePlan::Inlined(map) => {
+                let _ = self.take_edits_within(attr_span);
+                let text = if map.is_empty() {
+                    "{...({})}".to_string()
+                } else {
+                    jsx_attrs_text(&map)
+                };
+                self.push_edit(Edit::replace(attr_span, text));
+                if self.build_plan {
+                    let op = if map.is_empty() {
+                        JsxOp::SpreadEmptyObject
+                    } else {
+                        JsxOp::Attrs(map)
+                    };
+                    self.plan.jsx_ops.push((attr_span, op));
+                }
+                Flow::Skip
+            }
+            MergePlan::Table(entries) => {
+                let entries = object_leaves(entries);
+                let inner = self.take_edits_within(attr_span);
+                let table = self.table_text(&entries, &classified.tests, &inner);
+                self.push_edit(Edit::replace(attr_span, format!("{{...{table}}}")));
+                if self.build_plan {
+                    self.plan.jsx_ops.push((
+                        attr_span,
+                        JsxOp::SpreadTable {
+                            entries,
+                            tests: classified.tests,
+                        },
+                    ));
+                }
+                Flow::Skip
+            }
+        }
+    }
+
+    /// parity: stylex-props.js:277-300 — an argument object carrying `$$css:
+    /// true` hoists to module scope. Atom-scoped here; see docs/design-core.md.
+    fn hoist_atoms_in_arguments(&mut self, call: &'a CallExpression<'a>) {
+        let anchor = self.state.program_statement_start(call.node_id.get());
+        for argument in &call.arguments {
+            let arg_span = argument.span();
+            let sites: Vec<usize> = (0..self.atom_static_sites.len())
+                .filter(|i| {
+                    let site = &self.atom_static_sites[*i];
+                    !site.hoisted
+                        && site.span.start >= arg_span.start
+                        && site.span.end <= arg_span.end
+                })
+                .collect();
+            for index in sites {
+                let site = &self.atom_static_sites[index];
+                let (span, node_id, edit_idx, plan_idx) =
+                    (site.span, site.node_id, site.edit_idx, site.plan_idx);
+                let compiled = site.compiled.clone();
+                let uid = self.generate_uid("temp", node_id);
+                let hoist_idx = self.push_edit(Edit::insert(
+                    anchor,
+                    format!("const {uid} = {};\n", print_parens(&compiled)),
+                ));
+                self.edits[edit_idx] = Some(Edit::replace(span, uid.clone()));
+                if self.build_plan {
+                    if let Some(plan_idx) = plan_idx {
+                        self.plan.replace_exprs[plan_idx] = (span, SynthExpr::Ident(uid.clone()));
+                    }
+                    self.plan.inserts.push(InsertOp {
+                        anchor,
+                        seq: hoist_idx,
+                        span,
+                        stmt: SynthStmt::ConstDecl {
+                            name: uid,
+                            value: HoistValue::ParenValue(EvalValue::Obj(compiled)),
+                        },
+                    });
+                }
+                self.atom_static_sites[index].hoisted = true;
+            }
+        }
+    }
+
+    fn collect_from_arguments(
+        &mut self,
+        arguments: &'a [Argument<'a>],
+        bail_out_index: Option<usize>,
+    ) -> Result<(), StylexError> {
+        let mut collector = StyleVarsCollector::new(bail_out_index);
+        for (index, argument) in arguments.iter().enumerate() {
+            let expr = match argument {
+                Argument::SpreadElement(spread) => &spread.argument,
+                other => match other.as_expression() {
+                    Some(expr) => expr,
+                    None => continue,
+                },
+            };
+            self.collect_members(expr, index, &mut collector)?;
+        }
+        Ok(())
+    }
+
+    fn collect_single(
+        &mut self,
+        expr: &'a Expression<'a>,
+        bail_out_index: Option<usize>,
+    ) -> Result<(), StylexError> {
+        let mut collector = StyleVarsCollector::new(bail_out_index);
+        self.collect_members(expr, 0, &mut collector)
+    }
+
+    fn collect_members(
+        &mut self,
+        expr: &'a Expression<'a>,
+        index: usize,
+        collector: &mut StyleVarsCollector,
+    ) -> Result<(), StylexError> {
+        let mut hooks = CollectorHooks {
+            s: self,
+            collector,
+            index,
+            error: None,
+        };
+        walk_expression(&mut hooks, expr, ExprParent::Other);
+        match hooks.error.take() {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
+    }
+
+    fn eval_member_for_collector(
+        &mut self,
+        expr: &'a Expression<'a>,
+    ) -> Result<MemberEval, StylexError> {
+        match self.props_eval(expr)? {
+            EvalOutcome::NonStatic(_) => Ok(MemberEval::NonStatic),
+            EvalOutcome::Value(JsValue::Proxy(_)) => Ok(MemberEval::NonStatic),
+            EvalOutcome::Value(v) if is_nullish(&v) => Ok(MemberEval::NonStatic),
+            EvalOutcome::Value(v) => {
+                let value = to_eval_value(&v);
+                if let EvalValue::Obj(map) = &value
+                    && map.get("__IS_PROXY") == Some(&EvalValue::Bool(true))
+                {
+                    return Ok(MemberEval::NonStatic);
+                }
+                Ok(MemberEval::Value(value))
+            }
+        }
+    }
+
+    // ---- finalization -------------------------------------------------------
+
+    fn finalize_sx_bails(&mut self) {
+        let sites = std::mem::take(&mut self.sx_sites);
+        for site in sites.iter().filter(|s| s.bailed.get()) {
+            let inner = self.take_edits_within(site.attr_span);
+            let rendered = render_span(self.source, site.expr.span(), &inner);
+            self.push_edit(Edit::replace(
+                site.attr_span,
+                format!("{{...{}.props({})}}", site.local, rendered),
+            ));
+            if self.build_plan {
+                self.plan.jsx_ops.push((
+                    site.attr_span,
+                    JsxOp::SpreadProps {
+                        local: site.local.clone(),
+                        expr_span: site.expr.span(),
+                    },
+                ));
+            }
+        }
+    }
+
+    fn apply_dce(&mut self) {
+        let vars = compute_vars_to_keep(&self.tuples);
+        // Taken to borrow past the edit/plan mutations; restored for the
+        // caller's create_objects extraction.
+        let sites = std::mem::take(&mut self.create_sites);
+        let mut hoisted: BTreeSet<usize> = sites
+            .iter()
+            .flat_map(|s| s.hoist_edit_idxs.iter().copied())
+            .collect();
+        // The prologue lands at the body start and inject calls sit at their
+        // anchor's start, which a removed create's span would else swallow.
+        hoisted.extend(self.prologue_edit);
+        hoisted.extend(self.inject_edits.iter().copied());
+        type StmtRemovals = (Span, Rc<[Span]>, BTreeSet<usize>);
+        let mut removals: BTreeMap<u32, StmtRemovals> = BTreeMap::new();
+        for site in &sites {
+            if !site.style_var {
+                continue;
+            }
+            let name = site.var_name.as_deref().expect("style vars have names");
+            match dce_action(name, &site.compiled, site.exported, &vars, &self.tuples) {
+                DceAction::KeepAll => {}
+                DceAction::Prune(map) => {
+                    if let Some(slot) = self.edits.get_mut(site.edit_idx)
+                        && slot.is_some()
+                    {
+                        *slot = Some(Edit::replace(
+                            site.span,
+                            print_create_parens(&map, &site.dynamic),
+                        ));
+                        if let Some(plan_idx) = site.plan_idx
+                            && let Some((_, synth)) = self.plan.replace_exprs.get_mut(plan_idx)
+                        {
+                            *synth = SynthExpr::CreateObject {
+                                map: Arc::new(map),
+                                dynamic: site.dynamic_entries.clone(),
+                            };
+                        }
+                    }
+                }
+                DceAction::Remove => {
+                    let removal = site
+                        .removal
+                        .as_ref()
+                        .expect("style vars are top-level declarators");
+                    let entry = removals.entry(removal.stmt_span.start).or_insert_with(|| {
+                        (
+                            removal.stmt_span,
+                            Rc::clone(&removal.decl_spans),
+                            BTreeSet::new(),
+                        )
+                    });
+                    entry.2.insert(removal.decl_index);
+                }
+            }
+        }
+        for (stmt_span, decl_spans, removed) in removals.into_values() {
+            if self.build_plan {
+                self.plan.removes.push(RemoveOp {
+                    stmt_span,
+                    decl_count: decl_spans.len(),
+                    indices: removed.iter().copied().collect(),
+                });
+            }
+            for span in plan_removal_spans(stmt_span, &decl_spans, &removed) {
+                for (idx, slot) in self.edits.iter_mut().enumerate() {
+                    if hoisted.contains(&idx) {
+                        continue;
+                    }
+                    if let Some(edit) = slot
+                        && edit.start >= span.start
+                        && edit.end <= span.end
+                    {
+                        *slot = None;
+                    }
+                }
+                self.edits.push(Some(Edit::replace(span, String::new())));
+            }
+        }
+        self.create_sites = sites;
+    }
+
+    /// `rewriteAliases`: every import source that resolves through the option
+    /// becomes a `./`-prefixed relative path, extension stripped.
+    fn rewrite_import_sources(&mut self, program: &Program<'a>) -> BTreeMap<String, String> {
+        let mut rewrites: BTreeMap<String, String> = BTreeMap::new();
+        if !self.state.options.rewrite_aliases {
+            return rewrites;
+        }
+        let Some(filename) = self.state.filename.clone() else {
+            return rewrites;
+        };
+        for statement in &program.body {
+            let Statement::ImportDeclaration(decl) = statement else {
+                continue;
+            };
+            let source = decl.source.value.as_str();
+            let rewritten = match rewrites.get(source) {
+                Some(hit) => hit.clone(),
+                None => {
+                    let Some(rewritten) = rewritten_import_source(
+                        self.fs,
+                        source,
+                        Path::new(&filename),
+                        self.state.options,
+                    ) else {
+                        continue;
+                    };
+                    rewrites.insert(source.to_string(), rewritten.clone());
+                    rewritten
+                }
+            };
+            let text = js_string_literal(&rewritten);
+            self.push_edit(Edit::replace(decl.source.span, text));
+            if self.build_plan {
+                self.plan.import_sources.push((decl.source.span, rewritten));
+            }
+        }
+        rewrites
+    }
+
+    // parity: evaluate-path.js importPath.insertBefore — the exact declaring
+    // import; an unrewritten source node reprints with its raw quotes.
+    fn insert_treeshake_imports(&mut self, rewrites: &BTreeMap<String, String>) {
+        let imports = self.state.treeshake_imports.clone();
+        for import in imports {
+            let raw = match rewrites.get(&import.specifier) {
+                Some(rewritten) => js_string_literal(rewritten),
+                None => render_span(self.source, import.source_span, &[]),
+            };
+            let idx = self.push_edit(Edit::insert(import.decl_start, format!("import {raw};\n")));
+            if self.build_plan {
+                self.plan.inserts.push(InsertOp {
+                    anchor: import.decl_start,
+                    seq: idx,
+                    span: Span::new(import.decl_start, import.source_span.end),
+                    stmt: SynthStmt::SideEffectImport {
+                        specifier: rewrites
+                            .get(&import.specifier)
+                            .unwrap_or(&import.specifier)
+                            .clone(),
+                        source_span: import.source_span,
+                    },
+                });
+            }
+        }
+    }
+}
+
+// parity: babel path.remove() per dead declarator — kept declarators survive
+// with separators intact; an all-dead statement is removed whole.
+fn plan_removal_spans(
+    stmt_span: Span,
+    decl_spans: &[Span],
+    removed: &BTreeSet<usize>,
+) -> Vec<Span> {
+    if removed.len() == decl_spans.len() {
+        return vec![stmt_span];
+    }
+    let indices: Vec<usize> = removed.iter().copied().collect();
+    let mut out = Vec::new();
+    let mut k = 0;
+    while k < indices.len() {
+        let start_idx = indices[k];
+        let mut end_idx = start_idx;
+        while k + 1 < indices.len() && indices[k + 1] == end_idx + 1 {
+            k += 1;
+            end_idx = indices[k];
+        }
+        out.push(if end_idx + 1 < decl_spans.len() {
+            Span::new(decl_spans[start_idx].start, decl_spans[end_idx + 1].start)
+        } else {
+            Span::new(decl_spans[start_idx - 1].end, decl_spans[end_idx].end)
+        });
+        k += 1;
+    }
+    out
+}
+
+fn object_leaves(entries: Vec<(u32, JsObjectMap)>) -> Vec<(u32, EvalValue)> {
+    entries
+        .into_iter()
+        .map(|(key, map)| (key, EvalValue::Obj(Arc::new(map))))
+        .collect()
+}
+
+fn style_map_member(expr: &Expression<'_>) -> Option<(String, Option<String>)> {
+    match expr {
+        Expression::StaticMemberExpression(m) => match unwrap_parens(&m.object) {
+            Expression::Identifier(obj) => {
+                Some((obj.name.to_string(), Some(m.property.name.to_string())))
+            }
+            _ => None,
+        },
+        Expression::ComputedMemberExpression(m) => match unwrap_parens(&m.object) {
+            Expression::Identifier(obj) => {
+                let prop = match unwrap_parens(&m.expression) {
+                    Expression::StringLiteral(s) => Some(s.value.to_string()),
+                    Expression::NumericLiteral(n) => Some(js_number_to_string(n.value)),
+                    _ => None,
+                };
+                Some((obj.name.to_string(), prop))
+            }
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn flatten_call_args<'a>(arguments: &'a [Argument<'a>]) -> Vec<FlatArg<'a>> {
+    let mut flat = Vec::new();
+    for argument in arguments {
+        match argument {
+            Argument::SpreadElement(_) => flat.push(FlatArg::Bad),
+            other => match other.as_expression() {
+                Some(expr) => flatten_into(unwrap_parens(expr), &mut flat),
+                None => flat.push(FlatArg::Bad),
+            },
+        }
+    }
+    flat
+}
+
+fn flatten_single<'a>(expr: &'a Expression<'a>) -> Vec<FlatArg<'a>> {
+    let mut flat = Vec::new();
+    flatten_into(unwrap_parens(expr), &mut flat);
+    flat
+}
+
+// parity: stylex-props.js flatMap — exactly one level of array expansion.
+fn flatten_into<'a>(expr: &'a Expression<'a>, flat: &mut Vec<FlatArg<'a>>) {
+    if let Expression::ArrayExpression(arr) = expr {
+        for element in &arr.elements {
+            match element {
+                ArrayExpressionElement::Elision(_) => flat.push(FlatArg::Bad),
+                ArrayExpressionElement::SpreadElement(_) => flat.push(FlatArg::Bad),
+                other => match other.as_expression() {
+                    Some(e) => flat.push(FlatArg::Expr(unwrap_parens(e))),
+                    None => flat.push(FlatArg::Bad),
+                },
+            }
+        }
+    } else {
+        flat.push(FlatArg::Expr(expr));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pass A: main-traversal transforms (imports were scanned at state build)
+
+struct PassA<'w, 'a, 'env> {
+    s: &'w mut Shared<'a, 'env>,
+}
+
+impl<'a> Hooks<'a> for PassA<'_, 'a, '_> {
+    fn done(&self) -> bool {
+        self.s.error.is_some()
+    }
+
+    fn call(&mut self, call: &'a CallExpression<'a>, parent: ExprParent<'_>) -> Flow {
+        let Some(kind) = call_kind(call, self.s.state) else {
+            return Flow::Walk;
+        };
+        match kind {
+            CallKind::Keyframes => match parent {
+                ExprParent::Declarator(ctx) if ctx.name.is_some() => {
+                    let ctx = ctx.clone();
+                    self.s.transform_keyframes(call, &ctx);
+                    Flow::Skip
+                }
+                _ => Flow::Walk,
+            },
+            CallKind::PositionTry => match parent {
+                ExprParent::Declarator(ctx) if ctx.name.is_some() => {
+                    let ctx = ctx.clone();
+                    self.s.transform_position_try(call, &ctx);
+                    Flow::Skip
+                }
+                _ => Flow::Walk,
+            },
+            CallKind::ViewTransitionClass => match parent {
+                ExprParent::Declarator(ctx) if ctx.name.is_some() => {
+                    let ctx = ctx.clone();
+                    self.s.transform_view_transition(call, &ctx);
+                    Flow::Skip
+                }
+                _ => Flow::Walk,
+            },
+            CallKind::DefaultMarker => {
+                self.s.transform_default_marker(call, parent);
+                Flow::Skip
+            }
+            CallKind::DefineMarker => {
+                self.s.transform_define_marker(call, parent);
+                Flow::Skip
+            }
+            CallKind::DefineVars => {
+                self.s.transform_define_vars(call, parent);
+                Flow::Skip
+            }
+            CallKind::CreateTheme => {
+                self.s.transform_create_theme(call, parent);
+                Flow::Skip
+            }
+            CallKind::DefineVarsNested => {
+                self.s.transform_define_vars_nested(call, parent);
+                Flow::Skip
+            }
+            CallKind::DefineConstsNested => {
+                self.s.transform_define_consts_nested(call, parent);
+                Flow::Skip
+            }
+            CallKind::CreateThemeNested => {
+                self.s.transform_create_theme_nested(call, parent);
+                Flow::Skip
+            }
+            CallKind::DefineConsts => {
+                self.s.transform_define_consts(call, parent);
+                Flow::Skip
+            }
+            CallKind::Create => {
+                self.s.transform_create(call, parent);
+                Flow::Skip
+            }
+            CallKind::Props | CallKind::Attrs | CallKind::LegacyMerge => Flow::Walk,
+        }
+    }
+
+    fn jsx_opening(&mut self, el: &'a JSXOpeningElement<'a>) {
+        let Some(sx_name) = self.s.state.options.sx_prop_name.as_deref() else {
+            return;
+        };
+        let JSXElementName::Identifier(name) = &el.name else {
+            return;
+        };
+        let Some(first) = name.name.chars().next() else {
+            return;
+        };
+        // babel's lowercase-element test, allocation-free: the char is its own
+        // lowercase mapping.
+        if !first.to_lowercase().eq(std::iter::once(first)) {
+            return;
+        }
+        for item in &el.attributes {
+            let JSXAttributeItem::Attribute(attr) = item else {
+                continue;
+            };
+            let JSXAttributeName::Identifier(attr_name) = &attr.name else {
+                continue;
+            };
+            if attr_name.name != sx_name {
+                continue;
+            }
+            let Some(JSXAttributeValue::ExpressionContainer(container)) = &attr.value else {
+                continue;
+            };
+            let Some(expr) = container.expression.as_expression() else {
+                continue;
+            };
+            let local = self
+                .s
+                .stylex_local_for_site(el.node_id.get(), el.span.start);
+            self.s.sx_sites.push(SxSite {
+                attr_span: attr.span,
+                expr,
+                local,
+                bailed: Cell::new(false),
+            });
+            break;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pass B1: Program.exit identifier walk (composed-namespace marking)
+
+struct PassB1<'w, 'a, 'env> {
+    s: &'w mut Shared<'a, 'env>,
+}
+
+impl<'a> Hooks<'a> for PassB1<'_, 'a, '_> {
+    fn done(&self) -> bool {
+        false
+    }
+
+    fn call(&mut self, call: &'a CallExpression<'a>, _parent: ExprParent<'_>) -> Flow {
+        // Dead spans still walk when they carry live (spliced) sub-spans; the
+        // identifier/member hooks re-check per node.
+        if self.s.in_dead(call.span) && !self.s.contains_live(call.span) {
+            return Flow::Skip;
+        }
+        match call_kind(call, self.s.state) {
+            Some(CallKind::Props | CallKind::Attrs | CallKind::LegacyMerge) => Flow::Skip,
+            _ => Flow::Walk,
+        }
+    }
+
+    fn jsx_attribute(&mut self, attr: &'a JSXAttribute<'a>) -> Flow {
+        if self.s.sx_sites.iter().any(|s| s.attr_span == attr.span) {
+            Flow::Skip
+        } else {
+            Flow::Walk
+        }
+    }
+
+    fn identifier(&mut self, name: &str, span: Span) {
+        if self.s.in_dead(span) || !self.s.style_map.contains_key(name) {
+            return;
+        }
+        self.s.tuples.push(StyleVarToKeep {
+            var_name: name.to_string(),
+            namespace: None,
+            non_null_props: crate::transform::merge::NonNullProps::True,
+        });
+    }
+
+    fn member(&mut self, info: &MemberInfo<'a>) -> MemberFlow {
+        if info.optional || self.s.in_dead(info.span) {
+            return MemberFlow::Walk;
+        }
+        let Expression::Identifier(object) = unwrap_parens(info.object) else {
+            return MemberFlow::Walk;
+        };
+        if !self.s.style_map.contains_key(object.name.as_str()) {
+            return MemberFlow::Walk;
+        }
+        let namespace = match &info.prop {
+            MemberProp::Static(name) => Some((*name).to_string()),
+            MemberProp::Computed(expr) => match unwrap_parens(expr) {
+                Expression::StringLiteral(s) => Some(s.value.to_string()),
+                Expression::NumericLiteral(n) => Some(js_number_to_string(n.value)),
+                _ => None,
+            },
+        };
+        self.s.tuples.push(StyleVarToKeep {
+            var_name: object.name.to_string(),
+            namespace,
+            non_null_props: crate::transform::merge::NonNullProps::True,
+        });
+        MemberFlow::SkipObject
+    }
+
+    fn export_local(&mut self, name: &str, _span: Span) {
+        self.identifier(name, Span::default());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pass Atoms: Program.exit pass 2, between the identifier walk and props/attrs
+
+struct PassAtoms<'w, 'a, 'env> {
+    s: &'w mut Shared<'a, 'env>,
+    /// Member spans sitting in callee position; the static form skips those.
+    callee_spans: BTreeSet<Span>,
+}
+
+impl<'a> Hooks<'a> for PassAtoms<'_, 'a, '_> {
+    fn done(&self) -> bool {
+        self.s.error.is_some()
+    }
+
+    fn call(&mut self, call: &'a CallExpression<'a>, _parent: ExprParent<'_>) -> Flow {
+        if self.s.within_dead_span(call.span) {
+            return Flow::Skip;
+        }
+        self.callee_spans.insert(call.callee.span());
+        match dynamic_style(call, call.node_id.get(), self.s.state) {
+            Some((AtomStyle::Dynamic { property }, _arg)) => {
+                self.s.transform_atom_dynamic(call, &property);
+                Flow::ArgsOnly
+            }
+            _ => Flow::Walk,
+        }
+    }
+
+    fn member(&mut self, info: &MemberInfo<'a>) -> MemberFlow {
+        if info.optional
+            || self.callee_spans.contains(&info.span)
+            || self.s.within_dead_span(info.span)
+        {
+            return MemberFlow::Walk;
+        }
+        let key = match &info.prop {
+            MemberProp::Static(name) => Some((*name).to_string()),
+            MemberProp::Computed(expr) => match expr {
+                Expression::StringLiteral(s) => Some(s.value.to_string()),
+                Expression::NumericLiteral(n) => Some(js_number_to_string(n.value)),
+                _ => None,
+            },
+        };
+        match static_style(info.object, key.as_deref(), info.node_id, self.s.state) {
+            Some(AtomStyle::Static { property, value }) => {
+                self.s.transform_atom_static(info, &property, &value);
+                MemberFlow::SkipObject
+            }
+            _ => MemberFlow::Walk,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pass B2: Program.exit call transforms (legacy merge ban, props/attrs, sx)
+
+struct PassB2<'w, 'a, 'env> {
+    s: &'w mut Shared<'a, 'env>,
+}
+
+impl<'a> Hooks<'a> for PassB2<'_, 'a, '_> {
+    fn done(&self) -> bool {
+        self.s.error.is_some()
+    }
+
+    fn call(&mut self, call: &'a CallExpression<'a>, parent: ExprParent<'_>) -> Flow {
+        if self.s.in_dead(call.span) {
+            return Flow::Skip;
+        }
+        match call_kind(call, self.s.state) {
+            Some(CallKind::LegacyMerge) => self.s.process_legacy_merge_call(call),
+            Some(CallKind::Props) => self.s.process_props_call(call, parent, MergeMode::Props),
+            Some(CallKind::Attrs) => self.s.process_props_call(call, parent, MergeMode::Attrs),
+            _ => Flow::Walk,
+        }
+    }
+
+    fn jsx_attribute(&mut self, attr: &'a JSXAttribute<'a>) -> Flow {
+        let index = self
+            .s
+            .sx_sites
+            .iter()
+            .position(|s| s.attr_span == attr.span);
+        match index {
+            Some(index) => self.s.process_sx(index),
+            None => Flow::Walk,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bail-branch member collector (runs inside pass B2)
+
+struct CollectorHooks<'w, 'x, 'a, 'env> {
+    s: &'w mut Shared<'a, 'env>,
+    collector: &'x mut StyleVarsCollector,
+    index: usize,
+    error: Option<StylexError>,
+}
+
+impl<'a> Hooks<'a> for CollectorHooks<'_, '_, 'a, '_> {
+    fn done(&self) -> bool {
+        self.error.is_some()
+    }
+
+    fn member(&mut self, info: &MemberInfo<'a>) -> MemberFlow {
+        if info.optional {
+            return MemberFlow::Walk;
+        }
+        // Post-atoms the node is an object literal, so no member is visited.
+        if self.s.atom_site(info.span).is_some() {
+            return MemberFlow::SkipObject;
+        }
+        // A dynamic atom's callee reads as `_temp.<prop>`: never a style map
+        // member, and never statically evaluable.
+        if self.s.atom_dynamic_callees.contains(&info.span) {
+            self.collector
+                .record(self.index, None, || MemberEval::NonStatic);
+            return MemberFlow::SkipObject;
+        }
+        let member = style_map_member_info(info);
+        let style_member = member
+            .as_ref()
+            .filter(|(object, _)| self.s.style_map.contains_key(object));
+        let member_expr = info.expr;
+        let mut eval_error: Option<StylexError> = None;
+        let s = &mut *self.s;
+        let kept = self.collector.record(
+            self.index,
+            style_member.map(|(object, prop)| (object.as_str(), prop.as_deref())),
+            || match member_expr {
+                None => MemberEval::NonStatic,
+                Some(expr) => match s.eval_member_for_collector(expr) {
+                    Ok(result) => result,
+                    Err(error) => {
+                        eval_error = Some(error);
+                        MemberEval::NonStatic
+                    }
+                },
+            },
+        );
+        if let Some(error) = eval_error {
+            self.error = Some(error);
+            return MemberFlow::Walk;
+        }
+        if let Some(tuple) = kept {
+            self.s.tuples.push(tuple);
+        }
+        MemberFlow::Walk
+    }
+}
+
+fn style_map_member_info(info: &MemberInfo<'_>) -> Option<(String, Option<String>)> {
+    let Expression::Identifier(object) = unwrap_parens(info.object) else {
+        return None;
+    };
+    let prop = match &info.prop {
+        MemberProp::Static(name) => Some((*name).to_string()),
+        MemberProp::Computed(expr) => match unwrap_parens(expr) {
+            Expression::StringLiteral(s) => Some(s.value.to_string()),
+            Expression::NumericLiteral(n) => Some(js_number_to_string(n.value)),
+            _ => None,
+        },
+    };
+    Some((object.name.to_string(), prop))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn removal_spans_are_disjoint_per_statement() {
+        // const a = 1, b = 2, c = 3;  (statement 0..26, declarators below)
+        let stmt = Span::new(0, 26);
+        let decls = [Span::new(6, 11), Span::new(13, 18), Span::new(20, 25)];
+        let plan = |idxs: &[usize]| {
+            plan_removal_spans(stmt, &decls, &idxs.iter().copied().collect::<BTreeSet<_>>())
+        };
+        assert_eq!(plan(&[0, 1, 2]), vec![stmt]);
+        assert_eq!(plan(&[0]), vec![Span::new(6, 13)]);
+        assert_eq!(plan(&[1]), vec![Span::new(13, 20)]);
+        assert_eq!(plan(&[2]), vec![Span::new(18, 25)]);
+        assert_eq!(plan(&[0, 2]), vec![Span::new(6, 13), Span::new(18, 25)]);
+        assert_eq!(plan(&[0, 1]), vec![Span::new(6, 20)]);
+        assert_eq!(plan(&[1, 2]), vec![Span::new(11, 25)]);
+        for idxs in [&[0usize, 2][..], &[0, 1], &[1, 2]] {
+            let spans = plan(idxs);
+            for pair in spans.windows(2) {
+                assert!(pair[0].end <= pair[1].start, "overlap: {spans:?}");
+            }
+        }
+    }
+}

--- a/crates/stylex/src/transform/visitor.rs
+++ b/crates/stylex/src/transform/visitor.rs
@@ -49,7 +49,7 @@ use crate::shared::position_try::{position_try, position_try_shared};
 use crate::shared::types::create_css_type;
 use crate::shared::view_transition::view_transition_class;
 use crate::shared::when::{WhenRelation, when_selector};
-use crate::state::{CompileState, climb_parens, member_object_span};
+use crate::state::{CompileState, RefParent};
 use crate::transform::ast_backend::{
     AstPlan, DynamicEntry, HoistValue, InsertOp, JsxOp, PrologueStmt, RemoveOp, SynthExpr,
     SynthStmt,
@@ -400,13 +400,14 @@ fn pass_a_index(state: &CompileState<'_>, source: &str) -> SiteIndex {
         .map(|(name, _)| name.as_str())
         .chain(imports.stylex_namespaces.iter().map(String::as_str))
         .collect();
-    let mut starts = state.reference_starts_where(&names, |name, nodes, node| {
+    let mut starts = state.reference_starts_where(&names, |name, site| {
         if !imports.is_stylex_namespace(name) {
             return true;
         }
-        let (_, parent) = climb_parens(nodes, node);
-        match member_object_span(nodes.kind(parent)) {
-            Some((_, Some(property))) => !matches!(
+        match site.parent() {
+            RefParent::Member {
+                property: Some(property),
+            } => !matches!(
                 member_api_kind(property),
                 None | Some(CallKind::Props | CallKind::Attrs)
             ),
@@ -1338,31 +1339,46 @@ pub fn transform_module<'a>(
     if let Some(error) = shared.error.take() {
         return Err(error);
     }
-    let index = pass_b1_index(shared.state, &shared.style_map);
-    {
-        let mut pass = PassB1 {
-            s: &mut shared,
-            index,
-        };
-        walk_program(&mut pass, program);
-    }
-    if !shared.state.imports.atom_imports.is_empty()
-        || !shared.state.imports.atom_binding_locals.is_empty()
-    {
-        let mut pass = PassAtoms {
-            s: &mut shared,
-            callee_spans: BTreeSet::new(),
-        };
-        walk_program(&mut pass, program);
-    }
-    if let Some(error) = shared.error.take() {
-        return Err(error);
-    }
-    let index = pass_b2_index(shared.state, &shared.sx_sites);
-    {
+    let has_atoms = !shared.state.imports.atom_imports.is_empty()
+        || !shared.state.imports.atom_binding_locals.is_empty();
+    if has_atoms {
+        let index = pass_b1_index(shared.state, &shared.style_map);
+        {
+            let mut pass = PassB1 {
+                s: &mut shared,
+                index,
+            };
+            walk_program(&mut pass, program);
+        }
+        {
+            let mut pass = PassAtoms {
+                s: &mut shared,
+                callee_spans: BTreeSet::new(),
+            };
+            walk_program(&mut pass, program);
+        }
+        if let Some(error) = shared.error.take() {
+            return Err(error);
+        }
+        let index = pass_b2_index(shared.state, &shared.sx_sites);
         let mut pass = PassB2 {
             s: &mut shared,
             index,
+        };
+        walk_program(&mut pass, program);
+    } else {
+        // The atoms pass is the only writer of dead spans between B1 and B2;
+        // without it the two Program.exit walks fuse into one.
+        let mut index = pass_b1_index(shared.state, &shared.style_map);
+        index
+            .starts
+            .extend(pass_b2_index(shared.state, &shared.sx_sites).starts);
+        index.starts.sort_unstable();
+        let mut pass = PassB12 {
+            s: &mut shared,
+            index,
+            b1_skip: None,
+            b2_skip: None,
         };
         walk_program(&mut pass, program);
     }
@@ -3729,54 +3745,46 @@ struct PassB1<'w, 'a, 'env> {
     index: SiteIndex,
 }
 
-impl<'a> Hooks<'a> for PassB1<'_, 'a, '_> {
-    fn done(&self) -> bool {
-        false
-    }
-
-    fn wants(&self, span: Span) -> bool {
-        self.index.any_in(span)
-    }
-
-    fn call(&mut self, call: &'a CallExpression<'a>, _parent: ExprParent<'_>) -> Flow {
+impl<'a> Shared<'a, '_> {
+    fn b1_call(&self, call: &'a CallExpression<'a>) -> Flow {
         // Dead spans still walk when they carry live (spliced) sub-spans; the
         // identifier/member hooks re-check per node.
-        if self.s.in_dead(call.span) && !self.s.contains_live(call.span) {
+        if self.in_dead(call.span) && !self.contains_live(call.span) {
             return Flow::Skip;
         }
-        match call_kind(call, self.s.state) {
+        match call_kind(call, self.state) {
             Some(CallKind::Props | CallKind::Attrs | CallKind::LegacyMerge) => Flow::Skip,
             _ => Flow::Walk,
         }
     }
 
-    fn jsx_attribute(&mut self, attr: &'a JSXAttribute<'a>) -> Flow {
-        if self.s.sx_sites.iter().any(|s| s.attr_span == attr.span) {
+    fn b1_jsx_attribute(&self, attr: &'a JSXAttribute<'a>) -> Flow {
+        if self.sx_sites.iter().any(|s| s.attr_span == attr.span) {
             Flow::Skip
         } else {
             Flow::Walk
         }
     }
 
-    fn identifier(&mut self, name: &str, span: Span) {
-        if self.s.in_dead(span) || !self.s.style_map.contains_key(name) {
+    fn b1_identifier(&mut self, name: &str, span: Span) {
+        if self.in_dead(span) || !self.style_map.contains_key(name) {
             return;
         }
-        self.s.tuples.push(StyleVarToKeep {
+        self.tuples.push(StyleVarToKeep {
             var_name: name.to_string(),
             namespace: None,
             non_null_props: crate::transform::merge::NonNullProps::True,
         });
     }
 
-    fn member(&mut self, info: &MemberInfo<'a>) -> MemberFlow {
-        if info.optional || self.s.in_dead(info.span) {
+    fn b1_member(&mut self, info: &MemberInfo<'a>) -> MemberFlow {
+        if info.optional || self.in_dead(info.span) {
             return MemberFlow::Walk;
         }
         let Expression::Identifier(object) = unwrap_parens(info.object) else {
             return MemberFlow::Walk;
         };
-        if !self.s.style_map.contains_key(object.name.as_str()) {
+        if !self.style_map.contains_key(object.name.as_str()) {
             return MemberFlow::Walk;
         }
         let namespace = match &info.prop {
@@ -3787,7 +3795,7 @@ impl<'a> Hooks<'a> for PassB1<'_, 'a, '_> {
                 _ => None,
             },
         };
-        self.s.tuples.push(StyleVarToKeep {
+        self.tuples.push(StyleVarToKeep {
             var_name: object.name.to_string(),
             namespace,
             non_null_props: crate::transform::merge::NonNullProps::True,
@@ -3795,8 +3803,54 @@ impl<'a> Hooks<'a> for PassB1<'_, 'a, '_> {
         MemberFlow::SkipObject
     }
 
+    fn b2_call(&mut self, call: &'a CallExpression<'a>, parent: ExprParent<'_>) -> Flow {
+        if self.in_dead(call.span) {
+            return Flow::Skip;
+        }
+        match call_kind(call, self.state) {
+            Some(CallKind::LegacyMerge) => self.process_legacy_merge_call(call),
+            Some(CallKind::Props) => self.process_props_call(call, parent, MergeMode::Props),
+            Some(CallKind::Attrs) => self.process_props_call(call, parent, MergeMode::Attrs),
+            _ => Flow::Walk,
+        }
+    }
+
+    fn b2_jsx_attribute(&mut self, attr: &'a JSXAttribute<'a>) -> Flow {
+        let index = self.sx_sites.iter().position(|s| s.attr_span == attr.span);
+        match index {
+            Some(index) => self.process_sx(index),
+            None => Flow::Walk,
+        }
+    }
+}
+
+impl<'a> Hooks<'a> for PassB1<'_, 'a, '_> {
+    fn done(&self) -> bool {
+        false
+    }
+
+    fn wants(&self, span: Span) -> bool {
+        self.index.any_in(span)
+    }
+
+    fn call(&mut self, call: &'a CallExpression<'a>, _parent: ExprParent<'_>) -> Flow {
+        self.s.b1_call(call)
+    }
+
+    fn jsx_attribute(&mut self, attr: &'a JSXAttribute<'a>) -> Flow {
+        self.s.b1_jsx_attribute(attr)
+    }
+
+    fn identifier(&mut self, name: &str, span: Span) {
+        self.s.b1_identifier(name, span);
+    }
+
+    fn member(&mut self, info: &MemberInfo<'a>) -> MemberFlow {
+        self.s.b1_member(info)
+    }
+
     fn export_local(&mut self, name: &str, _span: Span) {
-        self.identifier(name, Span::default());
+        self.s.b1_identifier(name, Span::default());
     }
 }
 
@@ -3871,27 +3925,88 @@ impl<'a> Hooks<'a> for PassB2<'_, 'a, '_> {
     }
 
     fn call(&mut self, call: &'a CallExpression<'a>, parent: ExprParent<'_>) -> Flow {
-        if self.s.in_dead(call.span) {
-            return Flow::Skip;
-        }
-        match call_kind(call, self.s.state) {
-            Some(CallKind::LegacyMerge) => self.s.process_legacy_merge_call(call),
-            Some(CallKind::Props) => self.s.process_props_call(call, parent, MergeMode::Props),
-            Some(CallKind::Attrs) => self.s.process_props_call(call, parent, MergeMode::Attrs),
-            _ => Flow::Walk,
-        }
+        self.s.b2_call(call, parent)
     }
 
     fn jsx_attribute(&mut self, attr: &'a JSXAttribute<'a>) -> Flow {
-        let index = self
-            .s
-            .sx_sites
-            .iter()
-            .position(|s| s.attr_span == attr.span);
-        match index {
-            Some(index) => self.s.process_sx(index),
-            None => Flow::Walk,
+        self.s.b2_jsx_attribute(attr)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pass B1 + B2 in one walk (no atoms pass between them)
+
+/// Each pass keeps its own skipped subtree: the walk descends when either
+/// pass wants to, and a pass's hooks stay silent inside the span it skipped.
+struct PassB12<'w, 'a, 'env> {
+    s: &'w mut Shared<'a, 'env>,
+    index: SiteIndex,
+    b1_skip: Option<Span>,
+    b2_skip: Option<Span>,
+}
+
+fn within(skip: Option<Span>, span: Span) -> bool {
+    skip.is_some_and(|s| s.start <= span.start && span.end <= s.end)
+}
+
+fn skip_or_walk(flow: Flow, skip: &mut Option<Span>, span: Span, walk: &mut bool) {
+    match flow {
+        Flow::Skip => *skip = Some(span),
+        Flow::Walk | Flow::ArgsOnly => *walk = true,
+    }
+}
+
+impl<'a> Hooks<'a> for PassB12<'_, 'a, '_> {
+    fn done(&self) -> bool {
+        self.s.error.is_some()
+    }
+
+    fn wants(&self, span: Span) -> bool {
+        self.index.any_in(span)
+    }
+
+    fn call(&mut self, call: &'a CallExpression<'a>, parent: ExprParent<'_>) -> Flow {
+        let mut walk = false;
+        if !within(self.b1_skip, call.span) {
+            let flow = self.s.b1_call(call);
+            skip_or_walk(flow, &mut self.b1_skip, call.span, &mut walk);
         }
+        if !within(self.b2_skip, call.span) {
+            let flow = self.s.b2_call(call, parent);
+            skip_or_walk(flow, &mut self.b2_skip, call.span, &mut walk);
+        }
+        if walk { Flow::Walk } else { Flow::Skip }
+    }
+
+    fn jsx_attribute(&mut self, attr: &'a JSXAttribute<'a>) -> Flow {
+        let mut walk = false;
+        if !within(self.b1_skip, attr.span) {
+            let flow = self.s.b1_jsx_attribute(attr);
+            skip_or_walk(flow, &mut self.b1_skip, attr.span, &mut walk);
+        }
+        if !within(self.b2_skip, attr.span) {
+            let flow = self.s.b2_jsx_attribute(attr);
+            skip_or_walk(flow, &mut self.b2_skip, attr.span, &mut walk);
+        }
+        if walk { Flow::Walk } else { Flow::Skip }
+    }
+
+    fn identifier(&mut self, name: &str, span: Span) {
+        if !within(self.b1_skip, span) {
+            self.s.b1_identifier(name, span);
+        }
+    }
+
+    fn member(&mut self, info: &MemberInfo<'a>) -> MemberFlow {
+        if within(self.b1_skip, info.span) {
+            MemberFlow::Walk
+        } else {
+            self.s.b1_member(info)
+        }
+    }
+
+    fn export_local(&mut self, name: &str, _span: Span) {
+        self.s.b1_identifier(name, Span::default());
     }
 }
 
@@ -3973,7 +4088,7 @@ fn style_map_member_info(info: &MemberInfo<'_>) -> Option<(String, Option<String
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
     #[test]
@@ -4018,7 +4133,7 @@ mod tests {
         }
     }
 
-    fn corpus_sources() -> Vec<(String, String)> {
+    pub(crate) fn corpus_sources() -> Vec<(String, String)> {
         let root = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/../conformance"));
         let mut out = Vec::new();
         // Vendored copies of this crate ship without the conformance corpus.

--- a/crates/stylex/src/transform/visitor.rs
+++ b/crates/stylex/src/transform/visitor.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use memchr::memmem;
 use oxc_ast::ast::{
     Argument, ArrayExpressionElement, BindingPattern, CallExpression, ChainElement, ClassElement,
     Declaration, ExportDefaultDeclarationKind, Expression, ForStatementInit, ForStatementLeft,
@@ -24,7 +25,7 @@ use crate::eval::functions::{
 use crate::eval::value::{EvalValue, JsObjectMap};
 use crate::eval::{
     EvalOutcome, Evaluator, FunctionRegistry, JsValue, evaluate_stylex_create_arg, from_eval_value,
-    is_nullish, to_eval_value, unwrap_parens, validate_create_arg,
+    into_eval_value, into_js_value, is_nullish, to_eval_value, unwrap_parens, validate_create_arg,
 };
 use crate::imports::StylexNamedImport;
 use crate::jsrt::js_number_to_string;
@@ -48,7 +49,7 @@ use crate::shared::position_try::{position_try, position_try_shared};
 use crate::shared::types::create_css_type;
 use crate::shared::view_transition::view_transition_class;
 use crate::shared::when::{WhenRelation, when_selector};
-use crate::state::CompileState;
+use crate::state::{CompileState, climb_parens, member_object_span};
 use crate::transform::ast_backend::{
     AstPlan, DynamicEntry, HoistValue, InsertOp, JsxOp, PrologueStmt, RemoveOp, SynthExpr,
     SynthStmt,
@@ -56,8 +57,9 @@ use crate::transform::ast_backend::{
 use crate::transform::atoms::{AtomStyle, dynamic_style, static_style};
 use crate::transform::dce::{DceAction, compute_vars_to_keep, dce_action};
 use crate::transform::js_out::{
-    Edit, SpliceMap, apply_edits_tracked, is_identifier_key, js_string_literal,
-    print_dynamic_arrow, print_inject_arg, print_static_chunk, render_span, write_value,
+    Edit, SpliceMap, apply_edits_tracked, estimate_object_len, inject_call_text, is_identifier_key,
+    js_string_literal, print_dynamic_arrow, print_static_chunk, render_span, write_object,
+    write_value,
 };
 use crate::transform::merge::{
     MemberEval, MergeArg, MergeMode, MergePlan, NullableStyle, StyleVarToKeep, StyleVarsCollector,
@@ -273,6 +275,10 @@ fn call_kind(call: &CallExpression<'_>, state: &CompileState<'_>) -> Option<Call
     if !imports.is_stylex_namespace(object) {
         return None;
     }
+    member_api_kind(property)
+}
+
+fn member_api_kind(property: &str) -> Option<CallKind> {
     Some(match property {
         "create" => CallKind::Create,
         "keyframes" => CallKind::Keyframes,
@@ -352,6 +358,11 @@ enum MemberFlow {
 
 trait Hooks<'a> {
     fn done(&self) -> bool;
+    /// False when no hook of this pass can fire inside `span`: the walker
+    /// skips the subtree.
+    fn wants(&self, _span: Span) -> bool {
+        true
+    }
     fn call(&mut self, _call: &'a CallExpression<'a>, _parent: ExprParent<'_>) -> Flow {
         Flow::Walk
     }
@@ -366,7 +377,76 @@ trait Hooks<'a> {
     fn export_local(&mut self, _name: &str, _span: Span) {}
 }
 
-fn walk_program<'a>(hooks: &mut dyn Hooks<'a>, program: &'a Program<'a>) {
+/// Sorted source offsets at which a pass's hooks can fire.
+struct SiteIndex {
+    starts: Vec<u32>,
+}
+
+impl SiteIndex {
+    fn any_in(&self, span: Span) -> bool {
+        let i = self.starts.partition_point(|&s| s < span.start);
+        i < self.starts.len() && self.starts[i] < span.end
+    }
+}
+
+/// Pass A acts on `<local>(…)` for the non-props named imports and on
+/// `ns.<api>(…)`; `ns.props(…)`, `ns.attrs(…)` and bare `ns(…)` it walks past.
+fn pass_a_index(state: &CompileState<'_>, source: &str) -> SiteIndex {
+    let imports = &state.imports;
+    let names: Vec<&str> = imports
+        .named
+        .iter()
+        .filter(|(_, b)| !matches!(b, StylexNamedImport::Props | StylexNamedImport::Attrs))
+        .map(|(name, _)| name.as_str())
+        .chain(imports.stylex_namespaces.iter().map(String::as_str))
+        .collect();
+    let mut starts = state.reference_starts_where(&names, |name, nodes, node| {
+        if !imports.is_stylex_namespace(name) {
+            return true;
+        }
+        let (_, parent) = climb_parens(nodes, node);
+        match member_object_span(nodes.kind(parent)) {
+            Some((_, Some(property))) => !matches!(
+                member_api_kind(property),
+                None | Some(CallKind::Props | CallKind::Attrs)
+            ),
+            _ => false,
+        }
+    });
+    // A JSX attribute name is no reference; its source text stands in.
+    if let Some(sx) = state.options.sx_prop_name.as_deref() {
+        starts.extend(memmem::find_iter(source.as_bytes(), sx.as_bytes()).map(|i| i as u32));
+        starts.sort_unstable();
+    }
+    SiteIndex { starts }
+}
+
+fn pass_b1_index(
+    state: &CompileState<'_>,
+    style_map: &BTreeMap<String, Arc<JsObjectMap>>,
+) -> SiteIndex {
+    let names: Vec<&str> = style_map.keys().map(String::as_str).collect();
+    SiteIndex {
+        starts: state.reference_starts(&names),
+    }
+}
+
+fn pass_b2_index(state: &CompileState<'_>, sx_sites: &[SxSite<'_>]) -> SiteIndex {
+    let imports = &state.imports;
+    let names: Vec<&str> = imports
+        .named
+        .iter()
+        .filter(|(_, b)| matches!(b, StylexNamedImport::Props | StylexNamedImport::Attrs))
+        .map(|(name, _)| name.as_str())
+        .chain(imports.stylex_namespaces.iter().map(String::as_str))
+        .collect();
+    let mut starts = state.reference_starts(&names);
+    starts.extend(sx_sites.iter().map(|s| s.attr_span.start));
+    starts.sort_unstable();
+    SiteIndex { starts }
+}
+
+fn walk_program<'a, H: Hooks<'a>>(hooks: &mut H, program: &'a Program<'a>) {
     for statement in &program.body {
         walk_top_statement(hooks, statement);
         if hooks.done() {
@@ -375,17 +455,8 @@ fn walk_program<'a>(hooks: &mut dyn Hooks<'a>, program: &'a Program<'a>) {
     }
 }
 
-fn walk_top_statement<'a>(hooks: &mut dyn Hooks<'a>, statement: &'a Statement<'a>) {
+fn walk_top_statement<'a, H: Hooks<'a>>(hooks: &mut H, statement: &'a Statement<'a>) {
     match statement {
-        Statement::VariableDeclaration(decl) => {
-            walk_variable_declaration(hooks, decl, Some((false, statement.span())));
-        }
-        Statement::ExportDeclaration(export) => match &export.declaration {
-            Declaration::VariableDeclaration(decl) => {
-                walk_variable_declaration(hooks, decl, Some((true, statement.span())));
-            }
-            other => walk_declaration(hooks, other),
-        },
         Statement::ExportNamedDeclaration(export) => {
             for specifier in &export.specifiers {
                 if specifier.export_kind.is_type() {
@@ -402,12 +473,22 @@ fn walk_top_statement<'a>(hooks: &mut dyn Hooks<'a>, statement: &'a Statement<'a
                 }
             }
         }
+        _ if !hooks.wants(statement.span()) => {}
+        Statement::VariableDeclaration(decl) => {
+            walk_variable_declaration(hooks, decl, Some((false, statement.span())));
+        }
+        Statement::ExportDeclaration(export) => match &export.declaration {
+            Declaration::VariableDeclaration(decl) => {
+                walk_variable_declaration(hooks, decl, Some((true, statement.span())));
+            }
+            other => walk_declaration(hooks, other),
+        },
         other => walk_statement(hooks, other),
     }
 }
 
-fn walk_statement<'a>(hooks: &mut dyn Hooks<'a>, statement: &'a Statement<'a>) {
-    if hooks.done() {
+fn walk_statement<'a, H: Hooks<'a>>(hooks: &mut H, statement: &'a Statement<'a>) {
+    if hooks.done() || !hooks.wants(statement.span()) {
         return;
     }
     match statement {
@@ -539,7 +620,7 @@ fn walk_statement<'a>(hooks: &mut dyn Hooks<'a>, statement: &'a Statement<'a>) {
     }
 }
 
-fn walk_declaration<'a>(hooks: &mut dyn Hooks<'a>, declaration: &'a Declaration<'a>) {
+fn walk_declaration<'a, H: Hooks<'a>>(hooks: &mut H, declaration: &'a Declaration<'a>) {
     match declaration {
         Declaration::VariableDeclaration(decl) => walk_variable_declaration(hooks, decl, None),
         Declaration::FunctionDeclaration(f) => walk_function(hooks, f),
@@ -548,7 +629,7 @@ fn walk_declaration<'a>(hooks: &mut dyn Hooks<'a>, declaration: &'a Declaration<
     }
 }
 
-fn walk_for_left<'a>(hooks: &mut dyn Hooks<'a>, left: &'a ForStatementLeft<'a>) {
+fn walk_for_left<'a, H: Hooks<'a>>(hooks: &mut H, left: &'a ForStatementLeft<'a>) {
     match left {
         ForStatementLeft::VariableDeclaration(decl) => {
             walk_variable_declaration(hooks, decl, None);
@@ -561,14 +642,17 @@ fn walk_for_left<'a>(hooks: &mut dyn Hooks<'a>, left: &'a ForStatementLeft<'a>) 
     }
 }
 
-fn walk_variable_declaration<'a>(
-    hooks: &mut dyn Hooks<'a>,
+fn walk_variable_declaration<'a, H: Hooks<'a>>(
+    hooks: &mut H,
     decl: &'a VariableDeclaration<'a>,
     top: Option<(bool, Span)>,
 ) {
     let decl_spans: Option<Rc<[Span]>> =
         top.map(|_| decl.declarations.iter().map(|d| d.span).collect());
     for (i, declarator) in decl.declarations.iter().enumerate() {
+        if !hooks.wants(declarator.span) {
+            continue;
+        }
         let ctx = DeclCtx {
             name: declarator
                 .id
@@ -592,7 +676,7 @@ fn walk_variable_declaration<'a>(
     }
 }
 
-fn walk_binding_pattern<'a>(hooks: &mut dyn Hooks<'a>, pattern: &'a BindingPattern<'a>) {
+fn walk_binding_pattern<'a, H: Hooks<'a>>(hooks: &mut H, pattern: &'a BindingPattern<'a>) {
     match pattern {
         BindingPattern::BindingIdentifier(_) => {}
         BindingPattern::ObjectPattern(p) => {
@@ -623,7 +707,10 @@ fn walk_binding_pattern<'a>(hooks: &mut dyn Hooks<'a>, pattern: &'a BindingPatte
     }
 }
 
-fn walk_function<'a>(hooks: &mut dyn Hooks<'a>, function: &'a Function<'a>) {
+fn walk_function<'a, H: Hooks<'a>>(hooks: &mut H, function: &'a Function<'a>) {
+    if !hooks.wants(function.span) {
+        return;
+    }
     for param in &function.params.items {
         walk_binding_pattern(hooks, &param.pattern);
     }
@@ -637,7 +724,10 @@ fn walk_function<'a>(hooks: &mut dyn Hooks<'a>, function: &'a Function<'a>) {
     }
 }
 
-fn walk_class<'a>(hooks: &mut dyn Hooks<'a>, class: &'a oxc_ast::ast::Class<'a>) {
+fn walk_class<'a, H: Hooks<'a>>(hooks: &mut H, class: &'a oxc_ast::ast::Class<'a>) {
+    if !hooks.wants(class.span) {
+        return;
+    }
     if let Some(heritage) = &class.heritage {
         walk_expression(hooks, &heritage.expression, ExprParent::Other);
     }
@@ -676,8 +766,8 @@ fn walk_class<'a>(hooks: &mut dyn Hooks<'a>, class: &'a oxc_ast::ast::Class<'a>)
     }
 }
 
-fn walk_assignment_target<'a>(
-    hooks: &mut dyn Hooks<'a>,
+fn walk_assignment_target<'a, H: Hooks<'a>>(
+    hooks: &mut H,
     target: &'a oxc_ast::ast::AssignmentTarget<'a>,
 ) {
     use oxc_ast::ast::AssignmentTarget as At;
@@ -730,8 +820,8 @@ fn walk_assignment_target<'a>(
     }
 }
 
-fn walk_assignment_target_maybe<'a>(
-    hooks: &mut dyn Hooks<'a>,
+fn walk_assignment_target_maybe<'a, H: Hooks<'a>>(
+    hooks: &mut H,
     target: &'a oxc_ast::ast::AssignmentTargetMaybeDefault<'a>,
 ) {
     use oxc_ast::ast::AssignmentTargetMaybeDefault as Atd;
@@ -748,8 +838,8 @@ fn walk_assignment_target_maybe<'a>(
     }
 }
 
-fn walk_member_static<'a>(
-    hooks: &mut dyn Hooks<'a>,
+fn walk_member_static<'a, H: Hooks<'a>>(
+    hooks: &mut H,
     m: &'a oxc_ast::ast::StaticMemberExpression<'a>,
     expr: Option<&'a Expression<'a>>,
 ) {
@@ -766,8 +856,8 @@ fn walk_member_static<'a>(
     }
 }
 
-fn walk_member_computed<'a>(
-    hooks: &mut dyn Hooks<'a>,
+fn walk_member_computed<'a, H: Hooks<'a>>(
+    hooks: &mut H,
     m: &'a oxc_ast::ast::ComputedMemberExpression<'a>,
     expr: Option<&'a Expression<'a>>,
 ) {
@@ -785,7 +875,14 @@ fn walk_member_computed<'a>(
     walk_expression(hooks, &m.expression, ExprParent::Other);
 }
 
-fn walk_call<'a>(hooks: &mut dyn Hooks<'a>, call: &'a CallExpression<'a>, parent: ExprParent<'_>) {
+fn walk_call<'a, H: Hooks<'a>>(
+    hooks: &mut H,
+    call: &'a CallExpression<'a>,
+    parent: ExprParent<'_>,
+) {
+    if !hooks.wants(call.span) {
+        return;
+    }
     match hooks.call(call, parent) {
         Flow::Skip => return,
         Flow::Walk => walk_expression(hooks, &call.callee, ExprParent::Other),
@@ -794,7 +891,7 @@ fn walk_call<'a>(hooks: &mut dyn Hooks<'a>, call: &'a CallExpression<'a>, parent
     walk_arguments(hooks, &call.arguments);
 }
 
-fn walk_arguments<'a>(hooks: &mut dyn Hooks<'a>, arguments: &'a [Argument<'a>]) {
+fn walk_arguments<'a, H: Hooks<'a>>(hooks: &mut H, arguments: &'a [Argument<'a>]) {
     for argument in arguments {
         match argument {
             Argument::SpreadElement(spread) => {
@@ -809,8 +906,8 @@ fn walk_arguments<'a>(hooks: &mut dyn Hooks<'a>, arguments: &'a [Argument<'a>]) 
     }
 }
 
-fn walk_expression<'a>(
-    hooks: &mut dyn Hooks<'a>,
+fn walk_expression<'a, H: Hooks<'a>>(
+    hooks: &mut H,
     expr: &'a Expression<'a>,
     parent: ExprParent<'_>,
 ) {
@@ -836,6 +933,9 @@ fn walk_expression<'a>(
         }
         Expression::Identifier(id) => hooks.identifier(id.name.as_str(), id.span),
         Expression::ArrayExpression(arr) => {
+            if !hooks.wants(arr.span) {
+                return;
+            }
             for element in &arr.elements {
                 match element {
                     ArrayExpressionElement::Elision(_) => {}
@@ -851,6 +951,9 @@ fn walk_expression<'a>(
             }
         }
         Expression::ArrowFunctionExpression(arrow) => {
+            if !hooks.wants(arrow.span) {
+                return;
+            }
             for param in &arrow.params.items {
                 walk_binding_pattern(hooks, &param.pattern);
             }
@@ -905,6 +1008,9 @@ fn walk_expression<'a>(
             walk_arguments(hooks, &n.arguments);
         }
         Expression::ObjectExpression(o) => {
+            if !hooks.wants(o.span) {
+                return;
+            }
             for property in &o.properties {
                 match property {
                     ObjectPropertyKind::ObjectProperty(p) => {
@@ -977,7 +1083,7 @@ fn walk_expression<'a>(
 
 // Optional-chain tails are OptionalMemberExpression/OptionalCallExpression in
 // babel, so member/call hooks never fire for the links themselves.
-fn walk_chain<'a>(hooks: &mut dyn Hooks<'a>, element: &'a ChainElement<'a>) {
+fn walk_chain<'a, H: Hooks<'a>>(hooks: &mut H, element: &'a ChainElement<'a>) {
     match element {
         ChainElement::CallExpression(call) => {
             walk_expression(hooks, &call.callee, ExprParent::Other);
@@ -999,7 +1105,10 @@ fn walk_chain<'a>(hooks: &mut dyn Hooks<'a>, element: &'a ChainElement<'a>) {
     }
 }
 
-fn walk_jsx_element<'a>(hooks: &mut dyn Hooks<'a>, el: &'a JSXElement<'a>) {
+fn walk_jsx_element<'a, H: Hooks<'a>>(hooks: &mut H, el: &'a JSXElement<'a>) {
+    if !hooks.wants(el.span) {
+        return;
+    }
     hooks.jsx_opening(&el.opening_element);
     for item in &el.opening_element.attributes {
         match item {
@@ -1018,11 +1127,14 @@ fn walk_jsx_element<'a>(hooks: &mut dyn Hooks<'a>, el: &'a JSXElement<'a>) {
     walk_jsx_children(hooks, &el.children);
 }
 
-fn walk_jsx_fragment<'a>(hooks: &mut dyn Hooks<'a>, fragment: &'a JSXFragment<'a>) {
+fn walk_jsx_fragment<'a, H: Hooks<'a>>(hooks: &mut H, fragment: &'a JSXFragment<'a>) {
+    if !hooks.wants(fragment.span) {
+        return;
+    }
     walk_jsx_children(hooks, &fragment.children);
 }
 
-fn walk_jsx_children<'a>(hooks: &mut dyn Hooks<'a>, children: &'a [JSXChild<'a>]) {
+fn walk_jsx_children<'a, H: Hooks<'a>>(hooks: &mut H, children: &'a [JSXChild<'a>]) {
     for child in children {
         match child {
             JSXChild::Text(_) => {}
@@ -1038,7 +1150,7 @@ fn walk_jsx_children<'a>(hooks: &mut dyn Hooks<'a>, children: &'a [JSXChild<'a>]
     }
 }
 
-fn walk_jsx_attribute_value<'a>(hooks: &mut dyn Hooks<'a>, value: &'a JSXAttributeValue<'a>) {
+fn walk_jsx_attribute_value<'a, H: Hooks<'a>>(hooks: &mut H, value: &'a JSXAttributeValue<'a>) {
     match value {
         JSXAttributeValue::StringLiteral(_) => {}
         JSXAttributeValue::ExpressionContainer(container) => {
@@ -1049,7 +1161,7 @@ fn walk_jsx_attribute_value<'a>(hooks: &mut dyn Hooks<'a>, value: &'a JSXAttribu
     }
 }
 
-fn walk_jsx_expression<'a>(hooks: &mut dyn Hooks<'a>, expression: &'a JSXExpression<'a>) {
+fn walk_jsx_expression<'a, H: Hooks<'a>>(hooks: &mut H, expression: &'a JSXExpression<'a>) {
     match expression {
         JSXExpression::EmptyExpression(_) => {}
         other => {
@@ -1169,6 +1281,9 @@ struct Shared<'a, 'env> {
     /// False on the splice path: the plan would be dropped unread, and its
     /// recording clones compiled maps and object values per site.
     build_plan: bool,
+    /// Shared by every props()/attrs() evaluation: its inputs (import table,
+    /// env) are fixed for the compile.
+    props_registry: Option<FunctionRegistry>,
     error: Option<StylexError>,
 }
 
@@ -1209,17 +1324,26 @@ pub fn transform_module<'a>(
         atom_dynamic_callees: BTreeSet::new(),
         plan: AstPlan::default(),
         build_plan,
+        props_registry: None,
         error: None,
     };
+    let index = pass_a_index(shared.state, source);
     {
-        let mut pass = PassA { s: &mut shared };
+        let mut pass = PassA {
+            s: &mut shared,
+            index,
+        };
         walk_program(&mut pass, program);
     }
     if let Some(error) = shared.error.take() {
         return Err(error);
     }
+    let index = pass_b1_index(shared.state, &shared.style_map);
     {
-        let mut pass = PassB1 { s: &mut shared };
+        let mut pass = PassB1 {
+            s: &mut shared,
+            index,
+        };
         walk_program(&mut pass, program);
     }
     if !shared.state.imports.atom_imports.is_empty()
@@ -1234,8 +1358,12 @@ pub fn transform_module<'a>(
     if let Some(error) = shared.error.take() {
         return Err(error);
     }
+    let index = pass_b2_index(shared.state, &shared.sx_sites);
     {
-        let mut pass = PassB2 { s: &mut shared };
+        let mut pass = PassB2 {
+            s: &mut shared,
+            index,
+        };
         walk_program(&mut pass, program);
     }
     if let Some(error) = shared.error.take() {
@@ -1370,8 +1498,9 @@ fn prologue_text(stmt: &PrologueStmt) -> String {
 }
 
 fn print_parens(map: &JsObjectMap) -> String {
-    let mut out = String::from("(");
-    crate::transform::js_out::write_object(map, &mut out);
+    let mut out = String::with_capacity(estimate_object_len(map) + 2);
+    out.push('(');
+    write_object(map, &mut out);
     out.push(')');
     out
 }
@@ -1381,7 +1510,9 @@ fn print_create_parens(map: &JsObjectMap, dynamic: &[(String, String)]) -> Strin
     if dynamic.is_empty() {
         return print_parens(map);
     }
-    let mut out = String::from("({");
+    let arrows: usize = dynamic.iter().map(|(_, arrow)| arrow.len()).sum();
+    let mut out = String::with_capacity(estimate_object_len(map) + arrows + 2);
+    out.push_str("({");
     for (i, (key, value)) in map.entries().enumerate() {
         if i > 0 {
             out.push_str(", ");
@@ -1425,6 +1556,15 @@ impl<'a, 'env> Shared<'a, 'env> {
     fn push_edit(&mut self, edit: Edit) -> usize {
         self.edits.push(Some(edit));
         self.edits.len() - 1
+    }
+
+    /// Plan mode reads only edit spans (DCE, take_edits_within), never text.
+    fn splice_text(&self, print: impl FnOnce() -> String) -> String {
+        if self.build_plan {
+            String::new()
+        } else {
+            print()
+        }
     }
 
     fn in_dead(&self, span: Span) -> bool {
@@ -1623,10 +1763,9 @@ impl<'a, 'env> Shared<'a, 'env> {
                 None
             } else {
                 let uid = self.generate_uid("temp", call_node);
-                let idx = self.push_edit(Edit::insert(
-                    stmt_start,
-                    format!("const {uid} = {};\n", print_static_chunk(&dc)),
-                ));
+                let text =
+                    self.splice_text(|| format!("const {uid} = {};\n", print_static_chunk(&dc)));
+                let idx = self.push_edit(Edit::insert(stmt_start, text));
                 hoist_edit_idxs.push(idx);
                 if self.build_plan {
                     self.plan.inserts.push(InsertOp {
@@ -1641,10 +1780,12 @@ impl<'a, 'env> Shared<'a, 'env> {
                 }
                 Some(uid)
             };
-            dynamic.push((
-                ns.clone(),
-                print_dynamic_arrow(&dc, self.source, static_ident.as_deref()),
-            ));
+            if !self.build_plan {
+                dynamic.push((
+                    ns.clone(),
+                    print_dynamic_arrow(&dc, self.source, static_ident.as_deref()),
+                ));
+            }
             dynamic_entries.push(DynamicEntry {
                 namespace: ns.clone(),
                 compiled: dc,
@@ -1677,20 +1818,18 @@ impl<'a, 'env> Shared<'a, 'env> {
                 ));
                 plan_idx
             });
-            let edit_idx = self.push_edit(Edit::replace(
-                call.span,
-                print_create_parens(&out.compiled, &dynamic),
-            ));
+            let text = self.splice_text(|| print_create_parens(&out.compiled, &dynamic));
+            let edit_idx = self.push_edit(Edit::replace(call.span, text));
             (edit_idx, plan_idx)
         } else {
             let uid = self.generate_uid("styles", call_node);
-            let hoist_idx = self.push_edit(Edit::insert(
-                stmt_start,
+            let text = self.splice_text(|| {
                 format!(
                     "const {uid} = {};\n",
                     print_create_parens(&out.compiled, &dynamic)
-                ),
-            ));
+                )
+            });
+            let hoist_idx = self.push_edit(Edit::insert(stmt_start, text));
             if self.build_plan {
                 self.plan.inserts.push(InsertOp {
                     anchor: stmt_start,
@@ -1750,7 +1889,7 @@ impl<'a, 'env> Shared<'a, 'env> {
             evaluator.eval(arg_expr)
         };
         let value = match outcome {
-            Ok(EvalOutcome::Value(v)) => to_eval_value(&v),
+            Ok(EvalOutcome::Value(v)) => into_eval_value(v),
             Ok(EvalOutcome::NonStatic(_)) => {
                 return self.fail(StylexError::non_static_value("keyframes"));
             }
@@ -1761,7 +1900,8 @@ impl<'a, 'env> Shared<'a, 'env> {
             Err(error) => return self.fail(error),
         };
         self.register_rules(vec![rule], call);
-        self.push_edit(Edit::replace(call.span, js_string_literal(&name)));
+        let text = self.splice_text(|| js_string_literal(&name));
+        self.push_edit(Edit::replace(call.span, text));
         self.plan
             .replace_exprs
             .push((call.span, SynthExpr::Str(name.clone())));
@@ -1776,7 +1916,8 @@ impl<'a, 'env> Shared<'a, 'env> {
             return self.fail(StylexError::illegal_argument_length("defaultMarker", 0));
         }
         let object = Arc::new(default_marker_object(self.state.options));
-        self.push_edit(Edit::replace(call.span, print_parens(&object)));
+        let text = self.splice_text(|| print_parens(&object));
+        self.push_edit(Edit::replace(call.span, text));
         if self.build_plan {
             self.plan.replace_exprs.push((
                 call.span,
@@ -1809,7 +1950,8 @@ impl<'a, 'env> Shared<'a, 'env> {
             return self.fail(StylexError::cannot_generate_hash("defineMarker"));
         };
         let object = Arc::new(define_marker_object(&file, &name, self.state.options));
-        self.push_edit(Edit::replace(call.span, print_parens(&object)));
+        let text = self.splice_text(|| print_parens(&object));
+        self.push_edit(Edit::replace(call.span, text));
         if self.build_plan {
             self.plan.replace_exprs.push((
                 call.span,
@@ -1846,7 +1988,7 @@ impl<'a, 'env> Shared<'a, 'env> {
             evaluator.eval(arg_expr)
         };
         let value = match outcome {
-            Ok(EvalOutcome::Value(v)) => to_eval_value(&v),
+            Ok(EvalOutcome::Value(v)) => into_eval_value(v),
             Ok(EvalOutcome::NonStatic(_)) => {
                 return self.fail(StylexError::non_static_value("defineConsts"));
             }
@@ -1872,11 +2014,12 @@ impl<'a, 'env> Shared<'a, 'env> {
             if let EvalValue::Num(n) = source_value
                 && !n.is_finite()
             {
-                rule.const_val = non_finite_to_tag(*n);
+                rule.const_val = non_finite_to_tag(*n).map(Box::new);
             }
         }
         self.register_rules(out.rules, call);
-        self.push_edit(Edit::replace(call.span, print_parens(&out.js_output)));
+        let text = self.splice_text(|| print_parens(&out.js_output));
+        self.push_edit(Edit::replace(call.span, text));
         if self.build_plan {
             self.plan.replace_exprs.push((
                 call.span,
@@ -1930,10 +2073,8 @@ impl<'a, 'env> Shared<'a, 'env> {
             let callee = self.inject_callee(node, site_offset);
             let anchor = self.state.program_statement_start(node);
             for rule in &rules {
-                let idx = self.push_edit(Edit::insert(
-                    anchor,
-                    format!("{callee}({});\n", print_inject_arg(rule)),
-                ));
+                let text = self.splice_text(|| inject_call_text(&callee, rule));
+                let idx = self.push_edit(Edit::insert(anchor, text));
                 self.inject_edits.insert(idx);
                 if self.build_plan {
                     self.plan.inserts.push(InsertOp {
@@ -1971,7 +2112,7 @@ impl<'a, 'env> Shared<'a, 'env> {
             evaluator.eval(arg_expr)
         };
         let value = match outcome {
-            Ok(EvalOutcome::Value(v)) => to_eval_value(&v),
+            Ok(EvalOutcome::Value(v)) => into_eval_value(v),
             Ok(EvalOutcome::NonStatic(_)) => {
                 return self.fail(StylexError::non_static_value("positionTry"));
             }
@@ -1982,12 +2123,8 @@ impl<'a, 'env> Shared<'a, 'env> {
             Err(error) => return self.fail(error),
         };
         self.register_rules(vec![rule], call);
-        self.finish_replacement(
-            ctx,
-            call.span,
-            EvalValue::Str(name.clone()),
-            js_string_literal(&name),
-        );
+        let text = self.splice_text(|| js_string_literal(&name));
+        self.finish_replacement(ctx, call.span, EvalValue::Str(name), text);
     }
 
     fn transform_view_transition(&mut self, call: &'a CallExpression<'a>, ctx: &DeclCtx) {
@@ -2013,7 +2150,7 @@ impl<'a, 'env> Shared<'a, 'env> {
             evaluator.eval(arg_expr)
         };
         let value = match outcome {
-            Ok(EvalOutcome::Value(v)) => to_eval_value(&v),
+            Ok(EvalOutcome::Value(v)) => into_eval_value(v),
             Ok(EvalOutcome::NonStatic(_)) => {
                 return self.fail(StylexError::non_static_value("viewTransitionClass"));
             }
@@ -2024,12 +2161,8 @@ impl<'a, 'env> Shared<'a, 'env> {
             Err(error) => return self.fail(error),
         };
         self.drain_injected_then(vec![rule], call);
-        self.finish_replacement(
-            ctx,
-            call.span,
-            EvalValue::Str(name.clone()),
-            js_string_literal(&name),
-        );
+        let text = self.splice_text(|| js_string_literal(&name));
+        self.finish_replacement(ctx, call.span, EvalValue::Str(name), text);
     }
 
     fn transform_define_vars(&mut self, call: &'a CallExpression<'a>, parent: ExprParent<'_>) {
@@ -2074,7 +2207,7 @@ impl<'a, 'env> Shared<'a, 'env> {
             }
         };
         self.drain_injected_then(output.rules, call);
-        let text = print_parens(&output.js_output);
+        let text = self.splice_text(|| print_parens(&output.js_output));
         self.finish_replacement(
             &ctx,
             call.span,
@@ -2108,7 +2241,7 @@ impl<'a, 'env> Shared<'a, 'env> {
             self.state.options,
         );
         self.drain_injected_then(output.rules, call);
-        let text = print_parens(&js_output);
+        let text = self.splice_text(|| print_parens(&js_output));
         self.finish_replacement(&ctx, call.span, EvalValue::Obj(Arc::new(js_output)), text);
     }
 
@@ -2230,7 +2363,7 @@ impl<'a, 'env> Shared<'a, 'env> {
         };
         let js_output = nest_define_vars_js_output(&output.js_output);
         self.drain_injected_then(output.rules, call);
-        let text = print_parens(&js_output);
+        let text = self.splice_text(|| print_parens(&js_output));
         self.finish_replacement(&ctx, call.span, EvalValue::Obj(Arc::new(js_output)), text);
     }
 
@@ -2263,7 +2396,7 @@ impl<'a, 'env> Shared<'a, 'env> {
             evaluator.eval(arg_expr)
         };
         let value = match outcome {
-            Ok(EvalOutcome::Value(v)) => to_eval_value(&v),
+            Ok(EvalOutcome::Value(v)) => into_eval_value(v),
             Ok(EvalOutcome::NonStatic(_)) => {
                 return self.fail(StylexError::non_static_value(API));
             }
@@ -2285,12 +2418,12 @@ impl<'a, 'env> Shared<'a, 'env> {
                 if let EvalValue::Num(n) = source_value
                     && !n.is_finite()
                 {
-                    rule.const_val = non_finite_to_tag(*n);
+                    rule.const_val = non_finite_to_tag(*n).map(Box::new);
                 }
             }
         }
         self.register_rules(output.rules, call);
-        let text = print_parens(&output.js_output);
+        let text = self.splice_text(|| print_parens(&output.js_output));
         self.finish_replacement(
             &ctx,
             call.span,
@@ -2336,7 +2469,7 @@ impl<'a, 'env> Shared<'a, 'env> {
         };
         // parity: the __varGroupHash__ check runs before the overrides evaluate.
         let var_group_hash = match &theme_vars {
-            JsValue::Proxy(proxy) => proxy.var_group_hash.clone(),
+            JsValue::Proxy(proxy) => proxy.var_group_hash().to_string(),
             JsValue::Obj(obj) => match obj.get("__varGroupHash__") {
                 Some(JsValue::Str(s)) if !s.is_empty() => s.clone(),
                 _ => return self.fail(StylexError::nested_theme_invalid_vars()),
@@ -2399,8 +2532,8 @@ impl<'a, 'env> Shared<'a, 'env> {
             Err(error) => return self.fail(error),
         };
         let output = match create_theme(
-            &from_eval_value(&EvalValue::Obj(Arc::new(flat_theme_vars))),
-            &from_eval_value(&EvalValue::Obj(Arc::new(flat_overrides))),
+            &into_js_value(EvalValue::Obj(Arc::new(flat_theme_vars))),
+            &into_js_value(EvalValue::Obj(Arc::new(flat_overrides))),
             self.state.options,
         ) {
             Ok(out) => out,
@@ -2413,7 +2546,7 @@ impl<'a, 'env> Shared<'a, 'env> {
             self.state.options,
         );
         self.drain_injected_then(output.rules, call);
-        let text = print_parens(&js_output);
+        let text = self.splice_text(|| print_parens(&js_output));
         self.finish_replacement(&ctx, call.span, EvalValue::Obj(Arc::new(js_output)), text);
     }
 
@@ -2459,7 +2592,8 @@ impl<'a, 'env> Shared<'a, 'env> {
             ));
             plan_idx
         });
-        let edit_idx = self.push_edit(Edit::replace(info.span, print_parens(&compiled)));
+        let text = self.splice_text(|| print_parens(&compiled));
+        let edit_idx = self.push_edit(Edit::replace(info.span, text));
         self.dead_spans.push(info.span);
         self.atom_static_sites.push(AtomStaticSite {
             span: info.span,
@@ -2503,17 +2637,18 @@ impl<'a, 'env> Shared<'a, 'env> {
         let (prop_key, class_name) = (prop_key.to_string(), class_name.clone());
         let uid = self.generate_uid("temp", node);
         let anchor = self.state.program_statement_start(node);
-        let hoist_idx = self.push_edit(Edit::insert(
-            anchor,
+        let text = self.splice_text(|| {
             format!(
                 "const {uid} = {{{property}: _v => [{{{key}: _v != null ? {class} : _v, \"$$css\": true}}, {{{var}: _v != null ? _v : undefined}}]}};\n",
                 key = js_string_literal(&prop_key),
                 class = js_string_literal(&class_name),
                 var = js_string_literal(&var_name),
-            ),
-        ));
+            )
+        });
+        let hoist_idx = self.push_edit(Edit::insert(anchor, text));
         let callee_span = call.callee.span();
-        self.push_edit(Edit::replace(callee_span, format!("{uid}.{property}")));
+        let text = self.splice_text(|| format!("{uid}.{property}"));
+        self.push_edit(Edit::replace(callee_span, text));
         self.atom_dynamic_callees.insert(callee_span);
         if self.build_plan {
             self.plan.inserts.push(InsertOp {
@@ -2655,15 +2790,19 @@ impl<'a, 'env> Shared<'a, 'env> {
     fn push_prologue_group(&mut self, site_offset: u32, group: Vec<PrologueStmt>) {
         self.prologue_groups.push((site_offset, group));
         let offset = self.import_insert_offset;
-        let mut block: String = self
-            .prologue_statements()
-            .iter()
-            .map(prologue_text)
-            .collect();
-        // Empty program body: land on a fresh line after the directive prologue.
-        if offset > 0 && !self.source[..offset as usize].ends_with('\n') {
-            block = format!("\n{block}");
-        }
+        let block = self.splice_text(|| {
+            let block: String = self
+                .prologue_statements()
+                .iter()
+                .map(prologue_text)
+                .collect();
+            // Empty program body: land on a fresh line after the directive prologue.
+            if offset > 0 && !self.source[..offset as usize].ends_with('\n') {
+                format!("\n{block}")
+            } else {
+                block
+            }
+        });
         let idx = self.prologue_edit.expect("slot 0 is reserved at init");
         self.edits[idx] = Some(Edit::insert(offset, block));
     }
@@ -2686,9 +2825,12 @@ impl<'a, 'env> Shared<'a, 'env> {
     // ---- pass B2: props()/attrs() and the sx spread ------------------------
 
     fn props_eval(&mut self, expr: &'a Expression<'a>) -> Result<EvalOutcome, StylexError> {
-        let registry = FunctionRegistry::for_props(&self.state.imports, &self.state.options.env);
+        let _t = crate::timings::start(crate::timings::Stage::Eval);
+        let registry = self.props_registry.get_or_insert_with(|| {
+            FunctionRegistry::for_props(&self.state.imports, &self.state.options.env)
+        });
         let mut evaluator =
-            Evaluator::with_registry(&mut *self.state, self.fs, &RealCallables, registry, true);
+            Evaluator::with_registry_ref(&mut *self.state, self.fs, &RealCallables, registry, true);
         evaluator.eval(expr)
     }
 
@@ -2731,7 +2873,7 @@ impl<'a, 'env> Shared<'a, 'env> {
             EvalOutcome::NonStatic(_) => Ok(NullableStyle::Other),
             EvalOutcome::Value(JsValue::Proxy(_)) => Ok(NullableStyle::Other),
             EvalOutcome::Value(v) => {
-                let value = to_eval_value(&v);
+                let value = into_eval_value(v);
                 match &value {
                     EvalValue::Obj(map)
                         if map.get("__IS_PROXY") == Some(&EvalValue::Bool(true)) =>
@@ -2848,27 +2990,27 @@ impl<'a, 'env> Shared<'a, 'env> {
     }
 
     fn table_text(&self, entries: &[(u32, EvalValue)], tests: &[Span], inner: &[Edit]) -> String {
+        use std::fmt::Write;
         let n = tests.len();
-        let body: Vec<String> = entries
-            .iter()
-            .map(|(key, leaf)| {
-                let mut out = format!("{key}: ");
-                write_value(leaf, &mut out);
-                out
-            })
-            .collect();
-        let lookup: Vec<String> = tests
-            .iter()
-            .enumerate()
-            .map(|(i, span)| {
-                format!(
-                    "!!({}) << {}",
-                    render_span(self.source, *span, inner),
-                    n - 1 - i
-                )
-            })
-            .collect();
-        format!("({{{}}}[{}])", body.join(", "), lookup.join(" | "))
+        let mut out = String::from("({");
+        for (i, (key, leaf)) in entries.iter().enumerate() {
+            if i > 0 {
+                out.push_str(", ");
+            }
+            let _ = write!(out, "{key}: ");
+            write_value(leaf, &mut out);
+        }
+        out.push_str("}[");
+        for (i, span) in tests.iter().enumerate() {
+            if i > 0 {
+                out.push_str(" | ");
+            }
+            out.push_str("!!(");
+            out.push_str(&render_span(self.source, *span, inner));
+            let _ = write!(out, ") << {}", n - 1 - i);
+        }
+        out.push_str("])");
+        out
     }
 
     fn process_props_call(
@@ -2906,13 +3048,15 @@ impl<'a, 'env> Shared<'a, 'env> {
                     && !map.is_empty()
                 {
                     let _ = self.take_edits_within(attr_span);
-                    self.push_edit(Edit::replace(attr_span, jsx_attrs_text(&map)));
+                    let text = self.splice_text(|| jsx_attrs_text(&map));
+                    self.push_edit(Edit::replace(attr_span, text));
                     if self.build_plan {
                         self.plan.jsx_ops.push((attr_span, JsxOp::Attrs(map)));
                     }
                 } else {
                     let _ = self.take_edits_within(call.span);
-                    self.push_edit(Edit::replace(call.span, print_parens(&map)));
+                    let text = self.splice_text(|| print_parens(&map));
+                    self.push_edit(Edit::replace(call.span, text));
                     if self.build_plan {
                         self.plan.replace_exprs.push((
                             call.span,
@@ -2925,7 +3069,8 @@ impl<'a, 'env> Shared<'a, 'env> {
             MergePlan::Table(entries) => {
                 let entries = object_leaves(entries);
                 let inner = self.take_edits_within(call.span);
-                let text = self.table_text(&entries, &classified.tests, &inner);
+                let text =
+                    self.splice_text(|| self.table_text(&entries, &classified.tests, &inner));
                 self.push_edit(Edit::replace(call.span, text));
                 if self.build_plan {
                     self.plan.replace_exprs.push((
@@ -2962,7 +3107,8 @@ impl<'a, 'env> Shared<'a, 'env> {
             }
             MergePlan::Inlined(class_name) => {
                 let _ = self.take_edits_within(call.span);
-                self.push_edit(Edit::replace(call.span, js_string_literal(&class_name)));
+                let text = self.splice_text(|| js_string_literal(&class_name));
+                self.push_edit(Edit::replace(call.span, text));
                 if self.build_plan {
                     self.plan
                         .replace_exprs
@@ -2976,7 +3122,8 @@ impl<'a, 'env> Shared<'a, 'env> {
                     .map(|(key, class_name)| (key, EvalValue::Str(class_name)))
                     .collect();
                 let inner = self.take_edits_within(call.span);
-                let text = self.table_text(&entries, &classified.tests, &inner);
+                let text =
+                    self.splice_text(|| self.table_text(&entries, &classified.tests, &inner));
                 self.push_edit(Edit::replace(call.span, text));
                 if self.build_plan {
                     self.plan.replace_exprs.push((
@@ -3023,11 +3170,13 @@ impl<'a, 'env> Shared<'a, 'env> {
             }
             MergePlan::Inlined(map) => {
                 let _ = self.take_edits_within(attr_span);
-                let text = if map.is_empty() {
-                    "{...({})}".to_string()
-                } else {
-                    jsx_attrs_text(&map)
-                };
+                let text = self.splice_text(|| {
+                    if map.is_empty() {
+                        "{...({})}".to_string()
+                    } else {
+                        jsx_attrs_text(&map)
+                    }
+                });
                 self.push_edit(Edit::replace(attr_span, text));
                 if self.build_plan {
                     let op = if map.is_empty() {
@@ -3042,8 +3191,11 @@ impl<'a, 'env> Shared<'a, 'env> {
             MergePlan::Table(entries) => {
                 let entries = object_leaves(entries);
                 let inner = self.take_edits_within(attr_span);
-                let table = self.table_text(&entries, &classified.tests, &inner);
-                self.push_edit(Edit::replace(attr_span, format!("{{...{table}}}")));
+                let text = self.splice_text(|| {
+                    let table = self.table_text(&entries, &classified.tests, &inner);
+                    format!("{{...{table}}}")
+                });
+                self.push_edit(Edit::replace(attr_span, text));
                 if self.build_plan {
                     self.plan.jsx_ops.push((
                         attr_span,
@@ -3078,10 +3230,9 @@ impl<'a, 'env> Shared<'a, 'env> {
                     (site.span, site.node_id, site.edit_idx, site.plan_idx);
                 let compiled = site.compiled.clone();
                 let uid = self.generate_uid("temp", node_id);
-                let hoist_idx = self.push_edit(Edit::insert(
-                    anchor,
-                    format!("const {uid} = {};\n", print_parens(&compiled)),
-                ));
+                let text =
+                    self.splice_text(|| format!("const {uid} = {};\n", print_parens(&compiled)));
+                let hoist_idx = self.push_edit(Edit::insert(anchor, text));
                 self.edits[edit_idx] = Some(Edit::replace(span, uid.clone()));
                 if self.build_plan {
                     if let Some(plan_idx) = plan_idx {
@@ -3158,7 +3309,7 @@ impl<'a, 'env> Shared<'a, 'env> {
             EvalOutcome::Value(JsValue::Proxy(_)) => Ok(MemberEval::NonStatic),
             EvalOutcome::Value(v) if is_nullish(&v) => Ok(MemberEval::NonStatic),
             EvalOutcome::Value(v) => {
-                let value = to_eval_value(&v);
+                let value = into_eval_value(v);
                 if let EvalValue::Obj(map) = &value
                     && map.get("__IS_PROXY") == Some(&EvalValue::Bool(true))
                 {
@@ -3175,11 +3326,11 @@ impl<'a, 'env> Shared<'a, 'env> {
         let sites = std::mem::take(&mut self.sx_sites);
         for site in sites.iter().filter(|s| s.bailed.get()) {
             let inner = self.take_edits_within(site.attr_span);
-            let rendered = render_span(self.source, site.expr.span(), &inner);
-            self.push_edit(Edit::replace(
-                site.attr_span,
-                format!("{{...{}.props({})}}", site.local, rendered),
-            ));
+            let text = self.splice_text(|| {
+                let rendered = render_span(self.source, site.expr.span(), &inner);
+                format!("{{...{}.props({})}}", site.local, rendered)
+            });
+            self.push_edit(Edit::replace(site.attr_span, text));
             if self.build_plan {
                 self.plan.jsx_ops.push((
                     site.attr_span,
@@ -3215,13 +3366,10 @@ impl<'a, 'env> Shared<'a, 'env> {
             match dce_action(name, &site.compiled, site.exported, &vars, &self.tuples) {
                 DceAction::KeepAll => {}
                 DceAction::Prune(map) => {
-                    if let Some(slot) = self.edits.get_mut(site.edit_idx)
-                        && slot.is_some()
-                    {
-                        *slot = Some(Edit::replace(
-                            site.span,
-                            print_create_parens(&map, &site.dynamic),
-                        ));
+                    let live = self.edits.get(site.edit_idx).is_some_and(Option::is_some);
+                    if live {
+                        let text = self.splice_text(|| print_create_parens(&map, &site.dynamic));
+                        self.edits[site.edit_idx] = Some(Edit::replace(site.span, text));
                         if let Some(plan_idx) = site.plan_idx
                             && let Some((_, synth)) = self.plan.replace_exprs.get_mut(plan_idx)
                         {
@@ -3304,7 +3452,7 @@ impl<'a, 'env> Shared<'a, 'env> {
                     rewritten
                 }
             };
-            let text = js_string_literal(&rewritten);
+            let text = self.splice_text(|| js_string_literal(&rewritten));
             self.push_edit(Edit::replace(decl.source.span, text));
             if self.build_plan {
                 self.plan.import_sources.push((decl.source.span, rewritten));
@@ -3318,11 +3466,14 @@ impl<'a, 'env> Shared<'a, 'env> {
     fn insert_treeshake_imports(&mut self, rewrites: &BTreeMap<String, String>) {
         let imports = self.state.treeshake_imports.clone();
         for import in imports {
-            let raw = match rewrites.get(&import.specifier) {
-                Some(rewritten) => js_string_literal(rewritten),
-                None => render_span(self.source, import.source_span, &[]),
-            };
-            let idx = self.push_edit(Edit::insert(import.decl_start, format!("import {raw};\n")));
+            let text = self.splice_text(|| {
+                let raw = match rewrites.get(&import.specifier) {
+                    Some(rewritten) => js_string_literal(rewritten),
+                    None => render_span(self.source, import.source_span, &[]),
+                };
+                format!("import {raw};\n")
+            });
+            let idx = self.push_edit(Edit::insert(import.decl_start, text));
             if self.build_plan {
                 self.plan.inserts.push(InsertOp {
                     anchor: import.decl_start,
@@ -3444,11 +3595,16 @@ fn flatten_into<'a>(expr: &'a Expression<'a>, flat: &mut Vec<FlatArg<'a>>) {
 
 struct PassA<'w, 'a, 'env> {
     s: &'w mut Shared<'a, 'env>,
+    index: SiteIndex,
 }
 
 impl<'a> Hooks<'a> for PassA<'_, 'a, '_> {
     fn done(&self) -> bool {
         self.s.error.is_some()
+    }
+
+    fn wants(&self, span: Span) -> bool {
+        self.index.any_in(span)
     }
 
     fn call(&mut self, call: &'a CallExpression<'a>, parent: ExprParent<'_>) -> Flow {
@@ -3570,11 +3726,16 @@ impl<'a> Hooks<'a> for PassA<'_, 'a, '_> {
 
 struct PassB1<'w, 'a, 'env> {
     s: &'w mut Shared<'a, 'env>,
+    index: SiteIndex,
 }
 
 impl<'a> Hooks<'a> for PassB1<'_, 'a, '_> {
     fn done(&self) -> bool {
         false
+    }
+
+    fn wants(&self, span: Span) -> bool {
+        self.index.any_in(span)
     }
 
     fn call(&mut self, call: &'a CallExpression<'a>, _parent: ExprParent<'_>) -> Flow {
@@ -3697,11 +3858,16 @@ impl<'a> Hooks<'a> for PassAtoms<'_, 'a, '_> {
 
 struct PassB2<'w, 'a, 'env> {
     s: &'w mut Shared<'a, 'env>,
+    index: SiteIndex,
 }
 
 impl<'a> Hooks<'a> for PassB2<'_, 'a, '_> {
     fn done(&self) -> bool {
         self.s.error.is_some()
+    }
+
+    fn wants(&self, span: Span) -> bool {
+        self.index.any_in(span)
     }
 
     fn call(&mut self, call: &'a CallExpression<'a>, parent: ExprParent<'_>) -> Flow {
@@ -3831,5 +3997,188 @@ mod tests {
                 assert!(pair[0].end <= pair[1].start, "overlap: {spans:?}");
             }
         }
+    }
+
+    struct IdentifierRecorder {
+        index: Option<SiteIndex>,
+        seen: Vec<(String, u32)>,
+    }
+
+    impl Hooks<'_> for IdentifierRecorder {
+        fn done(&self) -> bool {
+            false
+        }
+
+        fn wants(&self, span: Span) -> bool {
+            self.index.as_ref().is_none_or(|index| index.any_in(span))
+        }
+
+        fn identifier(&mut self, name: &str, span: Span) {
+            self.seen.push((name.to_string(), span.start));
+        }
+    }
+
+    fn corpus_sources() -> Vec<(String, String)> {
+        let root = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/../conformance"));
+        let mut out = Vec::new();
+        // Vendored copies of this crate ship without the conformance corpus.
+        let Ok(dirs) = std::fs::read_dir(root.join("corpus")) else {
+            return out;
+        };
+        for dir in dirs {
+            let Ok(entries) = std::fs::read_dir(dir.unwrap().path()) else {
+                continue;
+            };
+            for entry in entries {
+                let path = entry.unwrap().path();
+                if !path.to_string_lossy().ends_with(".jobs.json") {
+                    continue;
+                }
+                let parsed: serde_json::Value =
+                    serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+                for job in parsed["jobs"].as_array().expect("jobs array") {
+                    // `sourceFile` corpora are fetched on demand; skip what is absent.
+                    let source = match job.get("source").and_then(|s| s.as_str()) {
+                        Some(source) => source.to_string(),
+                        None => match std::fs::read_to_string(
+                            root.join(job["sourceFile"].as_str().expect("source or sourceFile")),
+                        ) {
+                            Ok(source) => source,
+                            Err(_) => continue,
+                        },
+                    };
+                    let filename = job["filename"].as_str().unwrap_or("input.tsx");
+                    out.push((filename.to_string(), source));
+                }
+            }
+        }
+        out
+    }
+
+    struct PassACallRecorder<'s, 'a> {
+        state: &'s CompileState<'a>,
+        spans: Vec<Span>,
+    }
+
+    impl<'a> Hooks<'a> for PassACallRecorder<'_, 'a> {
+        fn done(&self) -> bool {
+            false
+        }
+
+        fn call(&mut self, call: &'a CallExpression<'a>, _parent: ExprParent<'_>) -> Flow {
+            if !matches!(
+                call_kind(call, self.state),
+                None | Some(CallKind::Props | CallKind::Attrs | CallKind::LegacyMerge)
+            ) {
+                self.spans.push(call.span);
+            }
+            Flow::Walk
+        }
+    }
+
+    /// Pass A's index, filtered to API-member callees, still opens every call
+    /// its hook acts on.
+    #[test]
+    fn pass_a_index_opens_every_pass_a_call() {
+        let options = crate::options::CompilerOptions::from_json(&serde_json::json!({}))
+            .unwrap()
+            .resolve()
+            .unwrap();
+        let mut checked = 0usize;
+        let sources = corpus_sources();
+        if sources.is_empty() {
+            eprintln!(
+                "skipping pass_a_index_opens_every_pass_a_call: conformance corpus not vendored"
+            );
+            return;
+        }
+        for (filename, source) in sources {
+            let allocator = oxc_allocator::Allocator::default();
+            let Ok(program) = crate::api::parse_program(&allocator, &source, &filename) else {
+                continue;
+            };
+            let Ok(state) = CompileState::build(&program, &options, None, String::new()) else {
+                continue;
+            };
+            let index = pass_a_index(&state, &source);
+            let mut recorder = PassACallRecorder {
+                state: &state,
+                spans: Vec::new(),
+            };
+            walk_program(&mut recorder, &program);
+            for span in recorder.spans {
+                assert!(
+                    index.any_in(span),
+                    "{filename}: pass-A call at {} is not indexed",
+                    span.start
+                );
+                checked += 1;
+            }
+        }
+        assert!(checked > 500, "only {checked} calls checked");
+    }
+
+    /// A walk pruned by one name's reference index fires the identifier hook
+    /// for that name exactly where the unpruned walk does.
+    #[test]
+    fn pruned_walk_reaches_every_identifier_of_the_indexed_name() {
+        let options = crate::options::CompilerOptions::from_json(&serde_json::json!({}))
+            .unwrap()
+            .resolve()
+            .unwrap();
+        let mut checked = 0usize;
+        let sources = corpus_sources();
+        if sources.is_empty() {
+            eprintln!(
+                "skipping pruned_walk_reaches_every_identifier_of_the_indexed_name: conformance corpus not vendored"
+            );
+            return;
+        }
+        for (filename, source) in sources {
+            let allocator = oxc_allocator::Allocator::default();
+            let Ok(program) = crate::api::parse_program(&allocator, &source, &filename) else {
+                continue;
+            };
+            let state = CompileState::build_with_imports(
+                &program,
+                &options,
+                None,
+                String::new(),
+                crate::imports::ImportTable::default(),
+            );
+            let mut full = IdentifierRecorder {
+                index: None,
+                seen: Vec::new(),
+            };
+            walk_program(&mut full, &program);
+            let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
+            for (name, _) in &full.seen {
+                *counts.entry(name.as_str()).or_default() += 1;
+            }
+            let mut names: Vec<(&str, usize)> = counts.into_iter().collect();
+            names.sort_by_key(|&(name, count)| (count, name));
+            for (name, _) in names.into_iter().take(30) {
+                let mut pruned = IdentifierRecorder {
+                    index: Some(SiteIndex {
+                        starts: state.reference_starts(&[name]),
+                    }),
+                    seen: Vec::new(),
+                };
+                walk_program(&mut pruned, &program);
+                let of_name = |seen: &[(String, u32)]| -> Vec<u32> {
+                    seen.iter()
+                        .filter(|(n, _)| n == name)
+                        .map(|(_, start)| *start)
+                        .collect()
+                };
+                assert_eq!(
+                    of_name(&pruned.seen),
+                    of_name(&full.seen),
+                    "{filename}: pruned walk misses `{name}`"
+                );
+                checked += 1;
+            }
+        }
+        assert!(checked > 1_000, "only {checked} names checked");
     }
 }


### PR DESCRIPTION
Adds native StyleX support to OJ's development and build pipelines, using the clean-room Rust compiler `fru` vendored at `crates/stylex`. The current compiler source is synced from `lovable@d61e617fb93d174d892bbffb0dc83e2290c39508`; the OJ workspace manifest remains adapted for this repository. Babel 0.19.0 is the compatibility oracle.

Development transforms OJ's parsed AST before lowering. Compiled rules travel with cached modules, populate the stylesheet registry, replace `@stylex;` in served CSS, and trigger CSS updates when gated modules change. The build pipeline uses a Rolldown string transform with a splice source map, then assembles and inserts the stylesheet after bundling. The pass auto-enables when the app depends on `@stylexjs/stylex`; the `stylex` config section, `--stylex-config`, or `OJ_STYLEX_CONFIG` supplies explicit settings.

```json
{ "stylex": { "include": ["src/**"], "useCssLayers": true, "dev": true } }
```

The latest compiler sync reduces temporary allocations by iterating simple evaluated namespaces directly and representing ordinary single-property paths implicitly. Complex styles retain the existing validation and flattening pipeline. The library's `RuleRegistry` also shares prepared rules when repetition warrants it, returns to inline storage when repetition disappears, and avoids duplicate preparation on first emission. OJ currently calls the one-shot assembler, so those registry savings require a later integration change. The standalone CLI queue change is outside this vendored library.

Compiler measurements on a 3,103-module corpus, Apple M5 Max, Rust 1.95.0, one worker:

| Production compilation metric | Before | After |
| --- | ---: | ---: |
| Time inside `create()` | 33.56 ms | 28.86 ms |
| Allocation/reallocation calls | 2,511,299 | 2,341,595 |
| Cumulative allocated bytes | 482.86 MB | 464.89 MB |

Total compiler instructions fell about 3%. The allocated-byte reduction is temporary allocation traffic; peak heap stayed unchanged. Stage timing and allocation counting used separate runs. Whole-OJ experiments using a separate AST-hook prototype found 0.7–1.5% fewer instructions with PGO, but no consistent wall-time improvement. Those are prototype measurements, not a claimed speedup for this PR's string build integration. The AST-hook adapter and whole-OJ PGO setup are separate work; native scope analysis remains opt-in through `FRU_NATIVE_SCOPES=1`.

The retained compiler snapshot produced byte-identical complete outputs before and after the optimizations across four corpora at one and eight workers and passed 5,325 live Babel comparisons in its source repository. That repository keeps the full conformance harness and integration fixtures. Tests in this sync pin numeric property order, the `$$css` insertion position, dynamic class paths, error ordering, and the registry's transition from repeated to unique rules.

Two known integration constraints remain:

- OJ's experimental disk module cache is off by default. Its StyleX configuration salt and rule replay do not validate filesystem resolution dependencies before a hit is accepted. A local restart probe reproduced stale output after changing only the package name. Correct invalidation must account for configuration, aliases, and resolved module identity; imported theme contents should not become importer dependencies. The compiler has dependency validation, but this host cache does not yet use it.
- Babel 0.19.0's malformed `@position-try` output is reproduced for compatibility. StyleX-substituted sheets therefore use Lightning CSS error recovery; other sheets remain strict.
