### PR TITLE
ssr loader: resolve first then classify, matching vite

### DIFF
--- a/crates/oj_server/src/assets/start/loader.mjs
+++ b/crates/oj_server/src/assets/start/loader.mjs
@@ -434,7 +434,23 @@ const stripQ = (u) => u.split("?")[0];
 const withV = (u) => (V ? `${stripQ(u)}?ojv=${V}` : stripQ(u));
 const isTanstack = (u) => /\/@tanstack\//.test(u) && /\.(js|mjs)$/.test(stripQ(u));
 const ASSET_SUFFIX = /\?(raw|url|inline)$/;
-const ASSET_EXT = /\.(png|jpe?g|gif|webp|avif|ico|woff2?|ttf|otf|eot|mp4|webm|wasm)$/;
+// Kept in sync with is_importable_asset_ext on the Rust side (the client
+// graph's classifier), plus wasm which only the SSR loader URL-exports; svg is
+// excluded here too, it routes through the svgr path.
+const ASSET_EXT = /\.(png|jpe?g|gif|webp|avif|ico|bmp|woff2?|ttf|otf|eot|mp4|webm|ogg|mp3|wav|flac|m4a|aac|mov|pdf|webmanifest|wasm)$/;
+// Vite inlines with the file's real content type (mrmime lookup, falling back
+// to octet-stream); match it for the types oj treats as assets.
+const MIME = {
+  png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg", gif: "image/gif",
+  webp: "image/webp", avif: "image/avif", ico: "image/x-icon", svg: "image/svg+xml",
+  woff: "font/woff", woff2: "font/woff2", ttf: "font/ttf", otf: "font/otf",
+  eot: "application/vnd.ms-fontobject", mp4: "video/mp4", webm: "video/webm",
+  ogg: "audio/ogg", mp3: "audio/mpeg", wav: "audio/wav", flac: "audio/flac",
+  m4a: "audio/mp4", aac: "audio/aac", mov: "video/quicktime", bmp: "image/bmp",
+  pdf: "application/pdf", webmanifest: "application/manifest+json",
+  wasm: "application/wasm", css: "text/css", json: "application/json", txt: "text/plain",
+};
+const mimeOf = (p) => MIME[p.slice(p.lastIndexOf(".") + 1).toLowerCase()] ?? "application/octet-stream";
 
 const ALIASES = {
   "#tanstack-router-entry": pathResolve(APP, "src/router"),
@@ -541,6 +557,75 @@ export function resolve(spec, context, next) {
   return r;
 }
 
+// One resolution ladder for every specifier, shared by asset, svg?react, and
+// plain module paths: relative probe, built-in aliases, package.json #imports,
+// tsconfig paths, then Node's resolver with its two error recoveries. `via`
+// records how the hit was found so the caller can keep versioning semantics:
+// "local" hits are user-reachable files that take a ?ojv version, "recovered"
+// hits short-circuit unversioned, "default" passes Node's result through.
+function resolveSpec(clean, context, next) {
+  if (clean.startsWith(".")) {
+    if (context.parentURL && context.parentURL.startsWith("file:")) {
+      const hit = probe(pathResolve(dirname(fileURLToPath(context.parentURL)), clean));
+      if (hit) return { abs: hit, via: "local" };
+    }
+  } else {
+    if (ALIASES[clean]) {
+      const hit = probe(ALIASES[clean]);
+      if (hit) return { abs: hit, via: "local" };
+    }
+    if (clean.startsWith("#")) {
+      const hit = resolveImports(clean);
+      if (hit) return { abs: hit, via: "local" };
+    }
+    if (clean.startsWith("/")) {
+      // A /-prefixed id resolves against the project root (Vite's asSrc
+      // behavior; the client graph already serves these URLs directly).
+      // True absolute fs paths miss this probe and fall through to Node.
+      const hit = probe(pathResolve(APP, clean.slice(1)));
+      if (hit) return { abs: hit, via: "local" };
+    } else {
+      const hit = resolveTsPaths(clean);
+      if (hit) return { abs: hit, via: "local" };
+    }
+  }
+  let r;
+  try {
+    r = next(clean, context);
+  } catch (err) {
+    if (err && err.code === "ERR_MODULE_NOT_FOUND") {
+      const tried = err.url && err.url.startsWith("file:")
+        ? fileURLToPath(err.url)
+        : (err.message.match(/Cannot find module '([^']+)'/) || [])[1];
+      const hit = tried ? probe(tried) : null;
+      if (hit) return { abs: hit, via: "recovered" };
+    }
+    // A dep subpath that is a directory with its own package.json (the legacy
+    // `pkg/query/react/package.json` entry pattern, e.g. @reduxjs/toolkit): Node
+    // ESM refuses the directory import, but CJS resolvers and bundlers read its
+    // module/main. Resolve it to that entry so oj serves the same file Vite does.
+    if (err && err.code === "ERR_UNSUPPORTED_DIR_IMPORT") {
+      const dir = err.url && err.url.startsWith("file:")
+        ? fileURLToPath(err.url)
+        : (err.message.match(/Directory import '([^']+)'/) || [])[1];
+      const hit = dir ? resolveDirEntry(dir) : null;
+      if (hit) return { abs: hit, via: "recovered" };
+    }
+    throw err;
+  }
+  return { result: r, via: "default" };
+}
+
+const toPath = (u) => {
+  try { return fileURLToPath(u); } catch { return null; }
+};
+
+// Resolve first, classify second (Vite's ordering: its alias plugin rewrites
+// the specifier before the asset plugin ever sees it). Strip the intent query,
+// resolve the cleaned specifier through the shared ladder, then decide asset /
+// svg-react / plain-module treatment from the *resolved* path, so every
+// resolution route (aliases, exports maps, error recoveries) gets the same
+// asset tagging.
 function resolveUncached(spec, context, next) {
   if (container && (spec.startsWith("virtual:") || spec.startsWith("\0"))) {
     const importer = context.parentURL && context.parentURL.startsWith("file:")
@@ -552,81 +637,27 @@ function resolveUncached(spec, context, next) {
       return { url: V ? `${u}?ojv=${V}` : u, shortCircuit: true };
     }
   }
-  const suffix = spec.match(ASSET_SUFFIX);
-  const isCss = !spec.includes("?") && /\.css$/.test(spec);
-  const isAsset = !spec.includes("?") && ASSET_EXT.test(spec);
-  if (suffix || isCss || isAsset) {
-    const kind = suffix ? suffix[1] : isCss ? "css" : "url";
-    const clean = spec.replace(ASSET_SUFFIX, "");
-    let abs = null;
-    if (clean.startsWith(".") && context.parentURL) {
-      abs = probe(pathResolve(dirname(fileURLToPath(context.parentURL)), clean));
-    } else if (ALIASES[clean]) {
-      abs = probe(ALIASES[clean]);
-    }
-    if (!abs && clean.startsWith("#")) abs = resolveImports(clean);
-    if (!abs && !clean.startsWith("/") && !clean.startsWith(".")) abs = resolveTsPaths(clean);
-    if (!abs) {
-      try { abs = fileURLToPath(stripQ(next(clean, context).url)); } catch {}
-    }
-    if (abs) return { url: pathToFileURL(abs).href + `?ojasset=${kind}`, shortCircuit: true };
+  const svgReact = /\.svg\?react$/.test(spec);
+  const intent = svgReact ? null : (spec.match(ASSET_SUFFIX)?.[1] ?? null);
+  const clean = svgReact || intent ? spec.replace(/\?(raw|url|inline|react)$/, "") : spec;
+
+  const res = resolveSpec(clean, context, next);
+  const abs = res.abs ?? (res.result && res.result.url && res.result.url.startsWith("file:")
+    ? toPath(stripQ(res.result.url))
+    : null);
+
+  if (abs) {
+    if (svgReact) return { url: pathToFileURL(abs).href + "?ojsvg=react", shortCircuit: true };
+    // Only classify by extension when the specifier carried no query: a spec
+    // with a leftover query is either already-tagged (a runner re-importing a
+    // ?ojasset/?ojv URL, which must pass through with its query intact) or
+    // asks for something we don't handle.
+    const kind = intent ?? (clean.includes("?") ? null : /\.css$/.test(abs) ? "css" : ASSET_EXT.test(abs) ? "url" : null);
+    if (kind) return { url: pathToFileURL(abs).href + `?ojasset=${kind}`, shortCircuit: true };
   }
-  if (/\.svg\?react$/.test(spec)) {
-    const clean = spec.replace(/\?react$/, "");
-    let abs = null;
-    if (clean.startsWith(".") && context.parentURL) {
-      abs = probe(pathResolve(dirname(fileURLToPath(context.parentURL)), clean));
-    } else if (clean.startsWith("#")) {
-      abs = resolveImports(clean);
-    } else if (!clean.startsWith("/")) {
-      abs = resolveTsPaths(clean);
-    }
-    if (!abs) {
-      try { abs = fileURLToPath(stripQ(next(clean, context).url)); } catch {}
-    }
-    if (abs) return { url: pathToFileURL(abs).href + "?ojsvg=react", shortCircuit: true };
-  }
-  if (ALIASES[spec]) {
-    const hit = probe(ALIASES[spec]);
-    if (hit) return { url: withV(pathToFileURL(hit).href), shortCircuit: true, _ojv: true };
-  }
-  if (spec.startsWith("#")) {
-    const hit = resolveImports(spec);
-    if (hit) return { url: withV(pathToFileURL(hit).href), shortCircuit: true, _ojv: true };
-  }
-  if (!spec.startsWith(".") && !spec.startsWith("/")) {
-    const hit = resolveTsPaths(spec);
-    if (hit) return { url: withV(pathToFileURL(hit).href), shortCircuit: true, _ojv: true };
-  }
-  if (spec.startsWith(".") && context.parentURL) {
-    const base = pathResolve(dirname(fileURLToPath(context.parentURL)), spec);
-    const hit = probe(base);
-    if (hit) return { url: withV(pathToFileURL(hit).href), shortCircuit: true, _ojv: true };
-  }
-  let r;
-  try {
-    r = next(spec, context);
-  } catch (err) {
-    if (err && err.code === "ERR_MODULE_NOT_FOUND") {
-      const tried = err.url && err.url.startsWith("file:")
-        ? fileURLToPath(err.url)
-        : (err.message.match(/Cannot find module '([^']+)'/) || [])[1];
-      const hit = tried ? probe(tried) : null;
-      if (hit) return { url: pathToFileURL(hit).href, shortCircuit: true };
-    }
-    // A dep subpath that is a directory with its own package.json (the legacy
-    // `pkg/query/react/package.json` entry pattern, e.g. @reduxjs/toolkit): Node
-    // ESM refuses the directory import, but CJS resolvers and bundlers read its
-    // module/main. Resolve it to that entry so oj serves the same file Vite does.
-    if (err && err.code === "ERR_UNSUPPORTED_DIR_IMPORT") {
-      const dir = err.url && err.url.startsWith("file:")
-        ? fileURLToPath(err.url)
-        : (err.message.match(/Directory import '([^']+)'/) || [])[1];
-      const hit = dir ? resolveDirEntry(dir) : null;
-      if (hit) return { url: pathToFileURL(hit).href, shortCircuit: true };
-    }
-    throw err;
-  }
+  if (res.via === "local") return { url: withV(pathToFileURL(res.abs).href), shortCircuit: true, _ojv: true };
+  if (res.via === "recovered") return { url: pathToFileURL(res.abs).href, shortCircuit: true };
+  const r = res.result;
   if (r && r.url && isTanstack(r.url)) return { ...r, url: withV(r.url), shortCircuit: true, _ojv: true };
   return r;
 }
@@ -651,7 +682,7 @@ export function load(url, context, next) {
     if (kind === "raw") src = `export default ${JSON.stringify(readFileSync(path, "utf8"))};`;
     else if (kind === "url") src = `export default ${JSON.stringify("/@oj-start/fs" + path)};`;
     else if (kind === "inline")
-      src = `export default ${JSON.stringify("data:application/octet-stream;base64," + readFileSync(path).toString("base64"))};`;
+      src = `export default ${JSON.stringify(`data:${mimeOf(path)};base64,` + readFileSync(path).toString("base64"))};`;
     return { format: "module", source: src, shortCircuit: true };
   }
   if (clean.endsWith(".json")) {

--- a/e2e/unit/ssr-loader-assets.test.mjs
+++ b/e2e/unit/ssr-loader-assets.test.mjs
@@ -75,7 +75,7 @@ test("SSR loader resolves tsconfig-aliased static assets as URL modules", () => 
     assert.equal(assets.font, "/@oj-start/fs" + join(fonts, "ui.woff2"));
     assert.equal(assets.notes, "synthetic notes");
     assert.equal(assets.explicitUrl, assets.icon);
-    assert.match(assets.inline, /^data:application\/octet-stream;base64,/);
+    assert.match(assets.inline, /^data:image\/png;base64,/);
     assert.deepEqual(assets.styles, {});
   } finally {
     rmSync(app, { recursive: true, force: true });

--- a/e2e/unit/ssr-loader-resolve.test.mjs
+++ b/e2e/unit/ssr-loader-resolve.test.mjs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT
+//
+// The SSR loader resolves a specifier through one shared ladder (relative,
+// aliases, #imports, tsconfig paths, Node) and only then classifies the
+// resolved path as asset / svg-react / plain module: Vite's ordering, where
+// the alias plugin rewrites specifiers before the asset plugin sees them.
+// These tests pin that ordering: asset tagging must apply to *every*
+// resolution route, and version tagging must survive the shared ladder.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const loader = resolve(here, "../../crates/oj_server/src/assets/start/loader.mjs");
+
+function makeApp() {
+  // realpath: on macOS the tmpdir is a symlink (/var -> /private/var) and
+  // Node's resolver reports realpathed URLs for node_modules hits.
+  const app = realpathSync(mkdtempSync(join(tmpdir(), "oj-ssr-resolve-")));
+  const source = join(app, "src");
+  const icons = join(source, "icons");
+  const lib = join(source, "lib");
+  const assetpkg = join(app, "node_modules", "assetpkg");
+  const csspkg = join(app, "node_modules", "csspkg");
+  const rolldown = join(app, "node_modules", "rolldown");
+
+  for (const directory of [icons, lib, assetpkg, csspkg, rolldown]) {
+    mkdirSync(directory, { recursive: true });
+  }
+
+  writeFileSync(join(app, "package.json"), JSON.stringify({ name: "synthetic-resolve-app", type: "module" }));
+  writeFileSync(join(app, "tsconfig.json"), JSON.stringify({
+    compilerOptions: { baseUrl: ".", paths: { "@/*": ["./src/*"] } },
+  }));
+  writeFileSync(join(rolldown, "package.json"), JSON.stringify({
+    name: "rolldown",
+    type: "module",
+    exports: { "./experimental": "./experimental.mjs" },
+  }));
+  writeFileSync(join(rolldown, "experimental.mjs"), "export const transformSync = (_path, code) => ({ code });\n");
+
+  // A dep whose exports map lands a non-asset-looking subpath on an asset
+  // file: only resolved-path classification can tag it.
+  writeFileSync(join(assetpkg, "package.json"), JSON.stringify({
+    name: "assetpkg",
+    exports: { "./logo": "./logo.png" },
+  }));
+  writeFileSync(join(assetpkg, "logo.png"), "synthetic-png");
+
+  // A dep whose legacy main is a stylesheet: same story for bare specifiers.
+  writeFileSync(join(csspkg, "package.json"), JSON.stringify({ name: "csspkg", main: "./styles.css" }));
+  writeFileSync(join(csspkg, "styles.css"), ".pkg { color: blue; }\n");
+
+  writeFileSync(join(icons, "logo.svg"), "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>\n");
+  writeFileSync(join(source, "local.png"), "synthetic-local-png");
+  writeFileSync(join(source, "track.mp3"), "synthetic-audio");
+  writeFileSync(join(lib, "util.ts"), "export const moduleUrl = import.meta.url;\n");
+
+  const entry = join(source, "entry.mjs");
+  writeFileSync(entry, [
+    'import logoUrl from "assetpkg/logo";',
+    'import styles from "csspkg";',
+    'import iconSvg from "@/icons/logo.svg?react";',
+    'import localUrl from "./local.png";',
+    'import { moduleUrl } from "@/lib/util";',
+    'import { transformSync } from "rolldown/experimental";',
+    "export default { logoUrl, styles, iconSvg, localUrl, moduleUrl, bareModuleOk: typeof transformSync === \"function\" };",
+  ].join("\n"));
+
+  return { app, source, icons, lib, assetpkg, csspkg, entry };
+}
+
+test("SSR loader resolves through one ladder, then classifies the resolved path", () => {
+  const { app, source, icons, assetpkg, csspkg, entry } = makeApp();
+
+  try {
+    const runner = [
+      'import { registerHooks, createRequire } from "node:module";',
+      'import { pathToFileURL } from "node:url";',
+      `const loader = await import(${JSON.stringify(pathToFileURL(loader).href)});`,
+      "loader.setVersion(9);",
+      "registerHooks({ resolve: loader.resolve, load: loader.load });",
+      `const entryUrl = ${JSON.stringify(pathToFileURL(entry).href)};`,
+      `const values = (await import(entryUrl)).default;`,
+      "",
+      // Direct resolve() calls to assert URL shapes the imported values can't
+      // distinguish (tag kind, version query).
+      "const ctx = { parentURL: entryUrl, conditions: [] };",
+      'const notFound = () => { const e = new Error("Cannot find module"); e.code = "ERR_MODULE_NOT_FOUND"; throw e; };',
+      "const req = createRequire(entryUrl);",
+      "const nodeNext = (s) => ({ url: pathToFileURL(req.resolve(s)).href });",
+      "const direct = {};",
+      'direct.svgReact = loader.resolve("@/icons/logo.svg?react", ctx, notFound).url;',
+      'direct.aliasAsset = loader.resolve("@/local.png", ctx, notFound).url;',
+      // Extension list matches the Rust client-side classifier (audio & co).
+      'direct.audioAsset = loader.resolve("@/track.mp3", ctx, notFound).url;',
+      // Root-relative ids resolve against the project root (Vite asSrc).
+      'direct.rootRelAsset = loader.resolve("/src/local.png", ctx, notFound).url;',
+      'direct.rootRelModule = loader.resolve("/src/lib/util", ctx, notFound).url;',
+      'direct.cssPkg = loader.resolve("csspkg", ctx, nodeNext).url;',
+      'direct.exportsMapAsset = loader.resolve("assetpkg/logo", ctx, nodeNext).url;',
+      'direct.versionedModule = loader.resolve("@/lib/util", ctx, notFound).url;',
+      'try { loader.resolve("@/lib/util?react", ctx, notFound); direct.nonSvgReactThrew = false; } catch { direct.nonSvgReactThrew = true; }',
+      // An already-tagged URL (module runner re-import) must pass through
+      // with its query intact, never be re-classified from the extension.
+      'const tagged = direct.aliasAsset.replace("?ojasset=url", "?ojasset=inline");',
+      "direct.taggedPassthrough = loader.resolve(tagged, ctx, (s) => ({ url: s })).url;",
+      "process.stdout.write(JSON.stringify({ values, direct }));",
+    ].join("\n");
+
+    const result = spawnSync(process.execPath, ["--input-type=module", "--eval", runner], {
+      encoding: "utf8",
+      timeout: 10_000,
+      env: { ...process.env, OJ_APP_ROOT: app, OJ_CACHE_ROOT: join(app, "cache"), OJ_SSR_LOADER_CACHE: "off" },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.error?.message);
+    const { values, direct } = JSON.parse(result.stdout);
+
+    // Exports-map subpath landing on an asset file: classified from the
+    // resolved path even though the specifier never looked like an asset.
+    assert.equal(values.logoUrl, "/@oj-start/fs" + join(assetpkg, "logo.png"));
+    assert.match(direct.exportsMapAsset, /\?ojasset=url$/);
+
+    // Bare package whose main is a stylesheet: tagged css, loads as {}.
+    assert.deepEqual(values.styles, {});
+    assert.match(direct.cssPkg, /\?ojasset=css$/);
+    assert.equal(direct.cssPkg, pathToFileURL(join(csspkg, "styles.css")).href + "?ojasset=css");
+
+    // svg?react through a tsconfig alias goes down the svg-react route
+    // (without a plugin container it falls back to a URL default export).
+    assert.match(direct.svgReact, /\?ojsvg=react$/);
+    assert.equal(direct.svgReact, pathToFileURL(join(icons, "logo.svg")).href + "?ojsvg=react");
+    assert.equal(values.iconSvg, "/@oj-start/fs" + join(icons, "logo.svg"));
+
+    // Relative and aliased asset paths still tag through the same ladder.
+    assert.equal(values.localUrl, "/@oj-start/fs" + join(source, "local.png"));
+    assert.match(direct.aliasAsset, /\?ojasset=url$/);
+    assert.match(direct.audioAsset, /\/track\.mp3\?ojasset=url$/);
+    assert.match(direct.rootRelAsset, /\/src\/local\.png\?ojasset=url$/);
+    assert.match(direct.rootRelModule, /\/src\/lib\/util\.ts\?ojv=9$/);
+
+    // Version tagging survives: local (user-code) hits carry ?ojv, asset
+    // URLs never do.
+    assert.match(direct.versionedModule, /\?ojv=9$/);
+    assert.match(values.moduleUrl, /\/src\/lib\/util\.ts\?ojv=9$/);
+    assert.doesNotMatch(direct.aliasAsset, /ojv=/);
+
+    // ?react is only an intent on .svg specifiers; anything else still fails
+    // resolution instead of being silently rewritten.
+    assert.equal(direct.nonSvgReactThrew, true);
+
+    // A re-imported tagged URL keeps its original tag (inline stays inline,
+    // it is not re-classified to url from the .png extension).
+    assert.match(direct.taggedPassthrough, /\?ojasset=inline$/);
+
+    // Bare specifiers that resolve to plain modules pass through untouched.
+    assert.equal(values.bareModuleOk, true);
+  } finally {
+    rmSync(app, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Collapse the SSR loader's three drifted resolution ladders (asset branch, svg?react branch, general path) into one shared resolveSpec, then classify asset / svg-react / plain-module treatment from the resolved path. This is Vite's ordering: its alias plugin rewrites specifiers before the asset plugin ever sees them, so every resolution route gets the same asset tagging. Kills the bug class behind #32 instead of one instance at a time.
- New behavior enabled by resolved-path classification: exports-map subpaths landing on asset files and bare packages whose main is a stylesheet now load instead of failing with ERR_UNKNOWN_FILE_EXTENSION; the svg?react route gains the built-in alias probe it was missing.
- Root-relative ids (/src/...) now resolve against the project root (Vite asSrc semantics); the client graph already served those URLs, only SSR threw. True absolute fs paths are unaffected.
- ?inline uses the file's real content type like Vite (mrmime lookup) instead of hardcoded octet-stream.
- ASSET_EXT aligned with the Rust client-side classifier (bmp, audio, mov, pdf, webmanifest), removing an SSR/client asymmetry.
- Versioning semantics preserved: user-code hits carry ?ojv, ?ojasset URLs never do, recovered hits stay unversioned, untouched Node results pass through. Specs already carrying a query (a runner re-importing a tagged URL) pass through untouched instead of being re-classified.

## Verification
- New e2e/unit/ssr-loader-resolve.test.mjs pins the ordering: exports-map asset tagging, bare css main, svg?react via tsconfig alias, root-relative ids, version tagging, tagged-URL passthrough, extension-list parity.
- Differential harness ran old vs new resolve() over 39 specifier shapes: 6 differences, all listed above; every other row byte-identical including error codes.
- 137/137 unit tests; e2e start, ssr-dev, ssr-prod, assets, assets-inline, query-assets, svgr, awkward-paths, build-target-raw-inline, new-url-asset all pa