### PR TITLE
fix(config): fail when a present vite.config cannot be loaded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
       - name: client env define (dotenv + process env + plugin config mutations)
         if: matrix.mode == 'unbundled'
         run: node e2e/env-define.mjs
+      - name: a vite.config that fails to load is an error, not an empty config
+        if: matrix.mode == 'unbundled'
+        run: node e2e/config-load-failure.mjs
 
   # i need to fix this or automate
   build:

--- a/crates/oj/src/build.rs
+++ b/crates/oj/src/build.rs
@@ -1428,7 +1428,8 @@ pub async fn build(
 
     let mut config =
         oj_config::load_with(&root, "build", mode).map_err(|e| anyhow::anyhow!("{e}"))?;
-    oj_server::plugins::adopt_vite_config_values(&mut config, &root, "build", mode);
+    oj_server::plugins::adopt_vite_config_values(&mut config, &root, "build", mode)
+        .map_err(|e| anyhow::anyhow!(e))?;
     let build_cfg = config.build.clone().unwrap_or_default();
     let ro_opts = oj_config::rolldown_options(&config);
     let out = out
@@ -2111,7 +2112,8 @@ pub(crate) async fn build_ssr(
 
     let mut config =
         oj_config::load_with(root, "build", mode).map_err(|e| anyhow::anyhow!("{e}"))?;
-    oj_server::plugins::adopt_vite_config_values(&mut config, root, "build", mode);
+    oj_server::plugins::adopt_vite_config_values(&mut config, root, "build", mode)
+        .map_err(|e| anyhow::anyhow!(e))?;
     let loaded_env = oj_env::load(root, mode);
     let node_env = oj_env::resolve_node_env(shell_node_env().as_deref(), &loaded_env, "production");
     let is_production = node_env == "production";
@@ -2268,7 +2270,8 @@ async fn build_server_fns(root: &Path, out_dir: &Path, mode: &str) -> anyhow::Re
     use rolldown::{IsExternal, Platform};
     let mut config =
         oj_config::load_with(root, "build", mode).map_err(|e| anyhow::anyhow!("{e}"))?;
-    oj_server::plugins::adopt_vite_config_values(&mut config, root, "build", mode);
+    oj_server::plugins::adopt_vite_config_values(&mut config, root, "build", mode)
+        .map_err(|e| anyhow::anyhow!(e))?;
     let node_env =
         oj_env::resolve_node_env(shell_node_env().as_deref(), &oj_env::load(root, mode), "production");
     let is_production = node_env == "production";
@@ -2624,7 +2627,8 @@ async fn build_client_entry(
 
     let mut config =
         oj_config::load_with(root, "build", mode).map_err(|e| anyhow::anyhow!("{e}"))?;
-    oj_server::plugins::adopt_vite_config_values(&mut config, root, "build", mode);
+    oj_server::plugins::adopt_vite_config_values(&mut config, root, "build", mode)
+        .map_err(|e| anyhow::anyhow!(e))?;
     let loaded_env = oj_env::load(root, mode);
     let node_env = oj_env::resolve_node_env(shell_node_env().as_deref(), &loaded_env, "production");
     let is_production = node_env == "production";

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -357,7 +357,8 @@ impl DevServer {
         boot_phase("build_app begin");
         prepare_cache_root(&root);
         let mut config = oj_config::load(&root).map_err(|e| anyhow::anyhow!("{e}"))?;
-        plugins::adopt_vite_config_values(&mut config, &root, "serve", "development");
+        plugins::adopt_vite_config_values(&mut config, &root, "serve", "development")
+            .map_err(|e| anyhow::anyhow!(e))?;
         boot_phase("vite config values adopted");
 
         // Feed optimizeDeps.include/exclude/needsInterop into partial bundling so

--- a/crates/oj_server/src/plugins.rs
+++ b/crates/oj_server/src/plugins.rs
@@ -247,25 +247,30 @@ pub fn extract_vite_values(root: &Path, command: &str, mode: &str) -> Option<Vit
         eprint!("{stderr}");
     }
     let json: serde_json::Value = serde_json::from_slice(&out.stdout).ok()?;
-    if json.get("__ok").and_then(|v| v.as_bool()) == Some(true) {
-        let deps: Vec<PathBuf> = json
-            .get("__deps")
-            .and_then(|v| v.as_array())
-            .map(|a| {
-                a.iter()
-                    .filter_map(|d| d.as_str().map(PathBuf::from))
-                    .collect()
-            })
-            .unwrap_or_default();
-        store.store(
-            &vite,
-            command,
-            mode,
-            &deps,
-            &String::from_utf8_lossy(&out.stdout),
-            &stderr,
-        );
+    // The extractor reports a config that failed to evaluate as `__ok: false`
+    // (having printed the cause to stderr above). That is not a config with no
+    // values, so never parse it into an empty ViteValues: return None and let the
+    // caller decide whether a present-but-broken vite.config is an error.
+    if json.get("__ok").and_then(|v| v.as_bool()) != Some(true) {
+        return None;
     }
+    let deps: Vec<PathBuf> = json
+        .get("__deps")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|d| d.as_str().map(PathBuf::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    store.store(
+        &vite,
+        command,
+        mode,
+        &deps,
+        &String::from_utf8_lossy(&out.stdout),
+        &stderr,
+    );
     crate::boot_phase("vite-extract cache miss (subprocess ran)");
     Some(parse_vite_values(&json))
 }
@@ -316,11 +321,23 @@ pub fn adopt_vite_config_values(
     root: &Path,
     command: &str,
     mode: &str,
-) {
+) -> Result<(), String> {
     let Some(v) = extract_vite_values(root, command, mode) else {
-        return;
+        // No vite.config is fine: nothing to adopt. A vite.config that exists but
+        // failed to evaluate is not: Vite fails hard here ("failed to load config
+        // from ..."), and silently carrying on would build or serve with defaults
+        // the app never asked for. An explicit oj.plugins file takes precedence over
+        // vite.config (the extractor skips it then), so only the vite path is an
+        // error. The extractor has already printed the underlying cause to stderr.
+        if plugins_file(root).is_none() {
+            if let Some(path) = vite_config_file(root) {
+                return Err(format!("failed to load config from {}", path.display()));
+            }
+        }
+        return Ok(());
     };
     merge_vite_values(config, v);
+    Ok(())
 }
 
 fn merge_vite_values(config: &mut oj_config::OjConfig, v: ViteValues) {

--- a/e2e/config-load-failure.mjs
+++ b/e2e/config-load-failure.mjs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const binary = path.join(root, "target", "debug", "oj");
+const project = fs.mkdtempSync(path.join(os.tmpdir(), "oj-config-failure-"));
+
+try {
+  fs.writeFileSync(path.join(project, "package.json"), JSON.stringify({ type: "module" }));
+  fs.writeFileSync(path.join(project, "index.html"), '<html><body><script type="module" src="/main.js"></script></body></html>');
+  fs.writeFileSync(path.join(project, "main.js"), 'document.body.textContent = "ready";');
+  fs.writeFileSync(path.join(project, "vite.config.mjs"), 'import "missing-config-plugin"; export default {};\n');
+
+  const build = spawnSync(binary, ["build", project], { cwd: root, encoding: "utf8" });
+  assert.notEqual(build.status, 0, `a broken Vite config must fail instead of being ignored:\n${build.stdout}\n${build.stderr}`);
+  assert.match(`${build.stdout}\n${build.stderr}`, /missing-config-plugin/);
+
+  console.log("CONFIG-LOAD-FAILURE E2E PASSED");
+} finally {
+  fs.rmSync(project, { recursive: true, force: true });
+}


### PR DESCRIPTION
Lands the fix from #36 by @williamhogman, re-implemented on the current config-extraction signatures (command + mode, from deca86c), with the original e2e preserved under its author.

Today a `vite.config` that exists but fails to evaluate (bad import, syntax error) is silently treated as an empty configuration: the extractor reports `__ok: false`, but that payload was still parsed into an empty `ViteValues`, so the build or dev server carried on with defaults the app never asked for. Vite fails hard here (`failed to load config from ...`).

- `extract_vite_values` now returns `None` for an `__ok: false` payload instead of parsing it into empty values (the extractor has already printed the underlying cause to stderr).
- `adopt_vite_config_values` returns `Result` and distinguishes "no vite.config at all" (nothing to adopt, fine) from "a vite.config is present but failed to load" (error, Vite's wording). An explicit `oj.plugins` file still takes precedence, so only the vite path is a failure.
- All five call sites (four build entry points, the dev server's `build_app`) propagate the error.

Verified: `e2e/config-load-failure.mjs` (broken config fails, cause surfaced), a valid config still builds, a project with no config still builds, workspace unit tests green.

Closes #36.