### PR TITLE
Hold the Start page reload behind the HMR gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,9 @@ jobs:
       - name: generic ssr dev runs requests concurrently, action bodies stay bytes
         if: matrix.mode == 'unbundled'
         run: node e2e/ssr-concurrent.mjs
+      - name: start dev holds the page reload behind the editor HMR gate until the flush
+        if: matrix.mode == 'unbundled'
+        run: node e2e/start-hmr-gate.mjs
 
   # i need to fix this or automate
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TanStack Start: an app's own server entry (`tanstackStart({ server: { entry } })`, the shape an SSR error wrapper takes) is honored in dev and in the prod server bundle, as Vite imports it: the configured module is the handler and `@tanstack/react-start/server-entry` inside it is oj's handler, so a wrapper composes. Previously oj always ran its own entry and the wrapper never executed.
 
 ### Fixed
+- TanStack Start dev ignored the editor-driven HMR gate: every write under `src/` rebuilt the client bundle and reloaded the page at once, so a preview reloaded over and over while files were being written. The rebuild still happens immediately, but the page reload now waits for `POST /__hmr_flush` (or the 240 second hold cap), as plain-mode updates already did and as the editor's Vite gate plugin holds a bundled dev server's full reload; `/__hmr_gate` reports `heldReload` and `startedAt`, and the flush response says whether a reload was released.
 - `vite.config` "not applied" warnings were emitted for Vite's own resolved defaults (`esbuild.jsxDev/charset/legalComments`, `worker`, `ssr.resolve`, `server.cors.origin`, `optimizeDeps.esbuildOptions`, `build.terserOptions`, the `@vite/env` and `@vite/client` aliases) on every config, and repeated on every config load (three times at Start startup, again after each rebuild). They now describe only options the config file itself sets, and each line prints once per dev session.
 
 ## [0.1.15] - 2026-09-03

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -41,6 +41,9 @@ struct StartState {
     css_host: Option<Arc<tokio::sync::Mutex<Runner>>>,
     /// The dev mode (`oj dev --mode`), handed to every node script respawn.
     mode: String,
+    /// The HMR gate, when the editor drives it: rebuilds still happen at once, the
+    /// page reload waits for the flush.
+    gate: Option<oj_server::HmrGateHandle>,
 }
 
 // A --config path is resolved against the app root, the way `build` resolves
@@ -148,10 +151,22 @@ pub async fn start_dev(
         workspace_root: workspace_root(&root),
         reload_tx: reload_tx.clone(),
         ws_tx: built.reload_tx.clone(),
+        gate: built.hmr_gate.clone(),
         css_host,
         mode: mode.clone(),
     });
 
+    // A gate flush (the editor's POST /__hmr_flush, or the hold cap) releases
+    // the reload the watcher held; the rebuild itself already happened.
+    if let Some(gate) = &state.gate {
+        let mut flushes = gate.subscribe_flush();
+        let reload_tx = state.reload_tx.clone();
+        tokio::spawn(async move {
+            while flushes.recv().await.is_ok() {
+                let _ = reload_tx.send(());
+            }
+        });
+    }
     spawn_start_watcher(root.clone(), cache.clone(), Arc::clone(&state));
     {
         let (root, mode) = (root.clone(), mode.clone());
@@ -384,7 +399,11 @@ fn spawn_start_watcher(root: PathBuf, cache: PathBuf, state: Arc<StartState>) {
                     *state.bundle.write().unwrap() = Arc::new(pinned);
                 }
             });
-            let _ = state.reload_tx.send(());
+            let path_list: Vec<PathBuf> = paths.iter().cloned().collect();
+            let held = state.gate.as_ref().is_some_and(|g| g.hold_reload(&path_list));
+            if !held {
+                let _ = state.reload_tx.send(());
+            }
             let modules = client_module_count(&cache);
             let _ = state.ws_tx.send(oj_server::update_progress_frame(
                 batch,
@@ -394,7 +413,11 @@ fn spawn_start_watcher(root: PathBuf, cache: PathBuf, state: Arc<StartState>) {
                 Some(0),
                 true,
             ));
-            println!("  oj start: rebuilt, reloading");
+            if held {
+                println!("  oj start: rebuilt, reload held for the editor's flush");
+            } else {
+                println!("  oj start: rebuilt, reloading");
+            }
         }
     });
 }

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -298,6 +298,12 @@ struct ServerState {
     jsx: oj_compiler::JsxConfig,
     host_policy: HostPolicy,
     hmr_gate: Option<Arc<HmrGate>>,
+    /// Fires when the HMR gate flushes, so the Start server releases the page
+    /// reload it held (the plain path's held changes go through `decide` instead).
+    gate_flush_tx: broadcast::Sender<()>,
+    /// Process start, epoch milliseconds: the gate status `startedAt` the editor
+    /// compares across dev server restarts.
+    started_at_ms: u64,
     hmr_enabled: bool,
     plugins: Option<std::sync::Arc<PluginHost>>,
     plugin_mw_port: Option<u16>,
@@ -370,6 +376,9 @@ pub struct BuiltApp {
     pub plugin_host: Option<Arc<PluginHost>>,
     /// `server.open`: launch the browser once bound.
     pub open: bool,
+    /// The HMR gate (the editor-driven hold), when enabled: the Start
+    /// server holds its page reload behind it like the plain path holds updates.
+    pub hmr_gate: Option<HmrGateHandle>,
 }
 
 pub async fn bind_dev_listener(
@@ -732,6 +741,7 @@ impl DevServer {
                     full_reload,
                     max_hold: Duration::from_millis(240_000),
                     inner: Mutex::new(GateInner::default()),
+                    held_reload: std::sync::atomic::AtomicBool::new(false),
                 }))
             } else {
                 None
@@ -897,6 +907,11 @@ impl DevServer {
             jsx,
             host_policy: HostPolicy::from_config(&server_cfg, self.host.as_deref()),
             hmr_gate,
+            gate_flush_tx: broadcast::channel::<()>(16).0,
+            started_at_ms: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0),
             hmr_enabled,
             plugins: plugin_host.clone(),
             plugin_mw_port,
@@ -1055,6 +1070,7 @@ impl DevServer {
             ));
         }
         let proxy_prefixes: Vec<String> = state.proxy.iter().map(|(p, _)| p.clone()).collect();
+        let hmr_gate = state.hmr_gate.as_ref().map(|_| HmrGateHandle { state: Arc::clone(&state) });
         let app = app.with_state(state);
 
         Ok(BuiltApp {
@@ -1069,6 +1085,7 @@ impl DevServer {
             reload_tx,
             plugin_host,
             open,
+            hmr_gate,
         })
     }
 }
@@ -7054,6 +7071,10 @@ struct HmrGate {
     full_reload: bool,
     max_hold: Duration,
     inner: Mutex<GateInner>,
+    /// A page reload the Start server is holding for the flush (the editor's
+    /// gate plugin's `heldReload`: a bundled dev server's reload is one event,
+    /// not a set of hot updates).
+    held_reload: std::sync::atomic::AtomicBool,
 }
 
 #[derive(Default)]
@@ -7117,6 +7138,10 @@ impl HmrGate {
             .map(|(p, _)| p.display().to_string())
             .collect();
         let count = entries.len();
+        let held_reload = self.held_reload.swap(false, std::sync::atomic::Ordering::SeqCst);
+        if held_reload || !entries.is_empty() {
+            let _ = state.gate_flush_tx.send(());
+        }
         if !entries.is_empty() {
             *state.chunk_cache.lock().unwrap() = None;
             state.dir_cache.lock().unwrap().clear();
@@ -7143,7 +7168,7 @@ impl HmrGate {
         }
     }
 
-    fn status(&self) -> serde_json::Value {
+    fn status(&self, state: &ServerState) -> serde_json::Value {
         let inner = self.inner.lock().unwrap();
         let mut pending = serde_json::Map::new();
         for (p, events) in &inner.pending {
@@ -7152,12 +7177,45 @@ impl HmrGate {
                 serde_json::json!(events.iter().collect::<Vec<_>>()),
             );
         }
+        let held_reload = self.held_reload.load(std::sync::atomic::Ordering::SeqCst);
         serde_json::json!({
             "enabled": true,
             "pending": pending,
             "count": inner.pending.len(),
             "mode": self.mode(),
+            "heldReload": held_reload,
+            "startedAt": state.started_at_ms,
         })
+    }
+}
+
+/// The HMR gate as the Start server sees it: hold the page reload a rebuild
+/// would send until the editor flushes (`POST /__hmr_flush`) or the hold cap
+/// releases it, like the editor's Vite gate plugin holds a bundled dev server's
+/// `full-reload`. Without it every write under `src/` reloaded the preview at
+/// once, gate or not.
+#[derive(Clone)]
+pub struct HmrGateHandle {
+    state: Arc<ServerState>,
+}
+
+impl HmrGateHandle {
+    /// Record the changed paths and hold the reload. False when nothing relevant
+    /// changed (build output, caches), in which case the caller reloads now.
+    pub fn hold_reload(&self, paths: &[PathBuf]) -> bool {
+        let Some(gate) = &self.state.hmr_gate else {
+            return false;
+        };
+        if !gate.hold(&self.state, paths) {
+            return false;
+        }
+        gate.held_reload.store(true, std::sync::atomic::Ordering::SeqCst);
+        true
+    }
+
+    /// Fires once per flush that released something.
+    pub fn subscribe_flush(&self) -> broadcast::Receiver<()> {
+        self.state.gate_flush_tx.subscribe()
     }
 }
 
@@ -7167,13 +7225,14 @@ async fn hmr_flush(State(state): State<Arc<ServerState>>) -> Response {
             serde_json::json!({ "flushed": [], "count": 0, "mode": "disabled" }),
         );
     };
+    let held_reload = gate.held_reload.load(std::sync::atomic::Ordering::SeqCst);
     let (files, count) = gate.flush(&state).await;
-    js_response_json(serde_json::json!({ "flushed": files, "count": count, "mode": gate.mode() }))
+    js_response_json(serde_json::json!({ "flushed": files, "count": count, "mode": gate.mode(), "reload": held_reload || count > 0 }))
 }
 
 async fn hmr_gate_status(State(state): State<Arc<ServerState>>) -> Response {
     match &state.hmr_gate {
-        Some(gate) => js_response_json(gate.status()),
+        Some(gate) => js_response_json(gate.status(&state)),
         None => js_response_json(serde_json::json!({ "enabled": false })),
     }
 }

--- a/e2e/start-hmr-gate.mjs
+++ b/e2e/start-hmr-gate.mjs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+// The editor-driven HMR gate (LOVABLE_DEV_SERVER=true) must hold a TanStack
+// Start page reload the way it holds plain-mode updates: a source write still
+// rebuilds the client bundle, but the iframe's reload waits for POST /__hmr_flush
+// (the editor's Vite gate plugin holds a bundled dev server's full-reload the same
+// way). Without the gate the reload is immediate.
+
+import { spawn, execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repo = path.resolve(here, "..");
+const app = path.join(repo, "e2e", "fixtures", "start-app");
+const oj = path.join(repo, "target", "debug", "oj");
+const PORT = Number(process.env.OJ_E2E_PORT || 5238);
+const installed = fs.existsSync(path.join(app, "node_modules", "@tanstack", "react-start"));
+if (!installed) {
+  console.log("SKIP start-hmr-gate: fixture deps not installed");
+  process.exit(0);
+}
+execSync("cargo build -p oj", { cwd: repo, stdio: "inherit" });
+
+const must = (cond, msg) => { if (!cond) throw new Error(msg); };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitUp = async () => {
+  for (let i = 0; i < 240; i++) {
+    try { if ((await fetch(`http://localhost:${PORT}/`)).ok) return; } catch {}
+    await sleep(500);
+  }
+  throw new Error(`server on :${PORT} did not start`);
+};
+const aboutFile = path.join(app, "src", "routes", "about.tsx");
+const original = fs.readFileSync(aboutFile, "utf8");
+
+// Connect to the Start live-reload socket and collect "reload" frames.
+async function reloadListener() {
+  const ws = new WebSocket(`ws://localhost:${PORT}/@oj-start/hmr`);
+  const reloads = [];
+  ws.addEventListener("message", (ev) => { if (String(ev.data) === "reload") reloads.push(Date.now()); });
+  await new Promise((resolve, reject) => { ws.addEventListener("open", resolve); ws.addEventListener("error", reject); });
+  return { reloads, close: () => ws.close() };
+}
+
+async function run(label, env, check) {
+  fs.rmSync(path.join(app, ".oj-cache"), { recursive: true, force: true });
+  const srv = spawn(oj, ["dev", app, "--port", String(PORT)], { stdio: ["ignore", "pipe", "pipe"], env: { ...process.env, ...env } });
+  let log = "";
+  srv.stdout.on("data", (d) => (log += d));
+  srv.stderr.on("data", (d) => (log += d));
+  try {
+    await waitUp();
+    const listener = await reloadListener();
+    // A real source change: the watcher rebuilds the client bundle.
+    fs.writeFileSync(aboutFile, original + `\n// gate probe ${label} ${Date.now()}\n`);
+    await check(listener, () => log);
+    listener.close();
+  } finally {
+    fs.writeFileSync(aboutFile, original);
+    srv.kill("SIGKILL");
+    await sleep(300);
+  }
+}
+
+// 1. Gate on: the rebuild happens, the reload is held, the status shows it, the
+//    flush releases exactly one reload.
+await run("gated", { LOVABLE_DEV_SERVER: "true", LOVABLE_HMR_FULL_RELOAD: "false" }, async (listener, log) => {
+  const deadline = Date.now() + 30000;
+  while (Date.now() < deadline && !log().includes("reload held")) await sleep(200);
+  must(log().includes("oj start: rebuilt, reload held"), `gated: the watcher should rebuild and hold the reload:\n${log().slice(-1200)}`);
+  await sleep(1500);
+  must(listener.reloads.length === 0, `gated: a reload reached the page before the flush (${listener.reloads.length})`);
+  const status = await (await fetch(`http://localhost:${PORT}/__hmr_gate`)).json();
+  must(status.enabled === true && status.heldReload === true && status.count >= 1, `gated: /__hmr_gate should report the held reload, got ${JSON.stringify(status)}`);
+  must(typeof status.startedAt === "number" && status.startedAt > 0, "gated: /__hmr_gate carries startedAt for the editor's restart detection");
+  const flushed = await (await fetch(`http://localhost:${PORT}/__hmr_flush`, { method: "POST" })).json();
+  must(flushed.reload === true, `gated: the flush response should say a reload was released, got ${JSON.stringify(flushed)}`);
+  const until = Date.now() + 10000;
+  while (Date.now() < until && listener.reloads.length === 0) await sleep(100);
+  must(listener.reloads.length === 1, `gated: expected exactly one reload after the flush, got ${listener.reloads.length}`);
+  const after = await (await fetch(`http://localhost:${PORT}/__hmr_gate`)).json();
+  must(after.heldReload === false && after.count === 0, `gated: the gate should be empty after the flush, got ${JSON.stringify(after)}`);
+  console.log("gated: rebuild held, status reported it, flush released one reload");
+});
+
+// 2. Gate off: the reload follows the rebuild at once.
+await run("plain", { LOVABLE_DEV_SERVER: "" }, async (listener) => {
+  const until = Date.now() + 30000;
+  while (Date.now() < until && listener.reloads.length === 0) await sleep(100);
+  must(listener.reloads.length >= 1, "plain: the rebuild should reload the page without a gate");
+  console.log("plain: rebuild reloads immediately");
+});
+
+console.log("START HMR GATE E2E PASSED");


### PR DESCRIPTION
TanStack Start dev ignored the editor-driven HMR gate: `spawn_start_watcher` rebundled the client and sent the iframe reload on every write under `src/`, gate or not, so a preview reloaded and repainted over and over while files were being written (the plain `oj dev` path already held changes in `HmrGate` until `POST /__hmr_flush` or the 240s cap).

Now the Start server gets an `HmrGateHandle` from `BuiltApp`: the rebuild still happens at once, but the page reload is held when the gate accepts the changed paths, and a flush (or the hold cap) releases exactly one reload. This mirrors the editor's Vite gate plugin, which intercepts a bundled dev server's `full-reload` as `heldReload` and releases it on flush. `/__hmr_gate` gains `heldReload` and `startedAt` (the fields the editor client reads), `/__hmr_flush` gains `reload`.

Test: `e2e/start-hmr-gate.mjs` (gated: rebuild logged as held, no reload for 1.5s, status reports it, flush returns `reload: true` and exactly one reload frame arrives, gate empty after; plain: the reload is immediate). Existing `hmr-gate.mjs`, `start.mjs` and `start-server-routes.mjs` still pass.
