### PR TITLE
Populate environments[name].resolve in the SSR plugin bridge

### DIFF
--- a/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
+++ b/crates/oj_server/src/assets/start/vite-plugin-bridge.mjs
@@ -272,6 +272,34 @@ export function createPluginContainer(vite, allPlugins, {
     plugins: allPlugins,
     isProduction: mode === "production",
   };
+  // Vite's resolveConfig runs resolveEnvironmentResolveOptions for EVERY
+  // environment, so each `environments[name].resolve` is a complete object
+  // (Vite's configDefaults.resolve: external:[], noExternal:[], dedupe:[],
+  // alias:[], extensions, plus consumer-based conditions/mainFields). Plugins
+  // read it in configResolved -- e.g. @cloudflare/vite-plugin's
+  // validateWorkerEnvironmentOptions inspects
+  // `environments[worker].resolve.external` and throws when `resolve` is
+  // undefined. Mirror Vite: layer the top-level resolve over the structural
+  // defaults for every environment (the env's own resolve wins). The actual SSR
+  // resolution conditions are applied by oj's resolver, not read from here, so
+  // the array defaults are the structural shape plugins inspect.
+  for (const name of Object.keys(resolvedConfig.environments)) {
+    const envc = resolvedConfig.environments[name] ?? {};
+    envc.resolve = {
+      conditions: [],
+      mainFields: [],
+      extensions: [],
+      dedupe: [],
+      noExternal: [],
+      external: [],
+      externalConditions: [],
+      alias: [],
+      preserveSymlinks: false,
+      ...(resolvedConfig.resolve ?? {}),
+      ...(envc.resolve ?? {}),
+    };
+    resolvedConfig.environments[name] = envc;
+  }
   // Vite resolves `build.outDir` ("dist") and an absolute `publicDir` ("" when
   // disabled); build plugins compute output paths from both.
   resolvedConfig.build = { outDir: "dist", ...resolvedConfig.build };

--- a/e2e/lib/hydration.mjs
+++ b/e2e/lib/hydration.mjs
@@ -69,7 +69,13 @@ export function collectBrowserErrors(page) {
     requestFailures.push({ url: r.url(), error: r.failure()?.errorText ?? "unknown" }),
   );
   page.on("response", (r) => {
-    if (r.status() >= 400 && isModuleUrl(r.url())) badResponses.push({ status: r.status(), url: r.url() });
+    if (r.status() >= 400 && isModuleUrl(r.url())) {
+      // Capture the body the BROWSER actually got (a re-fetch can return a
+      // different result on a flaky module); async, resolves before the assert.
+      const entry = { status: r.status(), url: r.url(), body: "" };
+      badResponses.push(entry);
+      r.text().then((t) => { entry.body = t.replace(/\s+/g, " ").trim().slice(0, 600); }).catch(() => {});
+    }
   });
 
   return { consoleMessages, pageErrors, requestFailures, badResponses };
@@ -192,15 +198,17 @@ export async function assertHydrates(browser, url, opts = {}) {
       // compile/resolve cause instead of a bare status line.
       const lines = [];
       for (const r of badModules) {
-        // The browser saw r.status; re-fetch for the server's error body. A
-        // flaky module can answer the re-fetch differently, so label the body
-        // with its own status rather than implying it shares r.status.
-        let detail = "";
-        try {
-          const again = await page.request.get(r.url);
-          const body = (await again.text()).replace(/\s+/g, " ").trim().slice(0, 400);
-          if (body) detail = `\n    :: (re-fetch ${again.status()}) ${body}`;
-        } catch {}
+        // Prefer the body the browser actually received (captured inline); a
+        // re-fetch can answer differently on a flaky module, so it's a labelled
+        // fallback only.
+        let detail = r.body ? `\n    :: ${r.body}` : "";
+        if (!r.body) {
+          try {
+            const again = await page.request.get(r.url);
+            const body = (await again.text()).replace(/\s+/g, " ").trim().slice(0, 400);
+            if (body) detail = `\n    :: (re-fetch ${again.status()}) ${body}`;
+          } catch {}
+        }
         lines.push(`  ${r.status} ${r.url}${detail}`);
       }
       failures.push("client module graph served >= 400:\n" + lines.join("\n"));

--- a/e2e/unit/plugin-bridge-env-resolve.test.mjs
+++ b/e2e/unit/plugin-bridge-env-resolve.test.mjs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+//
+// Vite's resolveConfig runs resolveEnvironmentResolveOptions for every
+// environment, so `environments[name].resolve` is always a complete object
+// (external:[], noExternal:[], dedupe:[], ...). Plugins read it in
+// configResolved -- @cloudflare/vite-plugin's validateWorkerEnvironmentOptions
+// inspects `environments[worker].resolve.external` and crashes when resolve is
+// undefined. The SSR plugin bridge must give every environment a resolve.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { repo } from "./harness.mjs";
+
+const bridge = await import(
+  pathToFileURL(join(repo, "crates/oj_server/src/assets/start/vite-plugin-bridge.mjs")).href
+);
+
+test("configResolved sees a complete environments[env].resolve (cloudflare plugin's .external read does not crash)", async () => {
+  let seen = null;
+  const plugins = [
+    {
+      // Mirror @cloudflare/vite-plugin's configResolved: read the worker
+      // environment's resolve.external. A bare `{}` environment (no resolve)
+      // makes this throw "Cannot read properties of undefined (reading 'external')".
+      name: "vite-plugin-cloudflare:config",
+      configResolved(config) {
+        const r = config.environments.ssr.resolve;
+        seen = { external: r.external, noExternal: r.noExternal, isArray: Array.isArray(r.external) };
+      },
+      transform() {
+        return null;
+      },
+    },
+  ];
+  const container = bridge.createPluginContainer({}, plugins, {
+    command: "serve",
+    environment: "ssr",
+    // The environments arrive as bare objects (as an extracted config or the
+    // bridge's own default does); the bridge must still populate their resolve.
+    config: { root: repo, environments: { client: {}, ssr: {} } },
+  });
+  // resolveId triggers the lazy configResolved dispatch.
+  await container.resolveId("virtual:probe", undefined);
+
+  assert.ok(seen, "configResolved ran without throwing on an undefined resolve");
+  assert.deepEqual(seen.external, [], "environments.ssr.resolve.external defaults to []");
+  assert.deepEqual(seen.noExternal, [], "environments.ssr.resolve.noExternal defaults to []");
+  assert.equal(seen.isArray, true);
+});


### PR DESCRIPTION
The SSR plugin bridge (vite-plugin-bridge.mjs) built its resolvedConfig with `environments: { client: {}, ssr: {} }` — bare objects with no `resolve`. Vite's resolveConfig runs `resolveEnvironmentResolveOptions` for every environment, so `environments[name].resolve` is always a complete object (`external: []`, `noExternal: []`, `dedupe: []`, ...). Plugins read it in configResolved: @cloudflare/vite-plugin's `validateWorkerEnvironmentOptions` inspects `environments[worker].resolve.external` and threw `Cannot read properties of undefined (reading 'external')` on every CF dev boot (caught + skipped, but the plugin half-ran its configResolved).

Fix: mirror Vite — layer the top-level resolve over the structural resolve defaults for every environment (the env's own resolve wins). Verified: the deterministic `configResolved failed (reading 'external')` warning is gone; unit test `plugin-bridge-env-resolve` reproduces the crash without the fix and passes with it.

Also: the browser hydration gate now captures the failing module's response body inline (the body the browser actually received) rather than only re-fetching, so a browser-observed 500 names its cause even when a re-fetch would succeed.

Note: this fixes a deterministic SSR-path configResolved failure; it is distinct from the residual ~1.6% client-side createCsrfMiddleware 500 (a client-transform issue in plugin-host, not this SSR bridge), which did not recur in 40 post-fix cold runs but remains statistically unconfirmed.