### PR TITLE
bump version to 0.1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to oj are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.22] - 2026-09-07
+
+### Fixed
+- The intermittent Cloudflare-dev hydration failure (a ~1% cold-load 500 on a server-function client module such as `@tanstack/start-client-core/.../createCsrfMiddleware.js`, which broke the client dynamic-import chain so the page rendered but never hydrated) is fixed. oj's plugin-host `environment.transformRequest` was a no-op stub, but TanStack Start's server-fn compiler depends on it in dev: to classify a module it calls `this.environment.transformRequest(<dep>?tss-server-fn-lookup)` so a capture transform hook ingests the dependency into the compiler's module cache before it reads it via `getModuleInfo`. Stubbed, the ingest never happened and correctness fell to module ordering — a cold concurrent load that compiled the dependent before its dependency threw `could not load module info`, which oj served as a hard 500 (browsers never retry a failed dynamic import). `environment.transformRequest` now mirrors Vite's `DevEnvironment.transformRequest` (resolve → load → transform): it runs the plugin `load` chain and the file (an absolute path, a `/@fs/` url, or a root-relative url), resolves a bare/unresolved id like Vite, and runs the transform pipeline so the capture hook fires and the cache is populated on demand — eliminating the ordering race.
+- The `vite-plugin-cloudflare:config` plugin no longer fails its `configResolved` hook on every Cloudflare-dev boot (a benign but noisy `Cannot read properties of undefined (reading 'external')`). The SSR plugin bridge built its resolved config with bare `environments: { client: {}, ssr: {} }`; Vite's `resolveConfig` runs `resolveEnvironmentResolveOptions` for every environment, so each `environments[name].resolve` is a complete object (`external: []`, `noExternal: []`, `dedupe: []`, …) that plugins read in `configResolved`. The bridge now populates each environment's `resolve` the same way.
+
 ## [0.1.21] - 2026-09-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,7 +1818,7 @@ dependencies = [
 
 [[package]]
 name = "oj"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "oj_cache"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "blake3",
  "proptest",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "oj_compiler"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "glob",
  "memchr",
@@ -1881,7 +1881,7 @@ dependencies = [
 
 [[package]]
 name = "oj_config"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "oxc_allocator",
  "oxc_codegen",
@@ -1900,7 +1900,7 @@ dependencies = [
 
 [[package]]
 name = "oj_css"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "grass",
  "lightningcss",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "oj_env"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "proptest",
  "serde_json",
@@ -1922,14 +1922,14 @@ dependencies = [
 
 [[package]]
 name = "oj_graph"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "oj_resolver"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "oxc_resolver",
  "tempfile",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "oj_server"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,19 +13,19 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.21"
+version = "0.1.22"
 edition = "2021"
 license = "MIT"
 
 [workspace.dependencies]
-oj_compiler = { version = "0.1.21", path = "crates/oj_compiler" }
-oj_resolver = { version = "0.1.21", path = "crates/oj_resolver" }
-oj_graph = { version = "0.1.21", path = "crates/oj_graph" }
-oj_cache = { version = "0.1.21", path = "crates/oj_cache" }
-oj_css = { version = "0.1.21", path = "crates/oj_css" }
-oj_env = { version = "0.1.21", path = "crates/oj_env" }
-oj_config = { version = "0.1.21", path = "crates/oj_config" }
-oj_server = { version = "0.1.21", path = "crates/oj_server" }
+oj_compiler = { version = "0.1.22", path = "crates/oj_compiler" }
+oj_resolver = { version = "0.1.22", path = "crates/oj_resolver" }
+oj_graph = { version = "0.1.22", path = "crates/oj_graph" }
+oj_cache = { version = "0.1.22", path = "crates/oj_cache" }
+oj_css = { version = "0.1.22", path = "crates/oj_css" }
+oj_env = { version = "0.1.22", path = "crates/oj_env" }
+oj_config = { version = "0.1.22", path = "crates/oj_config" }
+oj_server = { version = "0.1.22", path = "crates/oj_server" }
 
 oxc_allocator = "0.146.0"
 oxc_parser = "0.146.0"


### PR DESCRIPTION
Release 0.1.22: fixes the intermittent Cloudflare-dev hydration 500 (environment.transformRequest on-demand plugin loads, #167) and the SSR bridge configResolved environments.resolve gap (#166). See CHANGELOG.