### PR TITLE
SSR bridge: guard the request write so a dead container degrades instead of crashing (EPIPE)

### DIFF
--- a/crates/oj_server/src/assets/start/container-bridge.mjs
+++ b/crates/oj_server/src/assets/start/container-bridge.mjs
@@ -79,7 +79,20 @@ export function loadPluginContainerSync(app, _opts) {
     frame.writeUInt32LE(json.length, 0);
     json.copy(frame, 4);
     let off = 0;
-    while (off < frame.length) off += writeSync(reqFd, frame, off, frame.length - off);
+    while (off < frame.length) {
+      try {
+        off += writeSync(reqFd, frame, off, frame.length - off);
+      } catch (e) {
+        if (e.code === "EAGAIN" || e.code === "EINTR") { sleep(1); continue; }
+        // The SSR container's read end is gone (the plugin host exited or
+        // restarted): an unguarded writeSync throws EPIPE and crashes the whole
+        // loader/SSR process. Degrade to "down" and return null so the caller
+        // falls back to oj's own resolve/load, exactly as readExact handles the
+        // reply pipe closing.
+        state = "down";
+        return null;
+      }
+    }
     for (;;) {
       const head = readExact(4);
       const m = JSON.parse(readExact(head.readUInt32LE(0)).toString("utf8"));


### PR DESCRIPTION
A canary hit an uncaught `EPIPE` (broken pipe) that crashed the whole SSR loader/process:

```
...broken pipe, write
  at writeSync (node:fs)
  at call (.../start/container-bridge.mjs:82)
  at Object.load (.../start/container-bridge.mjs:95)
  at Object.load (.../start/loader.mjs:236)
```

The Start SSR plugin bridge talks to the plugin-host container over named-pipe (FIFO) request/reply fds. The reply side (`readExact`) already handles the container going away (sets `state = "down"`), and `call()` returns null gracefully once down — but the **request write** (`while (off < frame.length) off += writeSync(reqFd, ...)`) was unguarded. When the container's read end is gone (the plugin host exited/restarted mid-session), the next `writeSync` throws `EPIPE` uncaught and takes down the loader, instead of degrading.

Fix: guard the write exactly like `readExact` — retry on `EAGAIN`/`EINTR`, otherwise set `state = "down"` and return null so the caller falls back to oj's own resolve/load. A transient container death no longer crashes SSR.

Note: this is the robustness fix for the symptom. The root cause (why the container died in that sandbox — OOM / crash / restart) is separate and needs the container's own logs.