### PR TITLE
Node SSR loader: strip the browser condition and key the resolve cache on conditions

### DIFF
--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -500,6 +500,21 @@ fn start_script_env(root: &Path, command: &str, mode: &str) -> anyhow::Result<Ve
             ));
         }
     }
+    // `resolve.externalConditions` (Vite: what externalized SSR deps resolve
+    // with instead of the environment's conditions); the loader defaults to
+    // module-sync when unset.
+    if let Some(user) = oj_config::user_external_conditions(&config, "ssr") {
+        let conditions: Vec<String> = user
+            .into_iter()
+            .map(|c| if c == "development|production" { "development".to_string() } else { c })
+            .collect();
+        if !conditions.is_empty() {
+            vars.push((
+                "OJ_EXTERNAL_CONDITIONS".into(),
+                serde_json::to_string(&conditions).unwrap_or_default(),
+            ));
+        }
+    }
     // `ssr.noExternal`/`external`, consumed by the SSR loader to transform (rather
     // than hand to Node) the dependencies Vite would bundle.
     let externals = oj_config::ssr_externals(&config);
@@ -1334,18 +1349,22 @@ mod tests {
             let browser_root = tmp("script-env-browser-cond");
             std::fs::write(
                 browser_root.join("oj.config.json"),
-                r#"{ "environments": { "ssr": { "resolve": { "conditions": ["module", "browser", "development|production"] } } } }"#,
+                r#"{ "environments": { "ssr": { "resolve": { "conditions": ["module", "browser", "development|production"], "externalConditions": ["custom-ext", "development|production"] } } } }"#,
             )
             .unwrap();
             let vars = start_script_env(&browser_root, "serve", "development").unwrap();
-            let cond = vars
-                .iter()
-                .find(|(n, _)| n == "OJ_RESOLVE_CONDITIONS")
-                .map(|(_, v)| v.clone());
+            let var = |k: &str| {
+                vars.iter().find(|(n, _)| n == k).map(|(_, v)| v.clone())
+            };
             assert_eq!(
-                cond.as_deref(),
+                var("OJ_RESOLVE_CONDITIONS").as_deref(),
                 Some(r#"["module","development"]"#),
                 "browser must be stripped from Node SSR conditions"
+            );
+            assert_eq!(
+                var("OJ_EXTERNAL_CONDITIONS").as_deref(),
+                Some(r#"["custom-ext","development"]"#),
+                "externalConditions pass through with dev/prod mapped"
             );
         }
         let ssr: serde_json::Value = serde_json::from_str(&get("OJ_DEFINE_SSR").unwrap()).unwrap();

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -485,8 +485,12 @@ fn start_script_env(root: &Path, command: &str, mode: &str) -> anyhow::Result<Ve
     // Node's export conditions by the SSR loader the way Vite's resolver honors
     // them; the `development|production` placeholder is the dev one here.
     if let Some(user) = oj_config::user_resolve_conditions(&config, "ssr") {
+        // Drop `browser`: plugins targeting workerd SSR (e.g. @cloudflare/vite-plugin)
+        // set it, but this loader runs in Node — a browser conditional export there
+        // executes DOM code server-side (`document is not defined`).
         let conditions: Vec<String> = user
             .into_iter()
+            .filter(|c| c != "browser")
             .map(|c| if c == "development|production" { "development".to_string() } else { c })
             .collect();
         if !conditions.is_empty() {
@@ -1322,6 +1326,28 @@ mod tests {
         assert_eq!(get("OJ_DEFINE").as_deref(), Some(r#"{"__SHARED__":"1"}"#));
         assert_eq!(get("OJ_DEFINE_CLIENT").as_deref(), Some(r#"{"__SIDE__":"\"client\""}"#));
         assert_eq!(get("OJ_RESOLVE_CONDITIONS").as_deref(), Some(r#"["custom","development"]"#));
+
+        // `browser` never reaches the Node SSR loader (Vite parity:
+        // DEFAULT_SERVER_CONDITIONS excludes it) — workerd-targeting plugins
+        // set it and a browser conditional export would run DOM code in Node.
+        {
+            let browser_root = tmp("script-env-browser-cond");
+            std::fs::write(
+                browser_root.join("oj.config.json"),
+                r#"{ "environments": { "ssr": { "resolve": { "conditions": ["module", "browser", "development|production"] } } } }"#,
+            )
+            .unwrap();
+            let vars = start_script_env(&browser_root, "serve", "development").unwrap();
+            let cond = vars
+                .iter()
+                .find(|(n, _)| n == "OJ_RESOLVE_CONDITIONS")
+                .map(|(_, v)| v.clone());
+            assert_eq!(
+                cond.as_deref(),
+                Some(r#"["module","development"]"#),
+                "browser must be stripped from Node SSR conditions"
+            );
+        }
         let ssr: serde_json::Value = serde_json::from_str(&get("OJ_DEFINE_SSR").unwrap()).unwrap();
         assert_eq!(ssr["__SIDE__"], "\"server\"");
         assert_eq!(ssr["__ONLY_SSR__"], "true");

--- a/crates/oj_config/src/lib.rs
+++ b/crates/oj_config/src/lib.rs
@@ -655,6 +655,24 @@ pub fn user_resolve_conditions(config: &OjConfig, env_name: &str) -> Option<Vec<
         .or_else(|| config.resolve.as_ref().and_then(|r| r.conditions.clone()))
 }
 
+/// The user's `resolve.externalConditions` for an environment (Vite: the
+/// conditions externalized SSR deps resolve with, replacing — never merging —
+/// the environment's `resolve.conditions`).
+pub fn user_external_conditions(config: &OjConfig, env_name: &str) -> Option<Vec<String>> {
+    config
+        .environments
+        .as_ref()
+        .and_then(|e| e.get(env_name))
+        .and_then(|e| e.get("resolve"))
+        .and_then(|r| r.get("externalConditions"))
+        .and_then(|c| c.as_array())
+        .map(|c| {
+            c.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect::<Vec<_>>()
+        })
+}
+
 /// Export conditions for an environment, as Vite resolves them: the default set
 /// is `browser`/`node`, `module`, and `development` or `production` (per `dev`),
 /// plus `import` and `default`, which the resolver always matches. A user

--- a/crates/oj_server/src/assets/start/loader-util.mjs
+++ b/crates/oj_server/src/assets/start/loader-util.mjs
@@ -279,3 +279,12 @@ export function requestHost(...candidates) {
   }
   return "localhost";
 }
+
+// Package name of a bare import specifier (`react`, `@scope/pkg/sub` ->
+// `@scope/pkg`); null for relative, absolute, #imports, and URL-scheme specs.
+export function pkgNameOfSpec(spec) {
+  if (!spec || spec.startsWith(".") || spec.startsWith("/") || spec.startsWith("#") || spec.includes(":")) return null;
+  const parts = spec.split("/");
+  if (spec.startsWith("@")) return parts.length >= 2 && parts[1] ? `${parts[0]}/${parts[1]}` : null;
+  return parts[0] || null;
+}

--- a/crates/oj_server/src/assets/start/loader.mjs
+++ b/crates/oj_server/src/assets/start/loader.mjs
@@ -153,6 +153,9 @@ const EPOCH = (() => {
     hashBaseInputs(h);
     hashAdd(h, "define", JSON.stringify(DEFINE));
     hashAdd(h, "fnbase", process.env.TSS_SERVER_FN_BASE ?? "");
+    // Cached resolutions embed condition choices (browser vs node builds), so a
+    // conditions change must invalidate them or stale wrong-runtime picks replay.
+    hashAdd(h, "resolve-conditions", process.env.OJ_RESOLVE_CONDITIONS ?? "");
     return h.digest("hex");
   } catch {
     return null;

--- a/crates/oj_server/src/assets/start/loader.mjs
+++ b/crates/oj_server/src/assets/start/loader.mjs
@@ -4,7 +4,7 @@ import { pathToFileURL, fileURLToPath } from "node:url";
 import { readFileSync, unlinkSync, statSync, openSync, readSync, realpathSync } from "node:fs";
 import { writeFile, appendFile, rename, mkdir } from "node:fs/promises";
 import { createHash } from "node:crypto";
-import { resolve as pathResolve, dirname } from "node:path";
+import { resolve as pathResolve, dirname, sep } from "node:path";
 import { importPkg, viteEnvDefine, environmentDefines, emptyVirtualStub, jsxTransformOptions } from "./resolve-pkg.mjs";
 import { loadPluginContainerSync } from "./container-bridge.mjs";
 import { transformGlob } from "./glob-transform.mjs";
@@ -684,6 +684,39 @@ const EXTERNAL_CONDITIONS = (() => {
   } catch {}
   return ["module-sync"];
 })();
+// Vite's `isInNodeModules(resolved.id)` leg of `isExternalizable`: a bare
+// import whose package realpaths OUTSIDE node_modules (linked/workspace) is
+// not externalized and keeps the environment's conditions. Decided from the
+// package directory, not the resolved file — conditions pick files within a
+// package, never which package directory a specifier maps to — so one
+// resolution suffices (Node's resolver caches by specifier+parent and would
+// ignore a conditions-changed retry).
+const linkedPkgMemo = new Map();
+function isLinkedPkg(pkg, parentURL) {
+  let dir;
+  try {
+    dir = parentURL && parentURL.startsWith("file:") ? dirname(fileURLToPath(stripQ(parentURL))) : APP;
+  } catch {
+    dir = APP;
+  }
+  const memoKey = dir + "\0" + pkg;
+  const hit = linkedPkgMemo.get(memoKey);
+  if (hit !== undefined) return hit;
+  let linked = false;
+  for (let i = 0; i < 40; i++) {
+    try {
+      const real = realpathSync(pathResolve(dir, "node_modules", pkg));
+      linked = !real.includes(`${sep}node_modules${sep}`);
+      break;
+    } catch {}
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  linkedPkgMemo.set(memoKey, linked);
+  return linked;
+}
+
 function withExternalConditions(context) {
   if (!EXTERNAL_CONDITIONS.length || !Array.isArray(context.conditions)) return context;
   const missing = EXTERNAL_CONDITIONS.filter((c) => !context.conditions.includes(c));
@@ -693,8 +726,9 @@ function withExternalConditions(context) {
 export function resolve(spec, context, next) {
   if (isRequire(context)) return next(spec, context);
   const barePkg = pkgNameOfSpec(spec);
-  context = barePkg && !isNoExternalPkg(barePkg) ? withExternalConditions(context) : withUserConditions(context);
   if (context.parentURL) context = { ...context, parentURL: stripQ(context.parentURL) };
+  const external = !!barePkg && !isNoExternalPkg(barePkg) && !isLinkedPkg(barePkg, context.parentURL);
+  context = external ? withExternalConditions(context) : withUserConditions(context);
   const key = (context.parentURL ?? "") + "\0" + spec;
   const rc = EPOCH ? resolveCache.get(key) : undefined;
   if (rc !== undefined) {

--- a/crates/oj_server/src/assets/start/loader.mjs
+++ b/crates/oj_server/src/assets/start/loader.mjs
@@ -10,7 +10,7 @@ import { loadPluginContainerSync } from "./container-bridge.mjs";
 import { transformGlob } from "./glob-transform.mjs";
 import {
   EXTS, isFile, JS_TO_TS, probe, RESERVED, nearestPkgType,
-  hasEsmSyntax, isCjsFile, cjsFacade, jsonToEsm, stripJsonc, readJsonc, rewriteServerFns, substituteAlias,
+  hasEsmSyntax, isCjsFile, cjsFacade, jsonToEsm, stripJsonc, readJsonc, rewriteServerFns, substituteAlias, pkgNameOfSpec,
   parseImportsField, mergeTsConfig,
   PACK_FMT, PACK_PREFIX, packHash, packLine, packIntegrityFail, scanPack,
 } from "./loader-util.mjs";
@@ -671,9 +671,29 @@ function withUserConditions(context) {
   return missing.length ? { ...context, conditions: [...context.conditions, ...missing] } : context;
 }
 
+// Vite parity for externalized deps: their resolution swaps to
+// `externalConditions` (default node + module-sync, plus import) and never
+// sees the environment's conditions (`externalize ? options.externalConditions
+// : options.conditions` in Vite's resolver). Node already applies
+// node/import/default natively, so only the rest of the list is appended;
+// OJ_EXTERNAL_CONDITIONS carries the config's `resolve.externalConditions`.
+const EXTERNAL_CONDITIONS = (() => {
+  try {
+    const list = JSON.parse(process.env.OJ_EXTERNAL_CONDITIONS || "null");
+    if (Array.isArray(list)) return list.filter((c) => typeof c === "string" && c);
+  } catch {}
+  return ["module-sync"];
+})();
+function withExternalConditions(context) {
+  if (!EXTERNAL_CONDITIONS.length || !Array.isArray(context.conditions)) return context;
+  const missing = EXTERNAL_CONDITIONS.filter((c) => !context.conditions.includes(c));
+  return missing.length ? { ...context, conditions: [...context.conditions, ...missing] } : context;
+}
+
 export function resolve(spec, context, next) {
   if (isRequire(context)) return next(spec, context);
-  context = withUserConditions(context);
+  const barePkg = pkgNameOfSpec(spec);
+  context = barePkg && !isNoExternalPkg(barePkg) ? withExternalConditions(context) : withUserConditions(context);
   if (context.parentURL) context = { ...context, parentURL: stripQ(context.parentURL) };
   const key = (context.parentURL ?? "") + "\0" + spec;
   const rc = EPOCH ? resolveCache.get(key) : undefined;
@@ -792,14 +812,15 @@ function globMatch(pattern, value) {
   const re = new RegExp("^" + pattern.split("*").map((p) => p.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join(".*") + "$");
   return re.test(value);
 }
-function isNoExternalDep(path) {
-  if (!SSR_EXTERNALS) return false;
-  const pkg = pkgNameOfPath(path);
-  if (!pkg) return false;
+function isNoExternalPkg(pkg) {
+  if (!SSR_EXTERNALS || !pkg) return false;
   if ((SSR_EXTERNALS.external || []).includes(pkg) || SSR_EXTERNALS.externalAll) return false;
   if (SSR_EXTERNALS.noExternalAll) return true;
   if ((SSR_EXTERNALS.noExternal || []).some((p) => globMatch(p, pkg))) return true;
   return (SSR_EXTERNALS.noExternalRegex || []).some((src) => { try { return new RegExp(src).test(pkg); } catch { return false; } });
+}
+function isNoExternalDep(path) {
+  return isNoExternalPkg(pkgNameOfPath(path));
 }
 
 // oxc `lang` for a module url, or null for anything the transform does not own.

--- a/e2e/unit/loader-util.test.mjs
+++ b/e2e/unit/loader-util.test.mjs
@@ -364,3 +364,19 @@ test("requestHost prefers x-oj-host, keeps only the first host like Node, falls 
   assert.equal(requestHost("", " "), "localhost");
   assert.equal(requestHost(undefined, undefined), "localhost");
 });
+
+test("pkgNameOfSpec: bare package names only", async () => {
+  const { pkgNameOfSpec } = await import("../../crates/oj_server/src/assets/start/loader-util.mjs");
+  assert.equal(pkgNameOfSpec("react"), "react");
+  assert.equal(pkgNameOfSpec("react-dom/server"), "react-dom");
+  assert.equal(pkgNameOfSpec("@scope/pkg"), "@scope/pkg");
+  assert.equal(pkgNameOfSpec("@scope/pkg/deep/sub"), "@scope/pkg");
+  assert.equal(pkgNameOfSpec("@lonescope"), null);
+  assert.equal(pkgNameOfSpec("./relative"), null);
+  assert.equal(pkgNameOfSpec("../up"), null);
+  assert.equal(pkgNameOfSpec("/root/abs"), null);
+  assert.equal(pkgNameOfSpec("#imports-alias"), null);
+  assert.equal(pkgNameOfSpec("node:fs"), null);
+  assert.equal(pkgNameOfSpec("file:///x.js"), null);
+  assert.equal(pkgNameOfSpec(""), null);
+});

--- a/e2e/unit/ssr-loader-json-conditions.test.mjs
+++ b/e2e/unit/ssr-loader-json-conditions.test.mjs
@@ -83,9 +83,23 @@ test("SSR loader: JSON named exports and resolve.conditions reach Node's resolve
     // Without a configured condition Node's own set applies: the default entry.
     assert.equal(plain.which, "plain");
 
-    const custom = run({ OJ_RESOLVE_CONDITIONS: JSON.stringify(["custom"]) });
+    // Vite parity: the environment's `resolve.conditions` never reach an
+    // externalized dep (`externalize ? options.externalConditions :
+    // options.conditions`) — condpkg is external, so `custom` must NOT apply.
+    const notExternal = run({ OJ_RESOLVE_CONDITIONS: JSON.stringify(["custom"]) });
+    assert.equal(notExternal.which, "plain");
+
+    // `resolve.externalConditions` is the knob that reaches externals.
+    const custom = run({ OJ_EXTERNAL_CONDITIONS: JSON.stringify(["custom"]) });
     assert.equal(custom.which, "custom");
     assert.equal(custom.title, "Alpha");
+
+    // A noExternal dep resolves with the environment's conditions again.
+    const noExt = run({
+      OJ_RESOLVE_CONDITIONS: JSON.stringify(["custom"]),
+      OJ_SSR_EXTERNALS: JSON.stringify({ noExternal: ["condpkg"] }),
+    });
+    assert.equal(noExt.which, "custom");
   } finally {
     rmSync(app, { recursive: true, force: true });
   }

--- a/e2e/unit/ssr-loader-json-conditions.test.mjs
+++ b/e2e/unit/ssr-loader-json-conditions.test.mjs
@@ -8,7 +8,7 @@
 
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { test } from "node:test";
@@ -100,6 +100,57 @@ test("SSR loader: JSON named exports and resolve.conditions reach Node's resolve
       OJ_SSR_EXTERNALS: JSON.stringify({ noExternal: ["condpkg"] }),
     });
     assert.equal(noExt.which, "custom");
+  } finally {
+    rmSync(app, { recursive: true, force: true });
+  }
+});
+
+test("SSR loader: linked (workspace) packages take the environment's conditions, not externalConditions", () => {
+  const app = realpathSync(mkdtempSync(join(tmpdir(), "oj-ssr-linked-cond-")));
+  const source = join(app, "src");
+  const linkedsrc = join(app, "linkedsrc");
+  const rolldown = join(app, "node_modules", "rolldown");
+  for (const directory of [source, linkedsrc, rolldown]) mkdirSync(directory, { recursive: true });
+
+  writeFileSync(join(app, "package.json"), JSON.stringify({ name: "synthetic-linked-cond-app", type: "module" }));
+  writeFileSync(join(rolldown, "package.json"), JSON.stringify({
+    name: "rolldown", type: "module", exports: { "./experimental": "./experimental.mjs" },
+  }));
+  writeFileSync(join(rolldown, "experimental.mjs"), "export const transformSync = (_path, code) => ({ code });\n");
+  // A workspace-style package: symlinked into node_modules, real files outside it.
+  writeFileSync(join(linkedsrc, "package.json"), JSON.stringify({
+    name: "linkedpkg", type: "module",
+    exports: { ".": { custom: "./custom.js", default: "./plain.js" } },
+  }));
+  writeFileSync(join(linkedsrc, "custom.js"), 'export const which = "custom";\n');
+  writeFileSync(join(linkedsrc, "plain.js"), 'export const which = "plain";\n');
+  symlinkSync(linkedsrc, join(app, "node_modules", "linkedpkg"), "dir");
+
+  const entry = join(source, "entry.ts");
+  writeFileSync(entry, ['import { which } from "linkedpkg";', "export default { which };"].join("\n"));
+
+  const runner = [
+    'import { registerHooks } from "node:module";',
+    `const loader = await import(${JSON.stringify(pathToFileURL(loader).href)});`,
+    "registerHooks({ resolve: loader.resolve, load: loader.load });",
+    `process.stdout.write(JSON.stringify((await import(${JSON.stringify(pathToFileURL(entry).href)})).default));`,
+  ].join("\n");
+  try {
+    const result = spawnSync(process.execPath, ["--input-type=module", "--eval", runner], {
+      encoding: "utf8",
+      timeout: 10_000,
+      env: {
+        ...process.env,
+        OJ_APP_ROOT: app,
+        OJ_CACHE_ROOT: join(app, "cache"),
+        OJ_SSR_LOADER_CACHE: "off",
+        OJ_RESOLVE_CONDITIONS: JSON.stringify(["custom"]),
+      },
+    });
+    assert.equal(result.status, 0, result.stderr || result.error?.message);
+    // Vite's isExternalizable: resolved outside node_modules (via the symlink's
+    // realpath) means NOT external, so the environment's `custom` applies.
+    assert.equal(JSON.parse(result.stdout).which, "custom");
   } finally {
     rmSync(app, { recursive: true, force: true });
   }


### PR DESCRIPTION
Fixes the `document is not defined` SSR failure in #146 (root-caused; the other two signatures there are likely downstream).