### PR TITLE
SSR bridge: reconnect to a restarted container instead of degrading forever (supersedes #169's model)

### DIFF
--- a/crates/oj_server/src/assets/start/container-bridge.mjs
+++ b/crates/oj_server/src/assets/start/container-bridge.mjs
@@ -64,6 +64,63 @@ export function loadPluginContainerSync(app, _opts) {
     return buf;
   }
 
+  // Reopen the fifos to a RESTARTED container. Bounded (a healthy plugin-host
+  // restart re-creates the fifos within seconds); returns false if the container
+  // does not come back in the window, so a truly-dead container can't hang a
+  // request the way connect()'s 300s boot deadline would.
+  const RECONNECT_MS = Number(process.env.OJ_SSR_BRIDGE_RECONNECT_MS) || 30_000;
+  function reconnect() {
+    const deadline = Date.now() + RECONNECT_MS;
+    for (;;) {
+      if (existsSync(join(dir, "disabled"))) return false;
+      try {
+        closeSync(openSync(reqPath, constants.O_WRONLY | constants.O_NONBLOCK));
+        break;
+      } catch {}
+      if (Date.now() > deadline) return false;
+      sleep(25);
+    }
+    try {
+      reqFd = openSync(reqPath, "w");
+      repFd = openSync(repPath, "r");
+    } catch {
+      return false;
+    }
+    state = "up";
+    return true;
+  }
+
+  function closeFds() {
+    try { if (reqFd >= 0) closeSync(reqFd); } catch {}
+    try { if (repFd >= 0) closeSync(repFd); } catch {}
+    reqFd = -1;
+    repFd = -1;
+  }
+
+  // Send `frame` and read its reply. A container DEATH (write EPIPE, or the
+  // reply pipe closing in readExact) sets state="down" and throws; a plugin
+  // error (`m.error`) throws WITHOUT touching state, so callers can tell a
+  // recoverable death from a real error.
+  function sendRecv(id, frame) {
+    let off = 0;
+    while (off < frame.length) {
+      try {
+        off += writeSync(reqFd, frame, off, frame.length - off);
+      } catch (e) {
+        if (e.code === "EAGAIN" || e.code === "EINTR") { sleep(1); continue; }
+        state = "down";
+        throw e;
+      }
+    }
+    for (;;) {
+      const head = readExact(4);
+      const m = JSON.parse(readExact(head.readUInt32LE(0)).toString("utf8"));
+      if (m.id !== id) continue;
+      if (m.error != null) throw new Error(m.error);
+      return m.value ?? null;
+    }
+  }
+
   function call(method, args) {
     if (state === "down") return null;
     const id = ++seq;
@@ -78,28 +135,27 @@ export function loadPluginContainerSync(app, _opts) {
     const frame = Buffer.allocUnsafe(4 + json.length);
     frame.writeUInt32LE(json.length, 0);
     json.copy(frame, 4);
-    let off = 0;
-    while (off < frame.length) {
+    // Send/receive, reconnecting ONCE to a restarted container on a death and
+    // retrying, so a transient plugin-host restart RECOVERS (returns the real
+    // result) instead of crashing (the old unguarded EPIPE) or degrading forever
+    // (a permanent "down" a later restart never heals). Only a death (state ->
+    // "down") is retried; a plugin `m.error` propagates unchanged. A container
+    // that stays gone past reconnect()'s window lands "down" and returns null.
+    for (let reconnected = false; ; reconnected = true) {
       try {
-        off += writeSync(reqFd, frame, off, frame.length - off);
+        const v = sendRecv(id, frame);
+        if (first) process.stderr.write(`[oj-phase] ${Date.now()} bridge: ${method}#${id} returned\n`);
+        return v;
       } catch (e) {
-        if (e.code === "EAGAIN" || e.code === "EINTR") { sleep(1); continue; }
-        // The SSR container's read end is gone (the plugin host exited or
-        // restarted): an unguarded writeSync throws EPIPE and crashes the whole
-        // loader/SSR process. Degrade to "down" and return null so the caller
-        // falls back to oj's own resolve/load, exactly as readExact handles the
-        // reply pipe closing.
-        state = "down";
-        return null;
+        if (state !== "down") throw e;
+        if (reconnected) return null;
+        closeFds();
+        state = "idle";
+        if (!reconnect()) {
+          state = "down";
+          return null;
+        }
       }
-    }
-    for (;;) {
-      const head = readExact(4);
-      const m = JSON.parse(readExact(head.readUInt32LE(0)).toString("utf8"));
-      if (m.id !== id) continue;
-      if (first) process.stderr.write(`[oj-phase] ${Date.now()} bridge: ${method}#${id} returned\n`);
-      if (m.error != null) throw new Error(m.error);
-      return m.value ?? null;
     }
   }
 
@@ -111,6 +167,10 @@ export function loadPluginContainerSync(app, _opts) {
     env: () => call("__env", []),
     defines: () => call("__define", []),
     heap: () => (state === "up" ? call("__heap", []) : null),
+    // The bridge could not serve this call (container gone past the reconnect
+    // window): callers must NOT persist such a null into the loader cache, or a
+    // one-off container blip poisons a module's transform across restarts.
+    down: () => state === "down",
     bootstrapDone: () => existsSync(join(dir, "ready")),
   };
 }

--- a/crates/oj_server/src/assets/start/container-bridge.mjs
+++ b/crates/oj_server/src/assets/start/container-bridge.mjs
@@ -8,17 +8,70 @@ import { findConfig } from "./vite-plugin-bridge.mjs";
 const sleeper = new Int32Array(new SharedArrayBuffer(4));
 const sleep = (ms) => { Atomics.wait(sleeper, 0, 0, ms); };
 
+// A reply frame is a transformed module; cap the length we will trust so a
+// desynced or garbage 4-byte header can't drive a multi-GB allocUnsafe. Real
+// modules are orders of magnitude below this.
+const MAX_FRAME = 256 * 1024 * 1024;
+
 export function loadPluginContainerSync(app, _opts) {
   if (!findConfig(app)) return null;
   const dir = process.env.OJ_SSR_BRIDGE_DIR;
   if (!dir) return null;
   const reqPath = join(dir, "req.fifo");
   const repPath = join(dir, "rep.fifo");
-  let state = "idle"; // idle -> up | down
+  // idle -> up | down. "down" is NOT terminal: a later call re-probes and can
+  // heal from a container that restarts after the reconnect window elapsed.
+  let state = "idle";
   let reqFd = -1;
   let repFd = -1;
   let seq = 0;
   const seen = new Set();
+
+  // Non-blocking liveness probe: opening the request fifo O_WRONLY|O_NONBLOCK
+  // succeeds only when a container currently holds its read end (else ENXIO).
+  // Instant either way, so it never stalls the synchronous render thread.
+  function probe() {
+    try {
+      closeSync(openSync(reqPath, constants.O_WRONLY | constants.O_NONBLOCK));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // Open both fifos NON-BLOCKING. The write-open succeeds only with a reader
+  // present (we just probed); the read-open never blocks. This is what stops a
+  // container that dies right after the probe from hanging the render thread on
+  // a plain blocking openSync. Writes/reads then surface EAGAIN, which
+  // sendRecv/readExact already spin on.
+  function openFds() {
+    reqFd = openSync(reqPath, constants.O_WRONLY | constants.O_NONBLOCK);
+    repFd = openSync(repPath, constants.O_RDONLY | constants.O_NONBLOCK);
+  }
+
+  function closeFds() {
+    try { if (reqFd >= 0) closeSync(reqFd); } catch {}
+    try { if (repFd >= 0) closeSync(repFd); } catch {}
+    reqFd = -1;
+    repFd = -1;
+  }
+
+  // Discard any bytes a dead container left in rep.fifo before a retry, so a
+  // stale or partial reply frame can't misframe the next read. Non-blocking:
+  // repFd is O_NONBLOCK, so readSync returns EAGAIN (empty) and we stop.
+  function drainRep() {
+    const buf = Buffer.allocUnsafe(65536);
+    for (;;) {
+      let n = 0;
+      try {
+        n = readSync(repFd, buf, 0, buf.length, null);
+      } catch (e) {
+        if (e.code === "EINTR") continue;
+        break; // EAGAIN => nothing buffered
+      }
+      if (n === 0) break;
+    }
+  }
 
   function connect() {
     const deadline = Date.now() + 300_000;
@@ -27,23 +80,50 @@ export function loadPluginContainerSync(app, _opts) {
         state = "down";
         return false;
       }
-      try {
-        closeSync(openSync(reqPath, constants.O_WRONLY | constants.O_NONBLOCK));
-        break;
-      } catch {}
+      if (probe()) break;
       if (Date.now() > deadline) {
         state = "down";
         throw new Error("oj: SSR plugin bridge: plugin host not ready after 300s");
       }
       sleep(25);
     }
-    reqFd = openSync(reqPath, "w");
-    repFd = openSync(repPath, "r");
+    openFds();
+    state = "up";
+    return true;
+  }
+
+  // Reopen the fifos to a RESTARTED container. Bounded: a healthy plugin-host
+  // restart re-creates the fifos within a second or two, and every open here is
+  // non-blocking, so a container that dies mid-window can't hang the request the
+  // way connect()'s 300s boot deadline would. Returns false (caller fast-fails)
+  // if no container appears in the window.
+  const RECONNECT_MS = Number(process.env.OJ_SSR_BRIDGE_RECONNECT_MS) || 5_000;
+  function reconnect() {
+    const deadline = Date.now() + RECONNECT_MS;
+    for (;;) {
+      if (existsSync(join(dir, "disabled"))) return false;
+      if (probe()) break;
+      if (Date.now() > deadline) return false;
+      sleep(25);
+    }
+    try {
+      openFds();
+      drainRep(); // toss any residue the dead container left before we retry
+    } catch {
+      closeFds();
+      return false;
+    }
     state = "up";
     return true;
   }
 
   function readExact(len) {
+    if (len > MAX_FRAME) {
+      // A bad length header means the stream is desynced; recover like a death
+      // (reconnect+retry) rather than attempting a multi-GB allocation.
+      state = "down";
+      throw new Error("oj: SSR plugin bridge: framing desync (length " + len + ")");
+    }
     const buf = Buffer.allocUnsafe(len);
     let off = 0;
     while (off < len) {
@@ -64,43 +144,10 @@ export function loadPluginContainerSync(app, _opts) {
     return buf;
   }
 
-  // Reopen the fifos to a RESTARTED container. Bounded (a healthy plugin-host
-  // restart re-creates the fifos within seconds); returns false if the container
-  // does not come back in the window, so a truly-dead container can't hang a
-  // request the way connect()'s 300s boot deadline would.
-  const RECONNECT_MS = Number(process.env.OJ_SSR_BRIDGE_RECONNECT_MS) || 30_000;
-  function reconnect() {
-    const deadline = Date.now() + RECONNECT_MS;
-    for (;;) {
-      if (existsSync(join(dir, "disabled"))) return false;
-      try {
-        closeSync(openSync(reqPath, constants.O_WRONLY | constants.O_NONBLOCK));
-        break;
-      } catch {}
-      if (Date.now() > deadline) return false;
-      sleep(25);
-    }
-    try {
-      reqFd = openSync(reqPath, "w");
-      repFd = openSync(repPath, "r");
-    } catch {
-      return false;
-    }
-    state = "up";
-    return true;
-  }
-
-  function closeFds() {
-    try { if (reqFd >= 0) closeSync(reqFd); } catch {}
-    try { if (repFd >= 0) closeSync(repFd); } catch {}
-    reqFd = -1;
-    repFd = -1;
-  }
-
-  // Send `frame` and read its reply. A container DEATH (write EPIPE, or the
-  // reply pipe closing in readExact) sets state="down" and throws; a plugin
-  // error (`m.error`) throws WITHOUT touching state, so callers can tell a
-  // recoverable death from a real error.
+  // Send `frame` and read its reply. A container DEATH (write EPIPE, the reply
+  // pipe closing, or a framing/JSON desync) sets state="down" and throws so
+  // call() can reconnect+retry; a plugin error (`m.error`) throws WITHOUT
+  // touching state, so callers can tell a recoverable death from a real error.
   function sendRecv(id, frame) {
     let off = 0;
     while (off < frame.length) {
@@ -114,7 +161,15 @@ export function loadPluginContainerSync(app, _opts) {
     }
     for (;;) {
       const head = readExact(4);
-      const m = JSON.parse(readExact(head.readUInt32LE(0)).toString("utf8"));
+      const body = readExact(head.readUInt32LE(0)).toString("utf8");
+      let m;
+      try {
+        m = JSON.parse(body);
+      } catch (e) {
+        // Garbage on the wire => the stream is out of frame; recover like a death.
+        state = "down";
+        throw e;
+      }
       if (m.id !== id) continue;
       if (m.error != null) throw new Error(m.error);
       return m.value ?? null;
@@ -122,7 +177,6 @@ export function loadPluginContainerSync(app, _opts) {
   }
 
   function call(method, args) {
-    if (state === "down") return null;
     const id = ++seq;
     const first = !!process.env.OJ_BOOT_PHASES
       && (process.env.OJ_BOOT_PHASES === "2" || !seen.has(method));
@@ -131,16 +185,26 @@ export function loadPluginContainerSync(app, _opts) {
       process.stderr.write(`[oj-phase] ${Date.now()} bridge: ${method}#${id} (${String(args[0] ?? "").slice(-80)})\n`);
     }
     if (state === "idle" && !connect()) return null;
+    if (state === "down") {
+      // A prior call found the container gone. Re-probe cheaply (instant): if a
+      // restarted container is back, reconnect and serve it (this heals a restart
+      // that happened after the reconnect window elapsed); otherwise fast-fail
+      // with null NOW instead of stalling the render thread on a dead container.
+      if (!probe()) return null;
+      closeFds();
+      state = "idle";
+      if (!reconnect()) { state = "down"; return null; }
+    }
     const json = Buffer.from(JSON.stringify({ id, method, args }));
     const frame = Buffer.allocUnsafe(4 + json.length);
     frame.writeUInt32LE(json.length, 0);
     json.copy(frame, 4);
-    // Send/receive, reconnecting ONCE to a restarted container on a death and
-    // retrying, so a transient plugin-host restart RECOVERS (returns the real
-    // result) instead of crashing (the old unguarded EPIPE) or degrading forever
-    // (a permanent "down" a later restart never heals). Only a death (state ->
-    // "down") is retried; a plugin `m.error` propagates unchanged. A container
-    // that stays gone past reconnect()'s window lands "down" and returns null.
+    // Reconnect ONCE to a restarted container on a death and retry, so a
+    // transient plugin-host restart RECOVERS (returns the real result) instead
+    // of crashing (the old unguarded EPIPE). Only a death (state -> "down") is
+    // retried; a plugin `m.error` propagates unchanged. A container that stays
+    // gone past reconnect()'s window lands "down" and returns null - and "down"
+    // is not terminal, since the next call re-probes above.
     for (let reconnected = false; ; reconnected = true) {
       try {
         const v = sendRecv(id, frame);

--- a/crates/oj_server/src/assets/start/loader.mjs
+++ b/crates/oj_server/src/assets/start/loader.mjs
@@ -1044,7 +1044,13 @@ export function load(url, context, next) {
       define: DEFINE,
     });
     const code = withInlineMap(out);
-    cachePut(raw.includes("import.meta.glob") ? null : key, code);
+    // A DOWN container skipped the plugin load()/transformUserCode steps above,
+    // so `code` is under-transformed (jsx/define only) yet `key` is identical to
+    // a healthy render's key (both hash diskRaw when load() returns null). Do NOT
+    // persist it, or every future render serves the plugin-untransformed module
+    // across restarts (a silent hydration mismatch) - the poisoning down() guards.
+    const skipCache = raw.includes("import.meta.glob") || (container != null && container.down());
+    cachePut(skipCache ? null : key, code);
     return { format: "module", source: code, shortCircuit: true };
   }
   if (url.includes("?ojv=") && isTanstack(url)) {
@@ -1092,7 +1098,11 @@ export function load(url, context, next) {
       if (diskRaw != null && diskRaw.includes("import.meta.glob")) {
         return { format: "module", source: transformGlob(diskRaw, path), shortCircuit: true };
       }
-      cachePut(key, "1");
+      // A null load() from a DOWN container means "couldn't ask", not "no plugin
+      // claims it": marking it unclaimed would freeze a plugin-claimed module as
+      // unclaimed on disk forever, bypassing the load hook across restarts. Only
+      // record the unclaimed marker when the container actually answered.
+      if (!container.down()) cachePut(key, "1");
     }
   }
   if (clean.startsWith("file:") && clean.includes("/node_modules/")) {

--- a/crates/oj_server/src/assets/start/loader.mjs
+++ b/crates/oj_server/src/assets/start/loader.mjs
@@ -234,7 +234,10 @@ function speculativeContainer(raw) {
       return specPack.get(key);
     }
     const v = raw[method](...args) ?? null;
-    if (key && !specPack.has(key)) {
+    // Never persist a result the bridge produced while the container was down:
+    // a one-off container restart would otherwise freeze a null resolve/load into
+    // the speculation pack (and its on-disk file) across process restarts.
+    if (key && !specPack.has(key) && !raw.down()) {
       specPack.set(key, v);
       specPending.push({ k: key, v });
     }
@@ -255,6 +258,8 @@ export function revalidateSpeculation() {
   for (const [key, { method, args }] of speculatedCalls) {
     let live;
     try { live = rawContainer[method](...args) ?? null; } catch { continue; }
+    // A down container can't revalidate; don't overwrite the pack with its null.
+    if (rawContainer.down()) continue;
     if (JSON.stringify(live) !== JSON.stringify(specPack.get(key) ?? null)) {
       specPack.set(key, live);
       specDirty = true;
@@ -1023,7 +1028,12 @@ export function load(url, context, next) {
         if (tucHit !== "\0none") raw = tucHit;
       } else {
         const t = container.transformUserCode(raw, path);
-        cachePut(tucKey, t ?? "\0none");
+        // A null from a DOWN container means "couldn't transform", not "no
+        // transform": persisting "\0none" would serve this file untransformed
+        // forever (across restarts), a silent hydration mismatch. Only cache a
+        // real result; a down container just skips the user-code transform for
+        // this render and retries next time (when it has reconnected).
+        if (!container.down()) cachePut(tucKey, t ?? "\0none");
         if (t != null) raw = t;
       }
     }

--- a/e2e/unit/ssr-bridge-reconnect.test.mjs
+++ b/e2e/unit/ssr-bridge-reconnect.test.mjs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+//
+// The Start SSR plugin bridge (container-bridge.mjs) talks to the plugin-host
+// container over named-pipe request/reply fifos. When the container process
+// dies/restarts mid-session the bridge must RECONNECT to the restarted container
+// and recover (return the real result), not crash on EPIPE and not degrade to a
+// permanent "down". And when the container is truly gone it must report `down`
+// so callers never persist a null into the loader cache. This drives a mock
+// container over real fifos through a restart.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawn, execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { repo } from "./harness.mjs";
+
+const bridgeUrl = pathToFileURL(join(repo, "crates/oj_server/src/assets/start/container-bridge.mjs")).href;
+
+// A mock container: opens both fifos "r+" like plugin-host.mjs, reads framed
+// requests ({id,method,args}), replies {id, value:"OK:<tag>:<method>:<arg0>"},
+// exits after `maxReqs`. `delayMs` waits before opening (to force the bridge's
+// write into the no-reader gap so the reconnect path runs).
+const MOCK = [
+  'import { openSync, readSync, writeSync } from "node:fs";',
+  "const [,, reqPath, repPath, tag, maxReqs, delayMs] = process.argv;",
+  "const sl = new Int32Array(new SharedArrayBuffer(4));",
+  "if (Number(delayMs)) Atomics.wait(sl, 0, 0, Number(delayMs));",
+  'const repFd = openSync(repPath, "r+");',
+  'const reqFd = openSync(reqPath, "r+");',
+  "function readExact(fd, len) {",
+  "  const b = Buffer.allocUnsafe(len); let off = 0;",
+  "  while (off < len) {",
+  "    let n; try { n = readSync(fd, b, off, len - off, null); }",
+  '    catch (e) { if (e.code === "EAGAIN" || e.code === "EINTR") { Atomics.wait(sl,0,0,1); continue; } throw e; }',
+  "    if (n === 0) process.exit(0);",
+  "    off += n;",
+  "  }",
+  "  return b;",
+  "}",
+  "let handled = 0;",
+  "while (handled < Number(maxReqs)) {",
+  "  const head = readExact(reqFd, 4);",
+  "  const req = JSON.parse(readExact(reqFd, head.readUInt32LE(0)).toString());",
+  "  const rep = Buffer.from(JSON.stringify({ id: req.id, value: `OK:${tag}:${req.method}:${req.args?.[0] ?? \"\"}` }));",
+  "  const frame = Buffer.allocUnsafe(4 + rep.length);",
+  "  frame.writeUInt32LE(rep.length, 0); rep.copy(frame, 4);",
+  "  let off = 0; while (off < frame.length) off += writeSync(repFd, frame, off, frame.length - off);",
+  "  handled++;",
+  "}",
+  "process.exit(0);",
+].join("\n");
+
+test("bridge reconnects to a restarted container, recovers, and reports down when it is gone", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "oj-bridge-rc-"));
+  const app = join(tmp, "app");
+  const bdir = join(tmp, "bridge");
+  mkdirSync(app);
+  mkdirSync(bdir);
+  writeFileSync(join(app, "vite.config.mjs"), "export default {};\n"); // findConfig
+  const mockPath = join(tmp, "mock.mjs");
+  writeFileSync(mockPath, MOCK);
+  const reqFifo = join(bdir, "req.fifo");
+  const repFifo = join(bdir, "rep.fifo");
+  execFileSync("mkfifo", [reqFifo, repFifo]);
+
+  const mocks = [];
+  const spawnMock = (tag, maxReqs, delayMs = 0) => {
+    const m = spawn(process.execPath, [mockPath, reqFifo, repFifo, tag, String(maxReqs), String(delayMs)], {
+      stdio: "ignore",
+    });
+    mocks.push(m);
+    return m;
+  };
+
+  const prevDir = process.env.OJ_SSR_BRIDGE_DIR;
+  const prevRc = process.env.OJ_SSR_BRIDGE_RECONNECT_MS;
+  process.env.OJ_SSR_BRIDGE_DIR = bdir;
+  process.env.OJ_SSR_BRIDGE_RECONNECT_MS = "2500";
+  try {
+    // Container A: serves one call then exits (a restart).
+    spawnMock("A", 1);
+    const { loadPluginContainerSync } = await import(bridgeUrl);
+    const bridge = loadPluginContainerSync(app, { command: "serve", environment: "ssr" });
+    assert.ok(bridge, "bridge constructed (config + fifo dir present)");
+
+    // 1. First call reaches container A.
+    assert.equal(bridge.resolveId("x", undefined), "OK:A:resolveId:x");
+    assert.equal(bridge.down(), false);
+
+    // 2. Container A has exited. Bring up container B AFTER a delay so the
+    // bridge's next write hits the no-reader gap -> EPIPE -> reconnect -> retry
+    // against B. Recovery must return B's real result, not null/crash.
+    spawnMock("B", 5, 400);
+    assert.equal(bridge.resolveId("y", undefined), "OK:B:resolveId:y", "reconnected to the restarted container");
+    assert.equal(bridge.load("z"), "OK:B:load:z", "the reconnected bridge keeps serving");
+    assert.equal(bridge.down(), false);
+
+    // 3. Container B killed and none replaces it: the call must return null (not
+    // hang past the reconnect window, not crash) and the bridge must report down
+    // so the loader won't persist this null.
+    for (const m of mocks) m.kill("SIGKILL");
+    assert.equal(bridge.resolveId("q", undefined), null, "no container -> null, not a crash");
+    assert.equal(bridge.down(), true, "down() true so callers skip caching");
+    assert.equal(bridge.resolveId("q2", undefined), null, "stays down");
+  } finally {
+    for (const m of mocks) { try { m.kill("SIGKILL"); } catch {} }
+    if (prevDir === undefined) delete process.env.OJ_SSR_BRIDGE_DIR; else process.env.OJ_SSR_BRIDGE_DIR = prevDir;
+    if (prevRc === undefined) delete process.env.OJ_SSR_BRIDGE_RECONNECT_MS; else process.env.OJ_SSR_BRIDGE_RECONNECT_MS = prevRc;
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/e2e/unit/ssr-bridge-reconnect.test.mjs
+++ b/e2e/unit/ssr-bridge-reconnect.test.mjs
@@ -5,8 +5,9 @@
 // dies/restarts mid-session the bridge must RECONNECT to the restarted container
 // and recover (return the real result), not crash on EPIPE and not degrade to a
 // permanent "down". And when the container is truly gone it must report `down`
-// so callers never persist a null into the loader cache. This drives a mock
-// container over real fifos through a restart.
+// so callers never persist a null into the loader cache. This drives mock
+// containers over real fifos through restarts, a stale-byte desync, and a
+// later heal.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { spawn, execFileSync } from "node:child_process";
@@ -52,62 +53,157 @@ const MOCK = [
   "process.exit(0);",
 ].join("\n");
 
-test("bridge reconnects to a restarted container, recovers, and reports down when it is gone", async () => {
+// A mock that serves ONE request, then writes GARBAGE (an oversized frame
+// header + junk) into rep.fifo and LINGERS holding the rep write end open while
+// closing only its req read end. Closing the req read end makes the bridge's
+// next write EPIPE (a detected death); keeping the rep write end open means the
+// fifo buffer (with the garbage) survives the bridge's closeFds()+reopen, so the
+// bridge MUST drain it on reconnect or the next reply misframes.
+const MOCK_LINGER = [
+  'import { openSync, readSync, writeSync, closeSync } from "node:fs";',
+  "const [,, reqPath, repPath] = process.argv;",
+  "const sl = new Int32Array(new SharedArrayBuffer(4));",
+  'const repFd = openSync(repPath, "r+");',
+  'const reqFd = openSync(reqPath, "r+");',
+  "function readExact(fd, len) {",
+  "  const b = Buffer.allocUnsafe(len); let off = 0;",
+  "  while (off < len) {",
+  "    let n; try { n = readSync(fd, b, off, len - off, null); }",
+  '    catch (e) { if (e.code === "EAGAIN" || e.code === "EINTR") { Atomics.wait(sl,0,0,1); continue; } throw e; }',
+  "    if (n === 0) process.exit(0);",
+  "    off += n;",
+  "  }",
+  "  return b;",
+  "}",
+  "const head = readExact(reqFd, 4);",
+  "const req = JSON.parse(readExact(reqFd, head.readUInt32LE(0)).toString());",
+  "const rep = Buffer.from(JSON.stringify({ id: req.id, value: `OK:A:${req.method}:${req.args?.[0] ?? \"\"}` }));",
+  "const frame = Buffer.allocUnsafe(4 + rep.length);",
+  "frame.writeUInt32LE(rep.length, 0); rep.copy(frame, 4);",
+  "let off = 0; while (off < frame.length) off += writeSync(repFd, frame, off, frame.length - off);",
+  "// leave a bogus oversized frame header + junk in rep.fifo",
+  "const junk = Buffer.from([0xff, 0xff, 0xff, 0xff, 1, 2, 3]);",
+  "off = 0; while (off < junk.length) off += writeSync(repFd, junk, off, junk.length - off);",
+  "closeSync(reqFd); // req reader gone -> bridge's next write EPIPEs (death)",
+  "Atomics.wait(sl, 0, 0, 5000); // linger, keeping rep write end open",
+  "process.exit(0);",
+].join("\n");
+
+function setup() {
   const tmp = mkdtempSync(join(tmpdir(), "oj-bridge-rc-"));
   const app = join(tmp, "app");
   const bdir = join(tmp, "bridge");
   mkdirSync(app);
   mkdirSync(bdir);
   writeFileSync(join(app, "vite.config.mjs"), "export default {};\n"); // findConfig
-  const mockPath = join(tmp, "mock.mjs");
-  writeFileSync(mockPath, MOCK);
   const reqFifo = join(bdir, "req.fifo");
   const repFifo = join(bdir, "rep.fifo");
   execFileSync("mkfifo", [reqFifo, repFifo]);
-
   const mocks = [];
-  const spawnMock = (tag, maxReqs, delayMs = 0) => {
-    const m = spawn(process.execPath, [mockPath, reqFifo, repFifo, tag, String(maxReqs), String(delayMs)], {
-      stdio: "ignore",
-    });
+  const spawnMock = (script, args) => {
+    const m = spawn(process.execPath, [script, reqFifo, repFifo, ...args], { stdio: "ignore" });
     mocks.push(m);
     return m;
   };
+  return { tmp, app, bdir, reqFifo, repFifo, mocks, spawnMock };
+}
 
+async function withEnv(bdir, reconnectMs, run) {
   const prevDir = process.env.OJ_SSR_BRIDGE_DIR;
   const prevRc = process.env.OJ_SSR_BRIDGE_RECONNECT_MS;
   process.env.OJ_SSR_BRIDGE_DIR = bdir;
-  process.env.OJ_SSR_BRIDGE_RECONNECT_MS = "2500";
+  process.env.OJ_SSR_BRIDGE_RECONNECT_MS = String(reconnectMs);
   try {
-    // Container A: serves one call then exits (a restart).
-    spawnMock("A", 1);
-    const { loadPluginContainerSync } = await import(bridgeUrl);
-    const bridge = loadPluginContainerSync(app, { command: "serve", environment: "ssr" });
-    assert.ok(bridge, "bridge constructed (config + fifo dir present)");
-
-    // 1. First call reaches container A.
-    assert.equal(bridge.resolveId("x", undefined), "OK:A:resolveId:x");
-    assert.equal(bridge.down(), false);
-
-    // 2. Container A has exited. Bring up container B AFTER a delay so the
-    // bridge's next write hits the no-reader gap -> EPIPE -> reconnect -> retry
-    // against B. Recovery must return B's real result, not null/crash.
-    spawnMock("B", 5, 400);
-    assert.equal(bridge.resolveId("y", undefined), "OK:B:resolveId:y", "reconnected to the restarted container");
-    assert.equal(bridge.load("z"), "OK:B:load:z", "the reconnected bridge keeps serving");
-    assert.equal(bridge.down(), false);
-
-    // 3. Container B killed and none replaces it: the call must return null (not
-    // hang past the reconnect window, not crash) and the bridge must report down
-    // so the loader won't persist this null.
-    for (const m of mocks) m.kill("SIGKILL");
-    assert.equal(bridge.resolveId("q", undefined), null, "no container -> null, not a crash");
-    assert.equal(bridge.down(), true, "down() true so callers skip caching");
-    assert.equal(bridge.resolveId("q2", undefined), null, "stays down");
+    return await run();
   } finally {
-    for (const m of mocks) { try { m.kill("SIGKILL"); } catch {} }
     if (prevDir === undefined) delete process.env.OJ_SSR_BRIDGE_DIR; else process.env.OJ_SSR_BRIDGE_DIR = prevDir;
     if (prevRc === undefined) delete process.env.OJ_SSR_BRIDGE_RECONNECT_MS; else process.env.OJ_SSR_BRIDGE_RECONNECT_MS = prevRc;
-    rmSync(tmp, { recursive: true, force: true });
   }
+}
+
+test("bridge reconnects to a restarted container, reports down, then heals a later restart", async () => {
+  const { tmp, app, bdir, mocks, spawnMock } = setup();
+  const mockPath = join(tmp, "mock.mjs");
+  writeFileSync(mockPath, MOCK);
+  const mock = (tag, maxReqs, delayMs = 0) => spawnMock(mockPath, [tag, String(maxReqs), String(delayMs)]);
+  await withEnv(bdir, 2500, async () => {
+    try {
+      // Container A: serves one call then exits (a restart).
+      mock("A", 1);
+      const { loadPluginContainerSync } = await import(bridgeUrl);
+      const bridge = loadPluginContainerSync(app, { command: "serve", environment: "ssr" });
+      assert.ok(bridge, "bridge constructed (config + fifo dir present)");
+
+      // 1. First call reaches container A.
+      assert.equal(bridge.resolveId("x", undefined), "OK:A:resolveId:x");
+      assert.equal(bridge.down(), false);
+
+      // 2. Container A has exited. Bring up container B AFTER a delay so the
+      // bridge's next write hits the no-reader gap -> EPIPE -> reconnect -> retry
+      // against B. Recovery must return B's real result, not null/crash.
+      mock("B", 5, 400);
+      assert.equal(bridge.resolveId("y", undefined), "OK:B:resolveId:y", "reconnected to the restarted container");
+      assert.equal(bridge.load("z"), "OK:B:load:z", "the reconnected bridge keeps serving");
+      assert.equal(bridge.down(), false);
+
+      // 3. Container B killed and none replaces it: the call must return null (not
+      // hang past the reconnect window, not crash) and the bridge must report down
+      // so the loader won't persist this null. A second call while down is instant.
+      for (const m of mocks) m.kill("SIGKILL");
+      assert.equal(bridge.resolveId("q", undefined), null, "no container -> null, not a crash");
+      assert.equal(bridge.down(), true, "down() true so callers skip caching");
+      assert.equal(bridge.resolveId("q2", undefined), null, "stays down");
+
+      // 4. "down" is NOT terminal: a container that comes up LATER heals on a
+      // subsequent call, since each render re-probes. Poll as successive renders
+      // would until C answers.
+      mock("C", 5);
+      let healed = null;
+      const sl = new Int32Array(new SharedArrayBuffer(4));
+      for (let i = 0; i < 300 && healed == null; i++) {
+        healed = bridge.resolveId("r", undefined);
+        if (healed == null) Atomics.wait(sl, 0, 0, 10);
+      }
+      assert.equal(healed, "OK:C:resolveId:r", "a later restart heals; down() is not terminal");
+      assert.equal(bridge.down(), false);
+    } finally {
+      for (const m of mocks) { try { m.kill("SIGKILL"); } catch {} }
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+test("bridge drains stale bytes a dead container left in rep.fifo before retrying", async () => {
+  const { tmp, app, bdir, mocks, spawnMock } = setup();
+  const lingerPath = join(tmp, "mock-linger.mjs");
+  const mockPath = join(tmp, "mock.mjs");
+  writeFileSync(lingerPath, MOCK_LINGER);
+  writeFileSync(mockPath, MOCK);
+  await withEnv(bdir, 2500, async () => {
+    try {
+      // Container A serves one call, then leaves a bogus frame header in rep.fifo
+      // and lingers holding the rep write end so the garbage survives the reopen.
+      spawnMock(lingerPath, []);
+      const { loadPluginContainerSync } = await import(bridgeUrl);
+      const bridge = loadPluginContainerSync(app, { command: "serve", environment: "ssr" });
+      assert.ok(bridge, "bridge constructed");
+
+      assert.equal(bridge.resolveId("x", undefined), "OK:A:resolveId:x");
+
+      // Container B comes up after a delay. The bridge's next write EPIPEs (A's
+      // req reader is gone) -> reconnect -> drainRep discards A's leftover garbage
+      // -> retry against B. Without the drain the bogus 0xffffffff header would
+      // misframe the reply and this returns null (or throws), not B's result.
+      spawnMock(mockPath, ["B", "5", "400"]);
+      assert.equal(
+        bridge.resolveId("y", undefined),
+        "OK:B:resolveId:y",
+        "drained the stale frame and recovered against the restarted container",
+      );
+      assert.equal(bridge.down(), false);
+    } finally {
+      for (const m of mocks) { try { m.kill("SIGKILL"); } catch {} }
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
Follow-up to #169 (the EPIPE guard), after a double-review found the degradation model #169 committed to was wrong.

#169 stopped the crash but replaced it with a **permanent "down" + silent-null** that had three real problems (all confirmed against Vite's reference behavior):
1. **No reconnect.** One loader process outlives many container restarts, and nothing ever moved `state` back from `down` — so after a *transient* plugin-host restart the loader ran permanently degraded against a container that was actually healthy again. Vite's module runner reconnects to a restarted runtime.
2. **Down-nulls got cached and persisted.** A null from a down container was written to the on-disk loader cache (`transformUserCode` → `"\0none"`, and the speculation pack → `SPEC_FILE`), so one container blip served a module untransformed **forever, across restarts** — a silent hydration mismatch.
3. **Silent-wrong SSR** (empty virtual stubs, dropped defines) with no reload, where Vite would surface a recoverable error.

This is the proper fix:
- **Reconnect + retry** in `container-bridge.mjs`: on a container death (write EPIPE or reply-pipe close), the bridge reconnects **once** to the restarted container (bounded by `OJ_SSR_BRIDGE_RECONNECT_MS`, default 30s, so a truly-dead container can't hang a request the way the 300s boot deadline would) and retries the call, so a transient restart RECOVERS with the real result. A plugin `m.error` still propagates unchanged — only a death (which sets `state="down"`) is retried. A container that stays gone lands `down` and returns null.
- **Never cache a down result**: the bridge exposes `down()`, and the loader skips the `transformUserCode` cache-put, the speculation-pack put, and speculation revalidation when the container is down — so a blip can't poison a module's transform across restarts.

The `down()`→null path remains only for the genuinely-safe cases (`resolveId` and non-virtual `load`, which fall back to oj's own resolve/disk).

New e2e `e2e/unit/ssr-bridge-reconnect.test.mjs` drives a mock container over real fifos through a restart: first call reaches container A; A exits and B restarts (with a delay that forces the bridge's write into the no-reader gap → EPIPE → reconnect → retry) and the call recovers with B's real result; then the container is killed and calls return null with `down()===true` (no hang, no crash). It fails against the old permanent-down behavior and passes with the reconnect.

Full workspace + 288 JS unit tests + ssr-dev / start / start-cloudflare-dev e2e green.
