### PR TITLE
deflake: proxy cleanup ENOTEMPTY + oj_cache OJ_CACHE_DIR race

### DIFF
--- a/crates/oj_cache/src/lib.rs
+++ b/crates/oj_cache/src/lib.rs
@@ -305,6 +305,7 @@ mod tests {
 
     #[test]
     fn cache_root_is_versioned() {
+        let _g = env_guard(); // reads the default; must not race an OJ_CACHE_DIR setter
         let root = cache_root(Path::new("/app"));
         assert_eq!(
             root,
@@ -316,6 +317,7 @@ mod tests {
 
     #[test]
     fn heal_removes_legacy_layout_and_keeps_the_rest() {
+        let _g = env_guard(); // uses cache_root(default); must not race an OJ_CACHE_DIR setter
         let app = std::env::temp_dir().join(format!("oj-heal-test-{}", std::process::id()));
         let _ = fs::remove_dir_all(&app);
         let cache = app.join(".oj-cache");
@@ -370,9 +372,18 @@ mod tests {
         });
     }
 
-    // The env is process-wide; this keeps the case above from leaking into any
-    // other test that reads it.
+    // `OJ_CACHE_DIR` is process-wide, and cargo runs these tests as threads in
+    // one process, so a test that sets it races a test that reads the default.
+    // Every test touching `OJ_CACHE_DIR` (setters via temp_env_var, readers via
+    // this guard) serializes on one lock; a setter restores the var before it
+    // releases the lock, so the next reader sees the ambient (unset) value.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    fn env_guard() -> std::sync::MutexGuard<'static, ()> {
+        ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     fn temp_env_var(key: &str, value: Option<&str>, f: impl FnOnce()) {
+        let _guard = env_guard();
         let previous = std::env::var_os(key);
         match value {
             Some(v) => unsafe { std::env::set_var(key, v) },

--- a/e2e/proxy-regex-context.mjs
+++ b/e2e/proxy-regex-context.mjs
@@ -58,6 +58,11 @@ try {
 } finally {
   if (srv) srv.kill("SIGKILL");
   backend.close();
-  fs.rmSync(app, { recursive: true, force: true });
+  // The SIGKILLed server's node children flush for a beat and race the removal
+  // (ENOTEMPTY); retry like proxy-target-forms.mjs / start-cloudflare-dev.mjs.
+  for (let i = 0; ; i++) {
+    try { fs.rmSync(app, { recursive: true, force: true }); break; }
+    catch { if (i >= 20) break; Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100); }
+  }
 }
 process.exit(failed ? 1 : 0);

--- a/e2e/proxy-ws-stream.mjs
+++ b/e2e/proxy-ws-stream.mjs
@@ -250,6 +250,11 @@ try {
   upstream.close();
   tlsUpstream.close();
   await sleep(300);
-  fs.rmSync(app, { recursive: true, force: true });
+  // The SIGKILLed server's node children flush for a beat and race the removal
+  // (ENOTEMPTY); retry like proxy-target-forms.mjs / start-cloudflare-dev.mjs.
+  for (let i = 0; ; i++) {
+    try { fs.rmSync(app, { recursive: true, force: true }); break; }
+    catch { if (i >= 20) break; Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100); }
+  }
 }
 process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Two pre-existing test flakes reddening main CI (surfaced by the 0.1.21 bump run):

- **oj_cache `cache_root_is_versioned`**: `cache_root` reads the process-global `OJ_CACHE_DIR`, and `cache_root_is_relocatable_and_stays_versioned` sets it to `/out/oj` via `temp_env_var`. cargo runs tests as threads in one process, so the setter races the default-readers (`cache_root_is_versioned`, the `heal` test) → `left: /out/oj/v1`. Fix: one `ENV_LOCK` mutex every `OJ_CACHE_DIR` test holds (setters via `temp_env_var`, readers via `env_guard()`); a setter restores the var before releasing the lock. 10/10 clean under stress.
- **proxy-regex-context / proxy-ws-stream cleanup**: plain `rmSync` of the tmp dir races the SIGKILLed server's node children flushing caches (`ENOTEMPTY`). Added the same retry loop `proxy-target-forms.mjs` / `start-cloudflare-dev.mjs` already use.

Test-only; no crate code changes.