### PR TITLE
Client env define: merge process env and plugin config() mutations (Vite parity)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
       - name: plugin resolveId without a load hook serves from disk
         if: matrix.mode == 'unbundled'
         run: node e2e/plugin-resolve-no-load.mjs
+      - name: client env define (dotenv + process env + plugin config mutations)
+        if: matrix.mode == 'unbundled'
+        run: node e2e/env-define.mjs
 
   # i need to fix this or automate
   build:

--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -1550,7 +1550,7 @@ pub async fn build(
                 .unwrap_or(sourcemap)
                 .then_some(SourceMapType::File),
             define: Some({
-                let env = oj_env::load(&root, mode);
+                let env = oj_env::with_process_env(oj_env::load(&root, mode), std::env::vars(), &["VITE_"]);
                 let mut pairs: Vec<(String, String)> =
                     vec![("process.env.NODE_ENV".into(), "'production'".into())];
                 pairs.extend(oj_env::import_meta_env_defines(
@@ -1617,7 +1617,7 @@ pub async fn build(
     // %VITE_*% / import.meta.env substitution (Vite's htmlEnvHook), applied to
     // each page before the plugin transformIndexHtml below.
     let html_env = {
-        let env = oj_env::load(&root, mode);
+        let env = oj_env::with_process_env(oj_env::load(&root, mode), std::env::vars(), &["VITE_"]);
         let mut defines = oj_env::import_meta_env_defines(&env, mode, false, &base, &["VITE_"]);
         defines.extend(oj_config::config_defines(&config));
         oj_env::html_env_map(&defines)
@@ -2524,7 +2524,7 @@ async fn build_client_entry(
                 .unwrap_or(sourcemap)
                 .then_some(SourceMapType::File),
             define: Some({
-                let env = oj_env::load(root, "production");
+                let env = oj_env::with_process_env(oj_env::load(root, "production"), std::env::vars(), &["VITE_"]);
                 let mut pairs = vec![(
                     "process.env.NODE_ENV".to_string(),
                     "'production'".to_string(),

--- a/crates/oj_cache/src/lib.rs
+++ b/crates/oj_cache/src/lib.rs
@@ -102,6 +102,15 @@ impl PersistentCache {
         }
     }
 
+    /// Compiled modules embed inlined `import.meta.env` values, so anything
+    /// that changes the defines (dotenv edits, process env, plugin config()
+    /// mutations) must land in the salt or warm restarts serve stale env.
+    pub fn with_salt_extra(mut self, extra: &str) -> Self {
+        self.salt.push(':');
+        self.salt.push_str(extra);
+        self
+    }
+
     pub fn key(&self, source: &[u8], url: &str, mode: &str) -> String {
         let mut hasher = blake3::Hasher::new();
         hasher.update(self.salt.as_bytes());
@@ -207,6 +216,13 @@ mod tests {
             base,
             other_version.key(b"source", "/src/App.tsx", "dev"),
             "version"
+        );
+        let salted = PersistentCache::new(std::env::temp_dir(), "9.9.9").with_salt_extra("env-a");
+        let resalted = PersistentCache::new(std::env::temp_dir(), "9.9.9").with_salt_extra("env-b");
+        assert_ne!(
+            salted.key(b"source", "/src/App.tsx", "dev"),
+            resalted.key(b"source", "/src/App.tsx", "dev"),
+            "env defines salt"
         );
     }
 

--- a/crates/oj_compiler/src/lib.rs
+++ b/crates/oj_compiler/src/lib.rs
@@ -67,14 +67,16 @@ pub(crate) fn detect_refresh_registrations(program: &Program) -> bool {
     detector.found
 }
 
-static ENV_DEFINES: std::sync::OnceLock<Vec<(String, String)>> = std::sync::OnceLock::new();
+// RwLock, not OnceLock: the server re-sets these once the plugin host reports
+// config()-hook env mutations, which land after the initial dotenv-based set.
+static ENV_DEFINES: std::sync::RwLock<Option<Vec<(String, String)>>> = std::sync::RwLock::new(None);
 
 pub fn set_import_meta_env(defines: Vec<(String, String)>) {
-    let _ = ENV_DEFINES.set(defines);
+    *ENV_DEFINES.write().expect("ENV_DEFINES poisoned") = Some(defines);
 }
 
 pub(crate) fn import_meta_env_defines(dev: bool) -> Vec<(String, String)> {
-    if let Some(defines) = ENV_DEFINES.get() {
+    if let Some(defines) = ENV_DEFINES.read().expect("ENV_DEFINES poisoned").as_ref() {
         return defines.clone();
     }
     let mode = if dev { "development" } else { "production" };

--- a/crates/oj_env/src/lib.rs
+++ b/crates/oj_env/src/lib.rs
@@ -113,6 +113,22 @@ pub fn load(dir: &Path, mode: &str) -> Vec<(String, String)> {
     merged.into_iter().collect()
 }
 
+/// Vite parity: the actual process environment (and any plugin `config()` env
+/// mutations layered on top of it) wins over `.env` files for prefixed vars.
+pub fn with_process_env(
+    loaded: Vec<(String, String)>,
+    process_env: impl IntoIterator<Item = (String, String)>,
+    prefixes: &[&str],
+) -> Vec<(String, String)> {
+    let mut map: BTreeMap<String, String> = loaded.into_iter().collect();
+    for (k, v) in process_env {
+        if prefixes.iter().any(|p| k.starts_with(p)) {
+            map.insert(k, v);
+        }
+    }
+    map.into_iter().collect()
+}
+
 pub fn import_meta_env_defines(
     loaded: &[(String, String)],
     mode: &str,
@@ -291,6 +307,45 @@ mod tests {
         assert_eq!(map["MISSING"], "[]");
         assert_eq!(map["FROMBASE"], "envval");
         assert_eq!(map["UNCLOSED"], "${OOPS");
+    }
+
+    #[test]
+    fn process_env_wins_over_files_for_prefixed_vars() {
+        let loaded = vec![
+            ("VITE_A".into(), "file-a".into()),
+            ("VITE_B".into(), "file-b".into()),
+        ];
+        let process_env = vec![
+            ("VITE_A".into(), "proc-a".into()),
+            ("VITE_C".into(), "proc-c".into()),
+            ("SECRET".into(), "nope".into()),
+        ];
+        let merged = with_process_env(loaded, process_env, &["VITE_"]);
+        let map: std::collections::HashMap<_, _> = merged.into_iter().collect();
+        assert_eq!(map["VITE_A"], "proc-a", "process env wins over file value");
+        assert_eq!(map["VITE_B"], "file-b", "file-only var survives");
+        assert_eq!(map["VITE_C"], "proc-c", "process-only prefixed var is added");
+        assert!(!map.contains_key("SECRET"), "unprefixed process var excluded");
+    }
+
+    #[test]
+    fn process_env_overlay_flows_into_defines() {
+        let merged = with_process_env(
+            vec![("VITE_FLAG".into(), "off".into())],
+            vec![("VITE_FLAG".into(), "true".into())],
+            &["VITE_"],
+        );
+        let d = import_meta_env_defines(&merged, "development", true, "/", &["VITE_"]);
+        let map: std::collections::HashMap<_, _> = d.iter().cloned().collect();
+        assert_eq!(map["import.meta.env.VITE_FLAG"], "\"true\"");
+        assert!(map["import.meta.env"].contains("\"VITE_FLAG\":\"true\""));
+    }
+
+    #[test]
+    fn empty_process_env_is_a_no_op() {
+        let loaded = vec![("VITE_A".into(), "file-a".into())];
+        let merged = with_process_env(loaded.clone(), Vec::new(), &["VITE_"]);
+        assert_eq!(merged, loaded);
     }
 
     #[test]

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -951,6 +951,15 @@ async function run(hook, args) {
   }
   if (hook === "writeBundle") return writeBundle(args[0], args[1] === "true");
   if (hook === "getPluginCount") return String(plugins.length);
+  if (hook === "getEnvDelta") {
+    // config() hooks ran at module init (top-level await), so the diff vs the
+    // process-start snapshot is final by the time any stdio hook is answered.
+    const delta = {};
+    for (const [k, v] of Object.entries(process.env)) {
+      if (ssrEnvBase[k] !== v) delta[k] = v;
+    }
+    return JSON.stringify(delta);
+  }
   if (hook === "getHasTransform") {
     const has = plugins.some((p) => {
       const t = p && p.transform;

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -13,9 +13,10 @@ import { AsyncLocalStorage } from "node:async_hooks";
 const pluginsPath = process.argv[2];
 const initial = JSON.parse(process.argv[3] ?? "{}");
 
-const ssrEnvBase = { ...process.env };
-
 process.env.VITE_CONFIG_NATIVE_IGNORE_WARNING ??= "true";
+// Snapshot after the host's own env tweaks so the config()-hook delta reports
+// only plugin mutations, not host bootstrap noise.
+const ssrEnvBase = { ...process.env };
 const env = initial.env ?? { command: "serve", mode: "development" };
 
 // resolve.alias from the app's own vite config (loaded below for its plugins).

--- a/crates/oj_server/src/assets/start/loader.mjs
+++ b/crates/oj_server/src/assets/start/loader.mjs
@@ -80,12 +80,20 @@ const envDelta = (() => {
   if (process.env.OJ_SSR_LOADER_CACHE !== "off") {
     try {
       const h = createHash("sha256");
-      hashAdd(h, "v", "oj-ssr-env-delta-v1");
+      hashAdd(h, "v", "oj-ssr-env-delta-v2");
       hashBaseInputs(h);
       for (const name of [".env", ".env.local", ".env.development", ".env.development.local"]) {
         try { hashAdd(h, name, readFileSync(pathResolve(APP, name))); } catch {}
       }
       hashAdd(h, "git", gitStateBytes());
+      // config() hooks read arbitrary env (a sidecar URL, a profile toggle), so
+      // the cached delta must not outlive an env change; skip shell-session noise.
+      const ENV_HASH_SKIP = new Set(["_", "PWD", "OLDPWD", "SHLVL", "TERM", "TERM_PROGRAM", "TERM_SESSION_ID", "SSH_AUTH_SOCK", "XPC_SERVICE_NAME", "XPC_FLAGS"]);
+      hashAdd(h, "penv", Object.entries(process.env)
+        .filter(([k]) => !ENV_HASH_SKIP.has(k))
+        .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+        .map(([k, v]) => `${k}=${v}`)
+        .join("\n"));
       deltaKey = h.digest("hex");
     } catch {}
   }

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -411,8 +411,19 @@ impl DevServer {
             }
             defines
         };
+        let digest_defines = |defines: &[(String, String)]| {
+            let mut hasher = blake3::Hasher::new();
+            for (k, v) in defines {
+                hasher.update(k.as_bytes());
+                hasher.update(&[0]);
+                hasher.update(v.as_bytes());
+                hasher.update(&[0]);
+            }
+            hasher.finalize().to_hex().to_string()
+        };
         let defines = build_env_defines(&std::collections::BTreeMap::new());
         let mut html_env = oj_env::html_env_map(&defines);
+        let mut env_defines_digest = digest_defines(&defines);
         oj_compiler::set_import_meta_env(defines);
 
         let server_cfg = config.server.clone().unwrap_or_default();
@@ -536,6 +547,7 @@ impl DevServer {
             if !prefixed.is_empty() {
                 let defines = build_env_defines(&prefixed);
                 html_env = oj_env::html_env_map(&defines);
+                env_defines_digest = digest_defines(&defines);
                 oj_compiler::set_import_meta_env(defines);
             }
         }
@@ -634,7 +646,8 @@ impl DevServer {
                     preserve_symlinks: oj_config::resolve_preserve_symlinks(&config),
                 },
             )),
-            cache: PersistentCache::new(oj_cache::cache_root(&root), env!("CARGO_PKG_VERSION")),
+            cache: PersistentCache::new(oj_cache::cache_root(&root), env!("CARGO_PKG_VERSION"))
+                .with_salt_extra(&env_defines_digest),
             memory: Mutex::new(MemoryCache::new(memory_cache_budget())),
             mtime_keys: Mutex::new(HashMap::new()),
             compile_locks: Mutex::new(HashMap::new()),

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -374,34 +374,45 @@ impl DevServer {
             .map(|d| root.join(d))
             .unwrap_or_else(|| root.clone());
         let env = oj_env::load(&env_dir, "development");
-        let mut defines = oj_env::import_meta_env_defines(
-            &env,
-            "development",
-            true,
-            config.base.as_deref().unwrap_or("/"),
-            &env_prefix_refs,
-        );
-        defines.extend(oj_config::config_defines(&config));
-        defines.extend(oj_config::environment_defines(&config, "client"));
-        defines.extend(oj_config::environment_defines(&config, "ssr"));
-        // Vite defines process.env.NODE_ENV in dev too (nodeEnv = NODE_ENV || mode);
-        // without it, library code that reads it throws a ReferenceError in dev.
-        let node_env = std::env::var("NODE_ENV")
-            .ok()
-            .filter(|s| !s.is_empty())
-            .unwrap_or_else(|| "development".into());
-        let node_env_json =
-            serde_json::to_string(&node_env).unwrap_or_else(|_| "\"development\"".into());
-        for key in [
-            "process.env.NODE_ENV",
-            "global.process.env.NODE_ENV",
-            "globalThis.process.env.NODE_ENV",
-        ] {
-            if !defines.iter().any(|(k, _)| k == key) {
-                defines.push((key.to_string(), node_env_json.clone()));
+        // Rebuilt after plugin-host boot with the config()-hook env delta, so
+        // it stays a closure over the same inputs rather than a one-shot block.
+        let build_env_defines = |extra: &std::collections::BTreeMap<String, String>| {
+            let merged = oj_env::with_process_env(
+                env.clone(),
+                std::env::vars().chain(extra.iter().map(|(k, v)| (k.clone(), v.clone()))),
+                &env_prefix_refs,
+            );
+            let mut defines = oj_env::import_meta_env_defines(
+                &merged,
+                "development",
+                true,
+                config.base.as_deref().unwrap_or("/"),
+                &env_prefix_refs,
+            );
+            defines.extend(oj_config::config_defines(&config));
+            defines.extend(oj_config::environment_defines(&config, "client"));
+            defines.extend(oj_config::environment_defines(&config, "ssr"));
+            // Vite defines process.env.NODE_ENV in dev too (nodeEnv = NODE_ENV || mode);
+            // without it, library code that reads it throws a ReferenceError in dev.
+            let node_env = std::env::var("NODE_ENV")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "development".into());
+            let node_env_json =
+                serde_json::to_string(&node_env).unwrap_or_else(|_| "\"development\"".into());
+            for key in [
+                "process.env.NODE_ENV",
+                "global.process.env.NODE_ENV",
+                "globalThis.process.env.NODE_ENV",
+            ] {
+                if !defines.iter().any(|(k, _)| k == key) {
+                    defines.push((key.to_string(), node_env_json.clone()));
+                }
             }
-        }
-        let html_env = oj_env::html_env_map(&defines);
+            defines
+        };
+        let defines = build_env_defines(&std::collections::BTreeMap::new());
+        let mut html_env = oj_env::html_env_map(&defines);
         oj_compiler::set_import_meta_env(defines);
 
         let server_cfg = config.server.clone().unwrap_or_default();
@@ -512,6 +523,21 @@ impl DevServer {
         };
         if let Some(p) = plugin_mw_port {
             println!("  plugin middleware: forwarding unmatched requests to :{p}");
+        }
+        if let Some(host) = &plugin_host {
+            // Fold config()-hook env mutations (e.g. a plugin flipping a VITE_*
+            // flag) into the client defines before any module compiles.
+            let prefixed: std::collections::BTreeMap<String, String> = host
+                .env_delta()
+                .await
+                .into_iter()
+                .filter(|(k, _)| env_prefix_refs.iter().any(|p| k.starts_with(p)))
+                .collect();
+            if !prefixed.is_empty() {
+                let defines = build_env_defines(&prefixed);
+                html_env = oj_env::html_env_map(&defines);
+                oj_compiler::set_import_meta_env(defines);
+            }
         }
         let plugins_use_module_parsed = match &plugin_host {
             Some(host) => host.has_module_parsed().await,

--- a/crates/oj_server/src/plugins.rs
+++ b/crates/oj_server/src/plugins.rs
@@ -791,6 +791,17 @@ impl PluginHost {
             .unwrap_or(1)
     }
 
+    /// Env mutations made by plugin `config()` hooks in the host process (e.g.
+    /// a plugin flipping a VITE_* flag). Empty on RPC failure.
+    pub async fn env_delta(&self) -> std::collections::BTreeMap<String, String> {
+        self.call("getEnvDelta", &[])
+            .await
+            .ok()
+            .flatten()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default()
+    }
+
     /// Whether any active plugin has a `transform` hook. Defaults to true on RPC
     /// failure so the per-module transform pass is never skipped by mistake.
     pub async fn has_transform(&self) -> bool {

--- a/e2e/env-define.mjs
+++ b/e2e/env-define.mjs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+//
+// Client import.meta.env parity with Vite: values come from .env files,
+// the actual process environment (which wins over files), and plugin
+// config() hook env mutations — not from .env files alone.
+
+import { spawn, execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repo = path.join(here, "..");
+const oj = path.join(repo, "target", "debug", "oj");
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+execSync("cargo build -p oj", { cwd: repo, stdio: "inherit" });
+
+const app = fs.mkdtempSync(path.join(os.tmpdir(), "oj-env-define-"));
+fs.writeFileSync(path.join(app, "package.json"), JSON.stringify({ name: "env-app", version: "1.0.0" }));
+fs.writeFileSync(
+  path.join(app, ".env.development"),
+  "VITE_FROM_DOTENV=dotenv-value\nVITE_OVERRIDDEN=file-value\nUNPREFIXED_SECRET=leak-me-not\n",
+);
+fs.writeFileSync(
+  path.join(app, "vite.config.mjs"),
+  `export default {
+     plugins: [
+       {
+         name: "env-mutator",
+         config() { process.env.VITE_FROM_PLUGIN = "plugin-value"; },
+       },
+     ],
+   };\n`,
+);
+fs.writeFileSync(
+  path.join(app, "probe.js"),
+  `export const probe = {
+     dotenv: import.meta.env.VITE_FROM_DOTENV,
+     shell: import.meta.env.VITE_FROM_SHELL,
+     plugin: import.meta.env.VITE_FROM_PLUGIN,
+     overridden: import.meta.env.VITE_OVERRIDDEN,
+     secret: import.meta.env.UNPREFIXED_SECRET,
+   };\n`,
+);
+fs.writeFileSync(
+  path.join(app, "index.html"),
+  `<!doctype html><html><head><title>t</title></head><body><script type="module" src="/probe.js"></script></body></html>`,
+);
+
+const port = 5241;
+const srv = spawn(oj, ["dev", "--port", String(port)], {
+  cwd: app,
+  stdio: "ignore",
+  env: {
+    ...process.env,
+    VITE_FROM_SHELL: "shell-value",
+    VITE_OVERRIDDEN: "shell-wins",
+  },
+});
+try {
+  let served = null;
+  for (let i = 0; i < 150; i++) {
+    try {
+      const res = await fetch(`http://localhost:${port}/probe.js`);
+      if (res.ok) {
+        served = await res.text();
+        break;
+      }
+    } catch {}
+    await sleep(200);
+  }
+  assert.ok(served, "dev server never served /probe.js");
+  assert.match(served, /dotenv-value/, ".env file var must inline");
+  assert.match(served, /shell-value/, "process-env VITE_* must inline");
+  assert.match(served, /plugin-value/, "plugin config() env mutation must inline");
+  assert.match(served, /shell-wins/, "process env must win over the .env file value");
+  assert.doesNotMatch(served, /file-value/, "overridden file value must not survive");
+  assert.doesNotMatch(served, /leak-me-not/, "unprefixed vars must not reach the client");
+  console.log("env-define e2e: ok");
+} finally {
+  srv.kill("SIGKILL");
+  await sleep(300);
+  fs.rmSync(app, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Problem

The client `import.meta.env` define was built from `.env` files alone, diverging from Vite in two ways that bit a real app (lovable web):

1. **Process-env prefixed vars were dropped.** Vite's `loadEnv` overlays `process.env` last, so inline/profile overrides win over `.env` files (vite `node.js` chunk: file vars first, then `for (const key in process.env) … env[key] = process.env[key]`). oj's `oj_env::load()` used process env only as dotenv expansion base.
2. **Plugin `config()` env mutations never reached the client.** Vite resolves env *after* `runConfigHook` (`resolveConfig`: hook at L36513, `loadEnv` at L36608 — same process, mutation visible). oj already captured the plugin-host delta for the SSR define (`loader.mjs`: `{...process.env, ...envDelta}`) but the Rust-side client defines never consumed it — so a plugin like lovable's `meticulousDevFlag` (sets `VITE_METICULOUS_DEV_SERVER` in `config()`) silently no-ops: the recording token from dotenv inlines while the gate resolves undefined.

Related staleness: the SSR env-delta disk cache was keyed on `.env*` + git state only, and the persistent module cache salt was `tool_version:CACHE_FORMAT` only — both could serve stale env-dependent output after an env change.

## Fix

- `oj_env::with_process_env()` overlays prefixed process-env vars over file vars (process wins — Vite precedence). Applied in the dev server's define construction **and** the three `oj build` define sites (`vite build` has the same overlay).
- Plugin host gains a `getEnvDelta` stdio hook (diff vs a post-bootstrap snapshot; race-free since `runConfigHooks()` completes at module init before any hook is answered). After the host boots, the server folds prefixed delta keys into the defines and refreshes `html_env` — before any module compiles. The snapshot moved below the host's own `VITE_CONFIG_NATIVE_IGNORE_WARNING ??=` tweak so host bootstrap noise never reports as a plugin mutation (also cleans the SSR delta).
- `oj_compiler`'s `ENV_DEFINES` becomes an `RwLock` so the post-boot refresh takes effect (was set-once `OnceLock`).
- The SSR delta cache key now includes the process env minus shell-session noise (`oj-ssr-env-delta-v2`).
- The persistent module cache salt now includes a digest of the resolved env defines (`PersistentCache::with_salt_extra`) — previously `--enable-cache` could replay modules with stale inlined env after a dotenv/env change.

## Known follow-up (out of scope)

`oj dev --bundle`'s client define (`bundle-client.mjs`) inherits oj's process env — so it gets the process-env fix and its bundle cache already keys on `VITE_*` — but it still misses the plugin `config()` delta; wiring the plugin host into that bundling sequence is a structural change.

## Tests

- `oj_env` unit tests: process env beats file value, file-only survives, process-only prefixed added, unprefixed excluded; overlay flows into defines; empty overlay is a no-op.
- `oj_cache` unit test: different salt extras produce different module keys.
- New `e2e/env-define.mjs` (wired into CI, unbundled mode): scaffolds an app asserting all three channels inline in the served transform — dotenv value, shell-exported var, plugin `config()` mutation — plus shell-beats-file precedence and no unprefixed leakage.
- `cargo test --workspace` (all suites) and `node --test e2e/unit` (120 pass) green.

Verified against the lovable web app: with this fix the meticulous gate and shell `VITE_*` overrides inline correctly in the served client modules.