### PR TITLE
bump version to 0.1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to oj are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.17] - 2026-09-05
 
 ### Changed
 - Cloudflare dev (`@cloudflare/vite-plugin`): on a source edit the worker environments no longer get a blanket `full-reload` that made the module runner re-walk the whole server graph (the next document after an edit took several times what `vite dev` takes on a large TanStack Start app). oj now mirrors Vite's HMR propagation over each environment's module graph (plugin `hotUpdate` hooks included) and sends targeted `{type:"update"}` payloads to the nearest accept boundary (the plugin's worker entry self-accepts), falling back to `full-reload` where Vite does (a propagation dead end, a graph without the walk API) and sending Vite's `{type:"error"}` payload when a `hotUpdate` hook throws. Changes travel with Vite's watcher event types: a delete goes through `moduleGraph.onFileDelete`, a created file retries the modules whose imports previously failed to resolve, `pluginContainer.watchChange` runs with the matching event, legacy `handleHotUpdate` plugins are dispatched for the client environment, and a hook's `read()` retries a truncated write as Vite's `readModifiedFile` does.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,7 +1818,7 @@ dependencies = [
 
 [[package]]
 name = "oj"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "oj_cache"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "blake3",
  "proptest",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "oj_compiler"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "glob",
  "memchr",
@@ -1881,7 +1881,7 @@ dependencies = [
 
 [[package]]
 name = "oj_config"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "oxc_allocator",
  "oxc_codegen",
@@ -1900,7 +1900,7 @@ dependencies = [
 
 [[package]]
 name = "oj_css"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "grass",
  "lightningcss",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "oj_env"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "proptest",
  "serde_json",
@@ -1922,14 +1922,14 @@ dependencies = [
 
 [[package]]
 name = "oj_graph"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "oj_resolver"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "oxc_resolver",
  "tempfile",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "oj_server"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,19 +13,19 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 license = "MIT"
 
 [workspace.dependencies]
-oj_compiler = { version = "0.1.16", path = "crates/oj_compiler" }
-oj_resolver = { version = "0.1.16", path = "crates/oj_resolver" }
-oj_graph = { version = "0.1.16", path = "crates/oj_graph" }
-oj_cache = { version = "0.1.16", path = "crates/oj_cache" }
-oj_css = { version = "0.1.16", path = "crates/oj_css" }
-oj_env = { version = "0.1.16", path = "crates/oj_env" }
-oj_config = { version = "0.1.16", path = "crates/oj_config" }
-oj_server = { version = "0.1.16", path = "crates/oj_server" }
+oj_compiler = { version = "0.1.17", path = "crates/oj_compiler" }
+oj_resolver = { version = "0.1.17", path = "crates/oj_resolver" }
+oj_graph = { version = "0.1.17", path = "crates/oj_graph" }
+oj_cache = { version = "0.1.17", path = "crates/oj_cache" }
+oj_css = { version = "0.1.17", path = "crates/oj_css" }
+oj_env = { version = "0.1.17", path = "crates/oj_env" }
+oj_config = { version = "0.1.17", path = "crates/oj_config" }
+oj_server = { version = "0.1.17", path = "crates/oj_server" }
 
 oxc_allocator = "0.146.0"
 oxc_parser = "0.146.0"


### PR DESCRIPTION
Release 0.1.17: the Cloudflare dev edit-loop work (#151, #153) and the conditions/watcher fixes (#152). CHANGELOG Unreleased retitled.