### PR TITLE
Fix intermittent CF-dev hydration 500: implement environment.transformRequest for on-demand plugin loads

### DIFF
--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -439,27 +439,51 @@ environment.config.consumer =
 environment.transformRequest = async (rawId) => {
   const id = String(rawId ?? "");
   if (!id) return null;
-  const noQuery = id.split("?")[0];
-  // Vite's transformRequest loads the module (its plugin `load` chain, then the
-  // file) before running the transform pipeline. Mirror that so a dependency
-  // served by a plugin `load` hook (a virtual id, a `\0`-prefixed module) is
-  // handled too, not only an on-disk file -- a server-fn dependency in a real
-  // app can be plugin-served, and returning null there would re-throw the same
-  // `could not load module info`.
+  const qIdx = id.indexOf("?");
+  const bareId = qIdx === -1 ? id : id.slice(0, qIdx);
+  const query = qIdx === -1 ? "" : id.slice(qIdx);
+  // Vite's transformRequest is resolve -> load -> transform (doTransform). Mirror
+  // it: (1) the plugin `load` chain serves virtual/plugin-served ids (a `\0`
+  // module) and (2) the file backs an absolute path, a `/@fs/` url, or a
+  // root-relative url (Vite's asSrc). (3) A bare/relative specifier or a url that
+  // neither serves nor exists is RESOLVED like Vite and re-entered. An id that
+  // already loads or is an on-disk file is used as-is, so an already-resolved id
+  // -- what TanStack passes, and the key its getModuleInfo looks up -- is never
+  // rewritten.
   let source = null;
-  const loaded = await loadFull(id);
+  const loaded = await loadFull(bareId);
   if (loaded && loaded.code != null) {
     source = loaded.code;
   } else {
-    const filePath = noQuery.startsWith("/@fs/") ? noQuery.slice(4) : noQuery;
-    if (!isAbsolute(filePath) || !existsSync(filePath)) return null;
-    try {
-      source = readFileSync(filePath, "utf8");
-    } catch {
+    const root = resolvedConfig?.root ?? environment.config?.root ?? process.cwd();
+    // `/foo` is both a valid absolute fs path and a Vite root-relative url, so
+    // probe a real absolute file (TanStack passes bare `p.display()` paths)
+    // BEFORE treating a leading `/` as root-relative (Vite's asSrc).
+    let filePath = null;
+    if (bareId.startsWith("/@fs/")) {
+      const p = bareId.slice(4);
+      if (existsSync(p)) filePath = p;
+    } else if (isAbsolute(bareId) && existsSync(bareId)) {
+      filePath = bareId;
+    } else if (bareId.startsWith("/")) {
+      const p = pathResolve(root, "." + bareId);
+      if (existsSync(p)) filePath = p;
+    }
+    if (filePath) {
+      try {
+        source = readFileSync(filePath, "utf8");
+      } catch {
+        return null;
+      }
+    } else {
+      // Not loadable and not on disk: resolve it like Vite, then re-enter with
+      // the resolved id (`ctx.resolve` runs the plugin chain then oj's resolver).
+      const r = await ctx.resolve(bareId, undefined);
+      if (r && r.id && r.id !== bareId) return environment.transformRequest(r.id + query);
       return null;
     }
   }
-  const out = JSON.parse(await transform(source, id, null));
+  const out = JSON.parse(await transform(source, bareId + query, null));
   return { code: out.code };
 };
 // The resolved config (defaults + plugin `config` hooks). configureServer must

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -440,13 +440,24 @@ environment.transformRequest = async (rawId) => {
   const id = String(rawId ?? "");
   if (!id) return null;
   const noQuery = id.split("?")[0];
-  const filePath = noQuery.startsWith("/@fs/") ? noQuery.slice(4) : noQuery;
-  if (!isAbsolute(filePath) || !existsSync(filePath)) return null;
-  let source;
-  try {
-    source = readFileSync(filePath, "utf8");
-  } catch {
-    return null;
+  // Vite's transformRequest loads the module (its plugin `load` chain, then the
+  // file) before running the transform pipeline. Mirror that so a dependency
+  // served by a plugin `load` hook (a virtual id, a `\0`-prefixed module) is
+  // handled too, not only an on-disk file -- a server-fn dependency in a real
+  // app can be plugin-served, and returning null there would re-throw the same
+  // `could not load module info`.
+  let source = null;
+  const loaded = await loadFull(id);
+  if (loaded && loaded.code != null) {
+    source = loaded.code;
+  } else {
+    const filePath = noQuery.startsWith("/@fs/") ? noQuery.slice(4) : noQuery;
+    if (!isAbsolute(filePath) || !existsSync(filePath)) return null;
+    try {
+      source = readFileSync(filePath, "utf8");
+    } catch {
+      return null;
+    }
   }
   const out = JSON.parse(await transform(source, id, null));
   return { code: out.code };

--- a/crates/oj_server/src/assets/plugin-host.mjs
+++ b/crates/oj_server/src/assets/plugin-host.mjs
@@ -422,6 +422,35 @@ const environment = {
 // directly in applyToEnvironment, so it must be present or they throw.
 environment.config.consumer =
   environment.config.consumer ?? (envName === "client" ? "client" : "server");
+// Vite's DevEnvironment carries `transformRequest`, which runs the module
+// pipeline for one id. oj otherwise stubs it, but a plugin's transform can
+// depend on it: TanStack Start's server-fn compiler, in dev, calls
+// `this.environment.transformRequest(<id>?tss-server-fn-lookup)` so its
+// `capture-server-fn-module-lookup` transform hook ingests a dependency (e.g.
+// createMiddleware.js) into the compiler's module cache BEFORE it reads that
+// dependency via getModuleInfo. Stubbed to a no-op, the ingest never happens,
+// so correctness falls to module ordering -- and a cold concurrent first load
+// that compiles createCsrfMiddleware.js before its createMiddleware.js
+// dependency throws `could not load module info`, which oj serves as a hard 500
+// that permanently breaks hydration (~1% of cold loads). Running the transform
+// fires the capture hook and populates the cache on demand, as Vite does. Only
+// the capture hook matches the `?tss-server-fn-lookup` id (the compiler's own
+// transform excludes it), so there is no recompile or recursion here.
+environment.transformRequest = async (rawId) => {
+  const id = String(rawId ?? "");
+  if (!id) return null;
+  const noQuery = id.split("?")[0];
+  const filePath = noQuery.startsWith("/@fs/") ? noQuery.slice(4) : noQuery;
+  if (!isAbsolute(filePath) || !existsSync(filePath)) return null;
+  let source;
+  try {
+    source = readFileSync(filePath, "utf8");
+  } catch {
+    return null;
+  }
+  const out = JSON.parse(await transform(source, id, null));
+  return { code: out.code };
+};
 // The resolved config (defaults + plugin `config` hooks). configureServer must
 // receive this, not the raw initial.config, so plugins reading resolved-only
 // fields (experimental, environments, plugins) don't throw. Seeded with the

--- a/e2e/server-fs-allow.mjs
+++ b/e2e/server-fs-allow.mjs
@@ -18,10 +18,23 @@ const app = path.join(workspace, "app");
 const shared = path.join(workspace, "shared");
 const sharedFile = path.join(shared, "util.js");
 
+// A SIGKILLed server's node children flush for a beat and race the removal
+// (ENOTEMPTY); retry like start-cloudflare-dev.mjs / the proxy tests do.
+const rmDirRetry = (dir) => {
+  for (let i = 0; ; i++) {
+    try {
+      return fs.rmSync(dir, { recursive: true, force: true });
+    } catch (e) {
+      if (i >= 20) return;
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
+    }
+  }
+};
+
 let failed = false;
 let child;
 const startApp = async (port, viteConfig) => {
-  fs.rmSync(app, { recursive: true, force: true });
+  rmDirRetry(app);
   fs.mkdirSync(path.join(app, "src"), { recursive: true });
   fs.writeFileSync(path.join(app, "package.json"), '{"name":"fsallow","private":true}');
   fs.writeFileSync(
@@ -100,6 +113,6 @@ try {
   console.error("FAIL:", e.message);
 } finally {
   if (child) child.kill("SIGKILL");
-  fs.rmSync(workspace, { recursive: true, force: true });
+  rmDirRetry(workspace);
 }
 process.exit(failed ? 1 : 0);

--- a/e2e/unit/plugin-host-transform-request.test.mjs
+++ b/e2e/unit/plugin-host-transform-request.test.mjs
@@ -76,3 +76,60 @@ test("this.environment.transformRequest runs the pipeline so an on-demand depend
     fx.cleanup();
   }
 });
+
+test("transformRequest loads a plugin-served (virtual) dependency via the load chain, not only on-disk files", async () => {
+  const fx = tmpProject({ prefix: "oj-tr-virt-" });
+  const csrf = path.join(fx.root, "csrf.js");
+  fx.write("csrf.js", "export const x = 1;\n");
+  // The dependency is a virtual id that only a plugin `load` hook can serve (it
+  // is not on disk). transformRequest must run the load chain, or the capture
+  // ingest never happens and getModuleInfo throws -- the disk-only impl fails here.
+  fx.write(
+    "oj.plugins.mjs",
+    [
+      `const CSRF = ${JSON.stringify(csrf)};`,
+      'const VIRTUAL = "\\0virtual:middleware";',
+      "const cache = new Set();",
+      "export default [",
+      "  { name: 'virtual-dep', load(id) {",
+      "      if (id.split('?')[0] === VIRTUAL) return 'export const createMiddleware = () => ({});';",
+      "      return null;",
+      "  } },",
+      "  { name: 'capture', transform(code, id) {",
+      "      if (id.endsWith('?lookup')) { cache.add(id.slice(0, -'?lookup'.length)); return null; }",
+      "      return null;",
+      "  } },",
+      "  { name: 'compiler', async transform(code, id) {",
+      "      if (id !== CSRF) return null;",
+      "      if (!cache.has(VIRTUAL)) {",
+      "        await this.environment.transformRequest(VIRTUAL + '?lookup');",
+      "        if (!cache.has(VIRTUAL)) throw new Error('could not load module info for ' + VIRTUAL);",
+      "      }",
+      "      return { code: 'export const x = () => {};' };",
+      "  } },",
+      "];",
+      "",
+    ].join("\n"),
+  );
+  const host = rpcSidecar("plugin-host.mjs", {
+    args: [
+      path.join(fx.root, "oj.plugins.mjs"),
+      JSON.stringify({
+        config: { root: fx.root },
+        env: { command: "serve", mode: "development" },
+        environment: { name: "client", mode: "dev" },
+      }),
+    ],
+    env: { OJ_CACHE_ROOT: fx.root },
+    cwd: fx.root,
+  });
+  try {
+    const res = await host.send({ id: 1, hook: "transform", args: ["import '/x';\n", csrf, "null"] });
+    assert.equal(res.error, undefined, `transform must not error: ${res.error}`);
+    const out = JSON.parse(res.result);
+    assert.equal(out.code, "export const x = () => {};", "virtual dependency ingested via the load chain");
+  } finally {
+    host.close();
+    fx.cleanup();
+  }
+});

--- a/e2e/unit/plugin-host-transform-request.test.mjs
+++ b/e2e/unit/plugin-host-transform-request.test.mjs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+//
+// A plugin's transform can depend on `this.environment.transformRequest(id)` to
+// load a dependency on demand. TanStack Start's server-fn compiler does exactly
+// this in dev: to classify a module it calls
+// `this.environment.transformRequest(<dep>?tss-server-fn-lookup)` so a sibling
+// "capture" transform hook ingests <dep> into the compiler's module cache
+// before it reads it via getModuleInfo. If oj stubs transformRequest to a no-op
+// the ingest never happens, and correctness falls to module ordering -- a cold
+// concurrent first load that transforms the dependent before the dependency
+// throws "could not load module info" -> a hard 500 that breaks hydration.
+//
+// This mirrors that pattern with minimal plugins: transforming `csrf.js` on a
+// cold shared cache must drive `transformRequest("<middleware>?lookup")`, which
+// must run the capture hook and populate the cache, so the compiler succeeds.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { rpcSidecar, tmpProject } from "./harness.mjs";
+
+test("this.environment.transformRequest runs the pipeline so an on-demand dependency ingest works (no ordering race)", async () => {
+  const fx = tmpProject({ prefix: "oj-tr-" });
+  const mid = path.join(fx.root, "middleware.js");
+  const csrf = path.join(fx.root, "csrf.js");
+  fx.write("middleware.js", "export const createMiddleware = () => ({});\n");
+  fx.write("csrf.js", 'import { createMiddleware } from "./middleware.js";\nexport const x = createMiddleware();\n');
+  // Two plugins sharing a module-scope cache, like TanStack's compiler + capture
+  // hook. The compiler hook needs the dependency in `cache` and, on a miss,
+  // drives it in via transformRequest("<dep>?lookup"); the capture hook is the
+  // only thing that populates `cache`, and only for the `?lookup` request.
+  fx.write(
+    "oj.plugins.mjs",
+    [
+      `const MID = ${JSON.stringify(mid)};`,
+      `const CSRF = ${JSON.stringify(csrf)};`,
+      "const cache = new Set();",
+      "export default [",
+      "  { name: 'capture', transform(code, id) {",
+      "      if (id.endsWith('?lookup')) { cache.add(id.slice(0, -'?lookup'.length)); return null; }",
+      "      return null;",
+      "  } },",
+      "  { name: 'compiler', async transform(code, id) {",
+      "      if (id !== CSRF) return null;",
+      "      if (!cache.has(MID)) {",
+      "        await this.environment.transformRequest(MID + '?lookup');",
+      "        if (!cache.has(MID)) throw new Error('could not load module info for ' + MID);",
+      "      }",
+      "      return { code: 'export const x = () => {};' };",
+      "  } },",
+      "];",
+      "",
+    ].join("\n"),
+  );
+
+  const host = rpcSidecar("plugin-host.mjs", {
+    args: [
+      path.join(fx.root, "oj.plugins.mjs"),
+      JSON.stringify({
+        config: { root: fx.root },
+        env: { command: "serve", mode: "development" },
+        environment: { name: "client", mode: "dev" },
+      }),
+    ],
+    env: { OJ_CACHE_ROOT: fx.root },
+    cwd: fx.root,
+  });
+  try {
+    // Transform csrf.js FIRST, on a cold shared cache -> forces the miss the
+    // ordering race exposes. With a working transformRequest this succeeds.
+    const res = await host.send({ id: 1, hook: "transform", args: ["import '/x';\n", csrf, "null"] });
+    assert.equal(res.error, undefined, `transform must not error: ${res.error}`);
+    const out = JSON.parse(res.result);
+    assert.equal(out.code, "export const x = () => {};", "compiler ran after the dependency was ingested on demand");
+  } finally {
+    host.close();
+    fx.cleanup();
+  }
+});

--- a/e2e/unit/plugin-host-transform-request.test.mjs
+++ b/e2e/unit/plugin-host-transform-request.test.mjs
@@ -133,3 +133,58 @@ test("transformRequest loads a plugin-served (virtual) dependency via the load c
     fx.cleanup();
   }
 });
+
+test("transformRequest maps a root-relative url dependency to a file (Vite asSrc), not only absolute paths", async () => {
+  const fx = tmpProject({ prefix: "oj-tr-url-" });
+  const csrf = path.join(fx.root, "csrf.js");
+  fx.write("csrf.js", "export const x = 1;\n");
+  fx.write("middleware.js", "export const createMiddleware = () => ({});\n");
+  // The dependency is passed as a ROOT-RELATIVE URL ('/middleware.js'), the form
+  // a Vite plugin would hand transformRequest -- not an absolute path. The
+  // disk-only impl (isAbsolute check) returns null for it; the fix maps it to
+  // <root>/middleware.js so the capture ingest still runs.
+  fx.write(
+    "oj.plugins.mjs",
+    [
+      `const CSRF = ${JSON.stringify(csrf)};`,
+      'const URLID = "/middleware.js";',
+      "const cache = new Set();",
+      "export default [",
+      "  { name: 'capture', transform(code, id) {",
+      "      if (id.endsWith('?lookup')) { cache.add(id.slice(0, -'?lookup'.length)); return null; }",
+      "      return null;",
+      "  } },",
+      "  { name: 'compiler', async transform(code, id) {",
+      "      if (id !== CSRF) return null;",
+      "      if (!cache.has(URLID)) {",
+      "        await this.environment.transformRequest(URLID + '?lookup');",
+      "        if (!cache.has(URLID)) throw new Error('could not load module info for ' + URLID);",
+      "      }",
+      "      return { code: 'export const x = () => {};' };",
+      "  } },",
+      "];",
+      "",
+    ].join("\n"),
+  );
+  const host = rpcSidecar("plugin-host.mjs", {
+    args: [
+      path.join(fx.root, "oj.plugins.mjs"),
+      JSON.stringify({
+        config: { root: fx.root },
+        env: { command: "serve", mode: "development" },
+        environment: { name: "client", mode: "dev" },
+      }),
+    ],
+    env: { OJ_CACHE_ROOT: fx.root },
+    cwd: fx.root,
+  });
+  try {
+    const res = await host.send({ id: 1, hook: "transform", args: ["import '/x';\n", csrf, "null"] });
+    assert.equal(res.error, undefined, `transform must not error: ${res.error}`);
+    const out = JSON.parse(res.result);
+    assert.equal(out.code, "export const x = () => {};", "root-relative url dependency mapped to <root>/middleware.js");
+  } finally {
+    host.close();
+    fx.cleanup();
+  }
+});


### PR DESCRIPTION
## Root cause of the intermittent Cloudflare-dev hydration 500 (FLAKE 1)

An intermittent (~1% of cold loads) hard 500 on the browser's first fetch of `@tanstack/start-client-core/dist/esm/createCsrfMiddleware.js` broke hydration (page renders, never mounts). The 500 succeeds on retry, so it's a transient race — but browsers never retry a failed dynamic import, so it's a permanent hydration break.

Traced through Vite + TanStack Start + oj source:

- TanStack Start's server-fn compiler (`start-plugin-core`), to classify a module, resolves its imports and calls `getModuleInfo(dep)` (`start-compiler/compiler.js:954-960`). On a cache miss it calls `loadModule(dep)`, which in dev does `await this.environment.transformRequest(dep + "?tss-server-fn-lookup")` (`plugin.js:18-25,152`). A sibling `enforce`/capture transform hook filtered on `?tss-server-fn-lookup` then `ingestModule`s `dep` into the compiler's per-environment `moduleCache` (`plugin.js:233-248`). If that ingest doesn't happen, `getModuleInfo` throws `could not load module info for <dep>` (line 959).
- `createCsrfMiddleware.js` contains both `createIsomorphicFn` and `createMiddleware`, so it takes the full-traversal path and reads `getModuleInfo("./createMiddleware.js")`. The compiler self-ingests a module when it compiles it (`compiler.js:509`), so this normally hits the cache **because `createMiddleware.js` happened to be compiled first** — pure ordering luck during the concurrent cold crawl.
- **oj stubbed `environment.transformRequest` to a no-op** (and `this.environment` — the plugin ctx environment — didn't carry one at all). So the on-demand ingest never worked; correctness fell entirely to module ordering, and ~1% of cold concurrent loads compile `createCsrfMiddleware.js` before `createMiddleware.js` → miss → throw → oj serves a hard 500 with no recovery.

Vite's `DevEnvironment.transformRequest` actually transforms the dependency on demand, so Vite never has this race.

## Fix

Implement `environment.transformRequest(id)` on the plugin-host ctx environment (mirroring Vite's `DevEnvironment.transformRequest`): read the module for `id` and run oj's transform pipeline over it, so a plugin's on-demand `transformRequest("<dep>?tss-server-fn-lookup")` fires the capture hook and populates the compiler cache deterministically — eliminating the ordering race. The compiler's own transform excludes `?tss-server-fn-lookup`, so there's no recompile/recursion.

## Verification

New unit test `plugin-host-transform-request` reproduces the exact mechanism with minimal plugins (a capture hook + a compiler hook needing an on-demand ingest). Transforming the dependent on a cold shared cache **fails without the fix with the identical error `could not load module info for <dep>`** (the TanStack `compiler.js:959` throw) and passes with it. Full workspace + 285 JS unit tests + ssr-dev/start-cloudflare-dev e2e all green.
