### PR TITLE
bump version to 0.1.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to oj are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.23] - 2026-09-07
+
+### Fixed
+- A dead SSR-container process no longer crashes the whole loader/dev process. The Start SSR plugin bridge talks to the plugin-host container over named-pipe request/reply fds; the reply side already degrades to "down" when the container goes away, but the request write (`writeSync(reqFd, ...)`) was unguarded, so when the container exited or was restarted mid-session the next write threw an uncaught `EPIPE` (broken pipe) that took down the loader (surfacing as a 500 with a dead page). The write is now guarded like the reply side — retry on `EAGAIN`/`EINTR`, otherwise mark the bridge "down" and return null so the caller falls back to oj's own resolve/load — so a transient container death degrades instead of crashing SSR.
+
 ## [0.1.22] - 2026-09-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,7 +1818,7 @@ dependencies = [
 
 [[package]]
 name = "oj"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "oj_cache"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "blake3",
  "proptest",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "oj_compiler"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "glob",
  "memchr",
@@ -1881,7 +1881,7 @@ dependencies = [
 
 [[package]]
 name = "oj_config"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "oxc_allocator",
  "oxc_codegen",
@@ -1900,7 +1900,7 @@ dependencies = [
 
 [[package]]
 name = "oj_css"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "grass",
  "lightningcss",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "oj_env"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "proptest",
  "serde_json",
@@ -1922,14 +1922,14 @@ dependencies = [
 
 [[package]]
 name = "oj_graph"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "oj_resolver"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "oxc_resolver",
  "tempfile",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "oj_server"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,19 +13,19 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.22"
+version = "0.1.23"
 edition = "2021"
 license = "MIT"
 
 [workspace.dependencies]
-oj_compiler = { version = "0.1.22", path = "crates/oj_compiler" }
-oj_resolver = { version = "0.1.22", path = "crates/oj_resolver" }
-oj_graph = { version = "0.1.22", path = "crates/oj_graph" }
-oj_cache = { version = "0.1.22", path = "crates/oj_cache" }
-oj_css = { version = "0.1.22", path = "crates/oj_css" }
-oj_env = { version = "0.1.22", path = "crates/oj_env" }
-oj_config = { version = "0.1.22", path = "crates/oj_config" }
-oj_server = { version = "0.1.22", path = "crates/oj_server" }
+oj_compiler = { version = "0.1.23", path = "crates/oj_compiler" }
+oj_resolver = { version = "0.1.23", path = "crates/oj_resolver" }
+oj_graph = { version = "0.1.23", path = "crates/oj_graph" }
+oj_cache = { version = "0.1.23", path = "crates/oj_cache" }
+oj_css = { version = "0.1.23", path = "crates/oj_css" }
+oj_env = { version = "0.1.23", path = "crates/oj_env" }
+oj_config = { version = "0.1.23", path = "crates/oj_config" }
+oj_server = { version = "0.1.23", path = "crates/oj_server" }
 
 oxc_allocator = "0.146.0"
 oxc_parser = "0.146.0"


### PR DESCRIPTION
Release 0.1.23: SSR bridge EPIPE guard (#169) — a dead/restarted SSR container degrades instead of crashing the loader (the EPIPE burst seen on the lovbox canary). Builds on 0.1.22 (FLAKE 1 transformRequest fix #167, SSR bridge environments.resolve fix #166). See CHANGELOG.