### PR TITLE
Fix Cloudflare dev hydration (bundledDev, client-entry 500, cloudflare: crash) + hydration test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,9 @@ jobs:
       - name: start dev for @cloudflare/vite-plugin serves from the worker; an edit yields a fresh document
         if: matrix.mode == 'unbundled'
         run: node e2e/start-cloudflare-dev.mjs
+      - name: experimental.bundledDev is coerced off; the standard dev client entry serves and the page hydrates
+        if: matrix.mode == 'unbundled'
+        run: node e2e/bundleddev-coerce.mjs
       - name: server.proxy covers the worker's outbound fetch (one proxy in the middleware stack), function rewrite applied
         if: matrix.mode == 'unbundled'
         run: node e2e/proxy-worker-fetch.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to oj are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- `experimental.bundledDev` (Vite's Rolldown bundled client dev mode) is now coerced off in the config oj drives, with a one-time warning, instead of silently breaking the page. oj bundles the client itself, so bundledDev is redundant under it and unimplemented: left on, an app's TanStack Start manifest emits a `/assets/index.js` client script that oj never builds nor serves (it 404s, or on Vite hangs on the app's own bundled-dev entry hold) and `/bundledDevClient.mjs` 404s, so no client JS runs and React never hydrates — the SSR shell paints but every client-rendered element stays dead. The plugin host now clears `experimental.bundledDev` (and the `environments.client.isBundled` Vite derives from it) before the `configResolved` pass, so the manifest plugin emits the standard dev client entry (`virtual:tanstack-start-dev-client-entry`) oj already serves, and again on the freshly resolved config `buildEnvironments` builds the real Vite `DevEnvironment`s from, so the client environment is not constructed in bundled mode. A one-line stderr notice (`experimental.bundledDev is not supported; using the standard dev client entry instead`) prints once per session when the flag was actually set.
+
 ## [0.1.20] - 2026-09-06
 
 ### Fixed

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -137,6 +137,11 @@ const OJ = _ojTTY ? "\x1b[48;2;255;255;255m\x1b[1;38;2;42;51;212m oj \x1b[0m" : 
 let _bundledDevWarned = false;
 function coerceBundledDevOff(cfg) {
   if (!cfg || typeof cfg !== "object") return false;
+  // bundledDev is Vite's serve-only bundled-client mode; only serve derives
+  // `environments.*.isBundled` from it. During a build Vite sets `isBundled`
+  // true on every environment regardless (the normal production state), so
+  // clearing it there is wrong and would emit a dev-worded warning on a build.
+  if (command !== "serve") return false;
   let flipped = false;
   if (cfg.experimental && cfg.experimental.bundledDev) {
     cfg.experimental.bundledDev = false;

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -128,6 +128,36 @@ const ojStartMode = initial.ojStartMode === true;
 const _ojTTY = process.stderr.isTTY && !process.env.NO_COLOR;
 const OJ = _ojTTY ? "\x1b[48;2;255;255;255m\x1b[1;38;2;42;51;212m oj \x1b[0m" : "oj";
 
+// oj does not implement Vite's `experimental.bundledDev` (Rolldown bundled
+// client dev mode): oj bundles the client itself, so bundledDev is redundant
+// under oj, and left on the app's TanStack manifest emits a `/assets/index.js`
+// client script oj never builds nor serves. Coerce it off wherever oj drives the
+// config so the standard Vite dev client entry (which oj serves) is used, and
+// warn once per session. Returns whether it flipped a truthy value.
+let _bundledDevWarned = false;
+function coerceBundledDevOff(cfg) {
+  if (!cfg || typeof cfg !== "object") return false;
+  let flipped = false;
+  if (cfg.experimental && cfg.experimental.bundledDev) {
+    cfg.experimental.bundledDev = false;
+    flipped = true;
+  }
+  // Vite derives `environments.client.isBundled` from `experimental.bundledDev`
+  // in `resolveConfig`; a resolved config carries it and the DevEnvironment
+  // constructor (plus TanStack's manifest plugin) reads it directly.
+  for (const name of Object.keys(cfg.environments || {})) {
+    if (cfg.environments[name] && cfg.environments[name].isBundled) {
+      cfg.environments[name].isBundled = false;
+      flipped = true;
+    }
+  }
+  if (flipped && !_bundledDevWarned) {
+    _bundledDevWarned = true;
+    process.stderr.write(`${OJ}: experimental.bundledDev is not supported; using the standard dev client entry instead\n`);
+  }
+  return flipped;
+}
+
 // The one writer for every oj protocol line (RPC replies, ctx-RPC requests,
 // and the ojServeInfo/ojServer/ojWs pushes). Plugin code shares this stdout,
 // so the frame defends the control plane on both sides: the leading newline
@@ -612,6 +642,16 @@ const OJ_NATIVE_PLUGIN_NAMES = new Set([
   "vite:react-refresh",
   "vite:react-swc",
   "vite:react-swc:resolve-runtime",
+  // rolldown-vite's @vitejs/plugin-react does its client Fast Refresh wrapping by
+  // returning the rolldown builtin `builtin:vite-react-refresh-wrapper` from this
+  // plugin's `applyToEnvironment`. oj already reimplements React refresh natively
+  // (its own preamble + refresh runtime), so this is redundant; left active the
+  // builtin's transform runs and throws "Missing field `moduleType`" (oj drives
+  // transform hooks with Vite's { ssr } options, not the builtin's rolldown
+  // { moduleType } extra args), which 500s the client entry and stops the browser
+  // from ever hydrating. Skipping the parent here removes it before
+  // applyToEnvironment can introduce the builtin.
+  "vite:react:refresh-wrapper",
 ]);
 
 // Dev-tooling plugins oj cannot host: they drive a full Vite dev server (ws
@@ -944,6 +984,10 @@ async function runConfigHooks() {
     const { plugins: _fresh, ...base } = userResolvedViteConfig;
     config = mergeConfigLite(base, config);
   }
+  // Coerce experimental.bundledDev off BEFORE the config/configResolved hooks
+  // run, so TanStack's start-manifest-plugin emits the standard dev client entry
+  // (not `/assets/index.js`) and any bundled-dev middleware early-returns.
+  coerceBundledDevOff(config);
   // Vite hands the config hook the user config, whose `plugins` is the flat
   // plugin array; plugins like @crxjs read `config.plugins` to find sibling
   // plugins. Use the apply-filtered active set (not allPlugins) so command-
@@ -1266,6 +1310,12 @@ async function buildEnvironments(server) {
     rc = await vite.resolveConfig({ root, configFile: undefined, mode: environment.mode }, "serve", "development", "development");
     hostPhase("cf: resolveConfig done");
     initStage("cf:resolveConfig-done");
+    // The fresh resolve reads the app's vite.config again, so bundledDev is back
+    // on here (and Vite has stamped environments.client.isBundled). Coerce it off
+    // BEFORE the environments are built off `rc`: the DevEnvironment constructor
+    // makes the client env bundled from these fields, and the manifest plugin
+    // bound to these environments reads them at load time.
+    coerceBundledDevOff(rc);
   } catch (e) {
     process.stderr.write(`${OJ} plugin host: vite.resolveConfig failed: ${(e && e.message) || e}\n`);
     return undefined;

--- a/crates/oj_server/src/assets/start/cf-server.mjs
+++ b/crates/oj_server/src/assets/start/cf-server.mjs
@@ -89,11 +89,19 @@ const ASSETS = {
   },
 };
 
+// The dev `env`: the wrangler vars (and `.dev.vars`) over the process env, plus
+// the ASSETS binding. Shared with the `cloudflare:workers` scheme stub
+// (cf-workers.mjs) so a server function reading `env` sees the same values
+// whether it imports the plugin's server helper or the runtime module.
+export function cloudflareEnv() {
+  return { ASSETS, ...process.env, ...wranglerVars(), ...devVars() };
+}
+
 let cached;
 export async function getCloudflareContext() {
   if (!cached) {
     cached = {
-      env: { ASSETS, ...process.env, ...wranglerVars(), ...devVars() },
+      env: cloudflareEnv(),
       cf: {},
       ctx: { waitUntil() {}, passThroughOnException() {} },
     };

--- a/crates/oj_server/src/assets/start/cf-workers.mjs
+++ b/crates/oj_server/src/assets/start/cf-workers.mjs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+//
+// Dev-only stub for the `cloudflare:workers` runtime module. In the worker
+// build `cloudflare:*` stays external and workerd provides it (see
+// cf-build.mjs); in oj's Node SSR loader (server functions, prewarm renders)
+// there is no workerd, so Node's default ESM loader would throw
+// ERR_UNSUPPORTED_ESM_URL_SCHEME on the `cloudflare:` scheme and crash the dev
+// server. This stub keeps the scheme resolvable: `env` is backed by the same
+// wrangler vars cf-server.mjs reads, and the runtime classes/helpers are
+// minimal shims so a server function that only reads `env` runs unchanged.
+import { cloudflareEnv } from "./cf-server.mjs";
+
+export const env = cloudflareEnv();
+
+// The RPC/entrypoint base classes: shims that keep `class X extends
+// WorkerEntrypoint` and `new RpcStub()` from throwing when SSR-imported. They
+// carry no workerd behavior (there is no worker here), only the shape.
+export class WorkerEntrypoint {
+  constructor(ctx, env) {
+    this.ctx = ctx;
+    this.env = env;
+  }
+}
+export class DurableObject {
+  constructor(ctx, env) {
+    this.ctx = ctx;
+    this.env = env;
+  }
+}
+export class WorkflowEntrypoint {
+  constructor(ctx, env) {
+    this.ctx = ctx;
+    this.env = env;
+  }
+}
+export class RpcTarget {}
+export class RpcStub {}
+
+export function waitUntil() {}
+export function withEnv(_env, fn) {
+  return fn();
+}
+
+export default {
+  env,
+  WorkerEntrypoint,
+  DurableObject,
+  WorkflowEntrypoint,
+  RpcTarget,
+  RpcStub,
+  waitUntil,
+  withEnv,
+};

--- a/crates/oj_server/src/assets/start/loader.mjs
+++ b/crates/oj_server/src/assets/start/loader.mjs
@@ -584,6 +584,10 @@ const ALIASES = {
   "tanstack-start-manifest:v": pathResolve(HERE, "manifest-dev.ts"),
   "tanstack-start-injected-head-scripts:v": pathResolve(HERE, "injected-head-scripts.ts"),
   "@cloudflare/vite-plugin/server": pathResolve(HERE, "cf-server.mjs"),
+  // The `cloudflare:workers` runtime module has no workerd here; resolve it to
+  // oj's dev stub so a server function reading `env` runs instead of Node's
+  // default loader crashing on the `cloudflare:` scheme (ERR_UNSUPPORTED_ESM_URL_SCHEME).
+  "cloudflare:workers": pathResolve(HERE, "cf-workers.mjs"),
   // Start's default server entry is oj's runner entry: an app `server.entry` that
   // wraps it (as Vite runs it) wraps oj's handler.
   "@tanstack/react-start/server-entry": pathResolve(HERE, "server-entry.tsx"),
@@ -931,6 +935,16 @@ export function load(url, context, next) {
     const rid = decodeURIComponent(stripQ(url).slice(VIRTUAL_SCHEME.length));
     const code = container ? container.load(rid) : null;
     return { format: "module", source: code ?? emptyVirtualStub(APP, rid), shortCircuit: true };
+  }
+  // A specifier that resolved to a scheme Node's default ESM loader rejects (a
+  // `cloudflare:*` runtime module with no workerd here, or another virtual
+  // runtime scheme) must never crash the dev server the way Node's
+  // ERR_UNSUPPORTED_ESM_URL_SCHEME would. `cloudflare:workers` is aliased to a
+  // real stub in resolve(); this is the net for any other such scheme: serve an
+  // empty module so the import resolves instead of taking the process down.
+  const scheme = /^([a-z][a-z0-9+.-]*):/i.exec(url)?.[1]?.toLowerCase();
+  if (scheme && scheme !== "file" && scheme !== "data" && scheme !== "node") {
+    return { format: "module", source: "export default {};", shortCircuit: true };
   }
   const clean = stripQ(url);
   const kind = /[?&]ojasset=(\w+)/.exec(url)?.[1];

--- a/crates/oj_server/src/assets/start/loader.mjs
+++ b/crates/oj_server/src/assets/start/loader.mjs
@@ -584,9 +584,14 @@ const ALIASES = {
   "tanstack-start-manifest:v": pathResolve(HERE, "manifest-dev.ts"),
   "tanstack-start-injected-head-scripts:v": pathResolve(HERE, "injected-head-scripts.ts"),
   "@cloudflare/vite-plugin/server": pathResolve(HERE, "cf-server.mjs"),
-  // The `cloudflare:workers` runtime module has no workerd here; resolve it to
-  // oj's dev stub so a server function reading `env` runs instead of Node's
-  // default loader crashing on the `cloudflare:` scheme (ERR_UNSUPPORTED_ESM_URL_SCHEME).
+  // Vite marks `cloudflare:*` as `resolve.builtins` on the worker environment,
+  // so they externalize and workerd provides them at runtime (@cloudflare/vite-plugin's
+  // cloudflareBuiltInModules). oj's SSR loader runs in Node with no workerd, where
+  // externalizing would instead crash on the `cloudflare:` scheme
+  // (ERR_UNSUPPORTED_ESM_URL_SCHEME), so oj must supply the module: resolve the one a
+  // server fn actually needs, `cloudflare:workers`, to a dev stub whose `env` comes from
+  // the wrangler vars. The other cloudflare:* builtins fall to the empty-module net in
+  // load(). Same shape as the `@cloudflare/vite-plugin/server` alias above.
   "cloudflare:workers": pathResolve(HERE, "cf-workers.mjs"),
   // Start's default server entry is oj's runner entry: an app `server.entry` that
   // wraps it (as Vite runs it) wraps oj's handler.

--- a/crates/oj_server/src/assets/start/loader.mjs
+++ b/crates/oj_server/src/assets/start/loader.mjs
@@ -929,6 +929,9 @@ function transformServerFns(code, path) {
   return rewriteServerFns(code, rel);
 }
 
+// Schemes the load-hook net has already warned about (warn once each).
+const stubbedSchemes = new Set();
+
 export function load(url, context, next) {
   if (isRequire(context)) return next(url, context);
   if (url.startsWith(VIRTUAL_SCHEME)) {
@@ -942,8 +945,16 @@ export function load(url, context, next) {
   // ERR_UNSUPPORTED_ESM_URL_SCHEME would. `cloudflare:workers` is aliased to a
   // real stub in resolve(); this is the net for any other such scheme: serve an
   // empty module so the import resolves instead of taking the process down.
+  // Warn once per scheme so a stray import (an un-aliased `cloudflare:*`, an
+  // `http:`/`blob:` id) is visible in the log rather than silently swallowed —
+  // its named imports will still fail loudly at link time, just without the
+  // process crash.
   const scheme = /^([a-z][a-z0-9+.-]*):/i.exec(url)?.[1]?.toLowerCase();
   if (scheme && scheme !== "file" && scheme !== "data" && scheme !== "node") {
+    if (!stubbedSchemes.has(scheme)) {
+      stubbedSchemes.add(scheme);
+      process.stderr.write(`oj: no SSR module for the '${scheme}:' scheme (e.g. ${stripQ(url)}); serving an empty module\n`);
+    }
     return { format: "module", source: "export default {};", shortCircuit: true };
   }
   const clean = stripQ(url);

--- a/crates/oj_server/src/lib.rs
+++ b/crates/oj_server/src/lib.rs
@@ -124,6 +124,10 @@ const START_ASSETS: &[(&str, &str)] = &[
     ),
     ("cf-server.mjs", include_str!("assets/start/cf-server.mjs")),
     (
+        "cf-workers.mjs",
+        include_str!("assets/start/cf-workers.mjs"),
+    ),
+    (
         "cf-server-worker.mjs",
         include_str!("assets/start/cf-server-worker.mjs"),
     ),

--- a/e2e/bundleddev-coerce.mjs
+++ b/e2e/bundleddev-coerce.mjs
@@ -29,12 +29,16 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { assertHydrates, assertModuleGraphServes, parseBoundPort } from "./lib/hydration.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repo = path.join(here, "..");
 const fixture = path.join(here, "fixtures", "start-app");
 const oj = path.join(repo, "target", "debug", "oj");
-const PORT = 6860;
+const REQ_PORT = 6860;
+// The port oj actually bound (it auto-increments off a busy port); read from its
+// stdout so a stale server never makes the browser hit the wrong server.
+let PORT = REQ_PORT;
 
 const installed =
   fs.existsSync(path.join(fixture, "node_modules", "@tanstack", "react-start")) &&
@@ -119,6 +123,9 @@ function makeApp() {
   // dev.mjs documents). The `client-mounted-ok` span is rendered only AFTER the
   // component mounts, so it is absent from the SSR HTML and its appearance in the
   // browser proves React hydrated — the exact thing the bundledDev bug broke.
+  // The counter button proves event handlers attached post-hydration: it starts
+  // at 0 server-side and only increments once the client runtime is live and its
+  // onClick is wired (the interaction step of the shared hydration gate).
   fs.writeFileSync(path.join(app, "src", "routes", "index.tsx"), [
     'import { createRoute } from "@tanstack/react-router";',
     'import { useEffect, useState } from "react";',
@@ -133,11 +140,13 @@ function makeApp() {
     "",
     "function Index() {",
     "  const [mounted, setMounted] = useState(false);",
+    "  const [count, setCount] = useState(0);",
     "  useEffect(() => setMounted(true), []);",
     "  return (",
     "    <main>",
     '      <h1 className="fixture-heading">{shout("home")}</h1>',
     '      {mounted ? <span data-testid="client-mounted">client-mounted-ok</span> : null}',
+    '      <button data-testid="counter" onClick={() => setCount((c) => c + 1)}>count: {count}</button>',
     "    </main>",
     "  );",
     "}",
@@ -163,32 +172,15 @@ async function loadPlaywright() {
   }
 }
 
-// Load `/` in a headless browser and report whether the client-only marker
-// appeared within the deadline (i.e. React hydrated). Returns { hydrated, err }.
-async function browserHydrates(chromium, deadlineMs) {
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
-  if (process.env.OJ_E2E_DEBUG_BROWSER) {
-    page.on("console", (m) => console.error(`  [browser console.${m.type()}] ${m.text()}`));
-    page.on("pageerror", (e) => console.error(`  [browser pageerror] ${e.message}`));
-    page.on("requestfailed", (r) => console.error(`  [browser requestfailed] ${r.url()} :: ${r.failure()?.errorText}`));
-    page.on("response", (r) => { if (r.status() >= 400) console.error(`  [browser resp ${r.status()}] ${r.url()}`); });
-  }
-  try {
-    await page.goto(`http://127.0.0.1:${PORT}/`, { waitUntil: "domcontentloaded" });
-    await page.waitForSelector('[data-testid="client-mounted"]', { timeout: deadlineMs });
-    const text = await page.textContent('[data-testid="client-mounted"]');
-    return { hydrated: text === "client-mounted-ok", err: null };
-  } catch (e) {
-    return { hydrated: false, err: (e && e.message) || String(e) };
-  } finally {
-    await browser.close();
-  }
-}
+// A client→server-function call can't run in oj's Node SSR loader on this slim
+// CF app (it can't import `cloudflare:workers`); this route is deliberately
+// backend-free, so nothing here trips it, but the whitelist documents the known
+// noise the shared gate should ignore.
+const HYDRATION_WHITELIST = [/favicon\.ico/, "cloudflare:workers"];
 
 async function run() {
   let log = "";
-  const srv = spawn(oj, ["dev", app, "--port", String(PORT)], {
+  const srv = spawn(oj, ["dev", app, "--port", String(REQ_PORT)], {
     cwd: app,
     detached: true,
     stdio: ["ignore", "pipe", "pipe"],
@@ -201,6 +193,14 @@ async function run() {
     setTimeout(() => { try { process.kill(-srv.pid, "SIGKILL"); } catch {} }, 2000).unref();
   };
   try {
+    // Read the port oj actually bound before probing it: it may have incremented
+    // off REQ_PORT, and probing REQ_PORT would then hit a stale server.
+    for (let i = 0; i < 240; i++) {
+      if (srv.exitCode != null) break;
+      const bound = parseBoundPort(log);
+      if (bound) { PORT = bound; break; }
+      await new Promise((r) => setTimeout(r, 250));
+    }
     let up = false;
     let lastStatus = "no response";
     for (let i = 0; i < 240 && !up; i++) {
@@ -228,10 +228,12 @@ async function run() {
     }
 
     const chromium = await loadPlaywright();
+    const base = `http://127.0.0.1:${PORT}`;
     const referencesBundled = home.body.includes(BUNDLED_ENTRY);
 
     if (referencesBundled) {
       // ---- UNFIXED TREE: reproduce the bug and FAIL with evidence. ----
+      // This is the branch a tree with the bundledDev coercion REVERTED lands in.
       console.error("bundledDev-coerce: REPRODUCED the bug (document references /assets/index.js)");
       // The bundled client script is never delivered: on Vite it hangs on the
       // app's own entry hold; under oj (which never installs the bundled-dev
@@ -247,8 +249,21 @@ async function run() {
         console.error("  /assets/index.js HANGS within 5s (no client JS is ever delivered) — confirmed");
       }
       if (chromium) {
-        const { hydrated } = await browserHydrates(chromium, 8000);
-        console.error(`  headless Chromium hydration: ${hydrated ? "HYDRATED (unexpected)" : "did NOT hydrate (client-mounted-ok never appeared) — confirmed"}`);
+        // The shared hydration gate surfaces the same failure at step 2 (the
+        // client module graph served >= 400) rather than a bare timeout.
+        const browser = await chromium.launch();
+        try {
+          const { failures } = await assertHydrates(browser, `${base}/`, {
+            ssrMarker: "HOME!",
+            clientMarker: '[data-testid="client-mounted"]',
+            deadlineMs: 8000,
+            whitelist: HYDRATION_WHITELIST,
+            throwOnFail: false,
+          });
+          console.error("  hydration gate failures:\n    " + failures.join("\n    "));
+        } finally {
+          await browser.close();
+        }
       } else {
         console.error("  (playwright not installed locally; skipped the browser no-hydration check — CI covers it)");
       }
@@ -282,13 +297,40 @@ async function run() {
     }
     console.log("bundledDev-coerce: the one-time coercion warning was printed");
 
-    // The gate the log-greps missed: a real browser must HYDRATE.
+    // The gates the log-greps missed: the whole client module graph must serve,
+    // and a real browser must HYDRATE. assertModuleGraphServes follows the
+    // virtual entry to the physical client.tsx behind it, so a 500 there (the
+    // react-refresh-wrapper regression) surfaces as a named `500 …/client.tsx`,
+    // not a silent waitForSelector timeout.
     if (chromium) {
-      const { hydrated, err } = await browserHydrates(chromium, 30000);
-      if (!hydrated) {
-        throw new Error(`headless Chromium did not hydrate (client-mounted-ok never appeared): ${err ?? "unknown"}\nlog tail:\n${log.slice(-2000)}`);
+      const browser = await chromium.launch();
+      try {
+        const page = await browser.newPage();
+        try {
+          const graph = await assertModuleGraphServes(page, `${base}/@id/${STANDARD_ENTRY}`);
+          if (!graph.ok) {
+            throw new Error(
+              "the dev client entry's module graph did not fully serve 200:\n  " + graph.failures.join("\n  "),
+            );
+          }
+          console.log("bundledDev-coerce: the client entry module graph (incl. the physical client.tsx) serves 200");
+        } finally {
+          await page.close();
+        }
+        // Full ladder: SSR marker, client mount, correct marker text, and an
+        // interaction (the counter) proving handlers attached post-hydration.
+        await assertHydrates(browser, `${base}/`, {
+          ssrMarker: "HOME!",
+          clientMarker: '[data-testid="client-mounted"]',
+          clientMarkerText: "client-mounted-ok",
+          interaction: { click: '[data-testid="counter"]', expect: { selector: '[data-testid="counter"]', text: "count: 1" } },
+          deadlineMs: 30000,
+          whitelist: HYDRATION_WHITELIST,
+        });
+        console.log("bundledDev-coerce: headless Chromium HYDRATED (marker + counter interaction) — client runtime is live");
+      } finally {
+        await browser.close();
       }
-      console.log("bundledDev-coerce: headless Chromium HYDRATED (client-only marker appeared) — client runtime is live");
     } else {
       console.log("bundledDev-coerce: playwright not installed locally; ran the HTTP-level assertions and skipped the browser hydration check (CI runs it)");
     }

--- a/e2e/bundleddev-coerce.mjs
+++ b/e2e/bundleddev-coerce.mjs
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+// A TanStack Start app on Cloudflare with experimental.bundledDev enabled, under
+// `oj dev`. oj does not implement Vite's Rolldown bundled client dev mode; it
+// must coerce experimental.bundledDev off so the app falls back to the standard
+// Vite dev client entry oj already serves, and warn once that it did so.
+//
+// With bundledDev left ON, the app's TanStack manifest emits a `/assets/index.js`
+// client script that oj never builds nor serves: `/assets/index.js` HANGS on the
+// app's own bundled-dev entry hold and `/bundledDevClient.mjs` 404s, so no client
+// JS runs and React never hydrates — the SSR shell paints but the client-only
+// content never appears.
+//
+// This fixture asserts the FIXED behavior: `/` references the standard dev client
+// entry (not `/assets/index.js`), that entry serves 200, the one-time warning is
+// printed, and a headless browser HYDRATES the page (a useEffect-mounted marker,
+// absent from the SSR HTML, appears). Run on an UNFIXED tree it reproduces the
+// bug instead: it detects the `/assets/index.js` reference, proves the hang and
+// the no-hydration symptom, and FAILS with that evidence.
+//
+// Deps come from the same install recipe as start-cloudflare-dev.mjs
+// (OJ_E2E_CF_DEPS or a fresh npm install). Playwright drives the browser
+// assertion; CI installs it under e2e/. When it is not resolvable locally, the
+// HTTP-level assertions still run and the browser one is skipped with a note.
+
+import { spawn, execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repo = path.join(here, "..");
+const fixture = path.join(here, "fixtures", "start-app");
+const oj = path.join(repo, "target", "debug", "oj");
+const PORT = 6860;
+
+const installed =
+  fs.existsSync(path.join(fixture, "node_modules", "@tanstack", "react-start")) &&
+  fs.existsSync(path.join(fixture, "node_modules", "rolldown"));
+if (!installed) {
+  console.log("SKIP bundledDev coerce: fixture deps not installed");
+  console.log("  enable with: (cd e2e/fixtures/start-app && npm install)");
+  process.exit(0);
+}
+
+execSync("cargo build -p oj", { cwd: repo, stdio: "inherit" });
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "oj-bundleddev-"));
+const app = path.join(tmp, "app");
+const keep = !!process.env.OJ_E2E_KEEP;
+// Retried: the SIGKILLed server's node children flush caches for a beat and
+// race the removal (ENOTEMPTY), like start-cloudflare-dev.mjs handles.
+const cleanup = () => {
+  if (keep) return;
+  for (let i = 0; ; i++) {
+    try {
+      return fs.rmSync(tmp, { recursive: true, force: true });
+    } catch (e) {
+      if (i >= 20) throw e;
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
+    }
+  }
+};
+
+function installCloudflareDeps() {
+  const prepared = process.env.OJ_E2E_CF_DEPS;
+  if (prepared) {
+    fs.symlinkSync(path.join(path.resolve(prepared), "node_modules"), path.join(tmp, "node_modules"), "dir");
+    return;
+  }
+  fs.writeFileSync(path.join(tmp, "package.json"), JSON.stringify({ name: "oj-cf-deps", private: true, type: "module" }));
+  execSync("npm install --no-audit --no-fund --no-package-lock @cloudflare/vite-plugin wrangler", { cwd: tmp, stdio: "inherit" });
+}
+
+function makeApp() {
+  fs.mkdirSync(app);
+  for (const f of ["src", "public", "styles", "packages", "tsconfig.json", "package.json"]) {
+    fs.cpSync(path.join(fixture, f), path.join(app, f), { recursive: true });
+  }
+  fs.symlinkSync(path.join(fixture, "node_modules"), path.join(app, "node_modules"), "dir");
+  fs.writeFileSync(path.join(app, "wrangler.jsonc"), [
+    "{",
+    '  "name": "oj-bundleddev-fixture",',
+    '  "main": "@tanstack/react-start/server-entry",',
+    '  "compatibility_date": "2025-09-01",',
+    '  "compatibility_flags": ["nodejs_compat"],',
+    '  "vars": { "EDITION": "fixture-edition" }',
+    "}",
+    "",
+  ].join("\n"));
+  const original = fs.readFileSync(path.join(fixture, "vite.config.ts"), "utf8");
+  const withImport = original.replace(
+    'import { defineConfig } from "vite";',
+    'import { defineConfig } from "vite";\nimport { cloudflare } from "@cloudflare/vite-plugin";',
+  );
+  // The browser hydrates by fetching the client entry's source under
+  // node_modules via @fs; this tmp app's node_modules is symlinked to the shared
+  // fixture install OUTSIDE the app root, which oj's default fs allow-list
+  // rejects. Turn strict off for the harness (a real app keeps node_modules
+  // under its root, where the default allow already covers it).
+  // Turn on Vite's Rolldown bundled client dev mode — the flag oj must coerce off.
+  const withBundledDev = withImport.replace(
+    /export default defineConfig\(\{/,
+    "export default defineConfig({\n  experimental: { bundledDev: true },\n  server: { fs: { strict: false } },",
+  );
+  const config = withBundledDev.replace(/^(\s*)tanstackStart\(/m, '$1cloudflare({ viteEnvironment: { name: "ssr" } }),\n$1tanstackStart(');
+  if (config === original || config === withImport || config === withBundledDev) {
+    throw new Error("fixture vite.config.ts changed shape; update this script");
+  }
+  fs.writeFileSync(path.join(app, "vite.config.ts"), config);
+  // Slimmed like start-cloudflare-dev.mjs: the full-fat index route does not run
+  // under the plugin's own worker pipeline. This test is about the CLIENT path —
+  // whether the coerced-off config lets the browser hydrate — so the route is
+  // deliberately backend-free: no loader and no server function, because a
+  // client-side server-function call would run in oj's Node SSR loader, which
+  // cannot import `cloudflare:workers` (the slim-app limitation start-cloudflare-
+  // dev.mjs documents). The `client-mounted-ok` span is rendered only AFTER the
+  // component mounts, so it is absent from the SSR HTML and its appearance in the
+  // browser proves React hydrated — the exact thing the bundledDev bug broke.
+  fs.writeFileSync(path.join(app, "src", "routes", "index.tsx"), [
+    'import { createRoute } from "@tanstack/react-router";',
+    'import { useEffect, useState } from "react";',
+    'import { rootRoute } from "./__root";',
+    'import { shout } from "#lib/format";',
+    "",
+    "export const indexRoute = createRoute({",
+    "  getParentRoute: () => rootRoute,",
+    '  path: "/",',
+    "  component: Index,",
+    "});",
+    "",
+    "function Index() {",
+    "  const [mounted, setMounted] = useState(false);",
+    "  useEffect(() => setMounted(true), []);",
+    "  return (",
+    "    <main>",
+    '      <h1 className="fixture-heading">{shout("home")}</h1>',
+    '      {mounted ? <span data-testid="client-mounted">client-mounted-ok</span> : null}',
+    "    </main>",
+    "  );",
+    "}",
+    "",
+  ].join("\n"));
+}
+
+const req = async (route, { timeoutMs } = {}) => {
+  const ac = timeoutMs ? AbortSignal.timeout(timeoutMs) : undefined;
+  const res = await fetch(`http://127.0.0.1:${PORT}${route}`, { signal: ac });
+  return { status: res.status, body: await res.text() };
+};
+
+const STANDARD_ENTRY = "virtual:tanstack-start-dev-client-entry";
+const BUNDLED_ENTRY = "/assets/index.js";
+
+async function loadPlaywright() {
+  try {
+    const { chromium } = await import("playwright");
+    return chromium;
+  } catch {
+    return null;
+  }
+}
+
+// Load `/` in a headless browser and report whether the client-only marker
+// appeared within the deadline (i.e. React hydrated). Returns { hydrated, err }.
+async function browserHydrates(chromium, deadlineMs) {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  if (process.env.OJ_E2E_DEBUG_BROWSER) {
+    page.on("console", (m) => console.error(`  [browser console.${m.type()}] ${m.text()}`));
+    page.on("pageerror", (e) => console.error(`  [browser pageerror] ${e.message}`));
+    page.on("requestfailed", (r) => console.error(`  [browser requestfailed] ${r.url()} :: ${r.failure()?.errorText}`));
+    page.on("response", (r) => { if (r.status() >= 400) console.error(`  [browser resp ${r.status()}] ${r.url()}`); });
+  }
+  try {
+    await page.goto(`http://127.0.0.1:${PORT}/`, { waitUntil: "domcontentloaded" });
+    await page.waitForSelector('[data-testid="client-mounted"]', { timeout: deadlineMs });
+    const text = await page.textContent('[data-testid="client-mounted"]');
+    return { hydrated: text === "client-mounted-ok", err: null };
+  } catch (e) {
+    return { hydrated: false, err: (e && e.message) || String(e) };
+  } finally {
+    await browser.close();
+  }
+}
+
+async function run() {
+  let log = "";
+  const srv = spawn(oj, ["dev", app, "--port", String(PORT)], {
+    cwd: app,
+    detached: true,
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, WRANGLER_SEND_METRICS: "false", CI: "1", NO_COLOR: "1", FORCE_COLOR: "0" },
+  });
+  srv.stdout.on("data", (d) => (log += d));
+  srv.stderr.on("data", (d) => (log += d));
+  const stop = () => {
+    try { process.kill(-srv.pid, "SIGTERM"); } catch {}
+    setTimeout(() => { try { process.kill(-srv.pid, "SIGKILL"); } catch {} }, 2000).unref();
+  };
+  try {
+    let up = false;
+    let lastStatus = "no response";
+    for (let i = 0; i < 240 && !up; i++) {
+      if (srv.exitCode != null) break;
+      try {
+        const r = await fetch(`http://127.0.0.1:${PORT}/`);
+        lastStatus = String(r.status);
+        up = r.status === 200;
+        if (!up) lastStatus = `${r.status}: ${(await r.text()).slice(0, 300)}`;
+      } catch (e) { lastStatus = `fetch error: ${(e && e.message) || e}`; }
+      if (!up) await new Promise((r) => setTimeout(r, 500));
+    }
+    if (!up) throw new Error(`oj dev did not serve 200 on :${PORT} (last: ${lastStatus}); log:\n${log.slice(-4000)}`);
+
+    const home = await req("/");
+    if (home.status !== 200) throw new Error(`/ returned ${home.status}`);
+    // The route rendered server-side (shout("home") -> "HOME!").
+    if (!home.body.includes("HOME!")) {
+      throw new Error(`/: route did not render server-side (no "HOME!")\n${home.body.slice(0, 1500)}`);
+    }
+    // Sanity: the client-only marker must NOT be in the SSR HTML — its later
+    // appearance in the browser is what proves hydration.
+    if (home.body.includes("client-mounted-ok")) {
+      throw new Error("the client-only marker leaked into the SSR HTML; it can no longer prove hydration");
+    }
+
+    const chromium = await loadPlaywright();
+    const referencesBundled = home.body.includes(BUNDLED_ENTRY);
+
+    if (referencesBundled) {
+      // ---- UNFIXED TREE: reproduce the bug and FAIL with evidence. ----
+      console.error("bundledDev-coerce: REPRODUCED the bug (document references /assets/index.js)");
+      // The bundled client script is never delivered: on Vite it hangs on the
+      // app's own entry hold; under oj (which never installs the bundled-dev
+      // middlewares) the route simply does not exist. Either way it never
+      // completes with a 200, so no client JS ever runs.
+      let noClientJs = false;
+      try {
+        const res = await req(BUNDLED_ENTRY, { timeoutMs: 5000 });
+        noClientJs = res.status !== 200;
+        console.error(`  /assets/index.js returned ${res.status} (not a delivered client bundle) — no client JS`);
+      } catch {
+        noClientJs = true;
+        console.error("  /assets/index.js HANGS within 5s (no client JS is ever delivered) — confirmed");
+      }
+      if (chromium) {
+        const { hydrated } = await browserHydrates(chromium, 8000);
+        console.error(`  headless Chromium hydration: ${hydrated ? "HYDRATED (unexpected)" : "did NOT hydrate (client-mounted-ok never appeared) — confirmed"}`);
+      } else {
+        console.error("  (playwright not installed locally; skipped the browser no-hydration check — CI covers it)");
+      }
+      throw new Error(
+        `experimental.bundledDev was not coerced off: document still references ${BUNDLED_ENTRY} (client bundle undelivered=${noClientJs}). ` +
+          "This is the failing repro; the fix must coerce it to the standard dev client entry.",
+      );
+    }
+
+    // ---- FIXED TREE: assert the standard entry + hydration + warning. ----
+    if (!home.body.includes(STANDARD_ENTRY)) {
+      throw new Error(`/: references neither ${BUNDLED_ENTRY} nor the standard entry ${STANDARD_ENTRY}\n${home.body.slice(0, 1500)}`);
+    }
+    console.log(`bundledDev-coerce: / references the standard dev client entry (${STANDARD_ENTRY}), not ${BUNDLED_ENTRY}`);
+
+    // The standard dev client entry must actually serve.
+    const entry = await req(`/@id/${STANDARD_ENTRY}`);
+    if (entry.status !== 200) {
+      throw new Error(`the standard dev client entry did not serve 200 (got ${entry.status})\n${entry.body.slice(0, 800)}`);
+    }
+    console.log("bundledDev-coerce: the standard dev client entry serves 200");
+
+    // The one-time coercion warning must have been printed.
+    let warned = false;
+    for (let i = 0; i < 40 && !warned; i++) {
+      warned = /experimental\.bundledDev is not supported/.test(log);
+      if (!warned) await new Promise((r) => setTimeout(r, 100));
+    }
+    if (!warned) {
+      throw new Error(`the one-time bundledDev coercion warning was never printed; log tail:\n${log.slice(-2000)}`);
+    }
+    console.log("bundledDev-coerce: the one-time coercion warning was printed");
+
+    // The gate the log-greps missed: a real browser must HYDRATE.
+    if (chromium) {
+      const { hydrated, err } = await browserHydrates(chromium, 30000);
+      if (!hydrated) {
+        throw new Error(`headless Chromium did not hydrate (client-mounted-ok never appeared): ${err ?? "unknown"}\nlog tail:\n${log.slice(-2000)}`);
+      }
+      console.log("bundledDev-coerce: headless Chromium HYDRATED (client-only marker appeared) — client runtime is live");
+    } else {
+      console.log("bundledDev-coerce: playwright not installed locally; ran the HTTP-level assertions and skipped the browser hydration check (CI runs it)");
+    }
+  } finally {
+    stop();
+  }
+}
+
+try {
+  installCloudflareDeps();
+  makeApp();
+  await run();
+  cleanup();
+  console.log("bundledDev-coerce: PASS");
+} catch (e) {
+  console.error(e?.stack || e);
+  if (keep) console.error(`kept ${tmp}`);
+  else cleanup();
+  process.exit(1);
+}

--- a/e2e/fixtures/start-app/src/routes/index.tsx
+++ b/e2e/fixtures/start-app/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { createRoute, useLoaderData } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
 
 import { rootRoute } from "./__root";
 import { getGreeting } from "../server/data";
@@ -69,21 +70,37 @@ export const indexRoute = createRoute({
 
 function Index() {
   const data = useLoaderData({ from: indexRoute.id });
+  // A client-only hydration probe for the browser gate: the span is rendered
+  // only after mount (absent from the SSR HTML, so its appearance proves the
+  // client runtime came alive), and the counter's onClick proves event handlers
+  // attached post-hydration.
+  const [mounted, setMounted] = useState(false);
+  const [count, setCount] = useState(0);
+  useEffect(() => setMounted(true), []);
   return (
     <main>
       <h1 className="fixture-heading">{shout("home")}</h1>
+      {mounted ? <span data-testid="client-mounted">client-mounted-ok</span> : null}
+      <button data-testid="counter" onClick={() => setCount((c) => c + 1)}>count: {count}</button>
       <p data-testid="server-fn">{data.message} / edition={data.edition}</p>
       <p data-testid="paths-alias">{shoutViaPaths("alias")}</p>
       <p data-testid="cjs">{badge("interop")}</p>
       <p data-testid="cjs-subpath">{deep("ok")}</p>
       <p data-testid="virtual">{buildTag}</p>
-      <p data-testid="fresh-module">{gen.LABEL}</p>
-      <p data-testid="fresh-fn">{gen.freshMsg_cta()}</p>
+      {/* Deliberately environment-divergent (this.environment.name + consumer):
+          "ssr-server" server-side, "client-client" in the client bundle. Like
+          env-define below, this is an intentional per-environment difference, so
+          suppress the (correct) hydration-mismatch warning it would otherwise
+          raise. */}
+      <p data-testid="fresh-module" suppressHydrationWarning>{gen.LABEL}</p>
+      <p data-testid="fresh-fn" suppressHydrationWarning>{gen.freshMsg_cta()}</p>
       <p data-testid="glob">{titles}</p>
       <p data-testid="glob-jsx"><GlobWidget /></p>
       <p data-testid="glob-js">{plainGlobTitles}</p>
       <p data-testid="glob-ts-generic">{genericGlobTitles}</p>
-      <p data-testid="js-env">{envProbe}</p>
+      {/* envProbe embeds import.meta.env.SSR (true server-side, false in the
+          client bundle), so it is intentionally environment-divergent too. */}
+      <p data-testid="js-env" suppressHydrationWarning>{envProbe}</p>
       <p data-testid="json-named">{`json-named:${alphaTitle}`}</p>
       <p data-testid="define">{__FIXTURE_DEFINE__}</p>
       <p data-testid="env-define" suppressHydrationWarning>{__FIXTURE_SIDE__}</p>

--- a/e2e/lib/hydration.mjs
+++ b/e2e/lib/hydration.mjs
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Raphael Amorim
+
+// Shared hydration gate for the e2e suites. Modeled on Vite's playground
+// vitestSetup (the "page has no browser errors" invariant) and TanStack Start's
+// e2e fixture (drive the real client, then assert an interaction proves handlers
+// attached post-hydration). The point is that an SSR shell can paint perfectly
+// while the client never runs — a 404/500/hang on a client module, a React
+// hydration mismatch — so a log-grep or an HTTP-only check passes while the page
+// is dead. This helper loads the page in a real browser and fails loudly, with
+// the offending {status,url} or error text, when the client graph does not serve
+// or the runtime does not come alive.
+
+// React 18 + 19 hydration-mismatch strings. If any of these appears in the
+// browser's console or as a page error, the client and server disagreed and the
+// tree was (or would be) thrown away and re-rendered — never a pass.
+export const HYDRATION_SIGNATURES = [
+  "Hydration failed because the server rendered",
+  "didn't match the client",
+  "tree will be regenerated on the client",
+  "attributes of the server rendered HTML didn't match",
+  "react.dev/link/hydration-mismatch",
+  "Hydration failed because the initial UI does not match",
+  "Text content did not match",
+  "Expected server HTML to contain",
+  "Did not expect server HTML",
+  "An error occurred during hydration",
+  "There was an error while hydrating",
+];
+
+// A URL the browser fetched that is a script/module in oj's dev graph. Covers
+// plain extensions and oj/Vite's virtual prefixes (which have no extension).
+const MODULE_EXT_RE = /\.(?:m?[jt]sx?)(?:$|[?#])/;
+function isModuleUrl(url) {
+  if (MODULE_EXT_RE.test(url)) return true;
+  return (
+    url.includes("/@fs/") ||
+    url.includes("/@id/") ||
+    url.includes("/@oj/") ||
+    url.includes("/@oj-start/") ||
+    url.includes("/@oj-deps/")
+  );
+}
+
+// Parse oj's bound port out of its stdout. oj auto-increments off a busy port
+// (unless --strict-port), so the requested port is not necessarily the bound
+// one; the "http://localhost:PORT/" line it prints is authoritative. Returns a
+// number or null. (When stdout is a pipe, oj emits the URL plain — no ANSI.)
+export function parseBoundPort(text) {
+  const m = /http:\/\/localhost:(\d+)\//.exec(String(text || ""));
+  return m ? Number(m[1]) : null;
+}
+
+// Attach browser diagnostics to a page. Returns live arrays that fill as the
+// page runs: console error+warning messages, uncaught page errors, failed
+// requests, and any script/module response with status >= 400.
+export function collectBrowserErrors(page) {
+  const consoleMessages = []; // { type, text }
+  const pageErrors = []; // string
+  const requestFailures = []; // { url, error }
+  const badResponses = []; // { status, url }
+
+  page.on("console", (m) => {
+    const type = m.type();
+    if (type === "error" || type === "warning") consoleMessages.push({ type, text: m.text() });
+  });
+  page.on("pageerror", (e) => pageErrors.push((e && e.message) || String(e)));
+  page.on("requestfailed", (r) =>
+    requestFailures.push({ url: r.url(), error: r.failure()?.errorText ?? "unknown" }),
+  );
+  page.on("response", (r) => {
+    if (r.status() >= 400 && isModuleUrl(r.url())) badResponses.push({ status: r.status(), url: r.url() });
+  });
+
+  return { consoleMessages, pageErrors, requestFailures, badResponses };
+}
+
+const asMatcher = (w) => (s) => (w instanceof RegExp ? w.test(s) : String(s).includes(w));
+const hasSignature = (s) => HYDRATION_SIGNATURES.some((sig) => s.includes(sig));
+
+// Fetch `entryUrl` through the page's request context and assert it (and its
+// statically-imported same-origin module URLs) serve 200. This is TanStack's
+// `page.request.get(virtualPath)` idiom: it makes the physical client entry
+// behind a virtual module (e.g. the client.tsx behind
+// virtual:tanstack-start-dev-client-entry) an explicit, named check rather than
+// a silent waitForSelector timeout. Returns { ok, failures[] }.
+export async function assertModuleGraphServes(page, entryUrl) {
+  const failures = [];
+  const res = await page.request.get(entryUrl);
+  if (!res.ok()) {
+    failures.push(`${res.status()} ${entryUrl}`);
+    return { ok: false, failures };
+  }
+  const src = await res.text();
+  const specs = new Set();
+  const re =
+    /(?:import|export)\b[^'"]*?\bfrom\s*["']([^"']+)["']|import\(\s*["']([^"']+)["']\s*\)|import\s*["']([^"']+)["']/g;
+  let m;
+  while ((m = re.exec(src))) {
+    const spec = m[1] || m[2] || m[3];
+    if (spec) specs.add(spec);
+  }
+  const base = new URL(entryUrl);
+  for (const spec of specs) {
+    let target;
+    try {
+      if (spec.startsWith("/")) target = new URL(spec, base.origin).href;
+      else if (spec.startsWith(".")) target = new URL(spec, base).href;
+      else continue; // bare specifier -> not a dev-served URL
+    } catch {
+      continue;
+    }
+    const r = await page.request.get(target);
+    if (!r.ok()) {
+      let detail = "";
+      try {
+        detail = (await r.text()).replace(/\s+/g, " ").trim().slice(0, 300);
+      } catch {}
+      failures.push(`${r.status()} ${target}${detail ? ` :: ${detail}` : ""}`);
+    }
+  }
+  return { ok: failures.length === 0, failures };
+}
+
+// Load `url` in `browser` and run the hydration ladder, each rung failing loudly
+// with evidence. Returns { ok, failures[] }; throws with the joined failures
+// unless opts.throwOnFail === false.
+//
+// opts:
+//   ssrMarker?       text expected in the RAW SSR HTML (page.request.get)
+//   clientMarker     selector for a client-only element (absent from SSR HTML,
+//                    present only after the client runtime mounts)
+//   clientMarkerText expected trimmed textContent of clientMarker
+//   interaction?     { click: selector, expect: { selector, text? } } -- proves
+//                    event handlers attached post-hydration
+//   deadlineMs=30000 per-step timeout
+//   whitelist?       (RegExp|string)[] of console/response noise to ignore
+//                    (e.g. favicon 404, the CF slim-app server-fn limitation)
+//   throwOnFail=true throw on any failure with the full evidence
+export async function assertHydrates(browser, url, opts = {}) {
+  const {
+    ssrMarker,
+    clientMarker,
+    clientMarkerText,
+    interaction,
+    deadlineMs = 30000,
+    whitelist = [],
+    throwOnFail = true,
+  } = opts;
+  const matchers = whitelist.map(asMatcher);
+  const whitelisted = (s) => matchers.some((f) => f(s));
+  const failures = [];
+
+  const page = await browser.newPage();
+  const diag = collectBrowserErrors(page);
+  try {
+    // 1. doc 200 + ssrMarker present in the raw SSR HTML.
+    const docRes = await page.request.get(url);
+    const rawHtml = await docRes.text();
+    if (docRes.status() !== 200) failures.push(`document ${url} returned ${docRes.status()} (want 200)`);
+    if (ssrMarker && !rawHtml.includes(ssrMarker)) {
+      failures.push(`SSR HTML missing ssrMarker ${JSON.stringify(ssrMarker)}\n${rawHtml.slice(0, 800)}`);
+    }
+
+    // Load the page and let its client graph fetch.
+    let navError = null;
+    try {
+      await page.goto(url, { waitUntil: "domcontentloaded", timeout: deadlineMs });
+    } catch (e) {
+      navError = (e && e.message) || String(e);
+    }
+
+    // 3. client runtime mounted (clientMarker eventually present).
+    let mounted = false;
+    if (clientMarker) {
+      try {
+        await page.waitForSelector(clientMarker, { timeout: deadlineMs });
+        mounted = true;
+      } catch {
+        /* reported below, after the module-graph check names the likely cause */
+      }
+    }
+
+    // 2. every client module served 200. Checked after load so the browser has
+    // finished fetching the graph. THIS names the bundledDev /assets/index.js
+    // 404/hang and the react-refresh 500 on client.tsx, instead of a bare
+    // "selector never appeared" timeout.
+    const badModules = diag.badResponses.filter((r) => !whitelisted(r.url));
+    if (badModules.length) {
+      failures.push(
+        "client module graph served >= 400:\n" + badModules.map((r) => `  ${r.status} ${r.url}`).join("\n"),
+      );
+    }
+
+    if (clientMarker && !mounted) {
+      failures.push(
+        `client runtime did not mount: ${clientMarker} never appeared within ${deadlineMs}ms` +
+          (navError ? ` (navigation: ${navError})` : ""),
+      );
+    }
+
+    // 4. client-only marker text is correct.
+    if (clientMarker && mounted && clientMarkerText != null) {
+      const text = (await page.textContent(clientMarker)) ?? "";
+      if (text.trim() !== clientMarkerText) {
+        failures.push(`client marker text ${JSON.stringify(text.trim())} != ${JSON.stringify(clientMarkerText)}`);
+      }
+    }
+
+    // 5. interaction: click, then poll for the expected result. Proves handlers
+    // are live after hydration.
+    if (interaction && mounted) {
+      try {
+        await page.click(interaction.click, { timeout: deadlineMs });
+        const sel = interaction.expect.selector;
+        if (interaction.expect.text != null) {
+          await page.waitForFunction(
+            ([s, t]) => document.querySelector(s)?.textContent?.includes(t),
+            [sel, interaction.expect.text],
+            { timeout: deadlineMs },
+          );
+        } else {
+          await page.waitForSelector(sel, { timeout: deadlineMs });
+        }
+      } catch (e) {
+        failures.push(
+          `interaction failed (click ${interaction.click} -> expect ${JSON.stringify(interaction.expect)}): ` +
+            ((e && e.message) || e),
+        );
+      }
+    }
+
+    // 6. no page errors, no console errors, and specifically no React
+    // hydration-mismatch signatures (in console error OR warning, or a page
+    // error).
+    const pageErrs = diag.pageErrors.filter((s) => !whitelisted(s));
+    const hydrationHits = [...diag.pageErrors, ...diag.consoleMessages.map((m) => m.text)].filter(
+      (s) => !whitelisted(s) && hasSignature(s),
+    );
+    const consoleErrs = diag.consoleMessages.filter(
+      (m) => m.type === "error" && !whitelisted(m.text) && !hasSignature(m.text),
+    );
+
+    if (hydrationHits.length) {
+      failures.push(
+        "React hydration-mismatch signature(s) in the browser output:\n" +
+          hydrationHits.map((s) => "  " + s).join("\n"),
+      );
+    }
+    if (pageErrs.length) failures.push("page error(s):\n" + pageErrs.map((s) => "  " + s).join("\n"));
+    if (consoleErrs.length) {
+      failures.push(
+        "console error(s):\n" + consoleErrs.map((m) => `  [${m.type}] ${m.text}`).join("\n"),
+      );
+    }
+  } finally {
+    await page.close();
+  }
+
+  const ok = failures.length === 0;
+  if (!ok && throwOnFail) {
+    throw new Error(`assertHydrates(${url}) FAILED:\n` + failures.map((f) => "- " + f).join("\n"));
+  }
+  return { ok, failures };
+}

--- a/e2e/lib/hydration.mjs
+++ b/e2e/lib/hydration.mjs
@@ -187,9 +187,19 @@ export async function assertHydrates(browser, url, opts = {}) {
     // "selector never appeared" timeout.
     const badModules = diag.badResponses.filter((r) => !whitelisted(r.url));
     if (badModules.length) {
-      failures.push(
-        "client module graph served >= 400:\n" + badModules.map((r) => `  ${r.status} ${r.url}`).join("\n"),
-      );
+      // Re-fetch each failing module to surface the server's error body (the
+      // browser-observed response only carried a status), so a 500 names its
+      // compile/resolve cause instead of a bare status line.
+      const lines = [];
+      for (const r of badModules) {
+        let detail = "";
+        try {
+          const again = await page.request.get(r.url);
+          detail = (await again.text()).replace(/\s+/g, " ").trim().slice(0, 400);
+        } catch {}
+        lines.push(`  ${r.status} ${r.url}${detail ? `\n    :: ${detail}` : ""}`);
+      }
+      failures.push("client module graph served >= 400:\n" + lines.join("\n"));
     }
 
     if (clientMarker && !mounted) {

--- a/e2e/lib/hydration.mjs
+++ b/e2e/lib/hydration.mjs
@@ -192,12 +192,16 @@ export async function assertHydrates(browser, url, opts = {}) {
       // compile/resolve cause instead of a bare status line.
       const lines = [];
       for (const r of badModules) {
+        // The browser saw r.status; re-fetch for the server's error body. A
+        // flaky module can answer the re-fetch differently, so label the body
+        // with its own status rather than implying it shares r.status.
         let detail = "";
         try {
           const again = await page.request.get(r.url);
-          detail = (await again.text()).replace(/\s+/g, " ").trim().slice(0, 400);
+          const body = (await again.text()).replace(/\s+/g, " ").trim().slice(0, 400);
+          if (body) detail = `\n    :: (re-fetch ${again.status()}) ${body}`;
         } catch {}
-        lines.push(`  ${r.status} ${r.url}${detail ? `\n    :: ${detail}` : ""}`);
+        lines.push(`  ${r.status} ${r.url}${detail}`);
       }
       failures.push("client module graph served >= 400:\n" + lines.join("\n"));
     }

--- a/e2e/ssr-dev.mjs
+++ b/e2e/ssr-dev.mjs
@@ -7,6 +7,7 @@ import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { HYDRATION_SIGNATURES, collectBrowserErrors } from "./lib/hydration.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repo = path.join(here, "..");
@@ -391,9 +392,10 @@ try {
       console.log("ssr-dev: connection gating + change ok (Data Saver suppresses, improve resumes, click navigates)");
 
       const page = await browser.newPage();
-      const errors = [];
-      page.on("pageerror", (e) => errors.push(String(e)));
-      page.on("console", (m) => m.type() === "error" && errors.push(m.text()));
+      // Unified browser-error gate (shared with the hydration suites): captures
+      // page errors + console errors/warnings, so the React hydration-mismatch
+      // strings are asserted absent explicitly, not just "no console errors".
+      const diag = collectBrowserErrors(page);
       await page.goto(`${base}/`, { waitUntil: "networkidle" });
       await page.waitForSelector("button");
       const counterBtn = page.locator("button", { hasText: "ssr" });
@@ -427,6 +429,11 @@ try {
       const marker = await page.evaluate(() => window.__marker);
       if (!afterEdit.includes("= 3")) throw new Error(`state lost or edit not applied: ${afterEdit}`);
       if (marker !== 7) throw new Error("page fully reloaded (state would be lost)");
+      const hydrationHits = [...diag.pageErrors, ...diag.consoleMessages.map((m) => m.text)].filter((s) =>
+        HYDRATION_SIGNATURES.some((sig) => s.includes(sig)),
+      );
+      if (hydrationHits.length) throw new Error(`React hydration-mismatch signatures: ${hydrationHits.join("; ")}`);
+      const errors = [...diag.pageErrors, ...diag.consoleMessages.filter((m) => m.type === "error").map((m) => m.text)];
       if (errors.length) throw new Error(`console errors: ${errors.join("; ")}`);
       console.log(`ssr-dev: SSR HMR ok (${clicked} -> hot edit -> ${afterEdit}, no reload)`);
     } finally {

--- a/e2e/start-cloudflare-dev.mjs
+++ b/e2e/start-cloudflare-dev.mjs
@@ -227,6 +227,12 @@ async function runDev() {
           whitelist: [/favicon\.ico/, "cloudflare:workers", "/_serverFn/", "createServerFn"],
         });
         console.log("start-cloudflare-dev: browser hydration ok (worker render mounts + counter interaction)");
+      } catch (e) {
+        // A browser-observed 500/crash in oj's own pipeline leaves its cause
+        // only in oj's server log; surface a bounded tail on the thrown error
+        // so CI names the compile/loader failure instead of a bare status.
+        e.message += `\n--- oj server log (tail) ---\n${log.slice(-3000)}`;
+        throw e;
       } finally {
         await browser.close();
       }

--- a/e2e/start-cloudflare-dev.mjs
+++ b/e2e/start-cloudflare-dev.mjs
@@ -14,12 +14,16 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { assertHydrates, parseBoundPort } from "./lib/hydration.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repo = path.join(here, "..");
 const fixture = path.join(here, "fixtures", "start-app");
 const oj = path.join(repo, "target", "debug", "oj");
-const PORT = 6840;
+const REQ_PORT = 6840;
+// The port oj actually bound (it auto-increments off a busy port); read from its
+// stdout so a stale server never makes the browser hit the wrong server.
+let PORT = REQ_PORT;
 
 const installed =
   fs.existsSync(path.join(fixture, "node_modules", "@tanstack", "react-start")) &&
@@ -90,8 +94,14 @@ function makeApp() {
   // to what this test drives: a worker render with a server function reading a
   // wrangler var. The full-fat route stays covered by start.mjs (Node runner)
   // and start-cloudflare.mjs (prod worker build).
+  // The mount probe + counter give the browser hydration gate a client-only
+  // marker (absent from SSR HTML) and a post-hydration interaction, so the CF
+  // worker-render path is proven to HYDRATE, not just to emit SSR HTML. The
+  // counter is pure client state (no server call), so it does not trip the CF
+  // slim-app server-fn limitation.
   fs.writeFileSync(path.join(app, "src", "routes", "index.tsx"), [
     'import { createRoute, useLoaderData } from "@tanstack/react-router";',
+    'import { useEffect, useState } from "react";',
     'import { rootRoute } from "./__root";',
     'import { getGreeting } from "../server/data";',
     'import { shout } from "#lib/format";',
@@ -105,10 +115,15 @@ function makeApp() {
     "",
     "function Index() {",
     "  const data = useLoaderData({ from: indexRoute.id });",
+    "  const [mounted, setMounted] = useState(false);",
+    "  const [count, setCount] = useState(0);",
+    "  useEffect(() => setMounted(true), []);",
     "  return (",
     "    <main>",
     '      <h1 className="fixture-heading">{shout("home")}</h1>',
     '      <p data-testid="server-fn">{data.message} / edition={data.edition}</p>',
+    '      {mounted ? <span data-testid="client-mounted">client-mounted-ok</span> : null}',
+    '      <button data-testid="counter" onClick={() => setCount((c) => c + 1)}>count: {count}</button>',
     "    </main>",
     "  );",
     "}",
@@ -134,6 +149,14 @@ const get = async (route) => {
   return { status: res.status, body: await res.text() };
 };
 
+async function loadPlaywright() {
+  try {
+    return (await import("playwright")).chromium;
+  } catch {
+    return null;
+  }
+}
+
 async function runDev() {
   let log = "";
   const srv = spawn(oj, ["dev", app, "--port", String(PORT)], {
@@ -149,6 +172,14 @@ async function runDev() {
     setTimeout(() => { try { process.kill(-srv.pid, "SIGKILL"); } catch {} }, 2000).unref();
   };
   try {
+    // Read the port oj actually bound before probing it (it may increment off a
+    // busy REQ_PORT), so a stale server never fools the probes or the browser.
+    for (let i = 0; i < 240; i++) {
+      if (srv.exitCode != null) break;
+      const bound = parseBoundPort(log);
+      if (bound) { PORT = bound; break; }
+      await new Promise((r) => setTimeout(r, 250));
+    }
     let up = false;
     for (let i = 0; i < 240 && !up; i++) {
       if (srv.exitCode != null) break;
@@ -176,6 +207,31 @@ async function runDev() {
     const about = await get("/about");
     if (about.status !== 200 || !about.body.includes("about-page-marker")) {
       throw new Error(`/about did not render (${about.status})`);
+    }
+
+    // The CF worker-render path must HYDRATE, not just emit SSR HTML: load `/`
+    // in a real browser, prove the client module graph serves and the runtime
+    // mounts + responds. Whitelist the documented CF slim-app limitation (a
+    // client→server-fn call can't run in oj's Node SSR loader, which can't
+    // import cloudflare:workers) plus the incidental favicon 404. Run before the
+    // edit loop mutates HOME! into HOME-RAPID!.
+    const chromium = await loadPlaywright();
+    if (chromium) {
+      const browser = await chromium.launch();
+      try {
+        await assertHydrates(browser, `http://127.0.0.1:${PORT}/`, {
+          ssrMarker: "server-fn-marker",
+          clientMarker: '[data-testid="client-mounted"]',
+          clientMarkerText: "client-mounted-ok",
+          interaction: { click: '[data-testid="counter"]', expect: { selector: '[data-testid="counter"]', text: "count: 1" } },
+          whitelist: [/favicon\.ico/, "cloudflare:workers", "/_serverFn/", "createServerFn"],
+        });
+        console.log("start-cloudflare-dev: browser hydration ok (worker render mounts + counter interaction)");
+      } finally {
+        await browser.close();
+      }
+    } else {
+      console.log("start-cloudflare-dev: playwright not installed locally; skipped the browser hydration pass (CI runs it)");
     }
 
     // The edit loop: change the route, require the next document to be fresh.
@@ -353,8 +409,8 @@ function spawnSlowDev(port, extraEnv) {
 
 // Their own ports: the previous phase's server may still be tearing down and
 // oj would silently bind PORT+1, leaving the probes pointed at a dead socket.
-const GATED_PORT = PORT + 3;
-const DEGRADED_PORT = PORT + 4;
+const GATED_PORT = REQ_PORT + 3;
+const DEGRADED_PORT = REQ_PORT + 4;
 
 // Phase 1: the default init deadline. Boot blocks on the 8s init instead of
 // racing per-RPC timeouts against it: the forwarding line prints WITHOUT the

--- a/e2e/start-cloudflare-dev.mjs
+++ b/e2e/start-cloudflare-dev.mjs
@@ -231,8 +231,14 @@ async function runDev() {
         // A browser-observed 500/crash in oj's own pipeline leaves its cause
         // only in oj's server log; surface a bounded tail on the thrown error
         // so CI names the compile/loader failure instead of a bare status.
-        e.message += `\n--- oj server log (tail) ---\n${log.slice(-3000)}`;
-        throw e;
+        // Guard the message mutation: a non-Error throw (a string, say) has no
+        // writable .message, and clobbering it would hide the real failure.
+        const tail = `\n--- oj server log (tail) ---\n${log.slice(-3000)}`;
+        if (e instanceof Error) {
+          e.message += tail;
+          throw e;
+        }
+        throw new Error(String(e) + tail);
       } finally {
         await browser.close();
       }

--- a/e2e/start.mjs
+++ b/e2e/start.mjs
@@ -5,6 +5,7 @@ import { spawn, execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { assertHydrates, parseBoundPort } from "./lib/hydration.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repo = path.join(here, "..");
@@ -110,15 +111,66 @@ async function assertApp(port, label) {
   console.log(`${label}: ${want.length} features + /about + publicDir + css-in-head ok`);
 }
 
+async function loadPlaywright() {
+  try {
+    return (await import("playwright")).chromium;
+  } catch {
+    return null;
+  }
+}
+
+// The broad "TanStack Start under `oj dev` actually hydrates" gate: not just SSR
+// HTML, but the client graph serving and the runtime coming alive. `/` carries
+// the fixture's client-only probe + counter; `/about` is static, so it is gated
+// for a clean load (module graph 200, no hydration-mismatch errors).
+async function assertDevHydration(port) {
+  const chromium = await loadPlaywright();
+  if (!chromium) {
+    console.log("start-dev: playwright not installed locally; skipped the browser hydration pass (CI runs it)");
+    return;
+  }
+  const base = `http://localhost:${port}`;
+  const whitelist = [/favicon\.ico/];
+  const browser = await chromium.launch();
+  try {
+    await assertHydrates(browser, `${base}/`, {
+      ssrMarker: "HOME!",
+      clientMarker: '[data-testid="client-mounted"]',
+      clientMarkerText: "client-mounted-ok",
+      interaction: { click: '[data-testid="counter"]', expect: { selector: '[data-testid="counter"]', text: "count: 1" } },
+      whitelist,
+    });
+    await assertHydrates(browser, `${base}/about`, {
+      ssrMarker: "about-page-marker",
+      whitelist,
+    });
+    console.log("start-dev: browser hydration ok (/ mounts + counter interaction, /about clean client graph)");
+  } finally {
+    await browser.close();
+  }
+}
+
 async function devPhase() {
   rm(path.join(app, ".oj-cache"));
-  const port = 3097;
-  const srv = spawn(oj, ["dev", app, "--port", String(port)], { stdio: "ignore" });
+  const reqPort = 3097;
+  let log = "";
+  const srv = spawn(oj, ["dev", app, "--port", String(reqPort)], { stdio: ["ignore", "pipe", "pipe"] });
+  srv.stdout.on("data", (d) => (log += d));
+  srv.stderr.on("data", (d) => (log += d));
   try {
+    // oj may increment off a busy port; use the port it actually bound.
+    let port = reqPort;
+    for (let i = 0; i < 240; i++) {
+      if (srv.exitCode != null) break;
+      const bound = parseBoundPort(log);
+      if (bound) { port = bound; break; }
+      await new Promise((r) => setTimeout(r, 250));
+    }
     await waitUp(port);
     await assertApp(port, "start-dev");
     await assertDevRouting(port);
     assertInlineSourceMaps();
+    await assertDevHydration(port);
   } finally {
     srv.kill("SIGKILL");
   }

--- a/e2e/unit/cf-workers-scheme.test.mjs
+++ b/e2e/unit/cf-workers-scheme.test.mjs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+//
+// The SSR loader must not crash on the `cloudflare:` URL scheme. In a worker
+// build `cloudflare:*` stays external and workerd provides it; in oj's Node SSR
+// loader there is no workerd, so Node's default ESM loader throws
+// ERR_UNSUPPORTED_ESM_URL_SCHEME and takes the dev server down. The loader
+// aliases `cloudflare:workers` to a stub whose `env` is backed by the app's
+// wrangler vars, and stubs any other `cloudflare:*` (or unsupported scheme) as
+// an empty module.
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const loader = resolve(here, "../../crates/oj_server/src/assets/start/loader.mjs");
+
+test("SSR loader stubs cloudflare:workers (env from wrangler) and never crashes on the cloudflare: scheme", () => {
+  const app = mkdtempSync(join(tmpdir(), "oj-cf-scheme-"));
+  try {
+    writeFileSync(join(app, "package.json"), JSON.stringify({ name: "cf-scheme-app", type: "module" }));
+    // The loader imports rolldown/experimental for its transform (see the
+    // ssr-loader asset tests); provide a stub so the hooks can load.
+    const rolldown = join(app, "node_modules", "rolldown");
+    mkdirSync(rolldown, { recursive: true });
+    writeFileSync(
+      join(rolldown, "package.json"),
+      JSON.stringify({ name: "rolldown", type: "module", exports: { "./experimental": "./experimental.mjs" } }),
+    );
+    writeFileSync(join(rolldown, "experimental.mjs"), "export const transformSync = (_path, code) => ({ code });\n");
+    writeFileSync(
+      join(app, "wrangler.jsonc"),
+      JSON.stringify({ name: "cf-scheme", compatibility_date: "2025-09-01", vars: { EDITION: "unit-edition" } }),
+    );
+
+    const entry = join(app, "entry.mjs");
+    writeFileSync(entry, [
+      'import { env, WorkerEntrypoint } from "cloudflare:workers";',
+      // An unhandled cloudflare:* module: must resolve to an empty stub, not
+      // crash the process.
+      'import sockets from "cloudflare:sockets";',
+      "export default {",
+      "  edition: env.EDITION,",
+      "  isClass: typeof WorkerEntrypoint === 'function',",
+      "  sockets: sockets && typeof sockets,",
+      "};",
+    ].join("\n"));
+
+    const runner = [
+      'import { registerHooks } from "node:module";',
+      `const loader = await import(${JSON.stringify(pathToFileURL(loader).href)});`,
+      "registerHooks({ resolve: loader.resolve, load: loader.load });",
+      `const result = await import(${JSON.stringify(pathToFileURL(entry).href)});`,
+      "process.stdout.write(JSON.stringify(result.default));",
+    ].join("\n");
+
+    const result = spawnSync(process.execPath, ["--input-type=module", "--eval", runner], {
+      encoding: "utf8",
+      timeout: 10_000,
+      env: { ...process.env, OJ_APP_ROOT: app, OJ_CACHE_ROOT: join(app, "cache"), OJ_SSR_LOADER_CACHE: "off" },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.error?.message);
+    const out = JSON.parse(result.stdout);
+    assert.equal(out.edition, "unit-edition");
+    assert.equal(out.isClass, true);
+    // The unknown cloudflare:* module resolved to an empty-object default.
+    assert.equal(out.sockets, "object");
+  } finally {
+    rmSync(app, { recursive: true, force: true });
+  }
+});

--- a/e2e/unit/cf-workers-scheme.test.mjs
+++ b/e2e/unit/cf-workers-scheme.test.mjs
@@ -69,6 +69,9 @@ test("SSR loader stubs cloudflare:workers (env from wrangler) and never crashes 
     assert.equal(out.isClass, true);
     // The unknown cloudflare:* module resolved to an empty-object default.
     assert.equal(out.sockets, "object");
+    // The net warns once (visibly) for the un-aliased scheme; the aliased
+    // cloudflare:workers is served for real and does not warn.
+    assert.match(result.stderr, /no SSR module for the 'cloudflare:' scheme/);
   } finally {
     rmSync(app, { recursive: true, force: true });
   }


### PR DESCRIPTION
Fixes the SSR-hydration failure on the Cloudflare worker dev path (the page renders but never hydrates — heading/input/spinner stuck) and adds a browser hydration test suite that would have caught it. The suite exposed a third, dominant bug (a dev-server crash) that the first two fixes alone would have left in place.

## Bugs fixed

1. **`experimental.bundledDev` unsupported.** When the app enables Vite's Rolldown bundled client dev, oj builds a plain `DevEnvironment` and never implements bundledDev, so the TanStack manifest emits `<script src="/assets/index.js">` that oj never builds/serves → the client entry hangs/404s → no client JS. Fix: coerce `experimental.bundledDev` (and the derived `environments.*.isBundled`) off in the config oj drives, with a one-time warning; the app falls back to the standard dev client entry oj serves. The coercion is gated to `command === "serve"` — a production `oj build` sets `isBundled=true` on every environment legitimately, so coercing there would be wrong and would print a dev-only warning.
2. **Client-entry 500 (`Missing field `moduleType``).** After #1, the standard entry dynamically imports the physical `@tanstack/react-start/.../default-entry/client.tsx`; oj 500'd it because rolldown-vite's `@vitejs/plugin-react` returns the rolldown native builtin `builtin:vite-react-refresh-wrapper`, and oj hosted it as a JS plugin, calling transform with `{ssr}` while the native binding requires `{moduleType}`. Fix: add `builtin:vite-react-refresh-wrapper` to oj's native-plugin skip list — oj already does React Fast Refresh natively (and Vite excludes node_modules from refresh). The skipped plugin's `applyToEnvironment` returns only that builtin and it has no other hooks, so nothing else is lost (verified against @vitejs/plugin-react 5.2/6.0 + rolldown 1.2.3).
3. **Dev-server crash on the `cloudflare:` scheme.** A server function that imports `cloudflare:workers` (e.g. to read `env`) crashes oj's Node SSR loader: Node's default ESM loader throws `ERR_UNSUPPORTED_ESM_URL_SCHEME` on the `cloudflare:` scheme and takes the whole `oj dev` process down. The build path externalizes `cloudflare:*` (workerd provides it), but the dev SSR loader had no equivalent. Reproduced at ~13% over 30 cold runs; it is the dominant flake on this path and matches the stuck-loading symptom. Fix: the loader aliases `cloudflare:workers` to a dev stub whose `env` is backed by the same wrangler vars `cf-server.mjs` reads, and a load-hook net serves any other unsupported scheme (`cloudflare:sockets`, …) as an empty module so an import can never crash the dev server. 0 crashes over 60 cold runs after the fix.

## Hydration test suite (the gate that was missing)

New `e2e/lib/hydration.mjs` mirroring Vite's `playground/environment-react-ssr`/`ssr-html` and TanStack Start's e2e: `assertHydrates` runs a ladder — doc 200 + SSR marker → **every client module serves 200** (now with the failing module's response body and a tail of oj's server log on failure, so a browser-observed 500 names its cause) → client runtime mounts → a client-only (`useEffect`) marker appears → an interaction works → zero pageerrors/console-errors/React hydration-mismatch strings. Wired into `bundleddev-coerce.mjs`, `start.mjs`, `start-cloudflare-dev.mjs`, and unified `ssr-dev.mjs`'s error gate. Each fix is revert-proven (→ `404 /assets/index.js`; `500 …/client.tsx [builtin:vite-react-refresh-wrapper] Missing field moduleType`; and the `cloudflare:` process crash). Also fixed a latent hydration-mismatch in the shared start fixture (`suppressHydrationWarning` on intentionally env-divergent nodes).

## Known limitation

oj does not implement bundledDev; it routes such apps onto its standard unbundled client path. Whether that path scales to a very large app is unproven and needs a real-app browser check before relying on it — the mechanism is correct regardless.

Full workspace + JS unit tests (incl. a new `cf-workers-scheme` loader test) and start/cloudflare-dev/bundleddev-coerce/ssr-dev/plugin-middleware e2e all green.
