### PR TITLE
ci: run the playwright-based e2e in the e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,15 @@ jobs:
       - name: a vite.config that fails to load is an error, not an empty config
         if: matrix.mode == 'unbundled'
         run: node e2e/config-load-failure.mjs
+      # These drive a dev server (and svgr-plugin also a browser via playwright),
+      # so they belong here where e2e deps + chromium are installed, not in the
+      # prod build smoke job, which has neither.
+      - name: plugin load runs before the disk read (load-first)
+        if: matrix.mode == 'unbundled'
+        run: node e2e/plugin-load-first.mjs
+      - name: plain .svg import goes through the svgr plugin transform
+        if: matrix.mode == 'unbundled'
+        run: node e2e/svgr-plugin.mjs
 
   # i need to fix this or automate
   build:
@@ -156,10 +165,6 @@ jobs:
         run: node e2e/plugin-load-jsx.mjs
       - name: plugin transform runs on CSS sources before compile
         run: node e2e/css-plugin-transform.mjs
-      - name: plugin load runs before the disk read (load-first)
-        run: node e2e/plugin-load-first.mjs
-      - name: plain .svg import goes through the svgr plugin transform
-        run: node e2e/svgr-plugin.mjs
       - name: vite:css-post shim routes plugin CSS into output (UnoCSS pattern)
         run: node e2e/vite-css-post-shim.mjs
       - name: .vite/manifest.json is present in the generateBundle bundle


### PR DESCRIPTION
`prod build smoke` has failed on every push to main since e9e5459 registered `e2e/svgr-plugin.mjs` (and `e2e/plugin-load-first.mjs`) in the build job: svgr-plugin drives a browser through playwright, but only the `e2e` job installs `e2e` deps and chromium, so the build job died with `Cannot find module 'playwright'` (confirmed identical on every red run back to 9c4d136).

Both tests drive a dev server, so they belong in the `e2e` job alongside the other playwright-based tests, gated to one matrix mode like the rest of the single-run steps. No test logic changes.