### PR TITLE
Keep the browser Host intact behind a proxy in Start dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to oj are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- TanStack Start dev behind a proxy that sets `x-forwarded-host` (a preview or a tunnel) answered every request with `500 Failed to parse URL from http://proxy-host, localhost:port/`: oj forwarded the browser's `Host` to the SSR runner as a second `x-forwarded-host`, and Node joined the two. The original `Host` now travels in a private header and is restored as `Host` (first value only, as Node does for duplicate `Host` headers), and a proxy's `x-forwarded-host` reaches the app untouched, as under Vite. Plugin middlewares (`configureServer`) see the browser's `Host` in `req.headers.host` for the same reason.
+
 ## [0.1.14] - 2026-09-03
 
 A Vite-parity release: the fifth oj-versus-Vite audit round closed its last P0 (production builds for Cloudflare), every remaining P1 that did not need a redesign, and most of the P2 list across the dev server and HMR, the resolver and dependency optimizer, plugins, the production build, CSS and assets, and SSR with TanStack Start. Every change below ships with a unit or end-to-end test and was matched against rolldown-vite 8.3.0-beta.0.

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -1177,6 +1177,8 @@ async function setupConfigureServer() {
     }
     const headers = { ...req.headers };
     delete headers["x-oj-forward-to"];
+    // The runner rebuilds Host from x-oj-host (Node sets the loopback Host).
+    if (headers.host) headers["x-oj-host"] = headers.host;
     delete headers.host;
     const up = http.request({ host: "127.0.0.1", port, method: req.method, path: req.url, headers }, (r) => {
       res.writeHead(r.statusCode, r.headers);
@@ -1266,6 +1268,12 @@ async function setupConfigureServer() {
   if (stack.length === 0) return;
 
   const srv = http.createServer((req, res) => {
+    // The browser's Host travels as x-oj-host (hyper owns the loopback Host):
+    // middlewares read req.headers.host as they do under Vite.
+    if (typeof req.headers["x-oj-host"] === "string") {
+      req.headers.host = req.headers["x-oj-host"].split(",")[0].trim() || req.headers.host;
+      delete req.headers["x-oj-host"];
+    }
     if (req.method === "POST" && req.url === "/__oj_invalidate") {
       let body = "";
       req.on("data", (c) => (body += c));

--- a/crates/oj_server/src/assets/start/loader-util.mjs
+++ b/crates/oj_server/src/assets/start/loader-util.mjs
@@ -264,3 +264,18 @@ export function scanPack(file, store, epoch, verifyHashes, onRecord) {
   }
   return buf.length;
 }
+
+// The Host a forwarded request should present to the app. hyper owns the
+// loopback Host, so oj sends the browser's in x-oj-host; the runner takes that,
+// then the loopback Host. Node discards duplicate Host headers and keeps the
+// first, so a comma-joined value is cut the same way (a value like
+// "proxy.example.com, localhost:8080" would otherwise break `new Request`).
+export function requestHost(...candidates) {
+  for (const c of candidates) {
+    const v = Array.isArray(c) ? c[0] : c;
+    if (typeof v !== "string") continue;
+    const first = v.split(",")[0].trim();
+    if (first) return first;
+  }
+  return "localhost";
+}

--- a/crates/oj_server/src/assets/start/runner.mjs
+++ b/crates/oj_server/src/assets/start/runner.mjs
@@ -8,6 +8,7 @@ import { fstatSync } from "node:fs";
 import { pathToFileURL, fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import readline from "node:readline";
+import { requestHost } from "./loader-util.mjs";
 
 process.env.TSS_SERVER_FN_BASE ??= "/_serverFn/";
 process.env.TSS_DEV_SERVER ??= "true";
@@ -48,11 +49,13 @@ let entryReady;
 const server = http.createServer(async (req, res) => {
   try {
     await entryReady;
-    const host = req.headers["x-forwarded-host"] || req.headers.host || "localhost";
+    // The browser's Host arrives as x-oj-host (hyper owns the loopback Host);
+    // a proxy's x-forwarded-host is left to the app, as under Vite.
+    const host = requestHost(req.headers["x-oj-host"], req.headers.host);
     const method = req.method || "GET";
     const headers = new Headers();
     for (const [k, v] of Object.entries(req.headers)) {
-      if (v == null || k === "x-forwarded-host") continue;
+      if (v == null || k === "x-oj-host") continue;
       if (Array.isArray(v)) for (const x of v) headers.append(k, x);
       else headers.set(k, v);
     }

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -2846,7 +2846,8 @@ pub async fn notify_plugin_mw_invalidate(port: u16, paths: &[String]) {
 /// Proxy one request to a loopback HTTP service (the plugin middleware server or
 /// the Start SSR runner) and stream its response back. Bodies are passed as
 /// bytes, so binary uploads and responses survive; the original `Host` travels
-/// as `x-forwarded-host` so the service can build the app's own absolute URLs.
+/// as `x-oj-host` (see `loopback_request_headers`) so the service can build the
+/// app's own absolute URLs.
 /// Stream the response through instead of buffering it: TanStack Start streams
 /// its dehydrated data (queryStream + deferred promises) into the HTML, and
 /// buffering withholds the whole document until the SSR stream closes, so the
@@ -2860,6 +2861,30 @@ pub async fn proxy_to_loopback(
     body: Option<Vec<u8>>,
 ) -> Result<Response, String> {
     proxy_to_loopback_streaming(port, method, path_and_query, headers, body.map(Body::from)).await
+}
+
+/// The headers a request forwarded to a loopback service (the plugin middleware
+/// server, the Start SSR runner) carries. hyper writes the loopback `Host`
+/// itself, so the browser's `Host` travels as `x-oj-host` and the service
+/// rebuilds `Host` from it. Only the first `Host` is taken: Node discards
+/// duplicate `Host` headers and keeps the first, so a joined value would never
+/// reach an app under Vite. A proxy's own `x-forwarded-host` passes through
+/// untouched, as under Vite where the app reads it next to the dev server's
+/// `Host`; sending it as `x-forwarded-host` too made Node join the two into
+/// `proxy-host, localhost:port`, which no URL parser accepts. An incoming
+/// `x-oj-host` is dropped so a client cannot spoof it.
+pub fn loopback_request_headers(headers: &HeaderMap) -> Vec<(header::HeaderName, header::HeaderValue)> {
+    let mut out = Vec::with_capacity(headers.len() + 1);
+    if let Some(host) = headers.get(header::HOST) {
+        out.push((header::HeaderName::from_static("x-oj-host"), host.clone()));
+    }
+    for (name, value) in headers.iter() {
+        if name == header::HOST || name.as_str() == "x-oj-host" {
+            continue;
+        }
+        out.push((name.clone(), value.clone()));
+    }
+    out
 }
 
 /// `proxy_to_loopback` with the request body streamed through as it arrives
@@ -2876,11 +2901,7 @@ pub async fn proxy_to_loopback_streaming(
     let target = format!("http://127.0.0.1:{port}{path_and_query}");
     let m = reqwest::Method::from_bytes(method.as_bytes()).map_err(|e| e.to_string())?;
     let mut out = client.request(m, &target);
-    for (name, value) in headers.iter() {
-        if name == header::HOST {
-            out = out.header("x-forwarded-host", value);
-            continue;
-        }
+    for (name, value) in loopback_request_headers(headers) {
         out = out.header(name, value);
     }
     if let Some(b) = body {
@@ -9003,5 +9024,27 @@ mod adapter_tests {
         let mut html = HeaderMap::new();
         html.insert(header::ACCEPT, "text/html,*/*".parse().unwrap());
         assert!(is_spa_navigation("some.thing", &html));
+    }
+
+    #[test]
+    fn loopback_headers_carry_host_as_x_oj_host_and_pass_forwarded_host_through() {
+        let mut h = HeaderMap::new();
+        h.insert(header::HOST, "localhost:8080".parse().unwrap());
+        h.append("x-forwarded-host", "app.example.com".parse().unwrap());
+        h.append("x-forwarded-host", "edge.example.com".parse().unwrap());
+        h.insert("x-oj-host", "spoofed.example.com".parse().unwrap());
+        h.insert(header::ACCEPT, "text/html".parse().unwrap());
+        let out = loopback_request_headers(&h);
+        let get = |n: &str| {
+            out.iter()
+                .filter(|(k, _)| k.as_str() == n)
+                .map(|(_, v)| v.to_str().unwrap().to_string())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(get("x-oj-host"), ["localhost:8080"]);
+        assert_eq!(get("x-forwarded-host"), ["app.example.com", "edge.example.com"]);
+        assert!(get("host").is_empty(), "hyper writes the loopback Host itself");
+        assert_eq!(get("accept"), ["text/html"]);
+        assert!(loopback_request_headers(&HeaderMap::new()).is_empty());
     }
 }

--- a/e2e/fixtures/start-app/src/routeTree.ts
+++ b/e2e/fixtures/start-app/src/routeTree.ts
@@ -3,7 +3,8 @@ import { indexRoute } from "./routes/index";
 import { aboutRoute } from "./routes/about";
 import { userRoute } from "./routes/user";
 import { exportRoute } from "./routes/export";
+import { requestUrlRoute } from "./routes/request-url";
 
 // A code-based route tree (no file-based codegen), so the fixture has no
 // generated files to keep in sync.
-export const routeTree = rootRoute.addChildren([indexRoute, aboutRoute, userRoute, exportRoute]);
+export const routeTree = rootRoute.addChildren([indexRoute, aboutRoute, userRoute, exportRoute, requestUrlRoute]);

--- a/e2e/fixtures/start-app/src/routes/request-url.tsx
+++ b/e2e/fixtures/start-app/src/routes/request-url.tsx
@@ -1,0 +1,23 @@
+import { createRoute } from "@tanstack/react-router";
+
+import { rootRoute } from "./__root";
+
+// Echoes how a request reached the app: the URL the handler was given, the
+// Host it carries and any x-forwarded-host a proxy in front added. The dev
+// server must present them as Vite does (Host is the dev server's own,
+// x-forwarded-host passes through untouched) even when a proxy already set
+// x-forwarded-host; joining the two hosts used to break URL parsing.
+export const requestUrlRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/api/request-url",
+  server: {
+    handlers: {
+      GET: ({ request }: { request: Request }) =>
+        Response.json({
+          url: request.url,
+          host: request.headers.get("host"),
+          forwardedHost: request.headers.get("x-forwarded-host"),
+        }),
+    },
+  },
+});

--- a/e2e/start-server-routes.mjs
+++ b/e2e/start-server-routes.mjs
@@ -70,6 +70,20 @@ async function assertServerRoutes(port, label) {
   must((put.headers.get("content-type") || "").includes("text/html"),
     `${label}: PUT /files/a.b should reach the app (got ${put.status} ${put.headers.get("content-type")})`);
   console.log(`${label}: dotted POST server route + binary echo + 2 set-cookie + dotted PUT ok`);
+
+  // Behind a proxy that already set x-forwarded-host (a preview or a tunnel),
+  // the app must still get a parseable URL: Host is the server's own and the
+  // proxy's x-forwarded-host passes through untouched, Vite's shape. Joining
+  // the two hosts used to surface as a 500 "Failed to parse URL".
+  const viaProxy = await fetch(`http://localhost:${port}/api/request-url`, {
+    headers: { "x-forwarded-host": "preview.example.com" },
+  });
+  must(viaProxy.status === 200, `${label}: GET /api/request-url behind a proxy returned ${viaProxy.status}`);
+  const seen = await viaProxy.json();
+  must(seen.url.startsWith(`http://localhost:${port}/api/request-url`), `${label}: request.url should use the server's own host, got ${seen.url}`);
+  must(seen.host === `localhost:${port}`, `${label}: Host should be the server's own, got ${seen.host}`);
+  must(seen.forwardedHost === "preview.example.com", `${label}: x-forwarded-host should pass through, got ${seen.forwardedHost}`);
+  console.log(`${label}: proxied request keeps Host and passes x-forwarded-host through`);
 }
 
 async function devPhase() {

--- a/e2e/unit/loader-util.test.mjs
+++ b/e2e/unit/loader-util.test.mjs
@@ -7,7 +7,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   probe, isCjsFile, hasEsmSyntax, nearestPkgType, cjsFacade, stripJsonc, readJsonc,
-  rewriteServerFns, substituteAlias, parseImportsField, mergeTsConfig,
+  rewriteServerFns, substituteAlias, parseImportsField, mergeTsConfig, requestHost,
 } from "../../crates/oj_server/src/assets/start/loader-util.mjs";
 import { sep } from "node:path";
 
@@ -354,4 +354,13 @@ test("readJsonc accepts TypeScript configuration with a UTF-8 byte-order mark", 
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test("requestHost prefers x-oj-host, keeps only the first host like Node, falls back to localhost", () => {
+  assert.equal(requestHost("localhost:8080", "127.0.0.1:41234"), "localhost:8080");
+  assert.equal(requestHost(undefined, "127.0.0.1:41234"), "127.0.0.1:41234");
+  assert.equal(requestHost("preview.example.com, localhost:8080"), "preview.example.com");
+  assert.equal(requestHost(["a.example.com", "b.example.com"]), "a.example.com");
+  assert.equal(requestHost("", " "), "localhost");
+  assert.equal(requestHost(undefined, undefined), "localhost");
 });

--- a/e2e/unit/runner-protocol.test.mjs
+++ b/e2e/unit/runner-protocol.test.mjs
@@ -22,7 +22,7 @@ export default {
     console.log("APP_LOG_MUST_NOT_CORRUPT_PROTOCOL");
     const echo = request.method === "GET" ? "" : await request.text();
     return new Response(
-      JSON.stringify({ path: url.pathname, host: url.host, method: request.method, echo }),
+      JSON.stringify({ path: url.pathname, host: url.host, hostHeader: request.headers.get("host"), forwardedHost: request.headers.get("x-forwarded-host"), method: request.method, echo }),
       {
         status: url.pathname === "/missing" ? 404 : 200,
         headers: { "content-type": "application/json", "x-custom": "runner-ok" },
@@ -84,30 +84,41 @@ test("runner serves requests over loopback http and commands over stdin", async 
   try {
     await r.ready();
 
-    const g = await r.req({ method: "GET", url: "/hello", headers: { "x-forwarded-host": "example.test" } });
+    // The browser's Host arrives as x-oj-host (hyper owns the loopback Host);
+    // a proxy's x-forwarded-host is the app's to read, as under Vite (srvx
+    // only consults it behind a trusted proxy).
+    const g = await r.req({ method: "GET", url: "/hello", headers: { "x-oj-host": "example.test", "x-forwarded-host": "proxy.example.test" } });
     assert.equal(g.status, 200);
     assert.equal(g.headers["x-custom"], "runner-ok");
     const gbody = JSON.parse(g.body);
     assert.equal(gbody.path, "/hello");
     assert.equal(gbody.host, "example.test");
+    assert.equal(gbody.hostHeader, "example.test");
+    assert.equal(gbody.forwardedHost, "proxy.example.test");
     assert.equal(gbody.method, "GET");
 
-    const p = await r.req({ method: "POST", url: "/submit", headers: { "x-forwarded-host": "h" }, body: "payload" });
+    // Node keeps only the first of duplicate Host headers; a joined value is
+    // cut the same way instead of failing URL parsing.
+    const joined = await r.req({ url: "/hello", headers: { "x-oj-host": "first.test, second.test" } });
+    assert.equal(joined.status, 200);
+    assert.equal(JSON.parse(joined.body).host, "first.test");
+
+    const p = await r.req({ method: "POST", url: "/submit", headers: { "x-oj-host": "h" }, body: "payload" });
     assert.equal(JSON.parse(p.body).echo, "payload");
 
     const reloaded = await r.cmd({ cmd: "reload" });
     assert.equal(reloaded.reloaded, true);
-    const after = await r.req({ url: "/hello", headers: { "x-forwarded-host": "h" } });
+    const after = await r.req({ url: "/hello", headers: { "x-oj-host": "h" } });
     assert.equal(after.status, 200);
 
     // An exception escaping the handler is a 500 HTML page with message and
     // stack, like Vite's errorMiddleware fallback body.
-    const boom = await r.req({ url: "/boom", headers: { "x-forwarded-host": "h" } });
+    const boom = await r.req({ url: "/boom", headers: { "x-oj-host": "h" } });
     assert.equal(boom.status, 500);
     assert.match(boom.headers["content-type"], /text\/html/);
     assert.match(boom.body, /<h1>Internal Server Error<\/h1><h2>kaboom<\/h2><pre>Error: kaboom/);
 
-    const missing = await r.req({ url: "/missing", headers: { "x-forwarded-host": "h" } });
+    const missing = await r.req({ url: "/missing", headers: { "x-oj-host": "h" } });
     assert.equal(missing.status, 404);
 
     assert.match(r.getStderr(), /APP_LOG_MUST_NOT_CORRUPT_PROTOCOL/);


### PR DESCRIPTION
TanStack Start dev behind a proxy that already sets `x-forwarded-host` (a preview or a tunnel) answered every request with `500 Failed to parse URL from http://proxy-host, localhost:port/`.

Cause: oj forwarded the browser Host to the SSR runner as a second `x-forwarded-host`, and Node joined the two values.

Fix, matching Vite: the browser Host travels in a private `x-oj-host` header (hyper owns the loopback Host) and the runner rebuilds `Host` from it, first value only, as Node does for duplicate Host headers; a proxy `x-forwarded-host` reaches the app untouched (srvx, which Start uses under Vite, only consults it behind a trusted proxy and takes the first comma value). `configureServer` middlewares now see the browser Host in `req.headers.host` too.

Tests: Rust unit for the header mapping, JS unit for the host selection, runner protocol test updated to the new contract, and `e2e/start-server-routes.mjs` gains a proxied request in dev and prod against a new fixture route echoing url, host and x-forwarded-host. Reproduced before and after on a real TanStack Start app: 500 became 200.
