### PR TITLE
Honor the Start server entry; warn about user config only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to oj are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- TanStack Start: an app's own server entry (`tanstackStart({ server: { entry } })`, the shape an SSR error wrapper takes) is honored in dev and in the prod server bundle, as Vite imports it: the configured module is the handler and `@tanstack/react-start/server-entry` inside it is oj's handler, so a wrapper composes. Previously oj always ran its own entry and the wrapper never executed.
+
+### Fixed
+- `vite.config` "not applied" warnings were emitted for Vite's own resolved defaults (`esbuild.jsxDev/charset/legalComments`, `worker`, `ssr.resolve`, `server.cors.origin`, `optimizeDeps.esbuildOptions`, `build.terserOptions`, the `@vite/env` and `@vite/client` aliases) on every config, and repeated on every config load (three times at Start startup, again after each rebuild). They now describe only options the config file itself sets, and each line prints once per dev session.
+
 ## [0.1.15] - 2026-09-03
 
 ### Fixed

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -488,7 +488,31 @@ fn start_script_env(root: &Path, command: &str, mode: &str) -> anyhow::Result<Ve
         ))
         .unwrap_or_default(),
     ));
+    if let Some(entry) = configured_start_server_entry(&config, root) {
+        vars.push(("OJ_START_SERVER_ENTRY".into(), entry.to_string_lossy().into_owned()));
+    }
     Ok(vars)
+}
+
+/// The app's own TanStack Start server entry (`tanstackStart({ server: { entry } })`),
+/// when it configures one. Start's plugin publishes the resolved entry paths as
+/// `resolve.alias` entries (`virtual:tanstack-start-server-entry` -> file), which
+/// Vite's dev server imports as the SSR handler; oj reads the same alias. Only an
+/// app file counts: unconfigured, the alias points at Start's own package entry,
+/// which oj replaces with its runner entry as before.
+fn configured_start_server_entry(config: &oj_config::OjConfig, root: &Path) -> Option<PathBuf> {
+    let target = oj_config::resolve_alias(config, "ssr")
+        .into_iter()
+        .find(|(find, _)| find == "virtual:tanstack-start-server-entry")
+        .map(|(_, replacement)| replacement)?;
+    let path = PathBuf::from(target.split('?').next().unwrap_or(&target));
+    let path = if path.is_absolute() { path } else { root.join(path) };
+    let real = path.canonicalize().ok()?;
+    let root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    if !real.starts_with(&root) || real.components().any(|c| c.as_os_str() == "node_modules") || !real.is_file() {
+        return None;
+    }
+    Some(real)
 }
 
 pub async fn start_build(root: PathBuf, mode: &str, out: Option<PathBuf>) -> anyhow::Result<()> {
@@ -1611,5 +1635,41 @@ mod tests {
             Some(PathBuf::from("/out/vite.config.mjs")),
         );
         assert_eq!(config_path(root, None), None);
+    }
+
+    #[test]
+    fn configured_start_server_entry_reads_the_start_alias_for_app_files_only() {
+        let root = std::env::temp_dir().join(format!("oj-start-entry-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(root.join("node_modules/@tanstack/react-start/dist")).unwrap();
+        std::fs::write(root.join("src/ssr-entry.ts"), "export default {};").unwrap();
+        std::fs::write(root.join("node_modules/@tanstack/react-start/dist/server-entry.js"), "").unwrap();
+        let cfg = |target: &str| -> oj_config::OjConfig {
+            serde_json::from_str(&format!(
+                r#"{{"resolve":{{"alias":{{"virtual:tanstack-start-server-entry":"{}"}}}}}}"#,
+                target.replace('\\', "/")
+            ))
+            .unwrap()
+        };
+        let app = root.join("src/ssr-entry.ts");
+        assert_eq!(
+            configured_start_server_entry(&cfg(&app.to_string_lossy()), &root),
+            Some(app.canonicalize().unwrap()),
+            "an app file named by the Start alias is the server entry"
+        );
+        assert_eq!(configured_start_server_entry(&cfg("src/ssr-entry.ts"), &root).is_some(), true, "root-relative works too");
+        let pkg = root.join("node_modules/@tanstack/react-start/dist/server-entry.js");
+        assert_eq!(configured_start_server_entry(&cfg(&pkg.to_string_lossy()), &root), None, "Start's own default entry is not an app entry");
+        assert_eq!(configured_start_server_entry(&cfg("src/missing.ts"), &root), None);
+        let none: oj_config::OjConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(configured_start_server_entry(&none, &root), None);
+        let env_scoped: oj_config::OjConfig = serde_json::from_str(&format!(
+            r#"{{"environments":{{"ssr":{{"resolve":{{"alias":{{"virtual:tanstack-start-server-entry":"{}"}}}}}}}}}}"#,
+            app.to_string_lossy().replace('\\', "/")
+        ))
+        .unwrap();
+        assert!(configured_start_server_entry(&env_scoped, &root).is_some(), "environments.ssr.resolve.alias counts");
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/crates/oj_server/src/assets/start/build.mjs
+++ b/crates/oj_server/src/assets/start/build.mjs
@@ -303,9 +303,17 @@ const serverDefine = {
   "process.env.NODE_ENV": JSON.stringify(NODE_ENV), "process.env.TSS_SERVER_FN_BASE": '"/_serverFn/"',
   ...viteEnvDefine({ ssr: true, mode: MODE, base: BASE }),
 };
+// The bundle's entry is the app's own Start server entry when configured
+// (`tanstackStart({ server: { entry } })`, published by the plugin as the
+// `virtual:tanstack-start-server-entry` alias and exported by oj as
+// OJ_START_SERVER_ENTRY), else oj's; either way `@tanstack/react-start/server-entry`
+// inside it is oj's handler, so a wrapping entry composes as it does under Vite.
+const OJ_SERVER_ENTRY = join(HERE, "server-entry.tsx");
+const SERVER_ENTRY = process.env.OJ_START_SERVER_ENTRY || OJ_SERVER_ENTRY;
 const serverAlias = {
   ...clientAlias,
   "#tanstack-start-server-fn-resolver": join(HERE, "server-fn-resolver.mjs"),
+  "@tanstack/react-start/server-entry": OJ_SERVER_ENTRY,
 };
 const serverPlugins = () => [
   makeVitePlugins({ container: serverContainer, fallback: clientContainer, appRoot: APP, mode: "prod", emit }),
@@ -325,7 +333,7 @@ if (cfEnv) {
   // virtual Worker entry wrapping oj's server entry, and the plugin's
   // generateBundle/writeBundle emitting wrangler.json and the deploy config.
   workerDir = workerOutDir(cfEnv, APP, DIST, serverContainer.config);
-  const serverEntry = join(HERE, "server-entry.tsx");
+  const serverEntry = SERVER_ENTRY;
   const worker = await build({
     input: { index: CLOUDFLARE_WORKER_ENTRY },
     platform: "neutral",
@@ -343,7 +351,6 @@ if (cfEnv) {
       conditionNames: [...cfEnv.conditions, "import", NODE_ENV === "production" ? "production" : "development"],
       alias: {
         ...serverAlias,
-        "@tanstack/react-start/server-entry": serverEntry,
         "@cloudflare/vite-plugin/server": join(HERE, "cf-server-worker.mjs"),
       },
     },
@@ -378,7 +385,7 @@ if (cfEnv) {
   await serverContainer.writeBundle(bundle);
 } else {
   const server = await build({
-    input: { "server-bundle": join(HERE, "server-entry.tsx") },
+    input: { "server-bundle": SERVER_ENTRY },
     platform: "node",
     // Vite's `ssr.external`: those dependencies stay bare imports of the bundle.
     external: ssrExternalRule(APP),

--- a/crates/oj_server/src/assets/start/loader.mjs
+++ b/crates/oj_server/src/assets/start/loader.mjs
@@ -579,6 +579,9 @@ const ALIASES = {
   "tanstack-start-manifest:v": pathResolve(HERE, "manifest-dev.ts"),
   "tanstack-start-injected-head-scripts:v": pathResolve(HERE, "injected-head-scripts.ts"),
   "@cloudflare/vite-plugin/server": pathResolve(HERE, "cf-server.mjs"),
+  // Start's default server entry is oj's runner entry: an app `server.entry` that
+  // wraps it (as Vite runs it) wraps oj's handler.
+  "@tanstack/react-start/server-entry": pathResolve(HERE, "server-entry.tsx"),
 };
 
 const IMPORT_RULES = (() => {

--- a/crates/oj_server/src/assets/start/runner.mjs
+++ b/crates/oj_server/src/assets/start/runner.mjs
@@ -27,7 +27,10 @@ const phase = (label) => {
   if (process.env.OJ_BOOT_PHASES) process.stderr.write(`[oj-phase] ${Date.now()} runner: ${label}\n`);
 };
 phase("main begin");
-const ENTRY = pathToFileURL(process.env.OJ_RUNNER_ENTRY || join(HERE, "server-entry.tsx")).href;
+// The app's own Start server entry (`tanstackStart({ server: { entry } })`) when
+// configured, as Vite's dev server imports it; inside it, `@tanstack/react-start/
+// server-entry` is oj's handler (loader alias), so a wrapper composes the same way.
+const ENTRY = pathToFileURL(process.env.OJ_RUNNER_ENTRY || process.env.OJ_START_SERVER_ENTRY || join(HERE, "server-entry.tsx")).href;
 const LOADER = pathToFileURL(process.env.OJ_RUNNER_LOADER || join(HERE, "loader.mjs")).href;
 const loaderApi = await import(LOADER);
 if (loaderApi.resolve || loaderApi.load) module.registerHooks({ resolve: loaderApi.resolve, load: loaderApi.load });

--- a/crates/oj_server/src/assets/vite-extract.mjs
+++ b/crates/oj_server/src/assets/vite-extract.mjs
@@ -58,7 +58,15 @@ async function loadConfig() {
           if (modeExplicit) inline.mode = mode;
           const resolved = await vite.resolveConfig(inline, command, mode, mode);
           if (resolved) {
-            return { config: resolved, deps: absDeps(resolved.configFileDependencies) };
+            // The user's own file, for the "not applied" warnings: the resolved
+            // config carries Vite's defaults for every option (esbuild.jsxDev,
+            // worker, ssr.resolve, cors.origin, terserOptions...), which are not
+            // configuration oj is failing to honor.
+            let raw = null;
+            try {
+              raw = (await vite.loadConfigFromFile({ command, mode }, configPath, appRoot))?.config ?? null;
+            } catch {}
+            return { config: resolved, raw, deps: absDeps(resolved.configFileDependencies) };
           }
         } catch {
           // fall through to the raw loader below
@@ -67,7 +75,7 @@ async function loadConfig() {
       if (typeof vite.loadConfigFromFile === "function") {
         const loaded = await vite.loadConfigFromFile({ command, mode }, configPath, appRoot);
         if (loaded && loaded.config) {
-          return { config: loaded.config, deps: absDeps(loaded.dependencies) };
+          return { config: loaded.config, raw: loaded.config, deps: absDeps(loaded.dependencies) };
         }
       }
     } catch (e) {
@@ -141,6 +149,8 @@ function aliasDirFromReplacement(replacement) {
     .replace(/[\\/]index\.[a-z]+$/i, "");
 }
 
+const VITE_CLIENT_ALIAS = /^\^\\\/\?@vite\\\/(env|client)$/;
+
 function extractAlias(alias) {
   const out = {};
   if (!alias) return out;
@@ -152,6 +162,9 @@ function extractAlias(alias) {
     if (typeof find === "string") {
       if (out[find] == null) out[find] = replacement;
     } else if (find instanceof RegExp) {
+      // Vite adds these two for its own client (config.ts clientAlias); oj serves
+      // /@vite/client and /@vite/env itself, so they are not user aliases to warn about.
+      if (VITE_CLIENT_ALIAS.test(find.source)) continue;
       const key = aliasKeyFromRegex(find.source);
       if (!key || /[.*+?()[\]{}|^$]/.test(key)) {
         warn(`resolve.alias regex ${find} not convertible to a path alias; skipped`);
@@ -229,7 +242,6 @@ function extractBuild(b) {
   if (typeof b.outDir === "string") out.outDir = b.outDir;
   if (typeof b.sourcemap === "boolean" || typeof b.sourcemap === "string") out.sourcemap = b.sourcemap;
   if (typeof b.minify === "boolean" || typeof b.minify === "string") out.minify = b.minify;
-  if (b.terserOptions) warn("build.terserOptions is not applied (oj minifies with oxc)");
   if (typeof b.cssCodeSplit === "boolean") out.cssCodeSplit = b.cssCodeSplit;
   if (typeof b.target === "string") out.target = b.target;
   else if (Array.isArray(b.target)) out.target = b.target.filter((t) => typeof t === "string");
@@ -453,7 +465,14 @@ function extractCss(css) {
   }
 }
 
+// Warns about the options in the USER's config that oj does not apply. Call it
+// with the raw config file's export, not the resolved config: Vite's resolveConfig
+// fills every option with defaults (esbuild.jsxDev/charset/legalComments, worker,
+// ssr.resolve, cors.origin, optimizeDeps.esbuildOptions, terserOptions) and none of
+// those are configuration to warn about.
 function warnUnsupported(c) {
+  if (!c || typeof c !== "object") return;
+  if (c.build?.terserOptions) warn("build.terserOptions is not applied (oj minifies with oxc)");
   if (c.esbuild?.jsx === "preserve" || c.oxc?.jsx === "preserve") {
     warn("jsx: \"preserve\" is not supported; JSX is compiled with the automatic runtime");
   }
@@ -493,12 +512,12 @@ const isMainRun = (() => {
   };
   return real(self) === real(entry);
 })();
-export { extractAlias, extractOptimizeDeps, extractProxy };
+export { extractAlias, extractOptimizeDeps, extractProxy, warnUnsupported };
 
 if (isMainRun) try {
-  const { config, deps } = (await loadConfig()) ?? {};
+  const { config, raw, deps } = (await loadConfig()) ?? {};
   const c = config ?? {};
-  warnUnsupported(c);
+  warnUnsupported(raw ?? c);
   process.stdout.write(
     JSON.stringify({
       __ok: true,

--- a/crates/oj_server/src/plugins.rs
+++ b/crates/oj_server/src/plugins.rs
@@ -287,9 +287,7 @@ fn extract_vite_values_with(
     );
     if let Some(hit) = store.lookup(&vite, command, mode_key) {
         if let Ok(json) = serde_json::from_str::<serde_json::Value>(&hit.output) {
-            if !hit.stderr.is_empty() {
-                eprint!("{}", hit.stderr);
-            }
+            print_extraction_stderr(&hit.stderr);
             let _ = CONFIG_DEPS.set(hit.deps);
             crate::boot_phase("vite-extract cache hit");
             return Some(parse_vite_values(&json));
@@ -312,9 +310,7 @@ fn extract_vite_values_with(
         .output()
         .ok()?;
     let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    if !stderr.is_empty() {
-        eprint!("{stderr}");
-    }
+    print_extraction_stderr(&stderr);
     let parsed = serde_json::from_slice::<serde_json::Value>(&out.stdout);
     let parse_err = parsed.as_ref().err().map(|e| e.to_string());
     if let Some(why) = extraction_failure(out.status, &out.stdout, parse_err.as_deref()) {
@@ -351,6 +347,32 @@ fn extract_vite_values_with(
     );
     crate::boot_phase("vite-extract cache miss (subprocess ran)");
     Some(parse_vite_values(&json))
+}
+
+/// What the config extractor wrote to stderr (Vite's own notices and oj's
+/// "not applied" warnings), printed once per process. The config is loaded
+/// several times in a dev session (the Start route tree, server-fn resolver and
+/// client bundle each adopt it, and again after a rebuild), each replaying the
+/// cached stderr; Vite prints its config warnings once at startup.
+fn print_extraction_stderr(stderr: &str) {
+    let fresh = unseen_extraction_lines(stderr);
+    if !fresh.is_empty() {
+        eprint!("{fresh}");
+    }
+}
+
+fn unseen_extraction_lines(stderr: &str) -> String {
+    static SEEN: std::sync::Mutex<Option<std::collections::HashSet<String>>> = std::sync::Mutex::new(None);
+    let mut guard = SEEN.lock().unwrap_or_else(|e| e.into_inner());
+    let seen = guard.get_or_insert_with(std::collections::HashSet::new);
+    let mut out = String::new();
+    for line in stderr.lines() {
+        if line.trim().is_empty() || seen.insert(line.to_string()) {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    out
 }
 
 /// The part of the process environment a vite.config can observe while it
@@ -1949,5 +1971,14 @@ mod vite_values_tests {
         merge_vite_values(&mut config, v);
         assert_eq!(oj_config::css_additional_data(&config, "scss").as_deref(), Some("$b: red;"));
         assert_eq!(oj_config::css_load_paths(&config, "scss"), vec!["styles".to_string()]);
+    }
+
+    #[test]
+    fn extraction_stderr_lines_print_once_per_process() {
+        let first = unseen_extraction_lines("oj: vite.config: worker config is not applied\nsome plugin notice\n");
+        assert_eq!(first, "oj: vite.config: worker config is not applied\nsome plugin notice\n");
+        let again = unseen_extraction_lines("oj: vite.config: worker config is not applied\nsome plugin notice\nnew line\n");
+        assert_eq!(again, "new line\n", "only lines not printed before in this process come back");
+        assert_eq!(unseen_extraction_lines(""), "");
     }
 }

--- a/e2e/fixtures/start-app/src/ssr-entry.ts
+++ b/e2e/fixtures/start-app/src/ssr-entry.ts
@@ -1,0 +1,17 @@
+import serverEntry from "@tanstack/react-start/server-entry";
+
+// The app's own Start server entry (`tanstackStart({ server: { entry } })`), the
+// shape an SSR error wrapper takes: it wraps Start's default handler, which the
+// dev server and the prod bundle must run instead of the default (Vite imports
+// the configured entry as the SSR handler). Every response is marked so the
+// e2e can tell this entry answered.
+type Handler = { fetch: (request: Request, env?: unknown, ctx?: unknown) => Promise<Response> | Response };
+
+export default {
+  async fetch(request: Request, env?: unknown, ctx?: unknown): Promise<Response> {
+    const res = await (serverEntry as Handler).fetch(request, env, ctx);
+    const headers = new Headers(res.headers);
+    headers.set("x-server-entry", "fixture");
+    return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
+  },
+};

--- a/e2e/fixtures/start-app/vite.config.ts
+++ b/e2e/fixtures/start-app/vite.config.ts
@@ -75,7 +75,9 @@ export default defineConfig({
     // exportType:"default" makes a bare `.svg` import a component; the second
     // include pattern also claims the explicit `foo.svg?react` query form.
     svgr({ svgrOptions: { exportType: "default" }, include: ["src/**/*.svg", "src/**/*.svg?react"] }),
-    tanstackStart(),
+    // The app's own server entry (src/ssr-entry.ts), as an SSR error wrapper
+    // configures it: dev and the prod bundle must serve through it.
+    tanstackStart({ server: { entry: "ssr-entry" } }),
     react(),
   ],
 });

--- a/e2e/start-cloudflare.mjs
+++ b/e2e/start-cloudflare.mjs
@@ -73,7 +73,9 @@ function makeApp() {
     'import { defineConfig } from "vite";',
     'import { defineConfig } from "vite";\nimport { cloudflare } from "@cloudflare/vite-plugin";',
   );
-  const config = withImport.replace("    tanstackStart(),", '    cloudflare({ viteEnvironment: { name: "ssr" } }),\n    tanstackStart(),');
+  // Insert the Cloudflare plugin ahead of tanstackStart(...) whatever options the
+  // fixture passes it.
+  const config = withImport.replace(/^(\s*)tanstackStart\(/m, '$1cloudflare({ viteEnvironment: { name: "ssr" } }),\n$1tanstackStart(');
   if (config === original || config === withImport) throw new Error("fixture vite.config.ts changed shape; update this script");
   fs.writeFileSync(path.join(app, "vite.config.ts"), config);
 }

--- a/e2e/start-server-routes.mjs
+++ b/e2e/start-server-routes.mjs
@@ -84,6 +84,15 @@ async function assertServerRoutes(port, label) {
   must(seen.host === `localhost:${port}`, `${label}: Host should be the server's own, got ${seen.host}`);
   must(seen.forwardedHost === "preview.example.com", `${label}: x-forwarded-host should pass through, got ${seen.forwardedHost}`);
   console.log(`${label}: proxied request keeps Host and passes x-forwarded-host through`);
+
+  // The fixture configures its own Start server entry (src/ssr-entry.ts, a
+  // wrapper around the default handler, as an SSR error wrapper is). Vite runs
+  // the configured entry; so must oj, in dev and in the prod server bundle.
+  for (const route of ["/", "/api/request-url"]) {
+    const res = await fetch(`http://localhost:${port}${route}`);
+    must(res.headers.get("x-server-entry") === "fixture", `${label}: ${route} did not go through the configured server entry (x-server-entry=${res.headers.get("x-server-entry")})`);
+  }
+  console.log(`${label}: configured tanstackStart server.entry wraps the handler`);
 }
 
 async function devPhase() {

--- a/e2e/unit/vite-extract.test.mjs
+++ b/e2e/unit/vite-extract.test.mjs
@@ -2,7 +2,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { extractAlias, extractOptimizeDeps, extractProxy } from "../../crates/oj_server/src/assets/vite-extract.mjs";
+import { extractAlias, extractOptimizeDeps, extractProxy, warnUnsupported } from "../../crates/oj_server/src/assets/vite-extract.mjs";
 
 test("optimizeDeps carries needsInterop and force alongside the lists", () => {
   const out = extractOptimizeDeps({
@@ -101,4 +101,39 @@ test("function-valued proxy options are dropped with a warning, the entry still 
   assert.match(err, /server\.proxy\["\/api"\]\.rewrite is a function/);
   assert.match(err, /server\.proxy\["\/api"\]\.configure is a function and cannot cross the config bridge/);
   assert.match(err, /server\.proxy\["\/api"\]\.bypass is a function and cannot cross the config bridge/);
+});
+
+
+test("Vite's own client aliases (@vite/env, @vite/client) are skipped without a warning", () => {
+  let out;
+  const stderr = captureStderr(() => {
+    out = extractAlias([
+      { find: /^\/?@vite\/env/, replacement: "/vite/dist/client/env.mjs" },
+      { find: /^\/?@vite\/client/, replacement: "/vite/dist/client/client.mjs" },
+      { find: "@", replacement: "/app/src" },
+    ]);
+  });
+  assert.deepEqual(out, { "@": "/app/src" });
+  assert.equal(stderr, "", "Vite's built-in aliases are not the user's configuration");
+});
+
+test("warnUnsupported reports only options the user's config sets", () => {
+  // The shape resolveConfig produces for a config that sets none of these: all
+  // defaults Vite injects. Called with the RAW config instead, nothing is reported.
+  const resolvedDefaults = {
+    esbuild: { jsxDev: true, charset: "utf8", legalComments: "none" },
+    optimizeDeps: { esbuildOptions: { preserveSymlinks: false } },
+    worker: { format: "iife", plugins: () => [] },
+    ssr: { resolve: { conditions: [], externalConditions: [] } },
+    server: { cors: { origin: /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/ } },
+    build: { terserOptions: {} },
+  };
+  assert.notEqual(captureStderr(() => warnUnsupported(resolvedDefaults)), "", "the resolved shape would warn");
+  const rawUserConfig = { plugins: [], tanstackStart: { server: { entry: "server" } } };
+  assert.equal(captureStderr(() => warnUnsupported(rawUserConfig)), "");
+  assert.equal(captureStderr(() => warnUnsupported(null)), "");
+  const userSets = captureStderr(() => warnUnsupported({ worker: { format: "es" }, esbuild: { charset: "ascii" }, build: { terserOptions: { compress: true } } }));
+  assert.match(userSets, /worker config is not applied/);
+  assert.match(userSets, /esbuild options charset are not applied/);
+  assert.match(userSets, /build.terserOptions is not applied/);
 });


### PR DESCRIPTION
Two TanStack Start dev fixes, both matched against Vite and the Start plugin source.

**Honor `tanstackStart({ server: { entry } })`.** Start publishes the resolved server entry as the `resolve.alias` entry `virtual:tanstack-start-server-entry` (the file named by `server.entry`, or `src/server.ts` when that default name exists), and Vite imports that module as the SSR handler and uses it as the server build input. oj now reads the same alias (app files only), runs the configured module in dev and uses it as the server bundle input in the node and Cloudflare builds, with `@tanstack/react-start/server-entry` aliased to oj's handler inside it so a wrapping entry (the SSR error-wrapper shape) composes. Previously oj always ran its own entry and the wrapper never executed.

**Config warnings describe the user's config, once.** The "not applied" warnings ran on Vite's resolved config, so every app got eight of them for defaults Vite injects (`esbuild.jsxDev/charset/legalComments`, `worker`, `ssr.resolve`, `server.cors.origin`, `optimizeDeps.esbuildOptions`, `build.terserOptions`, the `@vite/env` and `@vite/client` aliases), repeated on each of the three Start config loads and after every rebuild. The extractor now inspects the raw config file for those warnings, skips Vite's own client aliases, and the Rust side prints each extractor line once per process. On a real Start app: 8x3 warnings at startup became 0.

Tests: Rust units for the entry lookup and the once-per-process printing, extractor units for the raw-vs-resolved gate and the alias skip, a fixture wrapper entry (`src/ssr-entry.ts`) asserted through an `x-server-entry` header in dev and prod in `e2e/start-server-routes.mjs`; the Cloudflare e2e rewrite now tolerates `tanstackStart(...)` options.

