### PR TITLE
ci: assert the bundled, hashed tailwind stylesheet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,10 @@ jobs:
           ls playground/dist/assets/*.js
           # publicDir assets are copied to the build output
           test -f playground/dist/robots.txt
-          grep -q underline playground/dist/tailwind.css
+          # the html's <link rel="stylesheet"> is bundled like Vite: emitted as a
+          # hashed asset and the href rewritten to it
+          grep -qE 'href="/assets/tailwind-[A-Za-z0-9_-]+\.css"' playground/dist/index.html
+          grep -q underline playground/dist/assets/tailwind-*.css
           test -f playground/dist/.vite/manifest.json
           grep -q isEntry playground/dist/.vite/manifest.json
           grep -rq hello-from-env playground/dist/assets/*.js


### PR DESCRIPTION
`prod build smoke` has failed on every push since fd7d627 at the "check outputs" step: `grep -q underline playground/dist/tailwind.css` exits 2 because `dist/tailwind.css` no longer exists.

That is the intended result of the stylesheet-bundling work that landed in that merge (550d81a "bundle html stylesheet links and inline module scripts", 97ff50c "rewrite bundled stylesheet hrefs in any quoting"): like Vite, the html's `<link rel="stylesheet">` is now emitted as a hashed asset (`assets/tailwind-<hash>.css`) and the href rewritten to it. The e2e job already covers the new behavior; only this smoke assertion still encoded the old unhashed root copy.

The assertion now checks the new contract, and more strictly than before: `index.html` must link a hashed `assets/tailwind-*.css`, and that asset must contain the `underline` utility. Verified against a fresh `oj build playground` at ba17aca: both new checks pass, the old one still exits 2. All 33 other assertions in the block pass.