### PR TITLE
fix(build): fail on unresolved imports, Vite-style

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,8 @@ jobs:
           node-version: 22
       - run: npm ci --prefix playground
       - run: cargo run -p oj -- build playground
+      - name: reject unresolved build imports
+        run: node e2e/build-unresolved.mjs
       - name: check outputs
         run: |
           test -f playground/dist/index.html

--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -1657,8 +1657,14 @@ pub async fn build(
         .map(|warning| warning.to_string())
         .collect();
     if !unresolved.is_empty() {
+        // Vite fails the build on an unresolved import and writes nothing. rolldown
+        // has already written the bundle by the time its diagnostics are readable, so
+        // drop the partial output (this directory is emptied at every build start
+        // anyway) so a failed build never leaves a broken bundle behind, and point at
+        // the escape hatch the way Vite's message does.
+        let _ = fs::remove_dir_all(&out_dir);
         bail!(
-            "build failed: unresolved imports:\n{}",
+            "build failed: unresolved imports:\n{}\n\nThis is most likely unintended because it can break your application at runtime.\nIf you do want to externalize a module explicitly, add it to `build.rollupOptions.external`.",
             unresolved.join("\n")
         );
     }

--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -1650,6 +1650,19 @@ pub async fn build(
         .await
         .map_err(|errs| anyhow::anyhow!("close failed:\n{errs:?}"))?;
 
+    let unresolved: Vec<String> = output
+        .warnings
+        .iter()
+        .filter(|warning| warning.kind().to_string() == "UNRESOLVED_IMPORT")
+        .map(|warning| warning.to_string())
+        .collect();
+    if !unresolved.is_empty() {
+        bail!(
+            "build failed: unresolved imports:\n{}",
+            unresolved.join("\n")
+        );
+    }
+
     if let Some(host) = &plugin_host {
         if let Err(e) = host.build_end().await {
             eprintln!("oj build: plugin buildEnd failed: {e}");

--- a/e2e/build-unresolved.mjs
+++ b/e2e/build-unresolved.mjs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const binary = path.join(root, "target", "debug", "oj");
+const project = fs.mkdtempSync(path.join(os.tmpdir(), "oj-unresolved-"));
+
+try {
+  fs.writeFileSync(path.join(project, "package.json"), JSON.stringify({ type: "module" }));
+  fs.writeFileSync(path.join(project, "index.html"), '<html><body><script type="module" src="/main.js"></script></body></html>');
+  fs.writeFileSync(path.join(project, "main.js"), 'import "missing-example-dependency"; document.body.textContent = "ready";');
+
+  const missing = spawnSync(binary, ["build", project], { cwd: root, encoding: "utf8" });
+  assert.notEqual(missing.status, 0, `an unresolved dependency must fail the build:\n${missing.stdout}\n${missing.stderr}`);
+  assert.match(`${missing.stdout}\n${missing.stderr}`, /missing-example-dependency/);
+
+  fs.writeFileSync(path.join(project, "oj.config.json"), JSON.stringify({
+    build: { rollupOptions: { external: ["missing-example-dependency"] } },
+  }));
+  const external = spawnSync(binary, ["build", project], { cwd: root, encoding: "utf8" });
+  assert.equal(external.status, 0, `an explicitly external dependency must remain allowed:\n${external.stdout}\n${external.stderr}`);
+
+  console.log("BUILD-UNRESOLVED E2E PASSED");
+} finally {
+  fs.rmSync(project, { recursive: true, force: true });
+}

--- a/e2e/build-unresolved.mjs
+++ b/e2e/build-unresolved.mjs
@@ -18,7 +18,12 @@ try {
 
   const missing = spawnSync(binary, ["build", project], { cwd: root, encoding: "utf8" });
   assert.notEqual(missing.status, 0, `an unresolved dependency must fail the build:\n${missing.stdout}\n${missing.stderr}`);
-  assert.match(`${missing.stdout}\n${missing.stderr}`, /missing-example-dependency/);
+  const missingOut = `${missing.stdout}\n${missing.stderr}`;
+  assert.match(missingOut, /missing-example-dependency/);
+  // Like Vite, the failure names the escape hatch for a deliberate external.
+  assert.match(missingOut, /build\.rollupOptions\.external/, `the failure must point at the externalization option:\n${missingOut}`);
+  // Like Vite (which writes nothing), a failed build leaves no broken bundle on disk.
+  assert.equal(fs.existsSync(path.join(project, "dist")), false, "a failed build must not leave a partial dist/ behind");
 
   fs.writeFileSync(path.join(project, "oj.config.json"), JSON.stringify({
     build: { rollupOptions: { external: ["missing-example-dependency"] } },


### PR DESCRIPTION
Lands #33 by @williamhogman (both commits preserved with authorship) plus one follow-up so the failure matches Vite's observable behavior:

- Vite fails the build on an unresolved import and writes nothing. rolldown has already written the bundle by the time its diagnostics are readable, so the partial `dist/` is dropped on this failure (the directory is emptied at every build start anyway) and a failed build never leaves a broken bundle behind.
- The error now names the escape hatch the way Vite's does: add a deliberate external to `build.rollupOptions.external`.

Reference: Vite 8 promotes `UNRESOLVED_IMPORT` to a hard error (`Rolldown failed to resolve import ... add it to build.rolldownOptions.external`); the only carve-out there is its internal `?commonjs-external` marker, which oj does not produce.

The e2e asserts the hint text and that no `dist/` survives the failed build, and still verifies an explicitly external dependency builds.

Closes #33.