### PR TITLE
release start live-reload sockets on client disconnect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,6 +1826,7 @@ dependencies = [
  "blake3",
  "clap",
  "flate2",
+ "futures-util",
  "notify",
  "oj_cache",
  "oj_compiler",
@@ -1841,6 +1842,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite",
 ]
 
 [[package]]

--- a/crates/oj/Cargo.toml
+++ b/crates/oj/Cargo.toml
@@ -31,8 +31,8 @@ oj_css.workspace = true
 axum.workspace = true
 notify.workspace = true
 tokio-stream = "0.1.19"
+futures-util = "0.3"
 
 [dev-dependencies]
 tokio = { version = "1.53.1", features = ["full", "test-util"] }
 tokio-tungstenite = "0.29"
-futures-util = "0.3"

--- a/crates/oj/Cargo.toml
+++ b/crates/oj/Cargo.toml
@@ -34,3 +34,5 @@ tokio-stream = "0.1.19"
 
 [dev-dependencies]
 tokio = { version = "1.53.1", features = ["full", "test-util"] }
+tokio-tungstenite = "0.29"
+futures-util = "0.3"

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -6,7 +6,10 @@ use std::process::Stdio;
 use std::sync::Arc;
 
 use axum::{
-    extract::{ws::Message, FromRequestParts, Request, State, WebSocketUpgrade},
+    extract::{
+        ws::{Message, WebSocket},
+        FromRequestParts, Request, State, WebSocketUpgrade,
+    },
     http::{header, Method, StatusCode},
     middleware::Next,
     response::{IntoResponse, Response},
@@ -1349,14 +1352,8 @@ async fn start_route(State(state): State<Arc<StartState>>, req: Request, next: N
         let (mut parts, _) = req.into_parts();
         return match WebSocketUpgrade::from_request_parts(&mut parts, &()).await {
             Ok(ws) => {
-                let mut rx = state.reload_tx.subscribe();
-                ws.on_upgrade(move |mut socket| async move {
-                    while rx.recv().await.is_ok() {
-                        if socket.send(Message::Text("reload".into())).await.is_err() {
-                            break;
-                        }
-                    }
-                })
+                let rx = state.reload_tx.subscribe();
+                ws.on_upgrade(move |socket| start_hmr_socket(socket, rx))
             }
             Err(e) => e.into_response(),
         };
@@ -1389,6 +1386,22 @@ async fn start_route(State(state): State<Arc<StartState>>, req: Request, next: N
         }
         Route::Api => forward_with_body(&state, req).await,
         Route::Pass => next.run(req).await,
+    }
+}
+
+async fn start_hmr_socket(mut socket: WebSocket, mut rx: broadcast::Receiver<()>) {
+    loop {
+        tokio::select! {
+            reload = rx.recv() => {
+                if reload.is_err() || socket.send(Message::Text("reload".into())).await.is_err() {
+                    break;
+                }
+            }
+            incoming = socket.recv() => match incoming {
+                None | Some(Err(_)) => break,
+                Some(Ok(_)) => {}
+            },
+        }
     }
 }
 
@@ -1789,6 +1802,116 @@ fn collect_headers(headers: &header::HeaderMap) -> Vec<(String, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures_util::{SinkExt, StreamExt};
+    use tokio_tungstenite::{connect_async, tungstenite::Message as ClientMessage};
+
+    struct HmrTestServer {
+        url: String,
+        reload_tx: broadcast::Sender<()>,
+        task: tokio::task::JoinHandle<()>,
+    }
+
+    impl Drop for HmrTestServer {
+        fn drop(&mut self) {
+            self.task.abort();
+        }
+    }
+
+    impl HmrTestServer {
+        async fn start() -> Self {
+            let (reload_tx, _) = broadcast::channel(16);
+            let app = axum::Router::new()
+                .route(
+                    "/@oj-start/hmr",
+                    axum::routing::get(
+                        |ws: WebSocketUpgrade, State(tx): State<broadcast::Sender<()>>| async move {
+                            let rx = tx.subscribe();
+                            ws.on_upgrade(move |socket| start_hmr_socket(socket, rx))
+                        },
+                    ),
+                )
+                .with_state(reload_tx.clone());
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let url = format!("ws://{}/@oj-start/hmr", listener.local_addr().unwrap());
+            let task = tokio::spawn(async move {
+                axum::serve(listener, app).await.unwrap();
+            });
+            Self {
+                url,
+                reload_tx,
+                task,
+            }
+        }
+
+        async fn wait_for_no_subscribers(&self) {
+            tokio::time::timeout(std::time::Duration::from_secs(2), async {
+                while self.reload_tx.receiver_count() != 0 {
+                    tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+                }
+            })
+            .await
+            .expect("disconnected HMR client retained its reload subscription");
+        }
+    }
+
+    #[tokio::test]
+    async fn start_hmr_releases_closed_clients_without_a_reload() {
+        let server = HmrTestServer::start().await;
+        for _ in 0..5 {
+            let (mut client, _) = connect_async(&server.url).await.unwrap();
+            assert_eq!(server.reload_tx.receiver_count(), 1);
+            client.close(None).await.unwrap();
+            server.wait_for_no_subscribers().await;
+            let response = tokio::time::timeout(std::time::Duration::from_secs(2), client.next())
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap();
+            assert!(matches!(response, ClientMessage::Close(_)));
+        }
+    }
+
+    #[tokio::test]
+    async fn start_hmr_releases_dropped_clients_without_a_reload() {
+        let server = HmrTestServer::start().await;
+        for _ in 0..5 {
+            let (client, _) = connect_async(&server.url).await.unwrap();
+            assert_eq!(server.reload_tx.receiver_count(), 1);
+            drop(client);
+            server.wait_for_no_subscribers().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn start_hmr_keeps_live_clients_subscribed_after_incoming_messages() {
+        let server = HmrTestServer::start().await;
+        let (mut client, _) = connect_async(&server.url).await.unwrap();
+        client
+            .send(ClientMessage::Text("ignored".into()))
+            .await
+            .unwrap();
+        client
+            .send(ClientMessage::Ping(vec![1, 2, 3].into()))
+            .await
+            .unwrap();
+        let pong = tokio::time::timeout(std::time::Duration::from_secs(2), client.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(pong, ClientMessage::Pong(vec![1, 2, 3].into()));
+        for _ in 0..2 {
+            assert_eq!(server.reload_tx.send(()).unwrap(), 1);
+            let reload = tokio::time::timeout(std::time::Duration::from_secs(2), client.next())
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap();
+            assert_eq!(reload, ClientMessage::Text("reload".into()));
+        }
+        client.close(None).await.unwrap();
+        server.wait_for_no_subscribers().await;
+    }
 
     fn tmp(label: &str) -> PathBuf {
         let d = std::env::temp_dir().join(format!("oj-startdev-{}-{label}", std::process::id()));

--- a/crates/oj/src/start_dev.rs
+++ b/crates/oj/src/start_dev.rs
@@ -14,6 +14,7 @@ use axum::{
     middleware::Next,
     response::{IntoResponse, Response},
 };
+use futures_util::SinkExt;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
 use tokio::process::{Child, ChildStdin, ChildStdout};
 use tokio::sync::broadcast;
@@ -1399,6 +1400,10 @@ async fn start_hmr_socket(mut socket: WebSocket, mut rx: broadcast::Receiver<()>
             }
             incoming = socket.recv() => match incoming {
                 None | Some(Err(_)) => break,
+                Some(Ok(Message::Close(_))) => {
+                    let _ = socket.close().await;
+                    break;
+                }
                 Some(Ok(_)) => {}
             },
         }
@@ -1819,18 +1824,31 @@ mod tests {
 
     impl HmrTestServer {
         async fn start() -> Self {
+            Self::start_with_gate(None).await
+        }
+
+        async fn start_with_gate(gate: Option<Arc<tokio::sync::Notify>>) -> Self {
             let (reload_tx, _) = broadcast::channel(16);
             let app = axum::Router::new()
                 .route(
                     "/@oj-start/hmr",
                     axum::routing::get(
-                        |ws: WebSocketUpgrade, State(tx): State<broadcast::Sender<()>>| async move {
+                        |ws: WebSocketUpgrade,
+                         State((tx, gate)): State<(
+                            broadcast::Sender<()>,
+                            Option<Arc<tokio::sync::Notify>>,
+                        )>| async move {
                             let rx = tx.subscribe();
-                            ws.on_upgrade(move |socket| start_hmr_socket(socket, rx))
+                            ws.on_upgrade(move |socket| async move {
+                                if let Some(gate) = gate {
+                                    gate.notified().await;
+                                }
+                                start_hmr_socket(socket, rx).await;
+                            })
                         },
                     ),
                 )
-                .with_state(reload_tx.clone());
+                .with_state((reload_tx.clone(), gate));
             let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
             let url = format!("ws://{}/@oj-start/hmr", listener.local_addr().unwrap());
             let task = tokio::spawn(async move {
@@ -1868,6 +1886,39 @@ mod tests {
                 .unwrap()
                 .unwrap();
             assert!(matches!(response, ClientMessage::Close(_)));
+        }
+    }
+
+    #[tokio::test]
+    async fn start_hmr_completes_close_handshakes_while_reloads_arrive() {
+        use tokio_tungstenite::tungstenite::protocol::{frame::coding::CloseCode, CloseFrame};
+
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let server = HmrTestServer::start_with_gate(Some(gate.clone())).await;
+        let close = CloseFrame {
+            code: CloseCode::Normal,
+            reason: "leaving the preview".into(),
+        };
+        for attempt in 0..64 {
+            let (mut client, _) = connect_async(&server.url).await.unwrap();
+            client.close(Some(close.clone())).await.unwrap();
+            assert_eq!(server.reload_tx.send(()).unwrap(), 1);
+            // Let the I/O driver observe the close frame before releasing the handler.
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            gate.notify_one();
+            let reply = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+                loop {
+                    match client.next().await {
+                        Some(Ok(ClientMessage::Close(frame))) => break frame,
+                        Some(Ok(ClientMessage::Text(text))) => assert_eq!(text, "reload"),
+                        other => panic!("close handshake failed on attempt {attempt}: {other:?}"),
+                    }
+                }
+            })
+            .await
+            .expect("close handshake did not finish while a reload was pending");
+            assert_eq!(reply, Some(close.clone()));
+            server.wait_for_no_subscribers().await;
         }
     }
 

--- a/e2e/start-hmr-gate.mjs
+++ b/e2e/start-hmr-gate.mjs
@@ -43,7 +43,18 @@ async function reloadListener() {
   const reloads = [];
   ws.addEventListener("message", (ev) => { if (String(ev.data) === "reload") reloads.push(Date.now()); });
   await new Promise((resolve, reject) => { ws.addEventListener("open", resolve); ws.addEventListener("error", reject); });
-  return { reloads, close: () => ws.close() };
+  return { reloads, close: async () => {
+    const closed = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("Start HMR socket did not close without a reload")), 2000);
+      ws.addEventListener("close", (event) => {
+        clearTimeout(timer);
+        if (event.wasClean) resolve();
+        else reject(new Error("Start HMR socket closed without completing the close handshake"));
+      }, { once: true });
+    });
+    ws.close();
+    await closed;
+  } };
 }
 
 async function run(label, gated, check) {
@@ -56,11 +67,12 @@ async function run(label, gated, check) {
   srv.stderr.on("data", (d) => (log += d));
   try {
     await waitUp();
+    await (await reloadListener()).close();
     const listener = await reloadListener();
     // A real source change: the watcher rebuilds the client bundle.
     fs.writeFileSync(aboutFile, original + `\n// gate probe ${label} ${Date.now()}\n`);
     await check(listener, () => log);
-    listener.close();
+    await listener.close();
   } finally {
     fs.writeFileSync(aboutFile, original);
     fs.rmSync(gateConfig, { force: true });


### PR DESCRIPTION
Carries #174 by @TIMTOMTOP unchanged (both commits, original authorship) plus one follow-up commit found in review.

**Review of #174 (verified):**
- The leak is real and the fix is right: the start live-reload handler only awaited the reload channel, so a disconnected client's socket + broadcast subscription lived until the next rebuild write failed. Reading alongside the channel (like `oj_server`'s general `hmr_socket`) lets the task see EOF/close and lets axum answer pings.
- Ran the PR's four socket tests (pass) and its hardened `start-hmr-gate` e2e both ways: on main the pre-edit clean-close check times out ("Start HMR socket did not close without a reload"); on this branch it passes.
- Vite baseline confirmed in rolldown-vite 8.2.1 dist: the `ws` library does close-handshake/ping handling in its read loop and the client set drops on close — this PR gives oj's Rust socket the same behavior.
- `futures_util::SinkExt` in prod is required (axum's `WebSocket` has no inherent `close`; compile fails without it).

**The follow-up commit:** #174 broke the connection on *any* `rx.recv()` error, including `Lagged` — a slow client that missed reload pings got disconnected instead of reloaded (pre-existing behavior, but wrong). Vite never drops a reload (per-socket unbounded send queue, node.js:17622), and a missed `()` ping is by definition a pending reload, so `Lagged` now sends one reload and keeps the client. The general handler's `continue` is right for its distinct-frame channel and left untouched. New test `start_hmr_reloads_lagged_clients_instead_of_dropping_them` overflows the gated 16-slot broadcast and fails on #174's version (client dropped), passes here.

Supersedes #174 — same credit, only the branch differs (maintainer pushes to the fork are blocked from this environment).
